### PR TITLE
Do not attach control callbacks when rerender is the consequence of a filter event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ builtdocs/
 discover/
 
 node_modules/
+
+# Examples temp data
+examples/*/cache

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -409,8 +409,11 @@ class Target(param.Parameterized):
                     if not view.controls:
                         continue
                     view_controls.append(view.control_panel)
-                    cb = partial(self._rerender, invalidate_cache=False)
-                    view.param.watch(cb, view.controls)
+                    # Attach controls callback only when there are events, i.e. new
+                    # filter values set.
+                    if not events:
+                        cb = partial(self._rerender, invalidate_cache=False)
+                        view.param.watch(cb, view.controls)
             prev_views = views
             if card is None:
                 continue


### PR DESCRIPTION
The _rerender callback is attached to the filter values. Each rerender triggered an _update_views, itself attaching a _rerender callback to the controls values. So changing the values of the filters and the callbacks meant that more and more of _rerender callbacks were added, without never being cleared.

I noticed that the callbacks in _update_views should not be attached if events arrive (i.e. filters being changed), so I just added that condition.

Would feel more comfortable with a review and some tests :)