### PR TITLE
Allow Source to expose a panel

### DIFF
--- a/lumen/monitor.py
+++ b/lumen/monitor.py
@@ -189,6 +189,10 @@ class Monitor(param.Parameterized):
     @property
     def filter_panel(self):
         views = []
+        source_panel = self.source.panel
+        if source_panel:
+            source_header = pn.pane.Markdown('### Source', margin=(0, 5))
+            views.extend([source_header, source_panel, pn.layout.Divider()])
         filters = [filt.panel for filt in self.filters if filt.panel is not None]
         if filters:
             views.append(pn.pane.Markdown('### Filters', margin=(0, 5)))

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -5,6 +5,7 @@ from functools import wraps
 
 import numpy as np
 import pandas as pd
+import panel as pn
 import param
 import requests
 
@@ -181,6 +182,10 @@ class Source(param.Parameterized):
     def __init__(self, **params):
         super().__init__(**params)
         self._cache = {}
+
+    @property
+    def panel(self):
+        return None
 
     def _get_key(self, table, **query):
         key = (table,)
@@ -548,6 +553,17 @@ class JoinedSource(Source):
                 df = pd.merge(df, df_merge, left_on=left_key,
                               right_on=right_key, how='outer')
         return df
+
+    @property
+    def panel(self):
+        column = pn.Column(sizing_mode='stretch_width')
+        for name, source in self.sources.items():
+            panel = source.panel
+            if not panel:
+                continue
+            header = pn.pane.Markdown(f'#### {name.title()}', margin=(0, 5))
+            column.extend([header, *source.panel])
+        return column
 
     def clear_cache(self):
         super().clear_cache()

--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from concurrent import futures
 
 import pandas as pd
+import panel as pn
 import param
 import requests
 
@@ -93,6 +94,11 @@ class PrometheusSource(Source):
             'schema': {"type": "number"}
         }
     }
+
+    @property
+    def panel(self):
+        return pn.Param(self.param, parameters=['period', 'samples', 'step'],
+                        sizing_mode='stretch_width', show_name=False)
 
     def _format_timestamps(self):
         end = dt.datetime.utcnow()


### PR DESCRIPTION
Certain sources have parameters that can be exposed as widgets or at least information they might want to display. This PR allows `Source` objects to publish a `panel` which will be displayed in the sidebar.