### PR TITLE
Fix filters showing up as shared

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -477,7 +477,7 @@ class Dashboard(param.Parameterized):
             for filt in target.filters:
                 if ((all(isinstance(target, (type(None), Future)) or filt in target.filters
                          for target in self.targets) and
-                    filt.panel is not None) or filt.shared) and filt not in filters:
+                    filt.panel is not None) and filt.shared) and filt not in filters:
                     views.append(filt.panel)
                     filters.append(filt)
         if not views or len(self.targets) == 1:


### PR DESCRIPTION
@philippjfr I didn't entirely get the logic in the condition I changed that decides whether a filter should be considered as global or not. Please double check that :)
