### PR TITLE
Add ability to join sources via JoinSource

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -59,6 +59,27 @@ class Source(param.Parameterized):
             df = df[mask]
         return df
 
+    def __init__(self, **params):
+        super().__init__(**params)
+        self._cache = {}
+
+    def _get_key(self, table, **query):
+        key = (table,)
+        for k, v in sorted(query.items()):
+            if isinstance(v, list):
+                v = tuple(v)
+            key += (k, v)
+        return key
+
+    def _get_cache(self, table, **query):
+        key = self._get_key(table, **query)
+        if key in self._cache:
+            return self._cache[key]
+
+    def _set_cache(self, data, table, **query):
+        key = self._get_key(table, **query)
+        self._cache[key] = data
+
     def get_schema(self, table=None):
         """
         Returns JSON schema describing the tables returned by the
@@ -97,6 +118,7 @@ class Source(param.Parameterized):
         """
         Clears any cached data.
         """
+        self._cache = {}
 
 
 class RESTSource(Source):
@@ -116,9 +138,14 @@ class RESTSource(Source):
                 response.json().items()}
 
     def get(self, table, **query):
+        cached = self._get_cache(table, **query)
+        if cached is not None:
+            return cached
         query = dict(table=table, **query)
         r = requests.get(self.url+'/data', params=query)
-        return pd.DataFrame(r.json())
+        df = pd.DataFrame(r.json())
+        self._set_cache(df, table, **query)
+        return df
 
 
 class WebsiteSource(Source):
@@ -140,6 +167,9 @@ class WebsiteSource(Source):
         return schema if table is None else schema[table]
 
     def get(self, table, **query):
+        cached = self._get_cache(table, **query)
+        if cached is not None:
+            return cached
         data = []
         for url in self.urls:
             try:
@@ -148,10 +178,14 @@ class WebsiteSource(Source):
             except Exception:
                 live = False
             data.append({"live": live, "url": self.url})
-        return pd.DataFrame(data)
+        df = pd.DataFrame(data)
+        self._set_cache(df, table, **query)
+        return df
 
 
 class PanelSessionSource(Source):
+
+    endpoint = param.String(default="rest/session_info")
 
     urls = param.List(doc="URL of the websites to monitor.")
 
@@ -180,9 +214,12 @@ class PanelSessionSource(Source):
         return schema if table is None else schema[table]
 
     def get(self, table, **query):
+        cached = self._get_cache(table, **query)
+        if cached is not None:
+            return cached
         data = []
         for url in self.urls:
-            r = requests.get(url).json()
+            r = requests.get(url + self.endpoint, verify=False).json()
             session_info = r['session_info']
             sessions = session_info['sessions']
             if table == "summary":
@@ -211,5 +248,94 @@ class PanelSessionSource(Source):
                         row["session_duration"] = session["ended"]-session["started"]
                     else:
                         row["session_duration"] = float('NaN')
-                    data.push(row)
-        return pd.DataFrame(data)
+                data.push(row)
+        df = pd.DataFrame(data)
+        self._set_cache(df, table, **query)
+        return df
+
+
+class JoinedSource(Source):
+    """
+    A JoinedSource applies a join on two or more sources returning
+    new table(s) with data from both sources.
+    """
+
+    sources = param.Dict(default={}, doc="""
+        A dictionary of sources indexed by their assigned name.""")
+
+    tables = param.Dict(default={}, doc="""
+        A dictionary with the names of the joined sources as keys
+        and a specification of the source, table and index to merge
+        on.
+
+        {"new_table": [
+            {'source': <source_name>,
+             'table': <table_name>,
+             'index': <index_name>
+            },
+            {'source': <source_name>,
+             'table': <table_name>,
+             'index': <index_name>
+            },
+            ...
+        ]}""")
+
+    source_type = 'join'
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        self._sources = {}
+        for name, source_spec in self.sources.items():
+            source_spec = dict(source_spec)
+            source_type = source_spec.pop('type')
+            self._sources[name] = Source._get_type(source_type)(**source_spec)
+
+    def get_schema(self, table=None):
+        schemas = {}
+        for name, specs in self.tables.items():
+            if table is not None and name != table:
+                continue
+            schemas[name] = schema = {}
+            for spec in specs:
+                source, subtable, key = spec['source'], spec['table'], spec['index']
+                table_schema = self._sources[source].get_schema(subtable)
+                if not schema:
+                    schema.update(table_schema)
+                else:
+                    for column, col_schema in table_schema.items():
+                        prev_schema = schema.get(column)
+                        if prev_schema is None:
+                            schema[column] = col_schema
+                        elif col_schema['type'] != prev_schema['type']:
+                            continue
+                        elif 'enum' in col_schema and 'enum' in prev_schema:
+                            prev_enum = schema[column]['enum']
+                            for enum in col_schema['enum']:
+                                if enum not in prev_enum:
+                                    prev_enum.append(enum)
+                        elif 'inclusiveMinimum' in col_schema and 'inclusiveMinimum' in prev_schema:
+                            prev_schema['inclusiveMinimum'] = min(
+                                col_schema['inclusiveMinimum'],
+                                prev_schema['inclusiveMinimum']
+                            )
+                            prev_schema['inclusiveMaximum'] = max(
+                                col_schema['inclusiveMaximum'],
+                                prev_schema['inclusiveMaximum']
+                            )
+        return schemas if table is None else schemas[table]
+
+    def get(self, table, **query):
+        cached = self._get_cache(table, **query)
+        if cached is not None:
+            return cached
+        df = None
+        for spec in self.tables[table]:
+            source, subtable, key = spec['source'], spec['table'], spec['index']
+            df_merge = self._sources[source].get(subtable, **query)
+            if df is None:
+                df = df_merge
+                left_key = key
+            else:
+                df = pd.merge(df, df_merge, left_on=left_key, right_on=key)
+        self._set_cache(df, table, **query)
+        return df


### PR DESCRIPTION
Allows joining tables from multiple sources, e.g. here is a join on a AE5 source and a Panel session info source:

```yaml
    source:
        type: join
        sources:
          ae5:
            type: ae5
            url: pyviz.demo.anaconda.com
            kubernetes_api: https://kube-control.pyviz.demo.anaconda.com
            username: anaconda-enterprise
            password: ...
          session_info:
            type: session_info
            urls:
              - https://attractors.pyviz.demo.anaconda.com/
              - https://nyc-taxi.pyviz.demo.anaconda.com/
              - https://portfolio-optimizer.pyviz.demo.anaconda.com/
        tables:
          deployments:
            - source: ae5
              table: deployments
              index: url
            - source: session_info
              table: summary
              index: url
```
