### PR TITLE
Combine sort and facet specs on Target

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -134,10 +134,14 @@ targets: This is the list of targets to monitor
 	    type: The type of the Filter to use, e.g. 'constant', 'widget' or 'facet'
         ...: Additional parameters for the Filter
     layout: The layout inside the card(s), e.g. 'row', 'column' or 'grid'
-    facet_layout: The layout of the cards if a FacetFilter is declared generating multiple cards.
-    refresh_rate: How frequently to poll for updates in milliseconds
+    facet:
+	  by: List of fields to facet by
+	  sort: List of fields to sort by
+	  reverse: Whether to reverse the sort order
+	refresh_rate: How frequently to poll for updates in milliseconds
     ...: Additional parameters passed to the Card layout(s), e.g. width or height
 ```
+
 
 ### `auth`
 

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -12,9 +12,12 @@ from .util import _LAYOUTS
 from .views import View
 
 
-class Sorter(param.Parameterized):
+class Facet(param.Parameterized):
 
-    fields = param.ListSelector(default=[], objects=[], doc="""
+    by = param.List(default=[], class_=FacetFilter, doc="""
+        Fields to facet by.""")
+
+    sort = param.ListSelector(default=[], objects=[], doc="""
         List of fields to sort by.""")
 
     reverse = param.Boolean(default=False, doc="""
@@ -22,32 +25,52 @@ class Sorter(param.Parameterized):
 
     def __init__(self, **params):
         super().__init__(**params)
-        self._fields_widget = pn.widgets.MultiSelect(
-            options=self.param.fields.objects,
+        self._sort_widget = pn.widgets.MultiSelect(
+            options=self.param.sort.objects,
             sizing_mode='stretch_width',
-            size=len(self.fields),
-            value=self.fields,
+            size=len(self.sort),
+            value=self.sort,
         )
-        self._fields_widget.link(self, value='fields')
+        self._sort_widget.link(self, value='sort')
         self._reverse_widget = pn.widgets.Checkbox(
             value=self.reverse, name='Reverse', margin=(5, 0, 0, 10)
         )
         self._reverse_widget.link(self, value='reverse')
 
+    @param.depends('sort:objects', watch=True)
+    def _update_options(self):
+        self._sort_widget.options = self.param.sort.objects
+
     @classmethod
-    def from_spec(cls, spec):
-        fields = spec.pop('fields', [])
-        sorter = cls(**spec)
-        sorter.param.fields.objects = fields
+    def from_spec(cls, spec, schema):
+        """
+        Creates a Facet object from a schema and a set of fields.
+        """
+        by = []
+        for by_spec in spec.pop('by', []):
+            if isinstance(by_spec, str):
+                f = Filter.from_spec({'type': 'facet', 'field': by_spec}, schema)
+            elif isinstance(by_spec, dict):
+                f = Filter.from_spec(dict(by_spec, type='facet'), schema)
+            elif isinstance(by_spec, Filter):
+                f = by_spec
+            by.append(f)
+        sort = spec.pop('sort', [b.field for b in by])
+        sorter = cls(by=by, **spec)
+        sorter.param.sort.objects = sort
         return sorter
 
     def get_key(self, views):
         sort_key = []
-        for field in self.fields:
+        for field in self.sort:
             values = [v.get_value(field) for v in views]
             if values:
                 sort_key.append(values[0])
         return tuple(sort_key)
+
+    @property
+    def filters(self):
+        return product(*[filt.filters for filt in self.by])
 
 
 
@@ -75,8 +98,9 @@ class Target(param.Parameterized):
     refresh_rate = param.Integer(default=None, doc="""
         How frequently to refresh the monitor by querying the adaptor.""")
 
-    sort = param.ClassSelector(class_=Sorter, doc="""
-        The sort object controls how the Cards in the target are to be sorted.""")
+    facet = param.ClassSelector(class_=Facet, doc="""
+        The facet object determines whether and how to facet the cards
+        on the target.""")
 
     source = param.ClassSelector(class_=Source, doc="""
         The Source queries the data from some data source.""")
@@ -100,7 +124,7 @@ class Target(param.Parameterized):
         super().__init__(**{k: v for k, v in params.items() if k in self.param})
 
         # Set up watchers
-        self.sort.param.watch(self._resort, ['fields', 'reverse'])
+        self.facet.param.watch(self._resort, ['sort', 'reverse'])
         for filt in self.filters:
             if isinstance(filt, FacetFilter):
                 continue
@@ -157,7 +181,7 @@ class Target(param.Parameterized):
         if not any(view for view in views):
             return None, None
 
-        sort_key = self.sort.get_key(views)
+        sort_key = self.facet.get_key(views)
 
         if facet_filters:
             title = ' '.join([f'{f.label}: {f.value}' for f in facet_filters])
@@ -186,11 +210,11 @@ class Target(param.Parameterized):
             views.append(pn.pane.Markdown('### Filters', margin=(0, 5)))
             views.extend(filters)
             views.append(pn.layout.Divider())
-        if self.sort.param.fields.objects:
+        if self.facet.param.sort.objects:
             views.extend([
                 pn.pane.Markdown('### Sort', margin=(0, 5)),
-                self.sort._fields_widget,
-                self.sort._reverse_widget
+                self.facet._sort_widget,
+                self.facet._reverse_widget
             ])
             views.append(pn.layout.Divider())
         self._reload_button = pn.widgets.Button(
@@ -210,23 +234,18 @@ class Target(param.Parameterized):
     ##################################################################
 
     def _update_views(self, invalidate_cache=True, update_views=True):
-        filters = [filt for filt in self.filters
-                   if not isinstance(filt, FacetFilter)]
-        facets = [filt.filters for filt in self.filters
-                  if isinstance(filt, FacetFilter)]
-
         cards = []
-        for facet_filters in product(*facets):
+        for facet_filters in self.facet.filters:
             key, card = self._get_card(
-                filters, facet_filters, invalidate_cache, update_views
+                self.filters, facet_filters, invalidate_cache, update_views
             )
             if card is None:
                 continue
             cards.append((key, card))
 
-        if self.sort.fields:
+        if self.facet.sort:
             cards = sorted(cards, key=lambda x: x[0])
-            if self.sort.reverse:
+            if self.facet.reverse:
                 cards = cards[::-1]
 
         cards = [card for _, card in cards]
@@ -297,7 +316,19 @@ class Target(param.Parameterized):
             Filter.from_spec(filter_spec, schema, source_filters)
             for filter_spec in filter_specs
         ]
-        spec['sort'] = Sorter.from_spec(spec.pop('sort', {}))
+        facet_filters = [f for f in filters if isinstance(f, FacetFilter)]
+        if 'sort' in spec:
+            param.main.warning(
+                'Specifying sort key for target is deprecated. Use the '
+                'facet key instead and declare facet filters under the '
+                '"by" keyword.')
+            sort_spec = spec['sort']
+            spec['facet'] = dict(
+                sort=sort_spec['fields'],
+                reverse=sort_spec.get('reverse', False),
+                by=facet_filters
+            )
+        spec['facet'] = Facet.from_spec(spec.pop('facet', {}), schema)
         params = dict(kwargs, **spec)
         return cls(filters=filters, source=source, **params)
 


### PR DESCRIPTION
Declaring sorting and faceting separately made no real sense since you can only sort over the facets. Therefore you now declare your facet fields and sort fields in a single `facet` spec on the `Target`.

So what was previously this:

```yaml
targets:
  - title: Example
    filters:
      - field: name
        label: Deployment
        type: facet
    sort:
      fields:
        - memory 
        - cpu
        - restarts
        - session_duration
        - render_duration
    reverse: true
```

is now this:

```yaml
targets:
  - title: Example
    facet:
      by:
        - field: name
          label: Deployment
      sort:
        - memory 
        - cpu
        - restarts
        - session_duration
        - render_duration
      reverse: true
```