### PR TITLE
CI: pip build - remove python 2.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c bokeh -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py37 --test-python=py27"
+      PKG_TEST_PYTHON: "--test-python=py37"
       PYTHON_VERSION: "3.7"
       CHANS: "-c pyviz"
       MPLBACKEND: "Agg"


### PR DESCRIPTION
`doit ecosystem=pip package_build` was still running for Python 2.7. I don't really know how that worked under the hood (using the system's python version maybe) but I believe this is anyway totally unnecessary.