### PR TITLE
Add auth field to dashboard specification

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -121,6 +121,29 @@ targets: This is the list of targets to monitor
     ...: Additional parameters passed to the Card layout(s), e.g. width or height
 ```
 
+### `auth`
+
+The `auth` field may provide a dictionary of any number of fields
+which are validated against the user information provided the the Auth
+provider, which is made available by Panel in the
+`panel.state.user_info` dictionary. To discover how to configure an
+Auth provider with Panel/Lumen see the [Panel documentation](https://panel.holoviz.org/user_guide/Authentication.html).
+
+As an example the GitHub OAuth provider returns the login of the user
+that is visiting the dashboard. If we add the following field to the
+yaml:
+
+```yaml
+auth:
+  login: [philippjfr]
+```
+
+Lumen will check the current user `login` against all user logins
+listed here. For a more generic Auth mechanism many Auth providers,
+such as Okta, make it possible to configure a list of groups a user
+belongs to in which case you could list the allowed groups in the auth
+field.
+
 ## Special Syntax
 
 To avoid repeating yourself the yaml specification supports some special syntax.

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -111,7 +111,7 @@ class Dashboard(param.Parameterized):
                     else:
                         authorized &= any(user_value == v for v in value)
                 elif isinstance(user_value, list):
-                    authorized &= any(uv == value for v in user_value)
+                    authorized &= any(v == value for v in user_value)
                 else:
                     authorized &= (value == user_value)
         return authorized

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -174,7 +174,7 @@ class Dashboard(param.Parameterized):
             error = ('## Unauthorized User\n'
                      f'{pn.state.user} is not authorized. Ensure '
                      f'{pn.state.user} is permissioned correctly on '
-                     f'{auth_keys} field(s) in OAuth user data.')
+                     f'the {auth_keys} field(s) in OAuth user data.')
             self.targets[:] = [pn.pane.Alert(error, alert_type='danger')]
             self._targets = []
             return

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -62,7 +62,8 @@ class Dashboard(param.Parameterized):
             theme='monokai'
         )
         self._edit_button = pn.widgets.Button(
-            name='✎', width=50, css_classes=['reload'], margin=0
+            name='✎', width=50, css_classes=['reload'], margin=0,
+            align='center'
         )
         self._editor.param.watch(self._edit, 'value')
         self._edit_button.on_click(self._open_modal)
@@ -85,7 +86,8 @@ class Dashboard(param.Parameterized):
             self.targets = pn.GridBox(margin=10, ncols=ncols,
                                       sizing_mode='stretch_width')
         self._reload_button = pn.widgets.Button(
-            name='↻', width=50, css_classes=['reload'], margin=0
+            name='↻', width=50, css_classes=['reload'], margin=0,
+            align='center'
         )
         self._reload_button.on_click(self._reload)
         self._reload()
@@ -94,10 +96,13 @@ class Dashboard(param.Parameterized):
         if len(self.filters):
             self.template.sidebar[:] = [self.filters]
         self.template.main[:] = [self.targets]
-        self.template.header.append(pn.Row(
-            self._reload_button,
-            self._edit_button
-        ))
+        header = pn.Row(self._reload_button, self._edit_button)
+        self.template.header.append(header)
+        if 'auth' in self._spec:
+            header.extend([
+                pn.layout.HSpacer(),
+                f'<b><font size="4.5em">User: {pn.state.user}</font></b>'
+            ])
 
     @property
     def _authorized(self):

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -108,17 +108,12 @@ class Dashboard(param.Parameterized):
     def _authorized(self):
         authorized = True
         for k, value in self._spec.get('auth', {}).items():
+            if not isinstance(value, list): value = [value]
             if k in pn.state.user_info:
                 user_value = pn.state.user_info[k]
-                if isinstance(value, list):
-                    if isinstance(user_value, list):
-                        authorized &= any(uv == v for v in value for uv in user_value)
-                    else:
-                        authorized &= any(user_value == v for v in value)
-                elif isinstance(user_value, list):
-                    authorized &= any(v == value for v in user_value)
-                else:
-                    authorized &= (value == user_value)
+                if not isinstance(user_value, list):
+                    user_value = [user_value]
+                authorized &= any(uv == v for v in value for uv in user_value)
         return authorized
 
     def _edit(self, event):


### PR DESCRIPTION
Adds an `auth` key to the dashboard specification which is checked against the `user_info` provided by the auth provider configured when launching the server. As an example the GitHub OAuth provider returns the `login` of the user that is visiting the dashboard. If we add the following field to the yaml:

```yaml
auth:
  login: [philippjfr]
```

It will check the current user against all users listed here. For a more generic auth mechanism auth providers such as Okta make it possible to return a list of groups a user belongs to in which case you could list the allowed groups to the `auth` field.

An unauthorized user will see this:

<img width="1673" alt="Screen Shot 2021-01-19 at 6 14 55 PM" src="https://user-images.githubusercontent.com/1550771/105069487-4c764600-5a82-11eb-8e03-b4bdcaeda806.png">

An authorized user will see:

<img width="1680" alt="Screen Shot 2021-01-19 at 6 43 19 PM" src="https://user-images.githubusercontent.com/1550771/105072574-41bdb000-5a86-11eb-8258-5e077d19f5b8.png">
