### PR TITLE
Ensure global filters are correctly linked

### DIFF
--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -190,4 +190,6 @@ class WidgetFilter(Filter):
 
     @property
     def panel(self):
-        return self.widget
+        widget = self.widget.clone()
+        self.widget.link(widget, value='value', bidirectional=True)
+        return widget


### PR DESCRIPTION
Currently a panel component cannot be reused more than once in a single application so we have to make a copy.