### PR TITLE
Add Download options to targets

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -122,9 +122,9 @@ therefore makes up the meat of the declaration.
 targets: This is the list of targets to monitor
   - title: The title of the monitoring endpoint
     download:
-	  format: When specified adds a section to the sidebar allowing users to download the filtered dataset
-	  kwargs: Additional keyword arguments to pass to the pandas/dask to_<format> method
-	  tables: Allows declaring a subset of tables to download
+      format: When specified adds a section to the sidebar allowing users to download the filtered dataset
+      kwargs: Additional keyword arguments to pass to the pandas/dask to_<format> method
+      tables: Allows declaring a subset of tables to download
     source: The Source used to monitor an endpoint (may also reference a Source in the sources section
       type: The type of Source to use, e.g. 'rest' or 'live'
       ...: Additional parameters for the Source

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -121,6 +121,10 @@ therefore makes up the meat of the declaration.
 ```yaml
 targets: This is the list of targets to monitor
   - title: The title of the monitoring endpoint
+    download:
+	  format: When specified adds a section to the sidebar allowing users to download the filtered dataset
+	  kwargs: Additional keyword arguments to pass to the pandas/dask to_<format> method
+	  tables: Allows declaring a subset of tables to download
     source: The Source used to monitor an endpoint (may also reference a Source in the sources section
       type: The type of Source to use, e.g. 'rest' or 'live'
       ...: Additional parameters for the Source

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -87,7 +87,7 @@ class Download(pn.viewable.Viewer):
     filters = param.List(class_=Filter, doc="""
         A list of filters to be rendered.""")
 
-    format = param.Selector(default='csv', objects=['csv', 'xlsx', 'json', 'parquet'], doc="""
+    format = param.Selector(default=None, objects=['csv', 'xlsx', 'json', 'parquet'], doc="""
         The format to download the data in.""")
 
     kwargs = param.Dict(default={}, doc="""

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -204,9 +204,6 @@ class Target(param.Parameterized):
         a Column of one row containing views 0 and 1 and a second Row
         containing view 2.""" )
 
-    schema = param.Dict(default=None, doc="""
-        The JSON schema of the source.""")
-
     title = param.String(doc="A title for this Target.")
 
     refresh_rate = param.Integer(default=None, doc="""
@@ -506,7 +503,7 @@ class Target(param.Parameterized):
 
         spec['facet'] = Facet.from_spec(facet_spec, schema)
         params = dict(kwargs, **spec)
-        return cls(filters=filters, source=source, schema=schema, **params)
+        return cls(filters=filters, source=source, **params)
 
     @property
     def panels(self):

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -145,7 +145,7 @@ class Download(pn.viewable.Viewer):
         data = self.source.get(table, **query)
         for filt in self.filters:
             if not isinstance(filt, ParamFilter):
-               continue
+                continue
             from holoviews import Dataset
             if filt.value is not None:
                 ds = Dataset(data)

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -459,6 +459,8 @@ class Target(param.Parameterized):
 
         # Resolve download options
         download_spec = spec.pop('download', {})
+        if isinstance(download_spec, str):
+            download_spec = {'format': download_spec}
         if 'tables' not in download_spec:
             download_spec['tables'] = list(schema)
         spec['download'] = Download.from_spec(download_spec, source, filters) 

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -1,12 +1,13 @@
 import datetime as dt
 
 from functools import partial
+from io import StringIO, BytesIO
 from itertools import product
 
 import param
 import panel as pn
 
-from .filters import Filter, FacetFilter
+from .filters import Filter, FacetFilter, ParamFilter
 from .sources import Source
 from .util import _LAYOUTS
 from .views import View
@@ -77,11 +78,117 @@ class Facet(param.Parameterized):
 
 
 
+class Download(pn.viewable.Viewer):
+    """
+    The Download object controls options to download the Source tables
+    in a variety of formats via the Dashboard UI.
+    """
+
+    filters = param.List(class_=Filter, doc="""
+        A list of filters to be rendered.""")
+
+    format = param.Selector(default='csv', objects=['csv', 'xlsx', 'json', 'parquet'], doc="""
+        The format to download the data in.""")
+
+    kwargs = param.Dict(default={}, doc="""
+        Keyword arguments passed to the serialization function, e.g. 
+        data.to_csv(file_obj, **kwargs).""")
+
+    source = param.ClassSelector(class_=Source, doc="""
+        The Source queries the data from some data source.""")
+
+    tables = param.List(default=[], doc="""
+        The list of tables to allow downloading.""")
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        default_table = self.tables[0] if self.tables else None
+        self._select_download = pn.widgets.Select(
+            name='Select table to download', options=self.tables, value=default_table,
+            sizing_mode='stretch_width'
+        )
+        self._select_download.param.watch(self._update_filename, 'value')
+        self._download_button = pn.widgets.FileDownload(
+            callback=self._table_data, align='end',
+            filename=f'{default_table}.{self.format}',
+            sizing_mode='stretch_width'
+        )
+        self._layout = pn.Column(
+            pn.pane.Markdown('### Download tables', margin=(0, 5, -10, 5)),
+            self._download_button,
+            pn.layout.Divider(),
+            sizing_mode='stretch_width'
+        )
+        if len(self.tables) > 1:
+            self._layout.insert(self._select_download, 1)
+
+    def __panel__(self):
+        return self._layout
+
+    def _update_filename(self, event):
+        self._download_button.filename = f'{event.new}.{self.format}'
+
+    def __bool__(self):
+        return self.format is not None
+
+    def _table_data(self):
+        if self.format in ('json', 'csv'):
+            io = StringIO()
+        else:
+            io = BytesIO()
+        table = self._select_download.value
+        query = {
+            filt.field: filt.query for filt in self.filters
+            if filt.query is not None and
+            (filt.table is None or filt.table == table)
+        }
+        data = self.source.get(table, **query)
+        for filt in self.filters:
+            if not isinstance(filt, ParamFilter):
+               continue
+            from holoviews import Dataset
+            if filt.value is not None:
+                ds = Dataset(data)
+                data = ds.select(filt.value).data
+        if self.format == 'csv':
+            data.to_csv(io, **self.kwargs)
+        elif self.format == 'json':
+            data.to_json(io, **self.kwargs)
+        elif self.format == 'xlsx':
+            data.to_excel(io, **self.kwargs)
+        elif self.format == 'parquet':
+            data.to_parquet(io, **self.kwargs)
+        io.seek(0)
+        return io
+
+    @classmethod
+    def from_spec(cls, spec, source, filters):
+        """
+        Creates a Download object from a specification.
+
+        Parameters
+        ----------
+        spec : dict
+            Specification declared as a dictionary of parameter values.
+        source: Source
+            The Source to monitor
+        filters: list
+            List of Filter objects
+
+        """
+        return cls(source=source, filters=filters, **spec)
+
+
+
 class Target(param.Parameterized):
     """
     A Target renders the results of a Source query using the defined
     set of filters and views.
     """
+
+    download = param.ClassSelector(class_=Download, default=Download(), doc="""
+        The download objects determines whether and how the source tables
+        can be downloaded.""")
 
     facet = param.ClassSelector(class_=Facet, doc="""
         The facet object determines whether and how to facet the cards
@@ -96,6 +203,9 @@ class Target(param.Parameterized):
         corresponding to the views, e.g. [[0, 1], [2]] will create
         a Column of one row containing views 0 and 1 and a second Row
         containing view 2.""" )
+
+    schema = param.Dict(default=None, doc="""
+        The JSON schema of the source.""")
 
     title = param.String(doc="A title for this Target.")
 
@@ -224,17 +334,19 @@ class Target(param.Parameterized):
         views = []
         source_panel = self.source.panel
         if source_panel:
-            source_header = pn.pane.Markdown('### Source', margin=(0, 5))
+            source_header = pn.pane.Markdown('### Source', margin=(0, 5, -10, 5))
             views.extend([source_header, source_panel, pn.layout.Divider()])
+        if self.download:
+            views.append(self.download)
         filters = [filt.panel for filt in self.filters
                    if filt not in skip and filt.panel is not None]
         if filters:
-            views.append(pn.pane.Markdown('### Filters', margin=(0, 5)))
+            views.append(pn.pane.Markdown('### Filters', margin=(0, 5, -10, 5)))
             views.extend(filters)
             views.append(pn.layout.Divider())
         if self.facet.param.sort.objects:
             views.extend([
-                pn.pane.Markdown('### Sort', margin=(0, 5)),
+                pn.pane.Markdown('### Sort', margin=(0, 5, -10, 5)),
                 self.facet._sort_widget,
                 self.facet._reverse_widget
             ])
@@ -348,6 +460,12 @@ class Target(param.Parameterized):
         facet_spec = spec.pop('facet', {})
         facet_filters = [f for f in filters if isinstance(f, FacetFilter)]
 
+        # Resolve download options
+        download_spec = spec.pop('download', {})
+        if 'tables' not in download_spec:
+            download_spec['tables'] = list(schema)
+        spec['download'] = Download.from_spec(download_spec, source, filters) 
+
         # Backward compatibility
         if facet_spec:
             if facet_filters:
@@ -388,7 +506,7 @@ class Target(param.Parameterized):
 
         spec['facet'] = Facet.from_spec(facet_spec, schema)
         params = dict(kwargs, **spec)
-        return cls(filters=filters, source=source, **params)
+        return cls(filters=filters, source=source, schema=schema, **params)
 
     @property
     def panels(self):


### PR DESCRIPTION
Adds a download section to the `Target` spec, e.g.:

```yaml
- title: Example
  download:
    format: csv
    kwargs:
      - index: null
  ... 
```