### PR TITLE
Refactored Lumen to be centered around tables

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -4,22 +4,23 @@ The Lumen dashboard can be configured by a `dashboard.yml` file. The dashboard y
 
 - `config`:
   - `title`: The title of the overall application
+  - `layout`: The layout to put the targets in
+  - `logo`: A URL or local path to an image file
   - `template`: The template to use for the monitoring application
   - `ncols`: The number of columns to use in the grid of cards
-- `sources`: This is the list of sources to monitor
+- `targets`: This is the list of targets to monitor
   - `title`: The title of the monitoring endpoint
-  - `source`: The `Source` used to monitor an endpoint
-    - `type`: The type of `Source` to use, e.g. 'rest' or 'live'
-	- ...: Additional parameters for the `Source`
-  - `views`: A list of metrics to monitor and display on the endpoint
-    - `variable`: The name of the metric
-	- `type`: The type of `View` to use for rendering the metric
-	- ...: Additional parameters for the `View`
-  - `filters`: A list of `Filter` types to select a subset of the data
-    - `name`: The name of the filter
-	- `type`: The type of the `Filter` to use, e.g. 'constant', 'widget' or 'facet'
-	- ...: Additional parameters for the `Filter`
-  - `height`: The height of the card(s)
-  - `width`: The width of the card(s)
-  - `layout`: The layout of the card(s), e.g. 'row', 'column' or 'grid'
-  - `refresh_rate`: How frequently to poll for updates in milliseconds
+    `source`: The `Source` used to monitor an endpoint
+      `type`: The type of `Source` to use, e.g. 'rest' or 'live'
+	  `...`: Additional parameters for the `Source`
+    `views`: A list of metrics to monitor and display on the endpoint
+      - `table`: The name of the table to visualize
+	    `type`: The type of `View` to use for rendering the table
+	    `...`: Additional parameters for the `View`
+    `filters`: A list of `Filter` types to select a subset of the data
+      - `field`: The name of the filter
+	    `type`: The type of the `Filter` to use, e.g. 'constant', 'widget' or 'facet'
+	    `...`: Additional parameters for the `Filter`
+    `layout`: The layout of the card(s), e.g. 'row', 'column' or 'grid'
+    `refresh_rate`: How frequently to poll for updates in milliseconds
+	`...`: Additional parameters passed to the `Card` layout(s), e.g. `width` or `height`

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,7 @@ Dashboard Specification <dashboard>
 ```
 
 The Lumen project provides a framework to build dashboards from a
-simple yaml specification. It is designed to query information from
-any source, filter it in various ways and then provide views of that
+simple yaml specification. It is designed to query data from any
+source, filter it in various ways and then provide views of that
 information, which can be anything from a simply indicator to a table
 or plot.
-
-A Lumen dashboard can be configured using a minimal yaml specification
-configuring the data source, filters and views, making it easy to view
-and monitor your data.

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -5,7 +5,7 @@ The REST specification defines the default format for data to be consumed by the
 - `schema`: Publishes a schema for each variable and all its associated indexes, the schema should follow the [JSON schema](https://json-schema.org/) specification:
 
     - Query: A query may define the variable to return the schema for:
-        `{'variable': <variable>}`
+        `{'table': <table>}`
     - Output:
     ```
     {
@@ -18,15 +18,15 @@ The REST specification defines the default format for data to be consumed by the
     }
     ```
 
-- `data`: This endpoints returns the actual data, it allows querying by one or more indexes:
+- `data`: This endpoints returns the actual data, it also allows filtering the data along the columns with query:
 
-    - Query: A query must contain the variable to be returned and any number of index queries:
-        `{'variable': <variable>, <index>: <value>, ...}`
+    - Query: A query must contain the table to be returned and may optionally provide a subset of columns and filters for the table columns:
+        `{'table': <table>, 'columns': [<column>, ...], <column>: <value>, ...}`
     - Output: It will always return a list of records containing all the metric and filter values:
     ```
     [
-        {<variable>: <value>, <index>: <value>, ...},
-        {<variable>: <value>, <index>: <value>, ...},
+        {<column>: <value>, <column>: <value>, ...},
+        {<column>: <value>, <column>: <value>, ...},
         ...
     ]
     ```
@@ -37,9 +37,9 @@ The REST specification defines the default format for data to be consumed by the
     - Output:
     ```
     {
-        <variable>: [
-            {<variable>: <value>, <index>: <value>, ...},
-            {<variable>: <value>, <index>: <value>, ...},
+        <table>: [
+            {<column>: <value>, <column>: <value>, ...},
+            {<column>: <value>, <column>: <value>, ...},
             ...
         ],
         ...

--- a/lumen/.version
+++ b/lumen/.version
@@ -1,1 +1,0 @@
-{"version_string": "None"}

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -45,7 +45,7 @@ class Dashboard(param.Parameterized):
         tmpl = self.config.get('template', 'material')
         kwargs = {'title': self.config.get('title', 'Lumen Dashboard')}
         if 'logo' in self.config:
-            logo = self.config['logo']
+            kwargs['logo'] = self.config['logo']
         self.template = _templates[tmpl](**kwargs)
 
         # Build layouts

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -30,8 +30,6 @@ class Dashboard(param.Parameterized):
 
     specification = param.Filename()
 
-    reload = param.Action(default=lambda x: x._reload())
-
     def __init__(self, specification, **params):
         with open(specification) as f:
             self._spec = yaml.load(f.read(), Loader=yaml.CLoader)
@@ -40,16 +38,16 @@ class Dashboard(param.Parameterized):
             specification=specification, **params
         )
         tmpl = self.config.get('template', 'material')
-        self.template = _templates[tmpl](title=self.config.get('title', 'Monitoring Dashboard'))
-        if not 'sources' in self._spec:
-            raise ValueError('%s did not specify any sources.'
-                             % self.specification)
+        title = self._spec.get('title', 'Lumen Dashboard')
+        self.template = _templates[tmpl](title=title)
+        if not 'targets' in self._spec:
+            raise ValueError('Yaml specification did not declare any targets.')
         self.filters = pn.Column(margin=0, sizing_mode='stretch_width')
-        self.monitors = pn.GridBox(ncols=self.config.get('ncols', 5), margin=10)
+        self.targets = pn.GridBox(ncols=self.config.get('ncols', 5), margin=10)
         self._reload()
         if len(self.filters):
             self.template.sidebar[:] = [self.filters]
-        self.template.main[:] = [self.monitors]
+        self.template.main[:] = [self.targets]
         self._reload_button = pn.widgets.Button(
             name='↻', width=50, css_classes=['reload'], margin=0
         )
@@ -57,36 +55,36 @@ class Dashboard(param.Parameterized):
         self.template.header.append(self._reload_button)
 
     def _reload_data(self, *events):
-        for monitor in self._monitors:
-            monitor.update()
+        for target in self._targets:
+            target.update()
 
     def _reload(self, *events):
-        self._monitors = self._resolve_sources(self._spec['sources'])
+        self._targets = self._resolve_sources(self._spec['targets'])
         self._rerender()
         filters = []
-        for monitor in self._monitors:
-            panel = monitor.filter_panel
+        for target in self._targets:
+            panel = target.filter_panel
             if panel is not None:
                 filters.append(panel)
         self.filters[:] = filters
 
     def _rerender(self):
-        self.monitors[:] = [p for monitor in self._monitors for p in monitor.panels]
+        self.targets[:] = [p for target in self._targets for p in target.panels]
 
     def _resolve_sources(self, sources, metadata={}):
-        monitors = []
-        for monitor_spec in sources:
-            monitor_spec = dict(monitor_spec)
+        targets = []
+        for target_spec in sources:
+            target_spec = dict(target_spec)
 
             # Create source
-            source_spec = dict(monitor_spec.pop('source'))
+            source_spec = dict(target_spec.pop('source'))
             source_type = source_spec.pop('type', 'rest')
             source = Source._get_type(source_type)(**source_spec)
             schema = source.get_schema()
 
             # Initialize filters
             source_filters = []
-            for filter_spec in monitor_spec.get('filters', []):
+            for filter_spec in target_spec.get('filters', []):
                 filter_spec = dict(filter_spec)
                 filter_name = filter_spec['name']
                 filter_schema = None
@@ -101,24 +99,25 @@ class Dashboard(param.Parameterized):
                 )
                 source_filters.append(filter_obj)
 
-            # Create monitor
-            monitor_spec['filters'] = source_filters
-            monitor = Monitor(source=source, application=self, schema=schema, **monitor_spec)
-            monitors.append(monitor)
-        return monitors
+            # Create target
+            target_spec['filters'] = source_filters
+            target = Monitor(source=source, application=self, schema=schema, **target_spec)
+            targets.append(target)
+        return targets
 
     def show(self):
         """
-        Opens the monitoring dashboard in a new window.
+        Opens the dashboard in a new window.
         """
         self.template.show()
-        for monitor in self._monitors:
-            monitor.start()
+        for target in self._targets:
+            target.start()
 
     def servable(self):
         """
-        Marks the monitoring dashboard for serving with `panel serve`.
+        Marks the dashboard for serving with `panel serve`.
         """
-        self.template.servable(title=self.config.get('title', 'Monitoring Dashboard'))
-        for monitor in self._monitors:
-            monitor.start()
+        title = self.config.get('title', 'Lumen Dashboard')
+        self.template.servable(title=title)
+        for target in self._targets:
+            target.start()

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -1,6 +1,6 @@
 """
-The Filter components provide the ability to filter by returning a
-query which is applied to the Source.
+The Filter components supply query parameters used to filter the
+tables returned by a Source.
 """
 
 import param
@@ -29,6 +29,10 @@ class Filter(param.Parameterized):
 
     @classmethod
     def _get_type(cls, filter_type):
+        try:
+            __import__(f'lumen.filters.{filter_type}')
+        except Exception:
+            pass
         for filt in param.concrete_descendents(cls).values():
             if filt.filter_type == filter_type:
                 return filt
@@ -42,6 +46,7 @@ class Filter(param.Parameterized):
         panel.Viewable or None
             A Panel Viewable object representing the filter.
         """
+        return None
 
     @property
     def query(self):
@@ -52,6 +57,7 @@ class Filter(param.Parameterized):
             The current filter query which will be used by the
             Source to filter the data.
         """
+
 
 class ConstantFilter(Filter):
     """
@@ -67,7 +73,7 @@ class ConstantFilter(Filter):
 
     @property
     def panel(self):
-        None
+        return None
 
 
 class FacetFilter(Filter):
@@ -89,8 +95,9 @@ class FacetFilter(Filter):
 
 class WidgetFilter(Filter):
     """
-    The WidgetFilter generates a Widget from the schema used for
-    generate the query to the Source.
+    The WidgetFilter generates a Widget from the table schema provided
+    by a Source and returns the current widget value to query the data
+    returned by the Source.
     """
 
     widget = param.ClassSelector(class_=pn.widgets.Widget)

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -15,11 +15,13 @@ class Filter(param.Parameterized):
     returned by a Source.
     """
 
+    field = param.String(doc="The field being filtered.")
+
+    label = param.String(doc="A label for the Filter.")
+
     schema = param.Dict(doc="""
         The JSON schema provided by the Source declaring information
         about the data to be filtered.""" )
-
-    label = param.String(doc="A label for the Filter.")
 
     value = param.Parameter(doc="The current filter value.")
 
@@ -88,8 +90,8 @@ class FacetFilter(Filter):
     @property
     def filters(self):
         return [
-            ConstantFilter(name=self.name, value=value, label=self.label)
-            for value in self.schema[self.name]['enum']
+            ConstantFilter(field=self.field, value=value, label=self.label)
+            for value in self.schema[self.field]['enum']
         ]
 
 
@@ -108,7 +110,7 @@ class WidgetFilter(Filter):
         super(WidgetFilter, self).__init__(**params)
         self.widget = JSONSchema(
             schema=self.schema, sizing_mode='stretch_width'
-        )._widgets[self.name]
+        )._widgets[self.field]
         if isinstance(self.widget, pn.widgets.Select):
             self.widget.options.insert(0, ' ')
             self.widget.value = ' '

--- a/lumen/monitor.py
+++ b/lumen/monitor.py
@@ -121,7 +121,7 @@ class Monitor(param.Parameterized):
             item = pn.Column(*(view.panel for view in views), **kwargs)
 
         return pn.Card(
-            item, title=title, **self.kwargs
+            item, title=title, name=title, **self.kwargs
         )
 
     def _get_card(self, filters, facet_filters, invalidate_cache=True, update_views=True):

--- a/lumen/monitor.py
+++ b/lumen/monitor.py
@@ -44,7 +44,6 @@ class Monitor(param.Parameterized):
     views = param.List(doc="A list of views to be displayed.")
 
     def __init__(self, **params):
-        views = params.get('views', [])
         sort = params.pop('sort', {})
         params['sort_fields'] = sort_fields = sort.get('fields', [])
         params['sort_reverse'] = sort_reverse = sort.get('reverse', False)

--- a/lumen/monitor.py
+++ b/lumen/monitor.py
@@ -1,5 +1,6 @@
 import datetime as dt
 
+from functools import partial
 from itertools import product
 
 import param
@@ -19,11 +20,9 @@ class Monitor(param.Parameterized):
 
     application = param.Parameter(doc="The overall monitoring application.")
 
-    current = param.List()
-
-    height = param.Integer(default=400, doc="Height of the monitor cards.")
-
     filters = param.List(doc="A list of filters to be rendered.")
+
+    layout = param.ObjectSelector(default='column', objects=['row', 'column', 'grid'])
 
     sort_fields = param.List(default=[], doc="List of fields to sort by.")
 
@@ -33,12 +32,6 @@ class Monitor(param.Parameterized):
     schema = param.Dict()
 
     title = param.String(doc="A title for this monitor.")
-
-    layout = param.ObjectSelector(default='column', objects=['row', 'column', 'grid'])
-
-    sizing_mode = param.ObjectSelector(default='fixed', objects=[
-        'stretch_width', 'stretch_both', 'stretch_height', 'fixed'], doc="""
-        Sizing mode to apply to the views.""")
 
     refresh_rate = param.Integer(default=None, doc="""
         How frequently to refresh the monitor by querying the adaptor.""")
@@ -50,17 +43,16 @@ class Monitor(param.Parameterized):
 
     views = param.List(doc="A list of views to be displayed.")
 
-    width = param.Integer(default=400, doc="Width of the monitor cards.")
-
     def __init__(self, **params):
         views = params.get('views', [])
         sort = params.pop('sort', {})
         params['sort_fields'] = sort_fields = sort.get('fields', [])
         params['sort_reverse'] = sort_reverse = sort.get('reverse', False)
         self._sort_widget = pn.widgets.MultiSelect(
-            options=[m.get('name') for m in views],
-            sizing_mode='stretch_width', value=sort_fields,
-            size=len(views)
+            options=sort_fields,
+            sizing_mode='stretch_width',
+            size=len(sort_fields),
+            value=sort_fields,
         )
         self._reverse_widget = pn.widgets.Checkbox(
             value=sort_reverse, name='Reverse', margin=(5, 0, 0, 10)
@@ -69,11 +61,12 @@ class Monitor(param.Parameterized):
             name='↻', width=50, css_classes=['reload'], margin=0
         )
         self._reload_button.on_click(self.update)
-        super(Monitor, self).__init__(**params)
+        self.kwargs = {k: v for k, v in params.items() if k not in self.param}
+        super().__init__(**{k: v for k, v in params.items() if k in self.param})
         self._cards = []
         self._cache = {}
-        self._stale = False
         self._cb = None
+        self._stale = False
         self.timestamp = pn.pane.HTML(
             f'Last updated: {dt.datetime.now().strftime(self.tsformat)}',
             align='end', margin=10, sizing_mode='stretch_width'
@@ -82,14 +75,139 @@ class Monitor(param.Parameterized):
         for filt in self.filters:
             if isinstance(filt, FacetFilter):
                 continue
-            filt.param.watch(self._rerender, 'value')
+            filt.param.watch(partial(self._rerender, invalidate_cache=True), 'value')
 
     @pn.depends('_sort_widget.value', '_reverse_widget.value', watch=True)
     def _resort(self, *events):
         self.sort_fields = self._sort_widget.value
         self.sort_reverse = self._reverse_widget.value
-        self._update_views()
-        self.application._rerender()
+        self._rerender(update_views=False)
+
+    def _get_transforms(self, transform_specs):
+        transforms = []
+        for transform in transform_specs:
+            transform = dict(transform)
+            transform_type = transform.pop('type', None)
+            transform = Transform._get_type(transform_type)(**transform)
+            transforms.append(transform)
+        return transforms
+
+    def _get_view(self, view_spec, filters):
+        view_type = view_spec.pop('type', None)
+        transform_specs = view_spec.pop('transforms', [])
+        transforms = self._get_transforms(transform_specs)
+        view = View._get_type(view_type)(
+            source=self.source, filters=filters,
+            transforms=transforms, monitor=self,
+            **view_spec
+        )
+        return view
+
+    def _get_sort_key(self, views):
+        sort_key = []
+        for field in self.sort_fields:
+            values = [v.get_value(field) for v in views]
+            if values:
+                sort_key.append(values[0])
+        return tuple(sort_key)
+
+    def _construct_card(self, title, views):
+        kwargs = self.kwargs
+        if self.layout == 'row':
+            item = pn.Row(*(view.panel for view in views), **kwargs)
+        elif self.layout == 'grid':
+            item = pn.GridBox(*(view.panel for view in views), ncols=2, **kwargs)
+        else:
+            item = pn.Column(*(view.panel for view in views), **kwargs)
+
+        return pn.Card(
+            item, title=title, **self.kwargs
+        )
+
+    def _get_card(self, filters, facet_filters, invalidate_cache=True, update_views=True):
+        view_filters = filters + list(facet_filters)
+        key = (tuple(str(f.value) for f in facet_filters) +
+               tuple(id(view) for view in self.views))
+
+        if key in self._cache:
+            card, views = self._cache[key]
+        else:
+            card = None
+            views = [self._get_view(dict(view_spec), view_filters)
+                     for view_spec in self.views]
+        if not any(view for view in views):
+            return None, None
+
+        sort_key = self._get_sort_key(views)
+
+        if facet_filters:
+            title = ' '.join([f'{f.label}: {f.value}' for f in facet_filters])
+        else:
+            title = self.title
+
+        if card is None:
+            card = self._construct_card(title, views)
+            self._cache[key] = (card, views)
+        else:
+            card.title = title
+            if update_views:
+                for view in views:
+                    view.update(invalidate_cache)
+        return sort_key, card
+
+    def _update_views(self, invalidate_cache=True, update_views=True):
+        filters = [filt for filt in self.filters
+                   if not isinstance(filt, FacetFilter)]
+        facets = [filt.filters for filt in self.filters
+                  if isinstance(filt, FacetFilter)]
+        cards = []
+        for facet_filters in product(*facets):
+            key, card = self._get_card(
+                filters, facet_filters, invalidate_cache, update_views
+            )
+            if card is None:
+                continue
+            cards.append((key, card))
+
+        if self.sort_fields:
+            cards = sorted(cards, key=lambda x: x[0])
+            if self.sort_reverse:
+                cards = cards[::-1]
+
+        cards = [card for _, card in cards]
+        if cards != self._cards:
+            self._cards[:] = cards
+            self._stale = True
+
+    def _rerender(self, *events, invalidate_cache=False, update_views=True):
+        self._update_views(invalidate_cache, update_views)
+        if self._stale:
+            self.application._rerender()
+            self._stale = False
+
+    # Public API
+
+    @property
+    def filter_panel(self):
+        views = []
+        filters = [filt.panel for filt in self.filters if filt.panel is not None]
+        if filters:
+            views.append(pn.pane.Markdown('### Filters', margin=(0, 5)))
+            views.extend(filters)
+            views.append(pn.layout.Divider())
+        if self.sort_fields:
+            views.extend([
+                pn.pane.Markdown('### Sort', margin=(0, 5)),
+                self._sort_widget,
+                self._reverse_widget
+            ])
+            views.append(pn.layout.Divider())
+        views.append(pn.Row(self._reload_button, self.timestamp, sizing_mode='stretch_width'))
+        return pn.Card(*views, title=self.title, sizing_mode='stretch_width') if views else None
+
+    @property
+    def panels(self):
+        return self._cards
 
     @pn.depends('refresh_rate', watch=True)
     def start(self, event=None):
@@ -103,109 +221,7 @@ class Monitor(param.Parameterized):
                 self.update, refresh_rate
             )
 
-    def _get_transforms(self, transform_specs):
-        transforms = []
-        for transform in transform_specs:
-            transform = dict(transform)
-            transform_type = transform.pop('type', None)
-            transform = Transform._get_type(transform_type)(**transform)
-            transforms.append(transform)
-        return transforms
-
-    def _get_view(self, key, view_spec, filters):
-        view_type = view_spec.pop('type', None)
-        transform_specs = view_spec.pop('transforms', [])
-        transforms = self._get_transforms(transform_specs)
-        if key not in self._cache:
-            view = View._get_type(view_type)(
-                source=self.source, filters=filters,
-                transforms=transforms, monitor=self, **view_spec
-            )
-            self._cache[key] = view
-        else:
-            view = self._cache.get(key)
-            view.update(rerender=False)
-        return view
-
-    def _get_card(self, title, views):
-        if self.layout == 'row':
-            item = pn.Row(*(view.panel for view in views))
-        elif self.layout == 'grid':
-            item = pn.GridBox(*(view.panel for view in views), ncols=2)
-        else:
-            item = pn.Column(*(view.panel for view in views))
-        item.sizing_mode = self.sizing_mode
-
-        return pn.Card(
-            item, height=self.height, width=self.width, title=title,
-            sizing_mode=self.sizing_mode
-        )
-
-    @pn.depends('current')
-    def _update_views(self):
-        filters = [filt for filt in self.filters
-                   if not isinstance(filt, FacetFilter)]
-        facets = [filt.filters for filt in self.filters
-                  if isinstance(filt, FacetFilter)]
-        cards = []
-        for facet_filters in product(*facets):
-            views = []
-            view_filters = filters + list(facet_filters)
-            key = tuple(str(f.value) for f in facet_filters)
-            for view_spec in self.views:
-                view = self._get_view(key+(id(view_spec),), dict(view_spec), view_filters)
-                if view:
-                    views.append(view)
-            if not views:
-                continue
-
-            sort_key = []
-            for field in self.sort_fields:
-                values = [m.get_value() for m in views if m.name == field]
-                if values:
-                    sort_key.append(values[0])
-
-            if facet_filters:
-                title = ' '.join([f'{f.label}: {f.value}' for f in facet_filters])
-            else:
-                title = self.title
-
-            card = self._get_card(title, views)
-            cards.append((tuple(sort_key), card))
-
-        if self.sort_fields:
-            cards = sorted(cards, key=lambda x: x[0])
-            if self.sort_reverse:
-                cards = cards[::-1]
-
-        self._cards[:] = [card for _, card in cards]
-
-    def _rerender(self, *events):
-        if not self._stale:
-            return
-        self._update_views()
-        self.application._rerender()
-
-    # Public API
-        
-    @property
-    def filter_panel(self):
-        views = []
-        filters = [filt.panel for filt in self.filters if filt.panel is not None]
-        if filters:
-            views.append(pn.pane.Markdown('### Filters', margin=(0, 5)))
-            views.extend(filters)
-            views.append(pn.layout.Divider())
-        views.extend([pn.pane.Markdown('### Sort', margin=(0, 5)), self._sort_widget, self._reverse_widget])
-        views.append(pn.layout.Divider())
-        views.append(pn.Row(self._reload_button, self.timestamp, sizing_mode='stretch_width'))
-        return pn.Card(*views, title=self.title, sizing_mode='stretch_width') if views else None
-
-    @property
-    def panels(self):
-        return self._cards
-
     def update(self, *events):
         self.source.clear_cache()
         self.timestamp.object = f'Last updated: {dt.datetime.now().strftime(self.tsformat)}'
-        self._update_views()
+        self._rerender(invalidate_cache=True)

--- a/lumen/rest.py
+++ b/lumen/rest.py
@@ -116,7 +116,7 @@ class ParameterEndpoint(TableEndpoint):
             else:
                 filter_fn = lambda o: getattr(o, k) == v
             objects = list(filter(objects, filter_fn))
-        return [o.param.serialize_parameters(columns) for o in self.objects]
+        return [o.param.serialize_parameters(self.columns) for o in self.objects]
 
     def schema(self):
         schema = super().schema()
@@ -160,7 +160,7 @@ def unpublish(table):
     """
     Unpublishes a table which was previously published.
     """
-    del _VARIABLES[table]
+    del _TABLES[table]
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/lumen/rest.py
+++ b/lumen/rest.py
@@ -66,12 +66,14 @@ class DataFrameEndpoint(TableEndpoint):
 
     def query(self, **kwargs):
         query = None
-        columns = [] if self.data is None else self.data.columns
+        data = self.data
+        columns = [] if self.data is None else list(self.data.columns)
+        selected_cols = kwargs.pop('columns', columns)
         for k, v in kwargs.items():
             if k not in columns:
                 self.param.warning(f"Query {k}={v} could not be resolved "
                                    "data does not have queried column.")
-            column = self.data[k]
+            column = data[k]
             if isinstance(v, list):
                 q = column.isin(v)
             elif isinstance(v, tuple):
@@ -82,6 +84,8 @@ class DataFrameEndpoint(TableEndpoint):
                 query = q
             else:
                 query &= q
+        if selected_cols is not columns:
+            data = data[selected_cols]
         data = self.data if query is None else self.data[query]
         return data.to_json(orient='records')
 

--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -88,7 +88,7 @@ class AE5KubeSource(Source):
         if statuses:
             status = statuses[0]
             state = status['state']
-            started = state.get('running', state.get('waiting')).get('startedAt')
+            started = state.get('running', state.get('waiting', {})).get('startedAt')
             record["restarts"] = status['restartCount']
             if started:
                 started_dt = dt.datetime.fromisoformat(started.replace('Z', ''))

--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -42,60 +42,63 @@ class AE5KubeSource(Source):
         self._resources = None
         self._update_cache()
 
-    def _get_usage(self, name, d, variable):
-        info = self._pod_info[d['id']].get('usage', self._empty)
-        containers = [container for container in info['containers'] if container['name'] == 'app']
-        if not containers:
-            return None
-        container = containers[0]
+    def _get_record(self, name, d):
+        pod_info = self._pod_info[d['id']]
+        usage_info = pod_info.get('usage', self._empty)
+        status_info = pod_info.get('status')
+
         record = {
             "name": name,
             "state": d['state'],
             "owner": d['owner'],
             "resource_profile": d['resource_profile'],
-            "timestamp": info['timestamp']
+            "timestamp": usage_info['timestamp']
         }
-        resource = self._resources[self._resources['name']==d['resource_profile']]
-        usage = container['usage']
-        if variable == 'cpu':
+
+        # Resource usage
+        containers = [
+            container for container in usage_info['containers']
+            if container['name'] == 'app'
+        ]
+        if containers:
+            container = containers[0]
+            resource = self._resources[self._resources['name']==d['resource_profile']]
+            usage = container['usage']
             cpu_cap = int(resource.cpu.item())
             if 'cpu' not in usage or 'm' not in usage['cpu']:
                 cpu = 0
             else:
                 cpu = int(usage['cpu'][:-1])
             record['cpu'] = round(((cpu/1000.) / cpu_cap)*100, 2)
-        else:
             mem_cap = int(resource.memory.item()[:-2])
             if 'memory' not in usage:
                 mem = 0
             else:
                 mem = int(usage['memory'][:-2])
             record['memory'] = round(((mem/1024.) / mem_cap)*100, 2)
-        return record
-
-    def _get_uptime(self, name, d, variable):
-        info = self._pod_info[d['id']].get('status')
-        statuses = [status for status in info['containerStatuses'] if status['name'] == 'app']
-        if not statuses:
-            return None
-
-        status = statuses[0]
-        started = status['state'].get('running', {}).get('startedAt')
-        if variable == 'uptime' and started is None:
-            return
-        record = {
-            "name": name,
-            "state": d['state'],
-            "owner": d['owner'],
-            "resource_profile": d['resource_profile'],
-
-        }
-        if variable == 'uptime':
-            started_dt = dt.datetime.fromisoformat(started.replace('Z', ''))
-            uptime = str(dt.datetime.now()-started_dt)
-            record['uptime'] = uptime[:uptime.index('.')]
         else:
+            record['cpu'] = float('NaN')
+            record['memory'] = float('NaN')
+
+        # Status
+        statuses = [
+            status for status in status_info['containerStatuses']
+            if status['name'] == 'app'
+        ]
+        if statuses:
+            status = statuses[0]
+            state = status['state']
+            started = state.get('running', state.get('waiting')).get('startedAt')
             record["restarts"] = status['restartCount']
+            if started:
+                started_dt = dt.datetime.fromisoformat(started.replace('Z', ''))
+                uptime = str(dt.datetime.now()-started_dt)
+                record["uptime"] = uptime[:uptime.index('.')]
+        else:
+            record["restarts"] = float('NaN')
+        if 'uptime' not in record:
+            record["uptime"] = '-' 
+        
         return record
 
     def _get_pod_info(self, pod=None):
@@ -115,54 +118,32 @@ class AE5KubeSource(Source):
 
     # Public API
 
-    def get_schema(self, variable=None):
+    def get_schema(self, table=None):
         name = sorted({d['name'] for d in self._deployment_cache})
         owners = sorted({d['project_owner'] for d in self._deployment_cache})
         state = sorted({d['state'] for d in self._deployment_cache})
         resources = sorted({d['resource_profile'] for d in self._deployment_cache})
         schema = {
-            "cpu": {
+            "deployments": {
                 "name": {"type": "string", "enum": name},
                 "state": {"type": "string", "enum": state},
                 "owner": {"type": "string", "enum": owners},
                 "resource_profile": {"type": "string", "enum": resources},
                 "timestamp": {"type": "string", "format": "datetime"},
-                "cpu": {"type": "number"}
-            },
-            "memory": {
-                "name": {"type": "string", "enum": name},
-                "state": {"type": "string", "enum": state},
-                "owner": {"type": "string", "enum": owners},
-                "resource_profile": {"type": "string", "enum": resources},
-                "timestamp": {"type": "string", "format": "datetime"},
-                "memory": {"type": "number"}
-            },
-            'uptime': {
-                "name": {"type": "string", "enum": name},
-                "state": {"type": "string", "enum": state},
-                "owner": {"type": "string", "enum": owners},
-                "uptime": {"type": "string"},
-                "restarts": {"type": "number"}
-            },
-            'restarts': {
-                "name": {"type": "string", "enum": name},
-                "state": {"type": "string", "enum": state},
-                "owner": {"type": "string", "enum": owners},
+                "cpu": {"type": "number"},
+                "memory": {"type": "number"},
                 "uptime": {"type": "string"},
                 "restarts": {"type": "number"}
             }
         }
-        return schema if variable is None else schema[variable]
+        return schema if table is None else schema[table]
 
-    def get(self, variable, **query):
+    def get(self, table, **query):
         if self._deployment_cache is None:
             self._update_cache()
         records = []
         for name, d in self._deployments.items():
-            if variable in ('cpu', 'memory'):
-                record = self._get_usage(name, d, variable)
-            else:
-                record = self._get_uptime(name, d, variable)
+            record = self._get_record(name, d)
             if record is None:
                 continue
             skip = False

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -6,10 +6,10 @@ import requests
 
 class Source(param.Parameterized):
     """
-    A Source provides a set of named variables and associated indexes
-    which can be queried. The Source must also be able to return a
-    schema describing the types of the variables and indexes in the
-    data.
+    A Source provides a set of tables which declare their indexes and
+    variables. The Source must also be able to return a schema
+    describing the types of the variables and indexes in each table
+    and allow querying the data.
     """
 
     source_type = None
@@ -59,39 +59,38 @@ class Source(param.Parameterized):
             df = df[mask]
         return df
 
-    def get_schema(self, variable=None):
+    def get_schema(self, table=None):
         """
-        Returns JSON schema describing the data returned by the
+        Returns JSON schema describing the tables returned by the
         Source.
 
         Parameters
         ----------
-        variable : str or None
-            The name of the variable to return the schema for. If None
-            returns schema for all available variables.
+        table : str or None
+            The name of the table to return the schema for. If None
+            returns schema for all available tables.
 
         Returns
         -------
         dict
-           JSON schema describing the types of the data.
+           JSON schema(s) for one or all the tables.
         """
 
-    def get(self, variable, **query):
+    def get(self, table, **query):
         """
-        Return data for a particular variable given a query.
+        Return a table; optionally filtered by the given query.
 
         Parameters
         ----------
-        variable : str
-            The name of the variable to query
+        table : str
+            The name of the table to query
         query : dict
             A dictionary containing all the query parameters
 
         Returns
         -------
         DataFrame
-           A DataFrame containing the indexes and data variables
-           declared in the schema.
+           A DataFrame containing the queried table.
         """
 
     def clear_cache(self):
@@ -110,14 +109,14 @@ class RESTSource(Source):
 
     source_type = 'rest'
 
-    def get_schema(self, variable=None):
-        query = {} if variable is None else {'variable': variable}
+    def get_schema(self, table=None):
+        query = {} if table is None else {'table': table}
         response = requests.get(self.url+'/schema', params=query)
-        return {var: schema['items']['properties'] for var, schema in
+        return {table: schema['items']['properties'] for table, schema in
                 response.json().items()}
 
-    def get(self, variable, **query):
-        query = dict(variable=variable, **query)
+    def get(self, table, **query):
+        query = dict(table=table, **query)
         r = requests.get(self.url+'/data', params=query)
         return pd.DataFrame(r.json())
 
@@ -127,20 +126,90 @@ class WebsiteSource(Source):
     Queries whether a website responds with a 400 status code.
     """
 
-    url = param.String(doc="URL of the website to monitor.")
+    urls = param.List(doc="URLs of the websites to monitor.")
 
     source_type = 'live'
 
-    def get_schema(self, variable=None):
+    def get_schema(self, table=None):
         schema = {
-            "live": {
-                "live": {"type": "boolean"},
-                "url": {"type": "string"}
+            "status": {
+                "url": {"type": "string"},
+                "live": {"type": "boolean"}
             }
         }
-        return schema if variable is None else schema[variable]
+        return schema if table is None else schema[table]
 
-    def get(self, variable, **query):
-        r = requests.get(self.url)
-        return pd.DataFrame([{"live": r.status_code == 200, "url": self.url}])
+    def get(self, table, **query):
+        data = []
+        for url in self.urls:
+            try:
+                r = requests.get(url)
+                live = r.status_code == 200
+            except Exception:
+                live = False
+            data.append({"live": live, "url": self.url})
+        return pd.DataFrame(data)
 
+
+class PanelSessionSource(Source):
+
+    urls = param.List(doc="URL of the websites to monitor.")
+
+    source_type = 'session_info'
+
+    def get_schema(self, table=None):
+        schema = {
+            "summary": {
+                "url": {"type": "string"},
+                "total": {"type": "int"},
+                "live": {"type": "int"},
+                "render_duration": {"type": "float"},
+                "session_duration": {"type": "float"}
+            },
+            "sessions": {
+                "url": {"type": "string", "enum": self.urls},
+                "id": {"type": "string"},
+                "started": {"type": "float"},
+                "ended": {"type": "float"},
+                "rendered": {"type": "float"},
+                "render_duration": {"type": "float"},
+                "session_duration": {"type": "float"},
+                "user_agent": {"type": "string"}
+            }
+        }
+        return schema if table is None else schema[table]
+
+    def get(self, table, **query):
+        data = []
+        for url in self.urls:
+            r = requests.get(url).json()
+            session_info = r['session_info']
+            sessions = session_info['sessions']
+            if table == "summary":
+                rendered = [s for s in sessions.values()
+                            if s['rendered'] is not None]
+                ended = [s for s in sessions.values()
+                         if s['ended'] is not None]
+                row = {
+                    'url': url,
+                    'total': session_info['total'],
+                    'live': session_info['live'],
+                    'render_duration': np.mean([s['rendered']-s['started']
+                                                for s in rendered]),
+                    'session_duration': np.mean([s['ended']-s['started']
+                                                for s in ended])
+                }
+                data.append(row)
+            elif table == "sessions":
+                for sid, session in sessions.items():
+                    row = dict(url=url, id=sid, **session)
+                    if session["rendered"]:
+                        row["render_duration"] = session["rendered"]-session["started"]
+                    else:
+                        row["render_duration"] = float('NaN')
+                    if session["ended"]:
+                        row["session_duration"] = session["ended"]-session["started"]
+                    else:
+                        row["session_duration"] = float('NaN')
+                    data.push(row)
+        return pd.DataFrame(data)

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -25,7 +25,7 @@ class Source(param.Parameterized):
         for source in param.concrete_descendents(cls).values():
             if source.source_type == source_type:
                 return source
-        return Source
+        raise ValueError(f"No Source for source_type '{source_type}' could be found.")
 
     @classmethod
     def _filter_dataframe(cls, df, **query):
@@ -160,7 +160,7 @@ class PanelSessionSource(Source):
     def get_schema(self, table=None):
         schema = {
             "summary": {
-                "url": {"type": "string"},
+                "url": {"type": "string", "enum": self.urls},
                 "total": {"type": "int"},
                 "live": {"type": "int"},
                 "render_duration": {"type": "float"},

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -6,10 +6,10 @@ import requests
 
 class Source(param.Parameterized):
     """
-    A Source provides a set of tables which declare their indexes and
-    variables. The Source must also be able to return a schema
-    describing the types of the variables and indexes in each table
-    and allow querying the data.
+    A Source provides a set of tables which declare their available
+    fields. The Source must also be able to return a schema describing
+    the types of the variables and indexes in each table and allow
+    querying the data.
     """
 
     source_type = None

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -1,6 +1,5 @@
 """
-A Transform component is given the data for a particular variable and
-transforms it.
+The Transform components allow transforming tables in arbitrary ways.
 """
 
 import datetime as dt
@@ -11,7 +10,7 @@ import param
 
 class Transform(param.Parameterized):
     """
-    A Transform provides the ability to transform the data supplied by
+    A Transform provides the ability to transform a table supplied by
     a Source.
     """
 
@@ -21,23 +20,27 @@ class Transform(param.Parameterized):
 
     @classmethod
     def _get_type(cls, transform_type):
+        try:
+            __import__(f'lumen.transforms.{transform_type}')
+        except Exception:
+            pass
         for transform in param.concrete_descendents(cls).values():
             if transform.transform_type == transform_type:
                 return transform
         raise ValueError(f"No Transform for transform_type '{transform_type}' could be found.")
 
-    def apply(self, data):
+    def apply(self, table):
         """
-        Given some data transform it in some way and return it.
+        Given a table transform it in some way and return it.
 
         Parameters
         ----------
-        data : pandas.DataFrame
-            The queried data as a pandas DataFrame.
+        table : DataFrame
+            The queried table as a DataFrame.
 
         Returns
         -------
-        pandas.DataFrame
+        DataFrame
             A DataFrame containing the transformed data.
         """
         return data
@@ -62,7 +65,7 @@ class HistoryTransform(Transform):
         super().__init__(**params)
         self._buffer = []
 
-    def apply(self, data):
+    def apply(self, table):
         """
         Accumulates a history of the data in a buffer up to the
         declared `length` and optionally adds the current datetime to
@@ -70,17 +73,17 @@ class HistoryTransform(Transform):
 
         Parameters
         ----------
-        data : pandas.DataFrame
-            The queried data as a pandas DataFrame.
+        data : DataFrame
+            The queried table as a DataFrame.
 
         Returns
         -------
-        pandas.DataFrame
+        DataFrame
             A DataFrame containing the buffered history of the data.
         """
         if self.date_column:
-            data = data.copy()
-            data[self.date_column] = dt.datetime.now()
-        self._buffer.append(data)
+            table = table.copy()
+            table[self.date_column] = dt.datetime.now()
+        self._buffer.append(table)
         self._buffer[:] = self._buffer[-self.length:]
         return pd.concat(self._buffer)

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -43,7 +43,7 @@ class Transform(param.Parameterized):
         DataFrame
             A DataFrame containing the transformed data.
         """
-        return data
+        return table
 
 
 class HistoryTransform(Transform):

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -5,8 +5,7 @@ from pandas.core.dtypes.dtypes import CategoricalDtype
 
 def get_dataframe_schema(df, columns=None):
     """
-    Returns a JSON schema for a dataframe given a set of indexes and
-    the variable.
+    Returns a JSON schema optionally filtered by a subset of the columns.
 
     Parameters
     ----------

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -3,7 +3,7 @@ import sys
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 
-def get_dataframe_schema(df, index, variable):
+def get_dataframe_schema(df, columns=None):
     """
     Returns a JSON schema for a dataframe given a set of indexes and
     the variable.
@@ -12,30 +12,27 @@ def get_dataframe_schema(df, index, variable):
     ----------
     df : pandas.DataFrame or dask.DataFrame
         The DataFrame to describe with the schema
-    index: list(str) or str
-        The index or list of indexes
-    variable: str
-        The data variable
+    columns: list(str) or None
+        List of columns to include in schema
 
     Returns
     -------
     dict
         The JSON schema describing the DataFrame
     """
-    if not isinstance(index, list):
-        index = [index]
-
     if 'dask.dataframe' in sys.modules:
         import dask.dataframe as dd
         is_dask = isinstance(df, dd.DataFrame)
     else:
         is_dask = False
 
+    if columns is None:
+        columns = list(df.columns)
+
     schema = {'type': 'array', 'items': {'type': 'object', 'properties': {}}}
     properties = schema['items']['properties']
-    for name, dtype in df.dtypes.iteritems():
-        if name != variable and name not in index:
-            continue
+    for name in columns:
+        dtype = df.dtypes[name]
         column = df[name]
         if dtype.kind in 'uifM':
             vmin, vmax = column.min(), column.max()

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -6,7 +6,6 @@ object.
 import param
 import panel as pn
 
-from ..filters import ConstantFilter
 from ..sources import Source
 
 
@@ -66,7 +65,7 @@ class View(param.Parameterized):
             if view.view_type == view_type:
                 return view
         if view_type is not None:
-            self.param.warning(f"View type '{view_type}' could not be found.")
+            raise ValueError(f"View type '{view_type}' could not be found.")
         return View
 
     def __bool__(self):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -14,8 +14,8 @@ class View(param.Parameterized):
     """
     A View renders the data returned by a Source as a Viewable Panel
     object. The base class provides methods which query the Source for
-    the latest data given the current filters and applies all specified
-    `transforms`.
+    the latest data given the current filters and applies all
+    specified `transforms`.
 
     Subclasses should use these methods to query the data and return
     a Viewable Panel object in the `get_panel` method.
@@ -40,7 +40,7 @@ class View(param.Parameterized):
 
     table = param.String(doc="The table being visualized.")
 
-    variable = param.String(doc="The variable being visualized.")
+    field = param.String(doc="The field being visualized.")
 
     view_type = None
 
@@ -101,7 +101,7 @@ class View(param.Parameterized):
         """
         if self._cache is not None:
             return self._cache
-        query = {filt.name: filt.query for filt in self.filters
+        query = {filt.field: filt.query for filt in self.filters
                  if filt.query is not None}
         data = self.source.get(self.table, **query)
         for transform in self.transforms:
@@ -111,31 +111,31 @@ class View(param.Parameterized):
         self._cache = data
         return data
 
-    def get_value(self, variable=None):
+    def get_value(self, field=None):
         """
         Queries the Source for the data associated with a particular
-        variable applying any filters and transformations specified on
+        field applying any filters and transformations specified on
         the View. Unlike `get_data` this method returns a single
-        scalar value associated with the variable and should therefore
+        scalar value associated with the field and should therefore
         only be used if only a single.
 
         Parameters
         ----------
-        variable: str (optional)
-            The variable from the table to return; if None uses
-            variable defined on the View.
+        field: str (optional)
+            The field from the table to return; if None uses
+            field defined on the View.
 
         Returns
         -------
         object
             A single scalar value representing the current value of
-            the queried variable.
+            the queried field.
         """
         data = self.get_data()
         if not len(data):
             return None
         row = data.iloc[-1]
-        return row[self.variable if variable is None else variable]
+        return row[self.field if field is None else field]
 
     def get_panel(self):
         """
@@ -173,12 +173,12 @@ class View(param.Parameterized):
 
 class StringView(View):
     """
-    The StringView renders the latest value of the variable as a HTML
+    The StringView renders the latest value of the field as a HTML
     string with a specified fontsize.
     """
 
     font_size = param.String(default='24pt', doc="""
-        The font size of the rendered variable value.""")
+        The font size of the rendered field value.""")
 
     view_type = 'string'
 
@@ -198,7 +198,7 @@ class StringView(View):
 
 class IndicatorView(View):
     """
-    The IndicatorView renders the latest variable value as a Panel
+    The IndicatorView renders the latest field value as a Panel
     Indicator.
     """
 
@@ -211,7 +211,7 @@ class IndicatorView(View):
 
     def __init__(self, **params):
         super().__init__(**params)
-        name = params.get('label', params.get('variable', ''))
+        name = params.get('label', params.get('field', ''))
         self.kwargs['name'] = name
         self._panel.name = name
 


### PR DESCRIPTION
The original design of Lumen was based around the idea that we were monitoring single metrics. However as we realized that Lumen could be far more general this presented significant challenges because visualizing a single `metric`/`variable`/`column` at a time was severely limiting. It also meant that variables which came from a single table would cause severe duplication because the only way to request them was by requesting each variable individually. Another thing I came to realize is that even in a simple monitoring scenario you may want to have multiple metrics/variables/columns feed into an individual View.

So this PR completely refocuses the project around the `table` as the unit. A `Source` can publish one or more tables, a `Filter` filters the table, `Transforms` operate on a table and a `View` can visualize one or more variables in a Table.