### PR TITLE
Refactor resolution of objects from specs

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -108,7 +108,7 @@ class Dashboard(param.Parameterized):
         self._load_config()
         self._sources = {
             name: Source.from_spec(source_spec)
-            for name, source_spec in source_specs.items()
+            for name, source_spec in self._spec.get('sources', {}).items()
         }
         self._targets = self._resolve_targets(self._spec['targets'])
         self._rerender()
@@ -133,9 +133,10 @@ class Dashboard(param.Parameterized):
             schema = source.get_schema()
 
             # Resolve filters
+            filter_specs = target_spec.pop('filters', [])
             filters = [
                 Filter.from_spec(filter_spec, schema)
-                for filter_spec in target_spec.get('filters', [])
+                for filter_spec in filter_specs
             ]
 
             # Create target

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -61,7 +61,7 @@ class Filter(param.Parameterized):
         spec = dict(spec)
         if not 'field' in spec:
             raise ValueError('Filter specification must declare field to filter on.')
-        field = filter_spec['field']
+        field = spec['field']
         schema = None
         for table_schema in source_schema.values():
             schema = table_schema.get(field)
@@ -69,9 +69,9 @@ class Filter(param.Parameterized):
                 break
         if not schema:
             raise ValueError("Source did not declare a schema for "
-                             f"'{filter_name}' filter.")
+                             f"'{field}' filter.")
         filter_type = Filter._get_type(spec.pop('type'))
-        return filter_type(schema={name: filter_schema}, **spec)
+        return filter_type(schema={field: schema}, **spec)
 
     @property
     def panel(self):

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -40,6 +40,39 @@ class Filter(param.Parameterized):
                 return filt
         raise ValueError(f"No Filter for filter_type '{filter_type}' could be found.")
 
+    @classmethod
+    def from_spec(cls, spec, source_schema):
+        """
+        Resolves a Filter specification given the schema of the Source
+        it will be filtering on.
+
+        Parameters
+        ----------
+        spec: dict
+            Specification declared as a dictionary of parameter values.
+        source_schema: dict
+            A dictionary containing the JSON schema of the Source to
+            be filtered on.
+
+        Returns
+        -------
+        The resolved Filter object.
+        """
+        spec = dict(spec)
+        if not 'field' in spec:
+            raise ValueError('Filter specification must declare field to filter on.')
+        field = filter_spec['field']
+        schema = None
+        for table_schema in source_schema.values():
+            schema = table_schema.get(field)
+            if schema is not None:
+                break
+        if not schema:
+            raise ValueError("Source did not declare a schema for "
+                             f"'{filter_name}' filter.")
+        filter_type = Filter._get_type(spec.pop('type'))
+        return filter_type(schema={name: filter_schema}, **spec)
+
     @property
     def panel(self):
         """

--- a/lumen/monitor.py
+++ b/lumen/monitor.py
@@ -8,7 +8,6 @@ import panel as pn
 
 from .filters import FacetFilter
 from .sources import Source
-from .transforms import Transform
 from .views import View
 
 

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -29,6 +29,24 @@ class Transform(param.Parameterized):
                 return transform
         raise ValueError(f"No Transform for transform_type '{transform_type}' could be found.")
 
+    @classmethod
+    def from_spec(cls, spec):
+        """
+        Resolves a Transform specification.
+
+        Parameters
+        ----------
+        spec: dict
+            Specification declared as a dictionary of parameter values.
+
+        Returns
+        -------
+        The resolved Transform object.
+        """
+        spec = dict(spec)
+        transform_type = Transform._get_type(spec.pop('type', None))
+        return transform_type(**transform)
+
     def apply(self, table):
         """
         Given a table transform it in some way and return it.

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -45,7 +45,7 @@ class Transform(param.Parameterized):
         """
         spec = dict(spec)
         transform_type = Transform._get_type(spec.pop('type', None))
-        return transform_type(**transform)
+        return transform_type(**spec)
 
     def apply(self, table):
         """


### PR DESCRIPTION
This refactoring adds `from_spec` methods to all core types (`Source`, `Filter`, `View`, `Transform`) to isolate the resolution from spec to object into well documented methods.