### PR TITLE
Make robust to warm and autoreload options

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -240,8 +240,8 @@ class Dashboard(param.Parameterized):
         self._create_header()
         self._populate_template()
 
-        pn.state.onload(self._render_dashboard)
         state._apps[pn.state.curdoc] = self
+        pn.state.onload(self._render_dashboard)
 
     ##################################################################
     # Load specification

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -97,9 +97,9 @@ class View(param.Parameterized):
             self._init_link_selections()
 
     def _init_link_selections(self):
-        if self._ls is not None:
-            return
         doc = pn.state.curdoc
+        if self._ls is not None or doc is None:
+            return
         if doc not in View._selections and self.selection_group:
             View._selections[doc] = {}
         self._ls = View._selections.get(doc, {}).get(self.selection_group)
@@ -444,6 +444,8 @@ class hvPlotView(View):
 
     def _link_plot(self, plot):
         self._init_link_selections()
+        if self._ls is None:
+            return plot
         linked_objs = list(self._ls._plot_reset_streams)
         plot = self._ls(plot)
         self._linked_objs += [


### PR DESCRIPTION
Recent panel versions execute onload callbacks on `--warm` and `--autoreload`. This ensures this does not raise errors in Lumen.