### PR TITLE
Refactor internals to allow lazy rendering

### DIFF
--- a/lumen/command.py
+++ b/lumen/command.py
@@ -13,6 +13,7 @@ from panel.io.server import Application
 from . import __version__
 from .config import config
 from .dashboard import Defaults, load_yaml
+from .state import state
 
 
 class YamlHandler(CodeHandler):
@@ -40,13 +41,13 @@ class YamlHandler(CodeHandler):
         with open(filename) as f:
             yaml_spec = f.read()
         spec = load_yaml(yaml_spec)
-        root = os.path.abspath(os.path.dirname(filename))
+        config._root = os.path.abspath(os.path.dirname(filename))
         warm = any(flag in sys.argv for flag in ('--dev', '--autoreload', '--warm'))
         Defaults.from_spec(spec.get('defaults', {})).apply()
         if warm:
-            config.load_local_modules(root)
+            config.load_local_modules()
             sources = spec.get('sources', {})
-            config.load_global_sources(sources, root, clear_cache=not config.dev)
+            state.load_global_sources(sources, clear_cache=not config.dev)
 
 
 def build_single_handler_application(path, argv):

--- a/lumen/config.py
+++ b/lumen/config.py
@@ -9,9 +9,6 @@ from panel.widgets.indicators import Indicator
 from panel.template.base import BasicTemplate
 from panel.template import DefaultTheme, DarkTheme
 
-from .filters import Filter
-from .sources import Source
-
 
 _INDICATORS = {k.lower(): v for k, v in param.concrete_descendents(Indicator).items()}
 

--- a/lumen/config.py
+++ b/lumen/config.py
@@ -36,11 +36,8 @@ class _config(param.Parameterized):
     Stores shared configuration for the entire Lumen application.
     """
 
-    filters = param.Dict(default={}, doc="""
-      A global dictionary of shared Filter objects.""")
-
-    sources = param.Dict(default={}, doc="""
-      A global dictionary of shared Source objects.""")
+    _root = param.String(default=None, doc="""
+      Root directory relative to which data and modules are loaded.""")
 
     template_vars = param.Dict(default={}, doc="""
       Template variables which may be referenced in a dashboard yaml
@@ -49,58 +46,19 @@ class _config(param.Parameterized):
     yamls = param.List(default=[], doc="""
       List of yaml files currently being served.""")
 
-    def load_global_sources(self, sources, root, clear_cache=True,
-                            loading_panel=None):
-        """
-        Loads global sources shared across all targets.
-        """
-        for name, source_spec in sources.items():
-            if not source_spec.get('shared'):
-                continue
-            source_spec = dict(source_spec)
-            filter_specs = source_spec.pop('filters', {})
-            source = self.sources.get(name)
-            source_type = Source._get_type(source_spec['type'])
-            if source is not None:
-                # Check if old source is the same as the new source
-                params = {
-                    k: v for k, v in source.param.get_param_values()
-                    if k != 'name'
-                }
-                new_spec = dict(source_spec, **{
-                    k: v for k, v in source_type.param.get_param_values()
-                    if k != 'name'
-                })
-                reinitialize = params == new_spec
-            else:
-                reinitialize = True
-            if loading_panel is not None:
-                loading_panel.object = f'Loading {name} source...'
-            if reinitialize:
-                source_spec['name'] = name
-                self.sources[name] = source = Source.from_spec(
-                    source_spec, self.sources, root=root
-                )
-            if source.cache_dir and clear_cache:
-                source.clear_cache()
-            schema = source.get_schema()
-            self.filters[name] = {
-                fname: Filter.from_spec(filter_spec, schema)
-                for fname, filter_spec in filter_specs.items()
-            }
+    @property
+    def root(self):
+        if self._root:
+            return self._root
+        return os.getcwd()
 
-    def load_local_modules(self, root):
+    def load_local_modules(self):
         """
         Loads local modules containing custom components and templates.
-
-        Arguments
-        ---------
-        root: str
-            The root directory the dashboard is being served from.
         """
         modules = {}
         for imp in ('filters', 'sources', 'transforms', 'template', 'views'):
-            path = os.path.join(root, imp+'.py')
+            path = os.path.join(self.root, imp+'.py')
             if not os.path.isfile(path):
                 continue
             spec = importlib.util.spec_from_file_location(f"local_lumen.{imp}", path)

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -124,7 +124,6 @@ class Config(param.Parameterized):
         return self.template(**params)
 
 
-
 class Defaults(param.Parameterized):
     """
     Defaults to apply to the component classes.
@@ -149,7 +148,6 @@ class Defaults(param.Parameterized):
                 params = dict(default)
                 obj_type = obj._get_type(params.pop('type', None))
                 obj_type.param.set_param(**params)
-
 
 
 class Dashboard(param.Parameterized):
@@ -340,7 +338,9 @@ class Dashboard(param.Parameterized):
     def _activate_filters(self, event):
         target = self.targets[event.new]
         if target is None:
-            target = self._load_target(state.spec['targets'][event.new])
+            spec = state.spec['targets'][event.new]
+            self._set_loading(spec['title'])
+            target = self._load_target(spec)
             self.targets[event.new] = target
             self._render_filters()
             self._layout[event.new] = target.panels

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -377,7 +377,8 @@ class Dashboard(param.Parameterized):
             if name and tab_name != name:
                 return
             items[self._layout.active] = pn.Row(
-                pn.layout.HSpacer(), loading, pn.layout.HSpacer()
+                pn.layout.HSpacer(), loading, pn.layout.HSpacer(),
+                name=tab_name
             )
         else:
             items = [pn.Row(pn.layout.HSpacer(), loading, pn.layout.HSpacer())]

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -18,6 +18,7 @@ import param
 import requests
 
 from ..filters import Filter
+from ..state import state
 from ..transforms import Transform
 from ..util import (
     get_dataframe_schema, merge_schemas, resolve_module_reference
@@ -155,7 +156,7 @@ class Source(param.Parameterized):
         return df
 
     @classmethod
-    def _resolve_reference(cls, reference, sources={}):
+    def _resolve_reference(cls, reference):
         refs = reference[1:].split('.')
         if len(refs) == 3:
             sourceref, table, field = refs
@@ -164,7 +165,7 @@ class Source(param.Parameterized):
         elif len(refs) == 1:
             (sourceref,) = refs
 
-        source = cls.from_spec(sourceref, sources)
+        source = cls.from_spec(sourceref)
         if len(refs) == 1:
             return source
         if len(refs) == 2:
@@ -180,20 +181,20 @@ class Source(param.Parameterized):
         return field_schema['enum']
 
     @classmethod
-    def _recursive_resolve(cls, spec, sources, source_type):
+    def _recursive_resolve(cls, spec, source_type):
         resolved_spec = {}
         if 'sources' in source_type.param and 'sources' in spec:
             resolved_spec['sources'] = {
-                source: cls.from_spec(source, sources)
+                source: cls.from_spec(source)
                 for source in spec.pop('sources')
             }
         if 'source' in source_type.param and 'source' in spec:
             resolved_spec['source'] = cls.from_spec(spec.pop('source'), sources)
         for k, v in spec.items():
             if isinstance(v, str) and v.startswith('@'):
-                v = cls._resolve_reference(v, sources)
+                v = cls._resolve_reference(v)
             elif isinstance(v, dict):
-                v = cls._recursive_resolve(v, sources, source_type)
+                v = cls._recursive_resolve(v, source_type)
             if k == 'filters' and 'source' in resolved_spec:
                 source_schema = resolved_spec['source'].get_schema()
                 v = [Filter.from_spec(fspec, source_schema) for fspec in v]
@@ -203,7 +204,7 @@ class Source(param.Parameterized):
         return resolved_spec
 
     @classmethod
-    def from_spec(cls, spec, sources={}, root=None):
+    def from_spec(cls, spec):
         """
         Creates a Source object from a specification. If a Source
         specification references other sources these may be supplied
@@ -214,36 +215,30 @@ class Source(param.Parameterized):
         spec : dict or str
             Specification declared as a dictionary of parameter values
             or a string referencing a source in the sources dictionary.
-        sources: dict
-            Dictionary of other Source objects
-        root: str
-            Root directory where dashboard specification was loaded
-            from.
 
         Returns
         -------
         Resolved and instantiated Source object
         """
-        from .. import config
         if spec is None:
             raise ValueError('Source specification empty.')
         elif isinstance(spec, str):
-            if spec in sources:
-                source = sources[spec]
-            elif spec in config.sources and config.sources[spec].shared:
-                source = config.sources[spec]
+            if spec in state.sources:
+                source = state.sources[spec]
+            elif spec in state.spec.get('sources', {}):
+                source = state.load_source(spec, state.spec['sources'][spec])
             else:
                 raise ValueError(f"Source with name '{spec}' was not found.")
             return source
 
         spec = dict(spec)
         source_type = Source._get_type(spec.pop('type'))
-        resolved_spec = cls._recursive_resolve(dict(spec), sources, source_type)
-        resolved_spec['root'] = root
+        resolved_spec = cls._recursive_resolve(dict(spec), source_type)
         return source_type(**resolved_spec)
 
     def __init__(self, **params):
-        self.root = params.pop('root', None)
+        from ..config import config
+        self.root = params.pop('root', config.root)
         super().__init__(**params)
         self._cache = {}
         self._schema_cache = {}

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -189,7 +189,7 @@ class Source(param.Parameterized):
                 for source in spec.pop('sources')
             }
         if 'source' in source_type.param and 'source' in spec:
-            resolved_spec['source'] = cls.from_spec(spec.pop('source'), sources)
+            resolved_spec['source'] = cls.from_spec(spec.pop('source'))
         for k, v in spec.items():
             if isinstance(v, str) and v.startswith('@'):
                 v = cls._resolve_reference(v)

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -1,0 +1,133 @@
+from weakref import WeakKeyDictionary
+
+import panel as pn
+
+
+class _session_state:
+    """
+    The session_state object holds both global and session specific
+    state making it easy to manage access to Sources and Filters
+    across components.
+    """
+
+    global_sources = {}
+
+    global_filters = {}
+
+    _loading = WeakKeyDictionary()
+
+    _sources = WeakKeyDictionary()
+
+    _filters = WeakKeyDictionary()
+
+    @property
+    def filters(self):
+        if pn.state.curdoc not in self._filters:
+            self._filters[pn.state.curdoc] = dict(self.global_filters)
+        return self._filters[pn.state.curdoc]
+
+    @property
+    def sources(self):
+        if pn.state.curdoc not in self._sources:
+            self._sources[pn.state.curdoc] = dict(self.global_sources)
+        return self._sources[pn.state.curdoc]
+
+    @property
+    def loading_msg(self):
+        return self._loading.get(pn.state.curdoc)
+
+    @loading_msg.setter
+    def loading_msg(self, loading_msg):
+        self._loading[pn.state.curdoc] = loading_msg
+
+    @property
+    def authorized(self):
+        if pn.state.user_info is None and self.spec.get('auth'):
+            return config.dev
+        authorized = True
+        for k, value in self.spec.get('auth', {}).items():
+            if not isinstance(value, list): value = [value]
+            if k in pn.state.user_info:
+                user_value = pn.state.user_info[k]
+                if not isinstance(user_value, list):
+                    user_value = [user_value]
+                authorized &= any(uv == v for v in value for uv in user_value)
+        return authorized
+
+    def load_global_sources(self, clear_cache=True):
+        """
+        Loads global sources shared across all targets.
+        """
+        from .filters import Filter
+        from .sources import Source
+        for name, source_spec in self.spec.get('sources', {}).items():
+            if not source_spec.get('shared'):
+                continue
+            source_spec = dict(source_spec)
+            filter_specs = source_spec.pop('filters', {})
+            source = self.global_sources.get(name)
+            source_type = Source._get_type(source_spec['type'])
+            if source is not None:
+                # Check if old source is the same as the new source
+                params = {
+                    k: v for k, v in source.param.get_param_values()
+                    if k != 'name'
+                }
+                new_spec = dict(source_spec, **{
+                    k: v for k, v in source_type.param.get_param_values()
+                    if k != 'name'
+                })
+                reinitialize = params == new_spec
+            else:
+                reinitialize = True
+            if self.loading_msg is not None:
+                self.loading_msg.object = f'Loading {name} source...'
+            if reinitialize:
+                source_spec['name'] = name
+                self.global_sources[name] = source = Source.from_spec(source_spec)
+            if source.cache_dir and clear_cache:
+                source.clear_cache()
+            schema = source.get_schema()
+            self.global_filters[name] = {
+                fname: Filter.from_spec(filter_spec, schema)
+                for fname, filter_spec in filter_specs.items()
+            }
+
+    def load_source(self, name, source_spec):
+        from .filters import Filter
+        from .sources import Source
+        source_spec = dict(source_spec)
+        filter_specs = source_spec.pop('filters', None)
+        if self.loading_msg:
+            self.loading_msg.object = f'Loading {name} source...'
+        if name in self.sources:
+            source = self.sources[name]
+        else:
+            source_spec['name'] = name
+            source = Source.from_spec(source_spec)
+        self.sources[name] = source
+        if not filter_specs:
+            return source
+        self.filters[name] = filters = dict(self.filters.get(name, {}))
+        schema = source.get_schema()
+        for fname, filter_spec in filter_specs.items():
+            if fname not in filters:
+                filters[fname] = Filter.from_spec(filter_spec, schema)
+        return source
+
+    def resolve_views(self):
+        from .views import View
+        exts = []
+        for target in self.spec.get('targets', []):
+            views = target.get('views', [])
+            if isinstance(views, dict):
+                views = list(views.values())
+            for view in views:
+                view_type = View._get_type(view.get('type'))
+                if view_type and view_type._extension:
+                    exts.append(view_type._extension)
+        for ext in exts:
+            __import__(pn.extension._imports[ext])
+
+
+state = _session_state()

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -16,11 +16,13 @@ class _session_state:
 
     global_filters = {}
 
-    _loading = WeakKeyDictionary()
+    spec = {}
 
-    _sources = WeakKeyDictionary()
+    _loading = WeakKeyDictionary() if pn.state.curdoc else {}
 
-    _filters = WeakKeyDictionary()
+    _sources = WeakKeyDictionary() if pn.state.curdoc else {}
+
+    _filters = WeakKeyDictionary() if pn.state.curdoc else {}
 
     @property
     def filters(self):

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -2,6 +2,8 @@ from weakref import WeakKeyDictionary
 
 import panel as pn
 
+from .config import config
+
 
 class _session_state:
     """

--- a/lumen/tests/conftest.py
+++ b/lumen/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+from lumen.config import config
+from lumen.sources import FileSource
+from lumen.state import state
+
+
+@pytest.fixture
+def set_root():
+    root = config._root
+    def _set_root(root):
+        config._root = root
+    yield _set_root
+    config._root = root
+
+
+@pytest.fixture
+def make_filesource():
+    root = config._root
+    def create(root):
+        config._root = root
+        source = FileSource(tables={'test': 'test.csv'},  kwargs={'parse_dates': ['D']})
+        state.sources['original'] = source
+        return source
+    yield create
+    config._root = root
+    state.global_sources.clear()

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -3,15 +3,16 @@ import os
 import pandas as pd
 
 from lumen.sources.base import FileSource, DerivedSource
+from lumen.state import state
 
 
-def test_derived_mirror_source():
+def test_derived_mirror_source(make_filesource):
     root = os.path.dirname(__file__)
-    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    original = make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'source': 'original',
-    }, sources={'original': original})
+    })
 
     assert derived.get_tables() == ['test']
     df = pd._testing.makeMixedDataFrame()
@@ -19,14 +20,14 @@ def test_derived_mirror_source():
     assert original.get_schema() == derived.get_schema()
 
 
-def test_derived_mirror_source_transforms():
+def test_derived_mirror_source_transforms(make_filesource):
     root = os.path.dirname(__file__)
-    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    original = make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'source': 'original',
         'transforms': [{'type': 'iloc', 'end': 3}]
-    }, sources={'original': original})
+    })
 
     assert derived.get_tables() == ['test']
     df = pd._testing.makeMixedDataFrame().iloc[:3]
@@ -44,14 +45,14 @@ def test_derived_mirror_source_transforms():
     }
 
 
-def test_derived_mirror_source_filters():
+def test_derived_mirror_source_filters(make_filesource):
     root = os.path.dirname(__file__)
-    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    original = make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'source': 'original',
         'filters': [{'type': 'constant', 'field': 'A', 'value': (0, 2)}]
-    }, sources={'original': original})
+    })
 
     assert derived.get_tables() == ['test']
     df = pd._testing.makeMixedDataFrame().iloc[:3]
@@ -69,13 +70,13 @@ def test_derived_mirror_source_filters():
     }
 
 
-def test_derived_tables_source():
+def test_derived_tables_source(make_filesource):
     root = os.path.dirname(__file__)
-    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    original = make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'tables': {'derived': {'source': 'original', 'table': 'test'}}
-    }, sources={'original': original})
+    })
 
     assert derived.get_tables() == ['derived']
     df = pd._testing.makeMixedDataFrame()
@@ -83,9 +84,9 @@ def test_derived_tables_source():
     assert original.get_schema('test') == derived.get_schema('derived')
 
 
-def test_derived_tables_source_transforms():
+def test_derived_tables_source_transforms(make_filesource):
     root = os.path.dirname(__file__)
-    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    original = make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'tables': {
@@ -95,7 +96,7 @@ def test_derived_tables_source_transforms():
                 'transforms': [{'type': 'iloc', 'end': 3}]
             }
         }
-    }, sources={'original': original})
+    })
 
     assert derived.get_tables() == ['derived']
     df = pd._testing.makeMixedDataFrame().iloc[:3]
@@ -113,9 +114,9 @@ def test_derived_tables_source_transforms():
     }
 
 
-def test_derived_tables_source_filters():
+def test_derived_tables_source_filters(make_filesource):
     root = os.path.dirname(__file__)
-    original = FileSource(tables={'test': 'test.csv'}, root=root, kwargs={'parse_dates': ['D']})
+    original = make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'tables': {
@@ -125,7 +126,7 @@ def test_derived_tables_source_filters():
                 'filters': [{'type': 'constant', 'field': 'A', 'value': (0, 2)}]
             }
         }
-    }, sources={'original': original})
+    })
 
     assert derived.get_tables() == ['derived']
     df = pd._testing.makeMixedDataFrame().iloc[:3]

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -2,8 +2,7 @@ import os
 
 import pandas as pd
 
-from lumen.sources.base import FileSource, DerivedSource
-from lumen.state import state
+from lumen.sources.base import DerivedSource
 
 
 def test_derived_mirror_source(make_filesource):
@@ -22,7 +21,7 @@ def test_derived_mirror_source(make_filesource):
 
 def test_derived_mirror_source_transforms(make_filesource):
     root = os.path.dirname(__file__)
-    original = make_filesource(root)
+    make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'source': 'original',
@@ -47,7 +46,7 @@ def test_derived_mirror_source_transforms(make_filesource):
 
 def test_derived_mirror_source_filters(make_filesource):
     root = os.path.dirname(__file__)
-    original = make_filesource(root)
+    make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'source': 'original',
@@ -86,7 +85,7 @@ def test_derived_tables_source(make_filesource):
 
 def test_derived_tables_source_transforms(make_filesource):
     root = os.path.dirname(__file__)
-    original = make_filesource(root)
+    make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'tables': {
@@ -116,7 +115,7 @@ def test_derived_tables_source_transforms(make_filesource):
 
 def test_derived_tables_source_filters(make_filesource):
     root = os.path.dirname(__file__)
-    original = make_filesource(root)
+    make_filesource(root)
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'tables': {

--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -1,11 +1,13 @@
-import os
+import pathlib
 
 from lumen.dashboard import Dashboard
+from lumen.state import state
 from lumen.views import View
 
-def test_dashboard_with_local_view():
-    root = os.path.dirname(__file__)
-    dashboard = Dashboard(os.path.join(root, 'sample_dashboard', 'dashboard.yml'))
+def test_dashboard_with_local_view(set_root):
+    root = pathlib.Path(__file__).parent / 'sample_dashboard'
+    set_root(str(root))
+    dashboard = Dashboard(str(root / 'dashboard.yml'))
     target = dashboard.targets[0]
     view = View.from_spec(target.views[0], target.source, [])
     assert isinstance(view, dashboard._modules['views'].TestView)

--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -1,7 +1,6 @@
 import pathlib
 
 from lumen.dashboard import Dashboard
-from lumen.state import state
 from lumen.views import View
 
 def test_dashboard_with_local_view(set_root):

--- a/lumen/tests/test_target.py
+++ b/lumen/tests/test_target.py
@@ -8,8 +8,9 @@ from lumen.sources import FileSource
 from lumen.target import Target
 
 
-def test_view_controls():
-    source = FileSource(tables={'test': 'sources/test.csv'}, root=str(Path(__file__).parent))
+def test_view_controls(set_root):
+    set_root(str(Path(__file__).parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
     views = {
         'test': {
             'type': 'hvplot', 'table': 'test', 'controls': ['x', 'y'],


### PR DESCRIPTION
- [x] Moves `root` onto `config` object
- [x] Moved `authorized` property onto `state` object
- [x] Stores global and session specific sources and filters onto `state` object