### PR TITLE
Hide Card header when in Tabs

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -279,6 +279,8 @@ class Dashboard(param.Parameterized):
         if 'reloadable' not in target_spec:
             target_spec['reloadable'] = self.config.reloadable
         target = Target.from_spec(target_spec, application=self)
+        if isinstance(self._layout, pn.Tabs):
+            target.show_title = False
         target.start()
         return target
 

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -219,6 +219,9 @@ class Target(param.Parameterized):
     reloadable = param.Boolean(default=True, doc="""
         Whether to allow reloading data target's source using a button.""")
 
+    show_title = param.Boolean(default=True, doc="""
+        Whether to show the title in Card headers.""")
+
     title = param.String(doc="A title for this Target.")
 
     refresh_rate = param.Integer(default=None, doc="""
@@ -598,6 +601,8 @@ class Target(param.Parameterized):
             kwargs['ncols'] = 3
         if self._cards:
             content = self._cards
+            if len(self._cards) == 1 and not self.show_title:
+                self._cards[0].hide_header = True
         else:
             content = (
                 pn.pane.Alert(


### PR DESCRIPTION
When rendering targets in tabs the card header duplicates the title in the Tabs component. Removing the header produces a cleaner look and feel.

Implements https://github.com/holoviz/lumen/issues/205