### PR TITLE
Allow declaring control options

### DIFF
--- a/lumen/tests/transforms/test_base.py
+++ b/lumen/tests/transforms/test_base.py
@@ -1,5 +1,45 @@
+import os
+import pathlib
+
+import param
+
 from lumen.transforms import Transform
+
+
+class CustomTransform(Transform):
+
+    value = param.Selector()
+
+    transform_type = 'test'
 
 
 def test_resolve_module_type():
     assert Transform._get_type('lumen.transforms.base.Transform') is Transform
+
+
+def test_transform_control_options(make_filesource):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+
+    transform = Transform.from_spec({
+        'type': 'test',
+        'controls': [{
+            'name': 'value',
+            'options': ['A', 'B', 'C']
+        }]
+    })
+    assert transform.param.value.objects == ['A', 'B', 'C']
+
+
+def test_transform_control_options_by_reference(make_filesource):
+    root = pathlib.Path(__file__).parent / '..' / 'sources' 
+    source = make_filesource(str(root))
+
+    transform = Transform.from_spec({
+        'type': 'test',
+        'controls': [{
+            'name': 'value',
+            'options': '@original.test.C'
+        }]
+    })
+    assert transform.param.value.objects == ['foo1', 'foo2', 'foo3', 'foo4', 'foo5']

--- a/lumen/tests/transforms/test_base.py
+++ b/lumen/tests/transforms/test_base.py
@@ -19,7 +19,7 @@ def test_resolve_module_type():
 
 def test_transform_control_options(make_filesource):
     root = os.path.dirname(__file__)
-    source = make_filesource(root)
+    make_filesource(root)
 
     transform = Transform.from_spec({
         'type': 'test',
@@ -33,7 +33,7 @@ def test_transform_control_options(make_filesource):
 
 def test_transform_control_options_by_reference(make_filesource):
     root = pathlib.Path(__file__).parent / '..' / 'sources' 
-    source = make_filesource(str(root))
+    make_filesource(str(root))
 
     transform = Transform.from_spec({
         'type': 'test',

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -54,6 +54,7 @@ class Transform(param.Parameterized):
         -------
         The resolved Transform object.
         """
+        from ..sources import Source
         spec = dict(spec)
         transform_type = Transform._get_type(spec.pop('type', None))
         new_spec = {}
@@ -63,7 +64,28 @@ class Transform(param.Parameterized):
                 not isinstance(v, list)):
                 v = [v]
             new_spec[k] = v
-        return transform_type(**new_spec)
+
+        # Allow declaring control options
+        controls, control_kwargs = [], {}
+        for control in new_spec.get('controls'):
+            if isinstance(control, dict):
+                ckws = {}
+                if 'options' in control:
+                    options = control['options']
+                    if isinstance(options, str):
+                        options = Source._resolve_reference(options)
+                    ckws['objects'] = options
+                if 'start' in control or 'end' in control:
+                    ckws['bounds'] = (control.get('start'), control.get('end'))
+                control = control['name']
+                control_kwargs[control] = ckws
+            controls.append(control)
+        new_spec['controls'] = controls
+        transform = transform_type(**new_spec)
+        for p, vs in control_kwargs.items():
+            for a, v in vs.items():
+                setattr(transform.param[p], a, v)
+        return transform
     
     @classmethod
     def apply_to(cls, table, **kwargs):

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -67,7 +67,7 @@ class Transform(param.Parameterized):
 
         # Allow declaring control options
         controls, control_kwargs = [], {}
-        for control in new_spec.get('controls'):
+        for control in new_spec.get('controls', []):
             if isinstance(control, dict):
                 ckws = {}
                 if 'options' in control:


### PR DESCRIPTION
Make it possible to set explicit options for controls or resolve options by reference:

```yaml
transforms:
  - type: custom
    controls:
       - name: some_parameter
         options: ['A', 'B', 'C']
```

We can also use references to resolve categorical column values:

```yaml
transforms:
  - type: custom
    controls:
       - name: some_parameter
         options: @some_source.some_table.some_categorical_field
```
