### PR TITLE
Add support for auth plugins

### DIFF
--- a/lumen/auth.py
+++ b/lumen/auth.py
@@ -1,0 +1,88 @@
+import yaml
+
+from collections import defaultdict
+
+import param
+
+
+class AuthPlugin(param.Parameterized):
+    """
+    An AuthPlugin is given the auth specfication and can apply arbitrary
+    transforms to it.
+    """
+
+    auth_type = None
+
+    @classmethod
+    def _get_type(cls, auth_type):
+        if '.' in auth_type:
+            return resolve_module_reference(auth_type, AuthPlugin)
+        try:
+            __import__(f'lumen.auth.{auth_type}')
+        except Exception:
+            pass
+        for auth in param.concrete_descendents(cls).values():
+            if auth.auth_type == auth_type:
+                return auth
+        raise ValueError(f"No AuthPlugin for auth_type '{auth_type}' could be found.")
+    
+    @classmethod
+    def from_spec(cls, spec):
+        spec = dict(spec)
+        auth_plugin = cls._get_type(spec.pop('type'))
+        return auth_plugin(**spec)
+
+    def transform(self, spec):
+        return dict(spec)
+
+
+
+class YamlAuthMapperPlugin(AuthPlugin):
+    """
+    The YamlAuthMapperPlugin uses a Yaml file to map auth keys
+    allowing more concise declarations for individual dashboards, e.g.
+    the following yaml specification:
+
+        group:
+          admins:
+            email:
+              - lumen@holoviz.org
+              - panel@holoviz.org
+              - param@holoviz.org
+          users:
+            email:
+              - philipp@holoviz.org
+
+    will expand this auth spec:
+
+        auth:
+          group:
+            - admins
+
+    to this expanded spec:
+   
+        auth:
+          email:
+            - lumen@holoviz.org 
+            - panel@holoviz.org
+            - param@holoviz.org
+            - philipp@holoviz.org
+    """
+    
+    yaml_file = param.Filename()
+
+    auth_type = 'yaml'
+
+    def transform(self, spec):
+        spec = dict(spec)
+        with open(self.yaml_file) as f:
+            text = f.read()
+        mapping = yaml.load(text, Loader=yaml.Loader)
+        new = defaultdict(list)
+        for origin, replacements in mapping.items():
+            values = spec.pop(origin)
+            for val in values:
+                for key, new_vals in replacements.get(val, {}).items():
+                    new[key] += new_vals
+        spec.update(new)
+        return spec

--- a/lumen/auth.py
+++ b/lumen/auth.py
@@ -4,6 +4,9 @@ from collections import defaultdict
 
 import param
 
+from .util import resolve_module_reference
+
+
 
 class AuthPlugin(param.Parameterized):
     """
@@ -34,7 +37,6 @@ class AuthPlugin(param.Parameterized):
 
     def transform(self, spec):
         return dict(spec)
-
 
 
 class YamlAuthMapperPlugin(AuthPlugin):

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -2,8 +2,6 @@ from weakref import WeakKeyDictionary
 
 import panel as pn
 
-from .config import config
-
 
 class _session_state:
     """

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -51,20 +51,6 @@ class _session_state:
     def loading_msg(self, loading_msg):
         self._loading[pn.state.curdoc] = loading_msg
 
-    @property
-    def authorized(self):
-        if pn.state.user_info is None and self.spec.get('auth'):
-            return config.dev
-        authorized = True
-        for k, value in self.spec.get('auth', {}).items():
-            if not isinstance(value, list): value = [value]
-            if k in pn.state.user_info:
-                user_value = pn.state.user_info[k]
-                if not isinstance(user_value, list):
-                    user_value = [user_value]
-                authorized &= any(uv == v for v in value for uv in user_value)
-        return authorized
-
     def load_global_sources(self, clear_cache=True):
         """
         Loads global sources shared across all targets.

--- a/lumen/tests/conftest.py
+++ b/lumen/tests/conftest.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import pytest
 
 from lumen.config import config
@@ -25,3 +27,11 @@ def make_filesource():
     yield create
     config._root = root
     state.global_sources.clear()
+
+
+
+@pytest.fixture
+def yaml_file():
+    tf = tempfile.NamedTemporaryFile(mode='w', suffix='.yaml')
+    yield tf
+    tf.close()

--- a/lumen/tests/test_auth.py
+++ b/lumen/tests/test_auth.py
@@ -1,0 +1,36 @@
+from lumen.auth import YamlAuthMapperPlugin
+
+
+auth_mapper = """
+group:
+  admins:
+    email:
+      - lumen@holoviz.org
+      - panel@holoviz.org
+      - param@holoviz.org
+  users:
+    email:
+      - philipp@holoviz.org
+"""
+
+
+def test_yaml_auth_mapper_plugin(yaml_file):
+    yaml_file.write(auth_mapper)
+    yaml_file.seek(0)
+    yaml_file.flush()
+    
+    mapper = YamlAuthMapperPlugin(yaml_file=yaml_file.name)
+
+    original = {
+        'group': ['admins', 'users']
+    }
+    transformed = mapper.transform(original)
+
+    assert transformed == {
+        'email': [
+            'lumen@holoviz.org',
+            'panel@holoviz.org',
+            'param@holoviz.org',
+            'philipp@holoviz.org'
+        ]
+    }


### PR DESCRIPTION
Allows defining auth plugins which can accept the auth spec declared in a dashboard.yaml and transform it in some way.