### PR TITLE
Refactoring of Source types

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -106,10 +106,9 @@ class Dashboard(param.Parameterized):
 
     def _reload(self, *events):
         self._load_config()
-        self._sources = {
-            name: Source.from_spec(source_spec)
-            for name, source_spec in self._spec.get('sources', {}).items()
-        }
+        self._sources = {}
+        for name, source_spec in self._spec.get('sources', {}).items():
+            self._sources[name] = Source.from_spec(source_spec, self._sources)
         self._targets = self._resolve_targets(self._spec['targets'])
         self._rerender()
         filters = []

--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -1,17 +1,81 @@
-import fnmatch
-import requests
 import datetime as dt
 
 from concurrent import futures
-from collections import defaultdict
 
 import param
 import pandas as pd
-import numpy as np
+import requests
 
 from ae5_tools.api import AEUserSession
 
 from .base import Source, cached
+from ..util import get_dataframe_schema
+
+
+class AE5Source(Source):
+
+    hostname = param.String(doc="URL of the AE5 host.")
+
+    username = param.String(doc="Username to authenticate with AE5.")
+
+    password = param.String(doc="Password to authenticate with AE5.")
+
+    pool_size = param.Integer(default=100, doc="""
+        Size of HTTP socket pool.""")
+
+    source_type = 'ae5'
+
+    _deployment_columns = [
+        'id', 'name', 'url', 'owner', 'resource_profile', 'public', 'state'
+    ]
+
+    _session_columns = [
+        'id', 'name', 'url', 'owner', 'resource_profile', 'state'
+    ]
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        self._session = AEUserSession(
+            self.hostname, self.username, self.password, persist=False
+        )
+        adapter = requests.adapters.HTTPAdapter(pool_maxsize=self.pool_size)
+        self._session.session.mount('https://', adapter)
+        self._session.session.mount('http://', adapter)
+
+    def get_schema(self, table=None):
+        if table in (None, 'deployments'):
+            deployments = self.get('deployments')
+            deployment_schema = get_dataframe_schema(deployments)['items']['properties']
+            if table is not None:
+                return deployment_schema
+        if table in (None, 'sessions'):
+            sessions = self.get('sessions')
+            session_schema = get_dataframe_schema(sessions)['items']['properties']
+            if table is not None:
+                return session_schema
+        if table in (None, 'resources'):
+            resources = self.get('resources')
+            resource_schema = get_dataframe_schema(resources)['items']['properties']
+        return {
+            'deployments': deployment_schema,
+            'resources': resource_schema,
+            'sessions': session_schema
+        }
+
+    @cached(with_query=False)
+    def get(self, table, **query):
+        if table not in ('deployments', 'resources', 'sessions'):
+            raise ValueError(f"AE5Source has no '{table}' table, choose "
+                             "from 'deployments', 'resources' and 'sessions'.")
+        if table == 'deployments':
+            deployments = self._session.deployment_list(format='dataframe')
+            return deployments[self._deployment_columns]
+        elif table == 'resources':
+            resources = self._session.resource_profile_list(format='dataframe')
+            return resources
+        else:
+            sessions = self._session.session_list(format='dataframe')
+            return sessions[self._session_columns]
 
 
 class AE5KubeSource(Source):
@@ -20,15 +84,12 @@ class AE5KubeSource(Source):
     information about sessions and deployments.
     """
 
-    url = param.String(doc="URL of the AE5 instance")
+    ae5_source = param.ClassSelector(class_=AE5Source)
 
-    kubernetes_api = param.String(doc="URL of the kube-control deployment")
+    kubernetes_api = param.String(doc="""
+        Endpoint of the kube-control deployment on AE5.""")
 
-    username = param.String(doc="Username to authenticate with AE5.")
-
-    password = param.String(doc="Password to authenticate with AE5.")
-
-    source_type = 'ae5'
+    source_type = 'ae5kube'
 
     _empty = {
         'containers': [
@@ -39,26 +100,14 @@ class AE5KubeSource(Source):
         'timestamp': ''
     }
 
-    def __init__(self, **params):
-        super().__init__(**params)
-        self._session = AEUserSession(self.url, self.username, self.password, persist=False)
-        self._deployment_cache = None
-        self._pod_info = {}
-        self._deployments = {}
-        self._resources = None
-        self._update_cache()
-
-    def _get_record(self, name, d):
-        pod_info = self._pod_info[d['id']]
+    def _get_record(self, deployment, resources, pod_info):
         usage_info = pod_info.get('usage', self._empty)
         status_info = pod_info.get('status')
 
         record = {
-            "name": name,
-            "state": d['state'],
-            "owner": d['owner'],
-            "url": d['url'],
-            "resource_profile": d['resource_profile'],
+            "id": deployment['id'],
+            "name": deployment['name'],
+            "url": deployment['url'],
             "timestamp": usage_info['timestamp']
         }
 
@@ -69,7 +118,8 @@ class AE5KubeSource(Source):
         ]
         if containers:
             container = containers[0]
-            resource = self._resources[self._resources['name']==d['resource_profile']]
+            profile = deployment['resource_profile']
+            resource = resources[resources['name']==profile]
             usage = container['usage']
             cpu_cap = int(resource.cpu.item())
             if 'cpu' not in usage or 'm' not in usage['cpu']:
@@ -112,275 +162,43 @@ class AE5KubeSource(Source):
         url = self.kubernetes_api+'/podinfo'
         if pod is not None:
             url += '?id='+pod
-        return self._session.session.get(url).json()
+        return self.ae5_source._session.session.get(url).json()
 
-    def _update_cache(self):
-        self._deployment_cache = self._session.deployment_list()
-        self._resources = self._session.resource_profile_list(format='dataframe')
-        self._deployments = {d['name']: d for d in self._deployment_cache}
-
-        usage = dict(self._pod_info)
-        with futures.ThreadPoolExecutor(len(self._deployments)) as executor:
+    def _fetch_data(self, deployments):
+        pod_info = {}
+        with futures.ThreadPoolExecutor(len(deployments)) as executor:
             tasks = {executor.submit(self._get_pod_info, d['id']): d['id']
-                     for d in self._deployments.values()}
+                     for i, d in deployments.iterrows()}
             for future in futures.as_completed(tasks):
                 deployment = tasks[future]
                 try:
-                    usage[deployment] = future.result()
+                    pod_info[deployment] = future.result()
                 except Exception:
                     continue
-
-        self._pod_info = usage
+        return pod_info
 
     # Public API
 
     def get_schema(self, table=None):
-        name = sorted({d['name'] for d in self._deployment_cache})
-        owners = sorted({d['project_owner'] for d in self._deployment_cache})
-        urls = sorted({d['url'] for d in self._deployment_cache})
-        state = sorted({d['state'] for d in self._deployment_cache})
-        resources = sorted({d['resource_profile'] for d in self._deployment_cache})
-        schema = {
-            "deployments": {
-                "name": {"type": "string", "enum": name},
-                "state": {"type": "string", "enum": state},
-                "owner": {"type": "string", "enum": owners},
-                "resource_profile": {"type": "string", "enum": resources},
-                "timestamp": {"type": "string", "format": "datetime"},
-                "url": {"type": "string", "enum": urls},
-                "cpu": {"type": "number"},
-                "memory": {"type": "number"},
-                "uptime": {"type": "string"},
-                "restarts": {"type": "number"}
-            }
-        }
-        return schema if table is None else schema[table]
+        deployments = self.get('deployments')
+        schema = get_dataframe_schema(deployments)['items']['properties']
+        return {'deployments': schema} if table is None else schema
 
     @cached(with_query=False)
     def get(self, table, **query):
-        if self._deployment_cache is None:
-            self._update_cache()
+        if table not in ('deployments',):
+            raise ValueError(f"AE5KubeSource has no '{table}' table, "
+                             "it currently only has a 'deployments' table.")
+        deployments = self.ae5_source.get('deployments')
+        resources = self.ae5_source.get('resources')
+        pod_info = self._fetch_data(deployments)
         records = []
-        for name, d in self._deployments.items():
-            record = self._get_record(name, d)
+        for i, row in deployments.iterrows():
+            record = self._get_record(row, resources, pod_info[row['id']])
             if record is None:
                 continue
             records.append(record)
-        df = pd.DataFrame(records, columns=[
-            'name', 'state', 'owner', 'resource_profile', 'timestamp',
-            'url', 'cpu', 'memory', 'uptime', 'restarts'
+        return pd.DataFrame(records, columns=[
+            'id', 'name', 'url', 'timestamp',
+            'cpu', 'memory', 'uptime', 'restarts'
         ])
-        return df
-
-    def clear_cache(self):
-        self._cache = {}
-        self._deployment_cache = None
-        self._deployments.clear()
-        self._resources = None
-        self._pod_info.clear()
-
-
-class PrometheusSource(Source):
-    """
-    Queries an endpoint on a Anaconda Enterprise 5 instance that exposes
-    the Prometheus PromQL REST API for timeseries information about
-    sessions and deployments.
-    """
-
-    hostname = param.String(doc="Hostname of the AE5 instance e.g ae5.organization.com")
-
-    promql_deployment = param.String(default='prometheus', doc="""
-       Name of the AE5 deployment exposing the Prometheus API""")
-
-    metrics = param.List(default=['memory_usage', 'cpu_usage', 'network_receive_bytes'],
-                         doc="Names of metric queries to execute")
-
-    username = param.String(doc="Username to authenticate with AE5.")
-
-    password = param.String(doc="Password to authenticate with AE5.")
-
-    step = param.String(default='10s', doc="Step value to use in PromQL query_range query")
-
-    deployments = param.List(default=['*'], doc="""
-      List of regular expressions over deployment names to match and query""")
-
-    start = param.Parameter(default=dt.timedelta(hours=-1), doc="""
-       Integer value (PromQL format), Python datetime for absolute
-       timestamp or negative timedelta object that is computed relative
-       to end parameter""")
-
-    end = param.Parameter(default=None, allow_None=True, doc="""
-       Integer value (PromQL format), Python datetime for absolute
-       timestamp or None which represents datetime.now()""")
-
-    source_type = 'prometheus'
-
-    memory_usage_query = """sum by(container_name)
-    (container_memory_usage_bytes{job="kubelet",
-    cluster="", namespace="default", pod_name=POD_NAME,
-    container_name=~"app|app-proxy", container_name!="POD"})"""
-
-    network_receive_bytes_query = """sort_desc(sum by (pod_name)
-    (rate(container_network_receive_bytes_total{job="kubelet", cluster="",
-    namespace="default", pod_name=POD_NAME}[1m])))"""
-
-    cpu_usage_query = """sum by (container_name)
-    (rate(container_cpu_usage_seconds_total{job="kubelet", cluster="",
-     namespace="default", image!="", pod_name=POD_NAME,
-     container_name=~"app|app-proxy", container_name!="POD"}[1m]))"""
-
-    _metrics = {'memory_usage': {'query':memory_usage_query, 'schema':{"type": "number"}},
-                'network_receive_bytes': {'query':network_receive_bytes_query,
-                                         'schema':{"type": "number"}},
-                'cpu_usage': {'query':cpu_usage_query, 'schema':{"type": "number"}}}
-
-    def __init__(self, **params):
-        super().__init__(**params)
-        self._session = AEUserSession(self.hostname, self.username, self.password, persist=False)
-        self._deployment_cache = None
-        self._deployments = {}
-        self._update_cache()
-
-
-    def _format_timestamps(self, start, end):
-        '''
-        Given a valid start and end value return the formatted
-        timestamps to be used in PromQL URL
-        '''
-        if end is None:
-            end = dt.datetime.now()
-            end_formatted = end.isoformat("T") + "Z"
-        elif isinstance(end, int):
-            end_formatted = str(end)
-        else:
-            end_formatted = end.isoformat("T") + "Z"
-
-        if isinstance(start, dt.timedelta):
-            if isinstance(end, int):
-                raise Exception('Timedelta can only be used if end is a datetime or None')
-            start = end + start
-
-        if isinstance(start, int):
-            start_formatted = str(start)
-        else:
-            start_formatted = start.isoformat("T") + "Z"
-        return start_formatted, end_formatted
-
-
-    def _url_query_parameters(self, pod_id, query, start, end, step):
-        "Uses regular expression to map ae5-tools pod_id to full id"
-        start_timestamp, end_timestamp = self._format_timestamps(start, end)
-        regexp = f'anaconda-app-{pod_id}-.*'
-        query = query.replace("pod_name=POD_NAME", f"pod_name=~'{regexp}'")
-        query = query.replace("pod=POD_NAME", f"pod=~'{regexp}'")
-        query = query.replace('\n',' ')
-        query = query.replace(' ','%20')
-        query_escaped = query.replace('\"','%22')
-        return f'query={query_escaped}&start={start_timestamp}&end={end_timestamp}&step={step}'
-
-
-    def _get_query_url(self, base_url, metric, pod_id, start, end, step):
-        "Return the full query URL"
-        query_template = self._metrics[metric]['query']
-        query_params = self._url_query_parameters(pod_id, query_template, start, end, step)
-        return f'{base_url}/query_range?{query_params}'
-
-
-    def _get_query_json(self, query_url):
-        "Function called in parallel to fetch JSON in ThreadPoolExecutor"
-        response = requests.get(query_url, verify=False)
-        data = response.json()
-        if len(data) == 0:
-            return None
-        return data
-
-
-    def _json_to_df(self, metric, response_json):
-        "Convert JSON response to pandas DataFrame"
-        timestamps = np.array(response_json)[:,0]
-        metrics = np.array(response_json)[:,1]
-        df = pd.DataFrame({'timestamp':timestamps, metric:metrics})
-        df[metric] = df[metric].astype(float)
-        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='s')
-        return df.set_index('timestamp')
-
-
-    def parallel_fetch(self, base_url, metrics, pod_ids, start, end, step):
-        "Returns fetched JSON in dictionary indexed by pod_id then metric name"
-        triples = [(pod_id, metric,
-                    self._get_query_url(base_url, metric, pod_id, start, end, step))
-                   for metric in metrics for pod_id in pod_ids]
-        fetched_json = defaultdict(dict)
-        with futures.ThreadPoolExecutor(len(triples)) as executor:
-            tasks = {executor.submit(self._get_query_json, query_url) :
-                     (pod_id, metric, query_url)
-                     for pod_id, metric, query_url in triples}
-            for future in futures.as_completed(tasks):
-                (pod_id, metric, query_url) = tasks[future]
-                try:
-                    fetched_json[pod_id][metric] = future.result()
-                except Exception:
-                    self.warning(f'Could not fetch {metric} for pod {pod_id}.'
-                                 f'Query used: {query_url}')
-                    continue
-
-        return fetched_json
-
-
-    def _make_query(self, **query):
-        base_url = f'http://{self.promql_deployment}.{self.hostname}'
-        deployments = query.get('deployments', self.deployments)
-        step = query.get('step', self.step)
-        metrics = query.get('metrics', self.metrics)
-        start = query.get('start', self.start)
-        end = query.get('end', self.end)
-
-        filtered_names = [k for k in self._deployments.keys()
-                          if any(fnmatch.fnmatch(k, d) for d in deployments)]
-        if filtered_names == []:
-            return None
-
-        pod_ids = [v['id'][3:] for k,v in self._deployments.items() if k in filtered_names]
-        # TODO: Remove need for slice
-        dfs = []
-        json_data = self.parallel_fetch(base_url, metrics, pod_ids, start, end, step)
-        for pod_id in pod_ids:
-            df = None
-            for metric in metrics:
-                response_json = json_data[pod_id][metric]
-                data_df = self._json_to_df(metric, response_json)
-                if df is None:
-                    df = data_df
-                else:
-                    df = pd.merge(df, data_df, on='timestamp')
-            url_matches = [v['url'] for v in self._deployment_cache
-                           if v['id'].endswith(pod_id)]
-
-            urls = np.full(len(df), url_matches[0])
-            df.insert(2, "url", urls, True)
-            dfs.append(df.reset_index())
-        return pd.concat(dfs)
-
-
-    def get_schema(self, table=None):
-        schema = {"url": {"type": "string"},
-                  "timestamp" : {"type": "string", "format": "datetime"}}
-        schema = dict({k:mdef['schema'] for k,mdef in self._metrics.items()}, **schema)
-        schemas = {"deployments": schema}
-        return schemas if table is None else schemas[table]
-
-
-    @cached(with_query=True)
-    def get(self, table=None, **query):
-        return self._make_query(**query)
-
-
-    def _update_cache(self):
-        self._deployment_cache = self._session.deployment_list()
-        self._deployments = {d['name']: d for d in self._deployment_cache}
-
-
-    def clear_cache(self):
-        super().clear_cache()
-        self._deployment_cache = None
-        self._deployments = {}

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -456,7 +456,7 @@ class JoinedSource(Source):
             source, subtable = spec['source'], spec['table']
             source_query = dict(query)
             right_key = spec.get('index')
-            if df is not None and right_key not in query:
+            if df is not None and left_key and right_key not in query:
                 source_query[right_key] = list(df[left_key].unique())
             df_merge = self.sources[source].get(subtable, **source_query)
             if df is None:

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -454,7 +454,7 @@ class JoinedSource(Source):
 
     @cached()
     def get(self, table, **query):
-        df = None
+        df, left_key = None, None
         for spec in self.tables[table]:
             source, subtable = spec['source'], spec['table']
             source_query = dict(query)

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -315,11 +315,14 @@ class PanelSessionSource(Source):
     def _get_session_info(self, table, url):
         r = requests.get(
             url + self.endpoint, verify=False, timeout=self.timeout
-        ).json()
+        )
+        data = []
+        if r.status_code != 200:
+            return data
+        r = r.json()
         session_info = r['session_info']
         sessions = session_info['sessions']
 
-        data = []
         if table == "summary":
             rendered = [s for s in sessions.values()
                         if s['rendered'] is not None]

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -451,13 +451,17 @@ class JoinedSource(Source):
         df = None
         for spec in self.tables[table]:
             source, subtable = spec['source'], spec['table']
-            df_merge = self.sources[source].get(subtable, **query)
+            source_query = dict(query)
+            right_key = spec.get('index')
+            if df is not None and right_key not in query:
+                source_query[right_key] = list(df[left_key].unique())
+            df_merge = self.sources[source].get(subtable, **source_query)
             if df is None:
                 df = df_merge
                 left_key = spec.get('index')
             else:
                 df = pd.merge(df, df_merge, left_on=left_key,
-                              right_on=spec.get('index'))
+                              right_on=right_key, how='outer')
         return df
 
     def clear_cache(self):

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -96,11 +96,18 @@ class Source(param.Parameterized):
     @classmethod
     def _resolve_reference(cls, reference, sources={}):
         refs = reference[1:].split('.')
-        if len(refs) != 3:
-            raise ValueError(f"Reference string '{reference} not valid. "
-                             "Must take the form @source.table.field.")
-        sourceref, table, field = refs
+        if len(refs) == 3:
+            sourceref, table, field = refs
+        elif len(refs) == 2:
+            sourceref, table = refs
+        elif len(refs) == 1:
+            (sourceref,) = refs
+
         source = cls.from_spec(sourceref, sources)
+        if len(refs) == 1:
+            return source
+        if len(refs) == 2:
+            return source.get(table)
         table_schema = source.get_schema(table)
         if field not in table_schema:
             raise ValueError(f"Field '{field}' was not found in "

--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -93,10 +93,11 @@ class PrometheusSource(Source):
         regexp = f'anaconda-app-{pod_id}-.*'
         query = query.replace("pod_name=POD_NAME", f"pod_name=~'{regexp}'")
         query = query.replace("pod=POD_NAME", f"pod=~'{regexp}'")
-        query = query.replace('\n',' ')
-        query = query.replace(' ','%20')
-        query_escaped = query.replace('\"','%22')
-        return f'query={query_escaped}&start={start_timestamp}&end={end_timestamp}&step={self.step}'
+        query_params = {
+            'query': query, 'start': start_timestamp,
+            'end': end_timestamp, 'step': self.step
+        }
+        return urlparse.urlencode(query_params)
 
     def _get_query_url(self, metric, pod_id):
         "Return the full query URL"

--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -1,0 +1,185 @@
+import datetime as dt
+import urllib.parse as urlparse
+
+from collections import defaultdict
+from concurrent import futures
+
+import pandas as pd
+import param
+import requests
+
+from .base import Source, cached
+from ..util import parse_timedelta
+
+
+class PrometheusSource(Source):
+    """
+    Queries a Prometheus PromQL endpoint for timeseries information
+    about Kubernetes pods.
+    """
+
+    ids = param.List(default=[], doc="""
+       List of pod IDs to query.""")
+
+    metrics = param.List(
+        default=['memory_usage', 'cpu_usage', 'network_receive_bytes'],
+        doc="Names of metric queries to execute")
+
+    promql_api = param.String(doc="""
+       Name of the AE5 deployment exposing the Prometheus API""")
+
+    period = param.String(default='3h', doc="""
+        Period to query over specified as a string. Supports:
+
+          - Week:   '1w'
+          - Day:    '1d'
+          - Hour:   '1h'
+          - Minute: '1m'
+          - Second: '1s'
+    """)
+
+    step = param.String(default='10s', doc="""
+        Step value to use in PromQL query_range query.""")
+
+    source_type = 'prometheus'
+
+    _memory_usage_query = """sum by(container_name)
+    (container_memory_usage_bytes{job="kubelet",
+    cluster="", namespace="default", pod_name=POD_NAME,
+    container_name=~"app|app-proxy", container_name!="POD"})"""
+
+    _network_receive_bytes_query = """sort_desc(sum by (pod_name)
+    (rate(container_network_receive_bytes_total{job="kubelet", cluster="",
+    namespace="default", pod_name=POD_NAME}[1m])))"""
+
+    _cpu_usage_query = """sum by (container_name)
+    (rate(container_cpu_usage_seconds_total{job="kubelet", cluster="",
+     namespace="default", image!="", pod_name=POD_NAME,
+     container_name=~"app|app-proxy", container_name!="POD"}[1m]))"""
+
+    _metrics = {
+        'memory_usage': {
+            'query': _memory_usage_query,
+            'schema': {"type": "number"}
+        },
+        'network_receive_bytes': {
+            'query': _network_receive_bytes_query,
+            'schema': {"type": "number"}
+        },
+        'cpu_usage': {
+            'query': _cpu_usage_query,
+            'schema': {"type": "number"}
+        }
+    }
+
+    def _format_timestamps(self):
+        end = dt.datetime.now()
+        end_formatted = end.isoformat("T") + "Z"
+        period = parse_timedelta(self.period)
+        if period is None:
+            raise ValueError(f"Could not parse period '{self.period}'. "
+                             "Must specify weeks ('1w'), days ('1d'), "
+                             "hours ('1h'), minutes ('1m'), or "
+                             "seconds ('1s').")
+        start = end - period
+        start_formatted = start.isoformat("T") + "Z"
+        return start_formatted, end_formatted
+
+    def _url_query_parameters(self, pod_id, query):
+        """
+        Uses regular expression to map ae5-tools pod_id to full id.
+        """
+        start_timestamp, end_timestamp = self._format_timestamps()
+        regexp = f'anaconda-app-{pod_id}-.*'
+        query = query.replace("pod_name=POD_NAME", f"pod_name=~'{regexp}'")
+        query = query.replace("pod=POD_NAME", f"pod=~'{regexp}'")
+        query = query.replace('\n',' ')
+        query = query.replace(' ','%20')
+        query_escaped = query.replace('\"','%22')
+        return f'query={query_escaped}&start={start_timestamp}&end={end_timestamp}&step={self.step}'
+
+    def _get_query_url(self, metric, pod_id):
+        "Return the full query URL"
+        query_template = self._metrics[metric]['query']
+        query_params = self._url_query_parameters(pod_id, query_template)
+        return f'{self.promql_api}/query_range?{query_params}'
+
+    def _get_query_json(self, query_url):
+        "Function called in parallel to fetch JSON in ThreadPoolExecutor"
+        response = requests.get(query_url, verify=False)
+        data = response.json()
+        if len(data) == 0:
+            return None
+        return data
+
+    def _json_to_df(self, metric, response_json):
+        "Convert JSON response to pandas DataFrame"
+        df = pd.DataFrame(response_json, columns=['timestamp', metric])
+        df[metric] = df[metric].astype(float)
+        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='s')
+        return df.set_index('timestamp')
+
+    def _fetch_data(self, pod_ids):
+        "Returns fetched JSON in dictionary indexed by pod_id then metric name"
+        if not pod_ids:
+            return {}
+        # ToDo: Remove need to slice
+        triples = [
+            (pod_id, metric, self._get_query_url(metric, pod_id[3:]))
+            for pod_id in pod_ids for metric in self.metrics 
+        ]
+        fetched_json = defaultdict(dict)
+        with futures.ThreadPoolExecutor(len(triples)) as executor:
+            tasks = {executor.submit(self._get_query_json, query_url):
+                     (pod_id, metric, query_url)
+                     for pod_id, metric, query_url in triples}
+            for future in futures.as_completed(tasks):
+                (pod_id, metric, query_url) = tasks[future]
+                try:
+                    fetched_json[pod_id][metric] = future.result()
+                except Exception as e:
+                    fetched_json[pod_id][metric] = []
+                    self.param.warning(
+                        f"Could not fetch {metric} for pod {pod_id}. "
+                        f"Query used: {query_url}, errored with {type(e)}({e})."
+                    )
+        return fetched_json
+
+    def _make_query(self, **query):
+        pod_ids = [
+            pod_id for pod_id in self.ids
+            if 'id' not in query or pod_id in query['id']
+        ]
+        json_data = self._fetch_data(pod_ids)
+        dfs = []
+        for pod_id, pod_data in json_data.items():
+            df = None
+            for metric in self.metrics:
+                data_df = self._json_to_df(metric, pod_data[metric])
+                if df is None:
+                    df = data_df
+                else:
+                    df = pd.merge(df, data_df, on='timestamp', how='outer')
+            df = df.reset_index()
+            df.insert(0, 'id', pod_id)
+            dfs.append(df)
+        if dfs:
+            return pd.concat(dfs)
+        else:
+            return pd.DataFrame(columns=list(self.get_schema('timeseries')))
+
+    def get_schema(self, table=None):
+        schema = {
+            "id": {"type": "string", "enum": self.ids},
+            "timestamp" : {"type": "string", "format": "datetime"}
+        }
+        for k, mdef in self._metrics.items():
+            schema[k] = mdef['schema']
+        return {"timeseries": schema} if table is None else schema
+
+    @cached(with_query=True)
+    def get(self, table, **query):
+        if table not in ('timeseries',):
+            raise ValueError(f"PrometheusSource has no '{table}' table, "
+                             "it currently only has a 'timeseries' table.")
+        return self._make_query(**query)

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -1,4 +1,7 @@
+import re
 import sys
+
+import datetime as dt
 
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
@@ -65,3 +68,17 @@ def get_dataframe_schema(df, columns=None):
                 cats = list(cats)
             properties[name] = {'type': 'string', 'enum': cats}
     return schema
+
+_period_regex = re.compile(r'((?P<weeks>\d+?)w)?((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
+
+
+def parse_timedelta(time_str):
+    parts = _period_regex.match(time_str)
+    if not parts:
+        return
+    parts = parts.groupdict()
+    time_params = {}
+    for (name, param) in parts.items():
+        if param:
+            time_params[name] = int(param)
+    return dt.timedelta(**time_params)


### PR DESCRIPTION
Refactors various Source types, especially the AE5 based sources to be more composable.

## TODO from #26 

- [ ] Update the deployment to be a pure reflection of the PromQL API (it currently does a few minor things that can be moved to `PrometheusSource`
- [ ] Add new metrics/queries and try to simplify existing ones.
- [ ] Improve and extend the templating used in the PromQL queries (e.g handle the `rate` syntax for different averaging windows)
- [ ] Think about how to handle timezone difference between where the AE5 instance is running and where Lumen is running.

## Other TODO

- [ ] Optionally expose Source parameters as UI components

## Example

```python
from lumen.sources.ae5 import AE5Source
from lumen.sources.prometheus import PrometheusSource

ae5_source = AE5Source(hostname='pyviz.demo.anaconda.com', username='anaconda-enterprise', password=...)

ids = ae5_source.get('deployments')['id']

prom_source = PrometheusSource(promql_api='https://prometheus.pyviz.demo.anaconda.com', ids=list(ids)[:3])

prom_source.get('timeseries')
```

<img width="759" alt="Screen Shot 2020-11-03 at 8 21 54 PM" src="https://user-images.githubusercontent.com/1550771/98031076-41603200-1e12-11eb-8152-3863a7bd4d94.png">
