### PR TITLE
Add support for making View data downloadable

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -46,6 +46,9 @@ pn.config.raw_css.append("""
 }
 """)
 
+pn.config.css_files.append(
+    pn.io.resources.CSS_URLS['font-awesome']
+)
 
 def load_yaml(yaml_spec, **kwargs):
     expanded = expand_spec(yaml_spec, config.template_vars, **kwargs)

--- a/lumen/panel.py
+++ b/lumen/panel.py
@@ -9,11 +9,15 @@ class DownloadButton(ReactiveHTML):
 
     callback = param.Callable(precedence=-1)
 
+    color = param.Color(default='grey', allow_None=True)
+
     data = param.String()
 
     filename = param.String()
 
-    size = param.Integer(default=24)
+    hide = param.Boolean(default=False)
+
+    size = param.Integer(default=20)
 
     _template = """
     <style>
@@ -24,11 +28,12 @@ class DownloadButton(ReactiveHTML):
       width: {{ size }}px;
       height: {{ size }}px;
       z-index: 10000;
-      opacity: 0;
+      opacity: {% if hide %}0{% else %}1{% endif %};
       transition-delay: 0.5s;
       transition: 0.5s;
       cursor: pointer;
       font-size: {{ size }}px;
+      {% if color %}color: {{ color }};{% endif %}
     }
 
     .download-button:hover {

--- a/lumen/panel.py
+++ b/lumen/panel.py
@@ -88,7 +88,7 @@ class DownloadButton(ReactiveHTML):
             params['object'] = object
         super().__init__(**params)
 
-    def _on_click(self, event):
+    def _on_click(self, event=None):
         file_input = FileDownload(callback=self.callback, filename=self.filename)
         file_input._transfer()
         self.data = file_input.data

--- a/lumen/panel.py
+++ b/lumen/panel.py
@@ -1,0 +1,89 @@
+import param
+
+from panel import panel
+from panel.reactive import ReactiveHTML
+from panel.widgets import FileDownload
+
+
+class DownloadButton(ReactiveHTML):
+
+    callback = param.Callable(precedence=-1)
+
+    data = param.String()
+
+    filename = param.String()
+
+    size = param.Integer(default=24)
+
+    _template = """
+    <style>
+    .download-button {
+      position: absolute;
+      top: 0px;
+      right: 0px;
+      width: {{ size }}px;
+      height: {{ size }}px;
+      z-index: 10000;
+      opacity: 0;
+      transition-delay: 0.5s;
+      transition: 0.5s;
+      cursor: pointer;
+      font-size: {{ size }}px;
+    }
+
+    .download-button:hover {
+      transition: 0.5s;
+      opacity: 1;
+    }
+
+    .download-button:focus {
+      opacity: 1;
+    }
+    </style>
+    <span id="download-button" onclick="${_on_click}" class="download-button">
+      <i class="fas fa-download"></i>
+    </span>
+    """
+
+    _scripts = {
+        'data': """
+          if (data.data == null || !data.data.length)
+            return
+          const byteString = atob(data.data.split(',')[1]);
+
+          // separate out the mime component
+          const mimeString = data.data.split(',')[0].split(':')[1].split(';')[0];
+
+          // Reset data
+
+          data.data = '';
+
+          // write the bytes of the string to an ArrayBuffer
+          const ab = new ArrayBuffer(byteString.length);
+          const ia = new Uint8Array(ab);
+          for (let i = 0; i < byteString.length; i++) {
+            ia[i] = byteString.charCodeAt(i);
+          }
+
+          // write the ArrayBuffer to a blob, and you're done
+          var bb = new Blob([ab], { type: mimeString });
+
+          var link = document.createElement('a');
+
+          link.href = URL.createObjectURL(bb)
+          link.download = data.filename
+          link.click()
+        """
+    }
+
+    def __init__(self, object=None, **params):
+        params['sizing_mode'] = 'stretch_width'
+        if object is not None:
+            object = panel(object)
+            params['object'] = object
+        super().__init__(**params)
+
+    def _on_click(self, event):
+        file_input = FileDownload(callback=self.callback, filename=self.filename)
+        file_input._transfer()
+        self.data = file_input.data

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import pandas as pd
 
+from lumen.panel import DownloadButton
 from lumen.sources import FileSource
-from lumen.views import View, hvPlotView
+from lumen.views import hvPlotView, View
 
 
 def test_resolve_module_type():
@@ -39,3 +40,24 @@ def test_view_hvplot_basis(set_root):
 
     assert plot.kdims == ['A']
     assert plot.vdims == ['B']
+
+
+def test_view_hvplot_download(set_root):
+    set_root(str(Path(__file__).parent.parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    view = {
+        'type': 'hvplot',
+        'table': 'test',
+        'x': 'A',
+        'y': 'B',
+        'kind': 'scatter',
+        'download': 'csv'
+    }
+
+    view = View.from_spec(view, source, [])
+
+    button = view.panel[0]
+    assert isinstance(button, DownloadButton)
+
+    button._on_click()
+    assert button.data.startswith('data:text/plain;charset=UTF-8;base64')

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -5,7 +5,7 @@ object.
 
 import sys
 
-from io import StringIO
+from io import StringIO, BytesIO
 from weakref import WeakKeyDictionary
 
 import numpy as np

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -65,7 +65,7 @@ class Download(pn.viewable.Viewer):
         return io
 
     def __panel__(self):
-        filename = f'{self.view.table}_view.{self.format}'
+        filename = f'{self.view.table}_{self.view.name}_view.{self.format}'
         return DownloadButton(
             callback=self._table_data, filename=filename
         )
@@ -400,7 +400,6 @@ class View(param.Parameterized):
             else:
                 panel = panel._layout
         if self.download:
-            print(self.download)
             return pn.Column(self.download, panel, sizing_mode='stretch_width')
         return panel
 

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -31,14 +31,23 @@ DOWNLOAD_FORMATS = ['csv', 'xlsx', 'json', 'parquet']
 
 class Download(pn.viewable.Viewer):
 
+    color = param.Color(default='grey', allow_None=True, doc="""
+      The color of the download button.""")
+
+    hide = param.Boolean(default=False, doc="""
+      Whether the download button hides when not in focus.""")
+
     format = param.ObjectSelector(default=None, objects=DOWNLOAD_FORMATS, doc="""
-        The format to download the data in.""")
+      The format to download the data in.""")
 
     kwargs = param.Dict(default={}, doc="""
-        Keyword arguments passed to the serialization function, e.g.
-        data.to_csv(file_obj, **kwargs).""")
+      Keyword arguments passed to the serialization function, e.g.
+      data.to_csv(file_obj, **kwargs).""")
 
-    view = param.Parameter()
+    size = param.Integer(default=18, doc="""
+      The size of the download button.""")
+
+    view = param.Parameter(doc="Holds the current view.")
 
     @classmethod
     def from_spec(cls, spec):
@@ -67,7 +76,8 @@ class Download(pn.viewable.Viewer):
     def __panel__(self):
         filename = f'{self.view.table}_{self.view.name}_view.{self.format}'
         return DownloadButton(
-            callback=self._table_data, filename=filename
+            callback=self._table_data, filename=filename, color=self.color,
+            size=18, hide=self.hide
         )
 
 


### PR DESCRIPTION
Adds a `download` option to Views, e.g. in the simplest case you just specify the download format:

```yaml
views:
      table:
        type: table
        table: penguins
        layout: fit_data_fill
        show_index: false
        theme: midnight
        sizing_mode: stretch_both
        download: csv
```

When enabled the View will have a button which displays when hovering above the view:

![download_button](https://user-images.githubusercontent.com/1550771/151021214-70388765-4247-4a3b-8b58-5a342c56ea40.gif)

- [x] Add tests
- [x] Make size and color configurable
- [ ] Allow multiple download formats (and buttons)?