### PR TITLE
Implement DerivedSource with ability to filter and transform existing sources

### DIFF
--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -182,3 +182,6 @@ class AE5Source(Source):
             if table is None or t == table:
                 schemas[t] = get_dataframe_schema(self.get(t))['items']['properties']
         return schemas if table is None else schemas[table]
+
+    def get_tables(self):
+        return self._tables

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -55,6 +55,9 @@ class IntakeSource(Source):
                 pass
         return entry.read()
 
+    def get_tables(self):
+        return list(self.cat)
+
     def get_schema(self, table=None):
         schemas = {}
         for entry in list(self.cat):

--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -236,3 +236,6 @@ class PrometheusSource(Source):
             raise ValueError(f"PrometheusSource has no '{table}' table, "
                              "it currently only has a 'timeseries' table.")
         return self._make_query()
+
+    def get_tables(self):
+        return list(self._metrics)

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -113,7 +113,7 @@ def test_derived_tables_source_transforms():
     }
 
 
-def test_derived_tables_source_transforms():
+def test_derived_tables_source_filters():
     root = os.path.dirname(__file__)
     original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
     derived = DerivedSource.from_spec({

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -44,6 +44,31 @@ def test_derived_mirror_source_transforms():
     }
 
 
+def test_derived_mirror_source_filters():
+    root = os.path.dirname(__file__)
+    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    derived = DerivedSource.from_spec({
+        'type': 'derived',
+        'source': 'original',
+        'filters': [{'type': 'constant', 'field': 'A', 'value': (0, 2)}]
+    }, sources={'original': original})
+
+    assert derived.get_tables() == ['test']
+    df = pd._testing.makeMixedDataFrame().iloc[:3]
+    pd.testing.assert_frame_equal(derived.get('test'), df)
+    assert derived.get_schema('test') == {
+        'A': {'inclusiveMaximum': 2.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'C': {'enum': ['foo1', 'foo2', 'foo3'], 'type': 'string'},
+        'D': {
+            'format': 'datetime',
+            'type': 'string',
+            'inclusiveMaximum': '2009-01-05T00:00:00',
+            'inclusiveMinimum': '2009-01-01T00:00:00'
+        }
+    }
+
+
 def test_derived_tables_source():
     root = os.path.dirname(__file__)
     original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
@@ -68,6 +93,36 @@ def test_derived_tables_source_transforms():
                 'source': 'original',
                 'table': 'test',
                 'transforms': [{'type': 'iloc', 'end': 3}]
+            }
+        }
+    }, sources={'original': original})
+
+    assert derived.get_tables() == ['derived']
+    df = pd._testing.makeMixedDataFrame().iloc[:3]
+    pd.testing.assert_frame_equal(derived.get('derived'), df)
+    assert derived.get_schema('derived') == {
+        'A': {'inclusiveMaximum': 2.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'C': {'enum': ['foo1', 'foo2', 'foo3'], 'type': 'string'},
+        'D': {
+            'format': 'datetime',
+            'type': 'string',
+            'inclusiveMaximum': '2009-01-05T00:00:00',
+            'inclusiveMinimum': '2009-01-01T00:00:00'
+        }
+    }
+
+
+def test_derived_tables_source_transforms():
+    root = os.path.dirname(__file__)
+    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    derived = DerivedSource.from_spec({
+        'type': 'derived',
+        'tables': {
+            'derived': {
+                'source': 'original',
+                'table': 'test',
+                'filters': [{'type': 'constant', 'field': 'A', 'value': (0, 2)}]
             }
         }
     }, sources={'original': original})

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -16,6 +16,7 @@ def test_derived_mirror_source():
     assert derived.get_tables() == ['test']
     df = pd._testing.makeMixedDataFrame()
     pd.testing.assert_frame_equal(derived.get('test'), df)
+    assert original.get_schema() == derived.get_schema()
 
 
 def test_derived_mirror_source_transforms():
@@ -30,6 +31,17 @@ def test_derived_mirror_source_transforms():
     assert derived.get_tables() == ['test']
     df = pd._testing.makeMixedDataFrame().iloc[:3]
     pd.testing.assert_frame_equal(derived.get('test'), df)
+    assert derived.get_schema('test') == {
+        'A': {'inclusiveMaximum': 2.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'C': {'enum': ['foo1', 'foo2', 'foo3'], 'type': 'string'},
+        'D': {
+            'format': 'datetime',
+            'type': 'string',
+            'inclusiveMaximum': '2009-01-05T00:00:00',
+            'inclusiveMinimum': '2009-01-01T00:00:00'
+        }
+    }
 
 
 def test_derived_tables_source():
@@ -43,6 +55,7 @@ def test_derived_tables_source():
     assert derived.get_tables() == ['derived']
     df = pd._testing.makeMixedDataFrame()
     pd.testing.assert_frame_equal(derived.get('derived'), df)
+    assert original.get_schema('test') == derived.get_schema('derived')
 
 
 def test_derived_tables_source_transforms():
@@ -62,3 +75,14 @@ def test_derived_tables_source_transforms():
     assert derived.get_tables() == ['derived']
     df = pd._testing.makeMixedDataFrame().iloc[:3]
     pd.testing.assert_frame_equal(derived.get('derived'), df)
+    assert derived.get_schema('derived') == {
+        'A': {'inclusiveMaximum': 2.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'C': {'enum': ['foo1', 'foo2', 'foo3'], 'type': 'string'},
+        'D': {
+            'format': 'datetime',
+            'type': 'string',
+            'inclusiveMaximum': '2009-01-05T00:00:00',
+            'inclusiveMinimum': '2009-01-01T00:00:00'
+        }
+    }

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -1,0 +1,64 @@
+import os
+
+import pandas as pd
+
+from lumen.sources.base import FileSource, DerivedSource
+
+
+def test_derived_mirror_source():
+    root = os.path.dirname(__file__)
+    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    derived = DerivedSource.from_spec({
+        'type': 'derived',
+        'source': 'original',
+    }, sources={'original': original})
+
+    assert derived.get_tables() == ['test']
+    df = pd._testing.makeMixedDataFrame()
+    pd.testing.assert_frame_equal(derived.get('test'), df)
+
+
+def test_derived_mirror_source_transforms():
+    root = os.path.dirname(__file__)
+    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    derived = DerivedSource.from_spec({
+        'type': 'derived',
+        'source': 'original',
+        'transforms': [{'type': 'iloc', 'end': 3}]
+    }, sources={'original': original})
+
+    assert derived.get_tables() == ['test']
+    df = pd._testing.makeMixedDataFrame().iloc[:3]
+    pd.testing.assert_frame_equal(derived.get('test'), df)
+
+
+def test_derived_tables_source():
+    root = os.path.dirname(__file__)
+    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    derived = DerivedSource.from_spec({
+        'type': 'derived',
+        'tables': {'derived': {'source': 'original', 'table': 'test'}}
+    }, sources={'original': original})
+
+    assert derived.get_tables() == ['derived']
+    df = pd._testing.makeMixedDataFrame()
+    pd.testing.assert_frame_equal(derived.get('derived'), df)
+
+
+def test_derived_tables_source_transforms():
+    root = os.path.dirname(__file__)
+    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    derived = DerivedSource.from_spec({
+        'type': 'derived',
+        'tables': {
+            'derived': {
+                'source': 'original',
+                'table': 'test',
+                'transforms': [{'type': 'iloc', 'end': 3}]
+            }
+        }
+    }, sources={'original': original})
+
+    assert derived.get_tables() == ['derived']
+    df = pd._testing.makeMixedDataFrame().iloc[:3]
+    pd.testing.assert_frame_equal(derived.get('derived'), df)


### PR DESCRIPTION
A DerivedSource references tables on other sources and optionally allows applying filters and transforms to the returned data which is then made available as a new (derived) table.

The DerivedSource has two modes:

1) When an explicit `tables` specification is provided full control over the exact tables to filter and transform is available. This is referred to as the 'table' mode.
2) When a `source` is declared all tables on that Source are mirrored and filtered and transformed according to the supplied `filters` and `transforms`. This is referred to as the 'mirror' mode. 

### 1. Table Mode

In 'table' mode the tables can reference any table on any source using the reference syntax and declare filters and transforms to apply to that specific table, e.g. a table specification might look like this:

```
{
  'type: 'derived',
  'tables': {
    'derived_table':  {
      'source': 'original_source',
      'table': 'original_table'
      'filters': [
        ...
      ],
      'transforms': [
        ...
      ]
    }
  }
}
```

### 2. Mirror
    
In mirror mode the DerivedSource may reference an existing source directly, e.g.:
    
```
{
  'type': 'derived',
  'source': 'original_source',
  'filters': [...],
  'transforms': [...],
}
```