### PR TITLE
add apply_to method for base transforms

### DIFF
--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -78,11 +78,7 @@ class Transform(param.Parameterized):
         -------
         A DataFrame with the results of the transformation.
         """
-        trans = cls()
-        for key, value in kwargs.items():
-            setattr(trans, key, value)
-            
-        return trans.apply(table)
+        return cls(**kwargs).apply(table)
 
     def apply(self, table):
         """

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -64,6 +64,25 @@ class Transform(param.Parameterized):
                 v = [v]
             new_spec[k] = v
         return transform_type(**new_spec)
+    
+    @classmethod
+    def apply_to(cls, table, **kwargs):
+        """
+        Calls the apply method based on keyword arguments passed to define transform.
+        
+        Parameters
+        ----------
+        table: `pandas.DataFrame`
+        
+        Returns
+        -------
+        A DataFrame with the results of the transformation.
+        """
+        trans = cls()
+        for key, value in kwargs.items():
+            setattr(trans, key, value)
+            
+        return trans.apply(table)
 
     def apply(self, table):
         """


### PR DESCRIPTION
Allows user to use logic imbedded in a `transform` in an ad-hoc context via the following syntax:
```python
df_transformed = MyWackyTransform.apply_to(df, param1='arg_for_param1', param2='arg_for_param2')
```