### PR TITLE
Clear the state after execution of each test

### DIFF
--- a/lumen/tests/conftest.py
+++ b/lumen/tests/conftest.py
@@ -51,3 +51,15 @@ def state_userinfo():
     pn.state = mock_state
     yield
     pn.state = state
+
+
+@pytest.fixture(autouse=True)
+def clear_state():
+    "Clear the state after the execution of each test"
+    yield
+    state.global_sources.clear()
+    state.global_filters.clear()
+    state.spec.clear()
+    state._loading.clear()
+    state._sources.clear()
+    state._filters.clear()

--- a/lumen/tests/test_target.py
+++ b/lumen/tests/test_target.py
@@ -5,6 +5,7 @@ import holoviews as hv
 from panel.param import Param
 
 from lumen.sources import FileSource
+from lumen.state import state
 from lumen.target import Target
 
 
@@ -39,8 +40,10 @@ def test_view_controls(set_root):
     assert hv_pane.object.vdims == ['D']
 
 
-def test_view_controls_facetted():
-    source = FileSource(tables={'test': 'sources/test.csv'}, root=str(Path(__file__).parent))
+def test_view_controls_facetted(set_root):
+    set_root(str(Path(__file__).parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    state.sources['test'] = source
     views = {
         'test': {
             'type': 'hvplot', 'table': 'test', 'controls': ['x', 'y'],


### PR DESCRIPTION
The tests were leaking state, which meant that the test `test_view_controls_facetted` was successful only due to the fact that a previous test populated the state with some source, preventing anyone to successfully run this test individually.

I've added a fixture that is automatically executed after each test and clears the state.