### PR TITLE
Add support for env and shell variables

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -152,11 +152,17 @@ that table to the `urls` parameter of the `WebsiteSource`.
 
 ### Templating
 
-In many cases you do not want to hardcode variables inside the yaml specification instead passing in variables from an environment variable, a shell command or as a CLI argument. This can be achieved using templating syntax:
+In many cases you do not want to hardcode variables inside the yaml specification instead passing in variables from an environment variable, a shell command, a CLI argument, a HTTP request header or cookie, or a OAuth token variable. This can be achieved using the following templating syntax:
 
 - `{{env("USER")}}`: look in the set environment variables for the named variable
 
 - `{{shell("get_login thisuser -t")}}`: execute the command, and use the output as the value. The output will be trimmed of any trailing whitespace.
+
+- `{{cookie("USER")}}`: look in the HTTP request cookies of the served application
+
+- `{{header("USER")}}`: look in the HTTP request headers of the served application
+
+- `{{oauth("USER")}}`: look in the OAuth user token
 
 - `{{USER}}`: Arguments passed in using `--template-vars="{'USER': 'lumen_user'}"` when using `lumen serve` on the commandline.
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -150,6 +150,16 @@ The `@csv.websites.url` syntax will look up a `Source` called 'csv',
 request a table called 'websites' and then feed the 'url' column in
 that table to the `urls` parameter of the `WebsiteSource`.
 
+### Templating
+
+In many cases you do not want to hardcode variables inside the yaml specification instead passing in variables from an environment variable, a shell command or as a CLI argument. This can be achieved using templating syntax:
+
+- `{{env("USER")}}`: look in the set environment variables for the named variable
+
+- `{{shell("get_login thisuser -t")}}`: execute the command, and use the output as the value. The output will be trimmed of any trailing whitespace.
+
+- `{{USER}}`: Arguments passed in using `--template-vars="{'USER': 'lumen_user'}"` when using `lumen serve` on the commandline.
+
 ## Local components
 
 While Lumen ships with a wide range of components users may also

--- a/lumen/__init__.py
+++ b/lumen/__init__.py
@@ -2,5 +2,14 @@ import param as _param
 
 from .dashboard import Dashboard # noqa
 
+
+class _config(_param.Parameterized):
+
+    template_vars = _param.Dict(default={})
+
+
+config = _config()
+
+
 __version__ = str(_param.version.Version(
     fpath=__file__, archive_commit="$Format:%h$", reponame="lumen"))

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -12,6 +12,7 @@ from .filters import ConstantFilter, Filter, WidgetFilter # noqa
 from .monitor import Monitor # noqa
 from .sources import Source, RESTSource # noqa
 from .transforms import Transform # noqa
+from .util import expand_spec
 from .views import View # noqa
 
 _templates = {k[:-8].lower(): v for k, v in param.concrete_descendents(BasicTemplate).items()}
@@ -110,7 +111,7 @@ class Dashboard(param.Parameterized):
         # Load config
         if from_file or self._yaml is None:
             with open(self.specification) as f:
-                self._yaml = f.read()
+                self._yaml = expand_spec(f.read())
         self._spec = yaml.load(self._yaml, Loader=yaml.Loader)
         if not 'targets' in self._spec:
             raise ValueError('Yaml specification did not declare any targets.')

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -109,9 +109,10 @@ class Dashboard(param.Parameterized):
 
     def _load_config(self, from_file=False):
         # Load config
+        from . import config
         if from_file or self._yaml is None:
             with open(self.specification) as f:
-                self._yaml = expand_spec(f.read())
+                self._yaml = expand_spec(f.read(), config.template_vars)
         self._spec = yaml.load(self._yaml, Loader=yaml.Loader)
         if not 'targets' in self._spec:
             raise ValueError('Yaml specification did not declare any targets.')


### PR DESCRIPTION
Adds support for templating env and shell variables into the dashboard yaml.

Here is an example using an env var:

```yaml
config:
  title: "AE5 Monitor"
  layout: tabs
sources:
  ae5:
    type: ae5
    hostname: pyviz.demo.anaconda.com
    username: anaconda-enterprise
    password: {{env("AE5_PASSWORD")}}
```

