### PR TITLE
Added PrometheusSource

### DIFF
--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -1,6 +1,9 @@
+import fnmatch
+import requests
 import datetime as dt
 
 from concurrent import futures
+from collections import defaultdict
 
 import param
 import pandas as pd
@@ -174,3 +177,209 @@ class AE5KubeSource(Source):
         self._deployments.clear()
         self._resources = None
         self._pod_info.clear()
+
+
+class PrometheusSource(Source):
+
+    hostname = param.String(doc="Hostname of the AE5 instance e.g ae5.organization.com")
+
+    promql_deployment = param.String(default='prometheus', doc="""
+       Name of the AE5 deployment exposing the Prometheus API""")
+
+    metrics = param.List(default=['memory_usage', 'cpu_usage', 'network_receive_bytes'],
+                         doc="Names of metric queries to execute")
+
+    username = param.String(doc="Username to authenticate with AE5.")
+
+    password = param.String(doc="Password to authenticate with AE5.")
+
+    step = param.String(default='10s', doc="Step value to use in PromQL query_range query")
+
+    deployments = param.List(default=['*'], doc="""
+      List of regular expressions over deployment names to match and query""")
+
+    start = param.Parameter(default=dt.timedelta(hours=-1), doc="""
+       Integer value (PromQL format), Python datetime for absolute
+       timestamp or negative timedelta object that is computed relative
+       to end parameter""")
+
+    end = param.Parameter(default=None, allow_None=True, doc="""
+       Integer value (PromQL format), Python datetime for absolute
+       timestamp or None which represents datetime.now()""")
+
+    source_type = 'prometheus'
+
+    memory_usage_query = """sum by(container_name)
+    (container_memory_usage_bytes{job="kubelet",
+    cluster="", namespace="default", pod_name=POD_NAME,
+    container_name=~"app|app-proxy", container_name!="POD"})"""
+
+    network_receive_bytes_query = """sort_desc(sum by (pod_name)
+    (rate(container_network_receive_bytes_total{job="kubelet", cluster="",
+    namespace="default", pod_name=POD_NAME}[1m])))"""
+
+    cpu_usage_query = """sum by (container_name)
+    (rate(container_cpu_usage_seconds_total{job="kubelet", cluster="",
+     namespace="default", image!="", pod_name=POD_NAME,
+     container_name=~"app|app-proxy", container_name!="POD"}[1m]))"""
+
+    _metrics = {'memory_usage': {'query':memory_usage_query, 'schema':{"type": "number"}},
+                'network_receive_bytes': {'query':network_receive_bytes_query,
+                                         'schema':{"type": "number"}},
+                'cpu_usage': {'query':cpu_usage_query, 'schema':{"type": "number"}}}
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        self._session = AEUserSession(self.hostname, self.username, self.password, persist=False)
+        self._deployment_cache = None
+        self._deployments = {}
+        self._update_cache()
+
+
+    def _format_timestamps(self, start, end):
+        '''
+        Given a valid start and end value return the formatted
+        timestamps to be used in PromQL URL
+        '''
+        if end is None:
+            end = dt.datetime.now()
+            end_formatted = end.isoformat("T") + "Z"
+        elif isinstance(end, int):
+            end_formatted = str(end)
+        else:
+            end_formatted = end.isoformat("T") + "Z"
+
+        if isinstance(start, dt.timedelta):
+            if isinstance(end, int):
+                raise Exception('Timedelta can only be used if end is a datetime or None')
+            start = end + start
+
+        if isinstance(start, int):
+            start_formatted = str(start)
+        else:
+            start_formatted = start.isoformat("T") + "Z"
+        return start_formatted, end_formatted
+
+
+    def _url_query_parameters(self, pod_id, query, start, end, step):
+        "Uses regular expression to map ae5-tools pod_id to full id"
+        start_timestamp, end_timestamp = self._format_timestamps(start, end)
+        regexp = f'anaconda-app-{pod_id}-.*'
+        query = query.replace("pod_name=POD_NAME", f"pod_name=~'{regexp}'")
+        query = query.replace("pod=POD_NAME", f"pod=~'{regexp}'")
+        query = query.replace('\n',' ')
+        query = query.replace(' ','%20')
+        query_escaped = query.replace('\"','%22')
+        return f'query={query_escaped}&start={start_timestamp}&end={end_timestamp}&step={step}'
+
+
+    def _get_query_url(self, base_url, metric, pod_id, start, end, step):
+        "Return the full query URL"
+        query_template = self._metrics[metric]['query']
+        query_params = self._url_query_parameters(pod_id, query_template, start, end, step)
+        return f'{base_url}/query_range?{query_params}'
+
+
+    def _get_query_json(self, query_url):
+        "Function called in parallel to fetch JSON in ThreadPoolExecutor"
+        response = requests.get(query_url, verify=False)
+        data = response.json()
+        if len(data) == 0:
+            return None
+        return data
+
+
+    def _json_to_df(self, metric, response_json):
+        "Convert JSON response to pandas DataFrame"
+        timestamps = np.array(response_json)[:,0]
+        metrics = np.array(response_json)[:,1]
+        df = pd.DataFrame({'timestamp':timestamps, metric:metrics})
+        df[metric] = df[metric].astype(float)
+        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='s')
+        return df.set_index('timestamp')
+
+
+    def parallel_fetch(self, base_url, metrics, pod_ids, start, end, step):
+        "Returns fetched JSON in dictionary indexed by pod_id then metric name"
+        triples = [(pod_id, metric,
+                    self._get_query_url(base_url, metric, pod_id, start, end, step))
+                   for metric in metrics for pod_id in pod_ids]
+        fetched_json = defaultdict(dict)
+        with futures.ThreadPoolExecutor(len(triples)) as executor:
+            tasks = {executor.submit(self._get_query_json, query_url) :
+                     (pod_id, metric, query_url)
+                     for pod_id, metric, query_url in triples}
+            for future in futures.as_completed(tasks):
+                (pod_id, metric, query_url) = tasks[future]
+                try:
+                    fetched_json[pod_id][metric] = future.result()
+                except Exception:
+                    self.warning(f'Could not fetch {metric} for pod {pod_id}.'
+                                 f'Query used: {query_url}')
+                    continue
+
+        return fetched_json
+
+
+    def _make_query(self, **query):
+        base_url = f'http://{self.promql_deployment}.{self.hostname}'
+        deployments = query.get('deployments', self.deployments)
+        step = query.get('step', self.step)
+        metrics = query.get('metrics', self.metrics)
+        start = query.get('start', self.start)
+        end = query.get('end', self.end)
+
+        filtered_names = [k for k in self._deployments.keys()
+                          if any(fnmatch.fnmatch(k, d) for d in deployments)]
+        if filtered_names == []:
+            return None
+
+        pod_ids = [v['id'][3:] for k,v in self._deployments.items() if k in filtered_names]
+        # TODO: Remove need for slice
+        dfs = []
+        json_data = self.parallel_fetch(base_url, metrics, pod_ids, start, end, step)
+        for pod_id in pod_ids:
+            df = None
+            for metric in metrics:
+                response_json = json_data[pod_id][metric]
+                data_df = self._json_to_df(metric, response_json)
+                if df is None:
+                    df = data_df
+                else:
+                    df = pd.merge(df, data_df, on='timestamp')
+            dfs.append(df.reset_index())
+        return pd.concat(dfs)
+
+
+    def get_schema(self, table=None):
+        name = sorted({d['name'] for d in self._deployment_cache})
+        owners = sorted({d['project_owner'] for d in self._deployment_cache})
+        urls = sorted({d['url'] for d in self._deployment_cache})
+        state = sorted({d['state'] for d in self._deployment_cache})
+        resources = sorted({d['resource_profile'] for d in self._deployment_cache})
+        schema = {
+                "name": {"type": "string", "enum": name},
+                "state": {"type": "string", "enum": state},
+                "owner": {"type": "string", "enum": owners},
+                "resource_profile": {"type": "string", "enum": resources}
+        }
+        schema["timestamp"] = {"type": "string", "format": "datetime"} # CHECK!
+        schema = dict({k:mdef['schema'] for k,mdef in self._metrics.items()}, **schema)
+        schemas = {"deployments": schema}
+        return schemas if table is None else schemas[table]
+
+
+    @cached(with_query=True)
+    def get(self, table=None, **query):
+        return self._make_query(**query)
+
+
+    def _update_cache(self):
+        self._deployment_cache = self._session.deployment_list()
+        self._deployments = {d['name']: d for d in self._deployment_cache}
+
+
+    def clear_cache(self):
+        super().clear_cache()
+        self._deployment_cache = None
+        self._deployments = {}

--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -181,6 +181,11 @@ class AE5KubeSource(Source):
 
 
 class PrometheusSource(Source):
+    """
+    Queries an endpoint on a Anaconda Enterprise 5 instance that exposes
+    the Prometheus PromQL REST API for timeseries information about
+    sessions and deployments.
+    """
 
     hostname = param.String(doc="Hostname of the AE5 instance e.g ae5.organization.com")
 

--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -358,11 +358,6 @@ class PrometheusSource(Source):
 
 
     def get_schema(self, table=None):
-        name = sorted({d['name'] for d in self._deployment_cache})
-        owners = sorted({d['project_owner'] for d in self._deployment_cache})
-        urls = sorted({d['url'] for d in self._deployment_cache})
-        state = sorted({d['state'] for d in self._deployment_cache})
-        resources = sorted({d['resource_profile'] for d in self._deployment_cache})
         schema = {"url": {"type": "string"},
                   "timestamp" : {"type": "string", "format": "datetime"}}
         schema = dict({k:mdef['schema'] for k,mdef in self._metrics.items()}, **schema)


### PR DESCRIPTION
This PR adds `PrometheusSource` which can access timeseries data for all sorts of metrics available from [Prometheus](https://prometheus.io/) running in AE5. Like `AE5KubeSource` this relies on a special deployment that make the Prometheus REST API available outside the AE5 master node and like `AE5KubeSource` this deployment should be folded into ae5-tools.

Here is an example of a query:

![image](https://user-images.githubusercontent.com/890576/97991499-2a382a80-1da7-11eb-93dd-2a5c3cd52324.png)

## TODO:

- [ ] Check the schema is correct for the datetimes in the 'timestamp' column
- [ ] Update the deployment to be a pure reflection of the PromQL API (it currently does a few minor things that can be moved to `PrometheusSource`
- [ ] Add new metrics/queries and try to simplify existing ones.
- [ ] Improve and extend the templating used in the PromQL queries (e.g handle the `rate` syntax for different averaging windows)
- [ ] Improve error handling for when the response is empty or fails entirely.
- [ ] Refactoring: `AE5KubeSource` and `PrometheusSource` should have a baseclass that handles `AEUserSession` and populates `_deployment_cache` and makes it easier to handle sessions as well as deployments.
- [ ] Refactoring: `AE5KubeSource` should possibly be queryable with the `deployments` regular expressions in the same way as `PrometheusSource`.
- [ ] `AE5KubeSource.url` should be called `AE5KubeSource.url` hostname
- [ ] Think about how to handle the fact that deployments can have vary variable uptimes e.g a deployment running for three months will be queryable over a much bigger timespan than one that has been up only for 10 minutes.
- [ ] Think about how to handle timezone difference between where the AE5 instance is running and where Lumen is running.
