### PR TITLE
Allow sharing sources between sessions

### DIFF
--- a/lumen/__init__.py
+++ b/lumen/__init__.py
@@ -4,8 +4,17 @@ from .dashboard import Dashboard # noqa
 
 
 class _config(_param.Parameterized):
+    """
+    Stores shared configuration for the entire Lumen application.
+    """
 
-    template_vars = _param.Dict(default={})
+    sources = _param.Dict(default={}, doc="""
+      A global dictionary of shared Source objects.""")
+
+    template_vars = _param.Dict(default={}, doc="""
+      Template variables which may be referenced in a dashboard yaml
+      specification.""")
+
 
 
 config = _config()

--- a/lumen/command.py
+++ b/lumen/command.py
@@ -43,8 +43,10 @@ class YamlHandler(CodeHandler):
         spec = yaml.load(expanded, Loader=yaml.Loader)
         for name, source_spec in spec.get('sources', {}).items():
             if source_spec.get('shared'):
-                config.sources[name] = Source.from_spec(
+                config.sources[name] = source = Source.from_spec(
                     source_spec, config.sources, root=root)
+                if source.cache_dir:
+                    source.clear_cache()
 
 
 def build_single_handler_application(path, argv):

--- a/lumen/command.py
+++ b/lumen/command.py
@@ -2,6 +2,7 @@ import argparse
 import ast
 import os
 import sys
+import yaml
 
 import bokeh.command.util
 
@@ -11,6 +12,8 @@ from bokeh.command.util import build_single_handler_application as _build_applic
 from panel.command import main as _pn_main
 
 from . import __version__
+from .sources import Source
+from .util import expand_spec
 
 
 class YamlHandler(CodeHandler):
@@ -28,9 +31,20 @@ class YamlHandler(CodeHandler):
         if 'filename' not in kwargs:
             raise ValueError('Must pass a filename to YamlHandler')
         filename = kwargs['filename']
-
         kwargs['source'] = f"from lumen import Dashboard; Dashboard('{filename}').servable();"
         super().__init__(*args, **kwargs)
+
+        # Initialize cached and shared sources
+        from . import config
+        root = os.path.abspath(os.path.dirname(filename))
+        with open(filename) as f:
+            yaml_spec = f.read()
+        expanded = expand_spec(yaml_spec, config.template_vars)
+        spec = yaml.load(expanded, Loader=yaml.Loader)
+        for name, source_spec in spec.get('sources', {}).items():
+            if source_spec.get('shared'):
+                config.sources[name] = Source.from_spec(
+                    source_spec, config.sources, root=root)
 
 
 def build_single_handler_application(path, argv):

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import shutil
+import sys
 
 from concurrent import futures
 from functools import wraps

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -52,6 +52,11 @@ class Source(param.Parameterized):
     root = param.String(default=None, doc="""
         Root directory where the dashboard specification was loaded from.""")
 
+    shared = param.Boolean(default=False, doc="""
+        Whether the Source can be shared across all instances of the
+        dashboard. If set to `True` the Source will be loaded on
+        initial server load.""")
+
     source_type = None
 
     __abstract = True
@@ -160,11 +165,14 @@ class Source(param.Parameterized):
         -------
         Resolved and instantiated Source object
         """
+        from .. import config
         if spec is None:
             raise ValueError('Source specification empty.')
         elif isinstance(spec, str):
             if spec in sources:
                 source = sources[spec]
+            elif spec.get('shared') and spec in config.sources:
+                source = config.sources[spec]
             else:
                 raise ValueError(f'Source with name {spec} was not found.')
             return source

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -64,9 +64,8 @@ class IntakeSource(Source):
             schemas[entry] = get_dataframe_schema(data)['items']['properties']
         return schemas if table is None else schemas[table]
 
-    @cached()
+    @cached(with_query=False)
     def get(self, table, **query):
         dask = query.pop('dask', self.dask)
         df = self._read(table)
-        df = self._filter_dataframe(df, **query)
         return df if dask or not hasattr(df, 'compute') else df.compute()

--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -12,6 +12,7 @@ import requests
 from .base import Source, cached
 from ..util import parse_timedelta
 
+
 class PrometheusSource(Source):
     """
     Queries a Prometheus PromQL endpoint for timeseries information
@@ -19,7 +20,7 @@ class PrometheusSource(Source):
     """
 
     ids = param.List(default=[], doc="""
-       List of pod IDs to query.""")
+      List of pod IDs to query.""")
 
     metrics = param.List(
         default=['memory_usage', 'cpu_usage', 'restarts',
@@ -27,21 +28,24 @@ class PrometheusSource(Source):
         doc="Names of metric queries to execute")
 
     promql_api = param.String(doc="""
-       Name of the AE5 deployment exposing the Prometheus API""")
+      Name of the AE5 deployment exposing the Prometheus API""")
 
     period = param.String(default='3h', doc="""
-        Period to query over specified as a string. Supports:
+      Period to query over specified as a string. Supports:
 
-          - Week:   '1w'
-          - Day:    '1d'
-          - Hour:   '1h'
-          - Minute: '1m'
-          - Second: '1s'
+        - Week:   '1w'
+        - Day:    '1d'
+        - Hour:   '1h'
+        - Minute: '1m'
+        - Second: '1s'
     """)
 
     samples = param.Integer(default=200, doc="""
-        Number of samples in the selected period to query. May
-        be overridden by explicit step value.""")
+      Number of samples in the selected period to query. May be
+      overridden by explicit step value.""")
+
+    shared = param.Boolean(default=False, readonly=True, doc="""
+      PrometheusSource cannot be shared because it has per-user state.""")
 
     step = param.String(doc="""
         Step value to use in PromQL query_range query.""")
@@ -70,7 +74,6 @@ class PrometheusSource(Source):
      (kube_pod_container_status_restarts_total{job="kube-state-metrics",
     cluster="", namespace="default", pod=POD_NAME,
     container=~"app"})"""
-
 
     _metrics = {
         'memory_usage': {


### PR DESCRIPTION
In the past each user visiting a Lumen dashboard would be given a distinct `Source` instance. Since sources can cache data this meant that each would potentially pull the same data from a remote source and keep that data in memory, needlessly growing memory usage. So on sources that do not have per-user state we can now allow the `Source` instance to be shared across sessions.