### PR TITLE
PrometheusSource now handles vanilla PromQL response

### DIFF
--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -50,7 +50,7 @@ class PrometheusSource(Source):
     _memory_usage_query = """sum by(container_name)
     (container_memory_usage_bytes{job="kubelet",
     cluster="", namespace="default", pod_name=POD_NAME,
-    container_name=~"app|app-proxy", container_name!="POD"})"""
+    container_name=~"app", container_name!="POD"})"""
 
     _network_receive_bytes_query = """sort_desc(sum by (pod_name)
     (rate(container_network_receive_bytes_total{job="kubelet", cluster="",
@@ -63,12 +63,12 @@ class PrometheusSource(Source):
     _cpu_usage_query = """sum by (container_name)
     (rate(container_cpu_usage_seconds_total{job="kubelet", cluster="",
      namespace="default", image!="", pod_name=POD_NAME,
-     container_name=~"app|app-proxy", container_name!="POD"}[1m]))"""
+     container_name=~"app", container_name!="POD"}[1m]))"""
 
     _restarts_query = """max by (container)
      (kube_pod_container_status_restarts_total{job="kube-state-metrics",
     cluster="", namespace="default", pod=POD_NAME,
-    container=~"app|app-proxy"})"""
+    container=~"app"})"""
 
 
     _metrics = {


### PR DESCRIPTION
To generalized `PrometheusSource`, I've updated it to handle the vanilla response from the [Prometheus HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api/). This should allow `PrometheusSource` to query any Prometheus server directly and additionally this will allow handling of queries where multiple columns are returned per metric (e.g cpu usage broken down per core on a node)