### PR TITLE
Fix the bikes example

### DIFF
--- a/examples/bikes/dashboard.yaml
+++ b/examples/bikes/dashboard.yaml
@@ -24,9 +24,16 @@ sources:
         - source: occupancy
           table: occupancy
           index: id
+  station_occupancy_projected:
+    type: derived
+    source: station_occupancy
+    transforms:
+      - type: project_lnglat
+        latitude: lat
+        longitude: lon
 targets:
   - title: "Occupancy"
-    source: station_occupancy
+    source: station_occupancy_projected
     views:
       locations:
         type: hvplot
@@ -35,7 +42,7 @@ targets:
         x: lon
         y: lat
         hover_cols: [commonName]
-        tiles: Wikipedia
+        tiles: EsriStreet
         responsive: true
         height: 500
         color: bikesCount
@@ -43,10 +50,6 @@ targets:
         xaxis: null
         yaxis: null
         selection_group: bikes
-        transforms:
-          - type: project_lnglat
-            latitude: lat
-            longitude: lon
       table:
         type: table
         table: station_occupancy

--- a/examples/nyc_taxi/dashboard.yaml
+++ b/examples/nyc_taxi/dashboard.yaml
@@ -24,7 +24,7 @@ targets:
         kind: points
         x: pickup_x
         y: pickup_y
-        tiles: Wikipedia
+        tiles: EsriStreet
         rasterize: true
         cnorm: eq_hist
         responsive: true
@@ -38,7 +38,7 @@ targets:
         kind: points
         x: dropoff_x
         y: dropoff_y
-        tiles: Wikipedia
+        tiles: EsriStreet
         rasterize: true
         cnorm: eq_hist
         responsive: true


### PR DESCRIPTION
The linked selection of bikes stations on the map wasn't selecting any sub-dataset on the histograms and table. What happened exactly is unclear to me (Lumen dashboards are not so easy to debug), it might be related to https://github.com/holoviz/geoviews/issues/497 which show that linked_selections don't work (so well) with geoviews. Or due to the fact that the `project_lnglat` (lat/lon to web mercator) transform in the map view created a selection whose coordinates were not in the same system as the tables in the other views. The issue was fixed by moving the transform to the source declaration, by using a `DerivedSource` to refer to the source to transform.