### PR TITLE
packaging: pin virtualenv

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -10,5 +10,5 @@ def task_pip_on_conda():
         # some ecosystem=pip build tools must be installed with conda when using conda...
         'conda install -y pip twine wheel rfc3986 keyring',
         # ..and some are only available via conda-forge
-        'conda install -y -c conda-forge tox virtualenv',
+        'conda install -y -c conda-forge tox "virtualenv<=20.4.7"',
     ]}


### PR DESCRIPTION
Second attempt at fixing pip build. I noticed that a lot of recent virtualenv versions were release on conda-forge in the past few days (https://anaconda.org/conda-forge/virtualenv/files?page=2). `pyctdev` actually vendors `tox` and calls it directly in `doit package_build` (https://github.com/pyviz-dev/pyctdev/blob/3e7526669b2893925ca1f40b43ea5e1025deef33/pyctdev/_pip.py#L135), so we don't benefit from recent versions of tox (and its compatibility with the ecosystem, like virtualenv).