### PR TITLE
Use SQLTransforms to compute SQL Source schemas on database

### DIFF
--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -31,11 +31,11 @@ class IntakeBaseSource(Source):
         for entry in list(self.cat):
             if table is not None and entry != table:
                 continue
-            data = self.get(entry, __dask=True)
-            if self.load_schema:
-                schemas[entry] = get_dataframe_schema(data)['items']['properties']
-            else:
+            elif not self.load_schema:
                 schemas[entry] = {}
+                continue
+            data = self.get(entry, __dask=True)
+            schemas[entry] = get_dataframe_schema(data)['items']['properties']
         return schemas if table is None else schemas[table]
 
     @cached(with_query=False)

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -48,11 +48,11 @@ class IntakeBaseSQLSource(IntakeBaseSource):
 
         schemas = {}
         limit = SQLLimit(limit=1)
-        for table in tables:
+        for entry in tables:
             if not self.load_schema:
                 schemas[entry] = {}
                 continue
-            source = self._get_source(table)
+            source = self._get_source(entry)
             data = self._read(self._apply_transforms(source, [limit]))
             schema = get_dataframe_schema(data)['items']['properties']
             enums, min_maxes = [], []
@@ -72,9 +72,9 @@ class IntakeBaseSQLSource(IntakeBaseSource):
             for col in min_maxes:
                 schema[col]['inclusiveMinimum'] = minmax_data[f'{col}_min'].iloc[0]
                 schema[col]['inclusiveMaximum'] = minmax_data[f'{col}_max'].iloc[0]
-            schemas[table] = schema
+            schemas[entry] = schema
         return schemas if table is None else schemas[table]
-            
+
 
 class IntakeSQLSource(IntakeBaseSQLSource, IntakeSource):
     """

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -61,11 +61,14 @@ class IntakeBaseSQLSource(IntakeBaseSource):
                     enums.append(name)
                 elif 'inclusiveMinimum' in col_schema:
                     min_maxes.append(name)
-            distinct_data = self._read(
-                self._apply_transforms(source, [SQLDistinct(columns=enums)])
-            )
             for col in enums:
-                schema[col]['enum'] = distinct_data[col].to_list()
+                distinct_transforms = [
+                    SQLDistinct(columns=[col]), SQLLimit(limit=1000)
+                ]
+                distinct = self._read(
+                    self._apply_transforms(source, distinct_transforms)
+                )
+                schema[col]['enum'] = distinct[col].to_list()
             minmax_data = self._read(
                 self._apply_transforms(source, [SQLMinMax(columns=min_maxes)])
             )

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -1,3 +1,5 @@
+from ..transforms.sql import SQLDistinct, SQLLimit, SQLMinMax
+from ..util import get_dataframe_schema
 from .base import cached
 from .intake import IntakeBaseSource, IntakeSource
 
@@ -7,6 +9,24 @@ class IntakeBaseSQLSource(IntakeBaseSource):
     # Declare this source supports SQL transforms
     _supports_sql = True
 
+    def _apply_transforms(self, source, sql_transforms):
+        if not sql_transforms:
+            return source
+        sql_expr = source._sql_expr
+        for sql_transform in sql_transforms:
+            sql_expr = sql_transform.apply(sql_expr)
+        return type(source)(**dict(source._init_args, sql_expr=sql_expr))
+
+    def _get_source(self, table):
+        try:
+            source = self.cat[table]
+        except KeyError:
+            raise KeyError(
+                f"'{table}' table could not be found in Intake catalog. "
+                f"Available tables include: {list(self.cat)}."
+            )
+        return source
+
     @cached()
     def get(self, table, **query):
         '''
@@ -15,21 +35,46 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         '''
         dask = query.pop('__dask', self.dask)
         sql_transforms = query.pop('sql_transforms', [])
-
-        try:
-            source = self.cat[table]
-        except KeyError:
-            raise KeyError(
-                f"'{table}' table could not be found in Intake catalog. "
-                f"Available tables include: {list(self.cat)}."
-            )
-        sql_expr = source._sql_expr
-        for sql_transform in sql_transforms:
-            sql_expr = sql_transform.apply(sql_expr)
-        new_source = type(source)(**dict(source._init_args, sql_expr=sql_expr))
-        df = self._read(new_source)
+        source = self._get_source(table)
+        source = self._apply_transforms(source, sql_transforms)
+        df = self._read(source)
         return df if dask or not hasattr(df, 'compute') else df.compute()
 
+    def get_schema(self, table=None):
+        if table is None:
+            tables = self.get_tables()
+        else:
+            tables = [table]
+
+        schemas = {}
+        limit = SQLLimit(limit=1)
+        for table in tables:
+            if not self.load_schema:
+                schemas[entry] = {}
+                continue
+            source = self._get_source(table)
+            data = self._read(self._apply_transforms(source, [limit]))
+            schema = get_dataframe_schema(data)['items']['properties']
+            enums, min_maxes = [], []
+            for name, col_schema in schema.items():
+                if 'enum' in col_schema:
+                    enums.append(name)
+                elif 'inclusiveMinimum' in col_schema:
+                    min_maxes.append(name)
+            distinct_data = self._read(
+                self._apply_transforms(source, [SQLDistinct(columns=enums)])
+            )
+            for col in enums:
+                schema[col]['enum'] = distinct_data[col].to_list()
+            minmax_data = self._read(
+                self._apply_transforms(source, [SQLMinMax(columns=min_maxes)])
+            )
+            for col in min_maxes:
+                schema[col]['inclusiveMinimum'] = minmax_data[f'{col}_min'].iloc[0]
+                schema[col]['inclusiveMaximum'] = minmax_data[f'{col}_max'].iloc[0]
+            schemas[table] = schema
+        return schemas if table is None else schemas[table]
+            
 
 class IntakeSQLSource(IntakeBaseSQLSource, IntakeSource):
     """

--- a/lumen/tests/sources/test_intake_sql.py
+++ b/lumen/tests/sources/test_intake_sql.py
@@ -14,6 +14,24 @@ def test_intake_sql_get():
     df = pd._testing.makeMixedDataFrame()
     pd.testing.assert_frame_equal(source.get('test_sql'), df)
 
+def test_intake_sql_get_schema():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    schema = source.get_schema('test_sql')
+    assert schema == {
+        'A': {'inclusiveMaximum': 4.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
+        'C': {'enum': ['foo1', 'foo2', 'foo3', 'foo4', 'foo5'], 'type': 'string'},
+        'D': {
+            'format': 'datetime',
+            'inclusiveMaximum': '2009-01-07 00:00:00',
+            'inclusiveMinimum': '2009-01-01 00:00:00',
+            'type': 'string'
+        }
+    }
+
 def test_intake_sql_transforms():
     root = os.path.dirname(__file__)
     source = IntakeSQLSource(

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -90,3 +90,41 @@ class SQLLimit(SQLTransform):
         return Template(template, trim_blocks=True, lstrip_blocks=True).render(
             limit=self.limit, sql_in=sql_in
         )
+
+
+class SQLDistinct(SQLTransform):
+
+    columns = param.List(default=[], doc="Columns to return distinct values for.")
+
+    transform_type = 'sql_distinct'
+
+    def apply(self, sql_in):
+        template = """
+            SELECT DISTINCT
+                {{columns}}
+            FROM ( {{sql_in}} )
+        """
+        return Template(template, trim_blocks=True, lstrip_blocks=True).render(
+            columns=', '.join(self.columns), sql_in=sql_in
+        )
+
+
+class SQLMinMax(SQLTransform):
+
+    columns = param.List(default=[], doc="Columns to return distinct values for.")
+
+    transform_type = 'sql_minmax'
+
+    def apply(self, sql_in):
+        aggs = []
+        for col in self.columns:
+            aggs.append(f'MIN({col}) as {col}_min')
+            aggs.append(f'MAX({col}) as {col}_max')
+        template = """
+            SELECT
+                {{columns}}
+            FROM ( {{sql_in}} )
+        """
+        return Template(template, trim_blocks=True, lstrip_blocks=True).render(
+            columns=', '.join(aggs), sql_in=sql_in
+        )


### PR DESCRIPTION
Currently all sources load the data into memory to compute the schema. For many sources this is okay because it can at least leverage dask to lazily load and compute the unique categories or range of a numerical or date value. Unfortunately for most SQL sources this can be extremely inefficient. So for SQL sources we leverage the `SQLTransform`s recently added to Lumen to let the database itself compute the ranges and unique categories for each column.

The approach can be described as follows:

1. Fetch the schema for the SQL query but with `LIMIT 1`
2. Now find all columns with ranges and all columns with enums and compute these values over the whole table using `MIN/MAX` and `DISTINCT` SQL statements respectively