### PR TITLE
Ignore quoting on IntakeDremioSource

### DIFF
--- a/lumen/sources/intake_dremio.py
+++ b/lumen/sources/intake_dremio.py
@@ -27,3 +27,13 @@ class IntakeDremioSource(IntakeBaseSQLSource):
             self.uri, cert=self.cert, tls=self.tls, username=self.username,
             password=self.password
         )
+
+    def get_schema(self, table=None):
+        if table is not None:
+            # Fuzzy matching to ignore quoting issues
+            normalized_table = table.replace('"', '').lower()
+            tables = self.get_tables()
+            normalized_tables = [t.replace('"', '').lower() for t in tables]
+            if table not in tables and normalized_table in normalized_tables:
+                table = tables[normalized_tables.index(normalized_table)]
+        super().get_schema(table)


### PR DESCRIPTION
Quotes are a nightmare in Dremio since they are very inconsistently handled. This PR ensures that a source can be queried with any variation of the quoted or unquoted string.