### PR TITLE
Make lumen package invokable with the -m flag

### DIFF
--- a/lumen/__main__.py
+++ b/lumen/__main__.py
@@ -1,0 +1,10 @@
+import sys
+
+def main():
+    from lumen.command import main as _main
+
+   # Main entry point (see setup.py)
+    _main(sys.argv)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I just copied and pasted this from Panel itself.

It comes in handy when I want to debug Lumen with VSCode, with this configuration that is executing `python -m lumen serve file.yaml`:
```
{
    "name": "Python: Serve lumen app",
    "type": "python",
    "request": "launch",
    "module": "lumen",
    "args": [
        "serve",
        "${file}",
    ],
}
```