### PR TITLE
Allow shipping custom components alongside yaml

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -148,3 +148,11 @@ sources:
 The `@csv.websites.url` syntax will look up a `Source` called 'csv',
 request a table called 'websites' and then feed the 'url' column in
 that table to the `urls` parameter of the `WebsiteSource`.
+
+## Local components
+
+While Lumen ships with a wide range of components users may also
+define custom components in files which live alongside the
+`dashboard.yml` file. Specifically Lumen will automatically import
+`filters.py`, `sources.py`, `transforms.py` and `views.py` if these
+files exist alongside the dashboard specification.

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -41,6 +41,7 @@ class Dashboard(param.Parameterized):
             specification=specification, **params
         )
         self._load_config(from_file=True)
+        self._modules = {}
         self._load_local_modules()
 
         # Construct template
@@ -123,7 +124,7 @@ class Dashboard(param.Parameterized):
             if not os.path.isfile(path):
                 continue
             spec = importlib.util.spec_from_file_location(f"local_lumen.{imp}", path)
-            module = importlib.util.module_from_spec(spec)
+            self._modules[imp] = module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
 
     def _apply_defaults(self, defaults):

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -320,7 +320,7 @@ class FileSource(Source):
     def get_schema(self, table=None):
         schemas = {}
         for file in self.files:
-            name = '.'.join(file.split('.')[:-1])
+            name = '.'.join(os.path.basename(file).split('.')[:-1])
             if table is not None and name != table:
                 continue
             df = self.get(name)
@@ -335,7 +335,7 @@ class FileSource(Source):
             if name != table:
                 continue
             load_fn, kwargs = self._load_fn(split_filename[-1])
-            df = load_fn(file, **kwargs)
+            df = load_fn(os.path.join(self.root, file), **kwargs)
         if df is None:
             tables = ['.'.join(f.split('.')[:-1]) for f in self.files]
             raise ValueError(f"Table '{table}' not found. Available tables include: {tables}.")

--- a/lumen/tests/sample_dashboard/dashboard.yaml
+++ b/lumen/tests/sample_dashboard/dashboard.yaml
@@ -1,0 +1,10 @@
+sources:
+  test:
+    type: 'file'
+    files: ['../sources/test.csv']
+targets:
+  - title: "Test"
+    source: test
+    views:
+      - table: test
+        type: test

--- a/lumen/tests/sample_dashboard/views.py
+++ b/lumen/tests/sample_dashboard/views.py
@@ -1,0 +1,12 @@
+from lumen.views import View
+
+class TestView(View):
+
+    view_type = 'test'
+
+    def get_panel(self):
+        return "TestView"
+
+
+import param
+print(">>>>>>>>>>>", param.concrete_descendents(View))

--- a/lumen/tests/sample_dashboard/views.py
+++ b/lumen/tests/sample_dashboard/views.py
@@ -6,7 +6,3 @@ class TestView(View):
 
     def get_panel(self):
         return "TestView"
-
-
-import param
-print(">>>>>>>>>>>", param.concrete_descendents(View))

--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -1,0 +1,11 @@
+import os
+
+from lumen.dashboard import Dashboard
+from lumen.views import View
+
+def test_dashboard_with_local_view():
+    root = os.path.dirname(__file__)
+    dashboard = Dashboard(os.path.join(root, 'sample_dashboard', 'dashboard.yaml'))
+    target = dashboard._targets[0]
+    view = View.from_spec(target.views[0], target, target.source, [])
+    assert isinstance(view, dashboard._modules['views'].TestView)


### PR DESCRIPTION
Allows shipping custom Filter, Source, Transform and View components in modules alongside the dashboard.yaml.