### PR TITLE
 Allow streaming to Views without rerender

### DIFF
--- a/lumen/monitor.py
+++ b/lumen/monitor.py
@@ -185,7 +185,11 @@ class Monitor(param.Parameterized):
 
     def _rerender(self, *events, invalidate_cache=False, update_views=True):
         self._update_views(invalidate_cache, update_views)
-        if update_views:
+        has_updates = (
+            any(view._updates for _, (_, views) in self._cache.items() for view in views) or
+            bool(self._updates)
+        )
+        if update_views and has_updates:
             self.application._loading(self.title)
             for card, views in self._updates.items():
                 card[0][:] = [view.panel for view in views]
@@ -195,7 +199,7 @@ class Monitor(param.Parameterized):
                     if view._updates:
                         view._panel.param.set_param(**view._updates)
                         view._updates = None
-        if self._stale or update_views:
+        if self._stale or (update_views and has_updates):
             self.application._rerender()
             self._stale = False
 


### PR DESCRIPTION
Previously an update in the data would require a full re-render of the pane. However in certain cases we can stream data directly to the view without re-rendering. This enables this support for the hvPlot pane.