### PR TITLE
Fix broken link to HoloViz Discourse

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ html_theme_options = {
         },
         {
             "name": "Discourse",
-            "url": "https://https://discourse.holoviz.org/",
+            "url": "https://discourse.holoviz.org/",
             "icon": "fab fa-discourse",
         },
     ]


### PR DESCRIPTION
The current link to the HoloViz Discourse on the Lumen documentation has an extra `https://` in it.