### PR TITLE
Add ability to expose View controls

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -207,6 +207,7 @@ class Dashboard(param.Parameterized):
             self._materialize_specification()
             self._rerender()
         except Exception as e:
+            self.param.warning(f'Rendering dashboard raised following error:\n\n {type(e).__name__}: {e}') 
             self._main.loading = False
             tb = html.escape(traceback.format_exc())
             alert = pn.pane.HTML(

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -320,7 +320,7 @@ class Target(param.Parameterized):
                 update_card = update_card or view_stale
 
         if not any(view for view in views):
-            return None, None
+            return None, None, views
 
         sort_key = self.facet.get_sort_key(views)
 

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -229,6 +229,8 @@ class Target(param.Parameterized):
         A list or dictionary of views to be displayed.""")
 
     def __init__(self, **params):
+        if 'facet' not in params:
+            params['facet'] = Facet()
         self._application = params.pop('application', None)
         self._cards = []
         self._cache = {}
@@ -390,7 +392,7 @@ class Target(param.Parameterized):
                 events=events
             )
             if prev_views:
-                for v1, v2 in zip(views, prev_views):
+                for v1, v2 in zip(prev_views, views):
                     v1.param.watch(partial(self._sync_view, v2), v1.controls)
             else:
                 for view in views:

--- a/lumen/tests/test_target.py
+++ b/lumen/tests/test_target.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+import holoviews as hv
+
+from panel.param import Param
+
+from lumen.sources import FileSource
+from lumen.target import Facet, Target
+
+
+def test_view_controls():
+    source = FileSource(tables={'test': 'sources/test.csv'}, root=str(Path(__file__).parent))
+    views = {
+        'test': {
+            'type': 'hvplot', 'table': 'test', 'controls': ['x', 'y'],
+            'x': 'A', 'y': 'B', 'kind': 'scatter'
+        }
+    }
+    target = Target(source=source, views=views)
+
+    filter_panel = target.get_filter_panel()
+    param_pane = filter_panel[0][0]
+    assert isinstance(param_pane, Param)
+    assert param_pane.parameters == ['x', 'y']
+
+    assert len(target._cards) == 1
+    card = target._cards[0]
+    hv_pane = card[0][0]
+    isinstance(hv_pane.object, hv.Scatter)
+    assert hv_pane.object.kdims == ['A']
+    assert hv_pane.object.vdims == ['B']
+
+    param_pane._widgets['x'].value = 'C'
+    param_pane._widgets['y'].value = 'D'
+
+    isinstance(hv_pane.object, hv.Scatter)
+    assert hv_pane.object.kdims == ['C']
+    assert hv_pane.object.vdims == ['D']
+
+
+def test_view_controls_facetted():
+    source = FileSource(tables={'test': 'sources/test.csv'}, root=str(Path(__file__).parent))
+    views = {
+        'test': {
+            'type': 'hvplot', 'table': 'test', 'controls': ['x', 'y'],
+            'x': 'A', 'y': 'B', 'kind': 'scatter'
+        }
+    }
+    spec = {
+        'source': 'test',
+        'facet': {'by': 'C'},
+        'views': views
+    }
+    target = Target.from_spec(spec, sources={'test': source})
+
+    filter_panel = target.get_filter_panel()
+    param_pane = filter_panel[4][0]
+    assert isinstance(param_pane, Param)
+    assert param_pane.parameters == ['x', 'y']
+
+    assert len(target._cards) == 5
+    for card in target._cards:
+        hv_pane = card[0][0]
+        isinstance(hv_pane.object, hv.Scatter)
+        assert hv_pane.object.kdims == ['A']
+        assert hv_pane.object.vdims == ['B']
+
+    param_pane._widgets['x'].value = 'C'
+    param_pane._widgets['y'].value = 'D'
+
+    for card in target._cards:
+        hv_pane = card[0][0]
+        isinstance(hv_pane.object, hv.Scatter)
+        assert hv_pane.object.kdims == ['C']
+        assert hv_pane.object.vdims == ['D']

--- a/lumen/tests/test_target.py
+++ b/lumen/tests/test_target.py
@@ -5,7 +5,7 @@ import holoviews as hv
 from panel.param import Param
 
 from lumen.sources import FileSource
-from lumen.target import Facet, Target
+from lumen.target import Target
 
 
 def test_view_controls():


### PR DESCRIPTION
Implements https://github.com/holoviz/lumen/issues/124

The implementation I settled on is very explicit, each `View` now has a `controls` parameter which declares which parameters on the view will be exposed as widgets. This can either be set via the yaml specification or in the case of custom views a default value can be set which will expose those parameters. I'm much happier making this explicit rather than relying on any precedence or constant declaration since the author of a View cannot really know ahead of time which parameters it makes sense to expose. 

To make this work well for parameters which reference fields in a table each `View` must declare `_field_params`. This allows the baseclass to know that it should populate the available options on this parameter with the available fields in the table so that the generated widgets offer a dropdown letting the user select between the available fields.