### PR TITLE
Allow declaring filters per global source

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -96,6 +96,23 @@ sources:
 
 This will declare a `Source` called `population` which publishes a table called `population`.
 
+It is also possible to declare filters associated with a global `Source`.
+
+```yaml
+sources:
+  population:
+    type: file
+    files: [population.csv]
+	filters:
+	  year:
+	    field: country
+		type: widget
+```
+
+Any target that uses the population `Source` can now refer to `year`
+filter by name. This allows multiple targets that are fed by the same
+`Source` to reuse a filter.
+
 ### `targets`
 
 The targets section defines the actual monitoring targets and
@@ -116,7 +133,8 @@ targets: This is the list of targets to monitor
         table: If set filters only on a specific table.
 	    type: The type of the Filter to use, e.g. 'constant', 'widget' or 'facet'
         ...: Additional parameters for the Filter
-    layout: The layout of the card(s), e.g. 'row', 'column' or 'grid'
+    layout: The layout inside the card(s), e.g. 'row', 'column' or 'grid'
+    facet_layout: The layout of the cards if a FacetFilter is declared generating multiple cards.
     refresh_rate: How frequently to poll for updates in milliseconds
     ...: Additional parameters passed to the Card layout(s), e.g. width or height
 ```

--- a/lumen/__init__.py
+++ b/lumen/__init__.py
@@ -8,6 +8,9 @@ class _config(_param.Parameterized):
     Stores shared configuration for the entire Lumen application.
     """
 
+    filters = _param.Dict(default={}, doc="""
+      A global dictionary of shared Filter objects.""")
+
     sources = _param.Dict(default={}, doc="""
       A global dictionary of shared Source objects.""")
 

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -189,7 +189,7 @@ class Dashboard(param.Parameterized):
             self._filters[name] = {
                 fname: Filter.from_spec(filter_spec, schema)
                 for fname, filter_spec in filter_specs.items()
-            ]
+            }
         self._targets = self._resolve_targets(self._spec['targets'])
         self._rerender()
         filters = []

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -44,23 +44,33 @@ class Filter(param.Parameterized):
         raise ValueError(f"No Filter for filter_type '{filter_type}' could be found.")
 
     @classmethod
-    def from_spec(cls, spec, source_schema):
+    def from_spec(cls, spec, source_schema, source_filters=None):
         """
         Resolves a Filter specification given the schema of the Source
         (and optionally the table) it will be filtering on.
 
         Parameters
         ----------
-        spec: dict
+        spec: dict or str
             Specification declared as a dictionary of parameter values.
         source_schema: dict
             A dictionary containing the JSON schema of the Source to
             be filtered on.
+        source_filters: dict
+            A dictionary of filters associated with the Source
 
         Returns
         -------
         The resolved Filter object.
         """
+        if isinstance(spec, str):
+            if source_filters is None:
+                raise ValueError(f"Filter spec {repr(spec)} could not be resolved "
+                                 "because source has declared not filters.")
+            elif spec not in source_filters:
+                raise ValueError(f"Filter spec {repr(spec)} could not be resolved, "
+                                 f"available filters on the source include {list(source_filters)}.")
+            return source_filters[spec]
         spec = dict(spec)
         if not 'field' in spec:
             raise ValueError('Filter specification must declare field to filter on.')

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -577,7 +577,7 @@ class JoinedSource(Source):
                     schema.update(table_schema)
                 else:
                     for column, col_schema in table_schema.items():
-                        schema[column] = merge_schema(col_schema, schema.get(column))
+                        schema[column] = merge_schemas(col_schema, schema.get(column))
         return schemas if table is None else schemas[table]
 
     @cached()

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -13,7 +13,7 @@ import panel as pn
 import param
 import requests
 
-from ..util import get_dataframe_schema
+from ..util import get_dataframe_schema, merge_schemas
 
 
 def cached(with_query=True):
@@ -577,25 +577,7 @@ class JoinedSource(Source):
                     schema.update(table_schema)
                 else:
                     for column, col_schema in table_schema.items():
-                        prev_schema = schema.get(column)
-                        if prev_schema is None:
-                            schema[column] = col_schema
-                        elif col_schema['type'] != prev_schema['type']:
-                            continue
-                        elif 'enum' in col_schema and 'enum' in prev_schema:
-                            prev_enum = schema[column]['enum']
-                            for enum in col_schema['enum']:
-                                if enum not in prev_enum:
-                                    prev_enum.append(enum)
-                        elif 'inclusiveMinimum' in col_schema and 'inclusiveMinimum' in prev_schema:
-                            prev_schema['inclusiveMinimum'] = min(
-                                col_schema['inclusiveMinimum'],
-                                prev_schema['inclusiveMinimum']
-                            )
-                            prev_schema['inclusiveMaximum'] = max(
-                                col_schema['inclusiveMaximum'],
-                                prev_schema['inclusiveMaximum']
-                            )
+                        schema[column] = merge_schema(col_schema, schema.get(column))
         return schemas if table is None else schemas[table]
 
     @cached()

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -183,8 +183,8 @@ def merge_schemas(schema, old_schema):
     elif 'enum' in schema and 'enum' in old_schema:
         merged_enum = list(old_schema['enum'])
         for enum in schema['enum']:
-            if enum not in prev_enum:
-                prev_enum.append(enum)
+            if enum not in merged_enum:
+                merged_enum.append(enum)
         return dict(old_schema, enum=merged_enum)
     elif 'inclusiveMinimum' in schema and 'inclusiveMinimum' in old_schema:
         merged_min = min(schema['inclusiveMinimum'], old_schema['inclusiveMinimum'])

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -170,3 +170,23 @@ def expand_spec(pars, context={}, getenv=True, getshell=True, getheaders=True,
     else:
         # no expansion
         return pars
+
+
+def merge_schemas(schema, old_schema):
+    """
+    Merges two JSON schemas on a column.
+    """
+    if old_schema is None:
+        return schema
+    elif schema['type'] != old_schema['type']:
+        return old_schema
+    elif 'enum' in schema and 'enum' in old_schema:
+        merged_enum = list(old_schema['enum'])
+        for enum in schema['enum']:
+            if enum not in prev_enum:
+                prev_enum.append(enum)
+        return dict(old_schema, enum=merged_enum)
+    elif 'inclusiveMinimum' in schema and 'inclusiveMinimum' in old_schema:
+        merged_min = min(schema['inclusiveMinimum'], old_schema['inclusiveMinimum'])
+        merged_max = min(schema['inclusiveMaximum'], old_schema['inclusiveMaximum'])
+        return dict(old_schema, inclusiveMinimum=merged_min, inclusiveMaximum=merged_max)


### PR DESCRIPTION
In case a `Source` is shared across multiple targets this allows declaring filters associated with that source.