### PR TITLE
Markdown view

### DIFF
--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -2,6 +2,7 @@ from ..transforms.sql import SQLDistinct, SQLLimit, SQLMinMax
 from ..util import get_dataframe_schema
 from .base import cached
 from .intake import IntakeBaseSource, IntakeSource
+import pandas as pd
 
 
 class IntakeBaseSQLSource(IntakeBaseSource):
@@ -15,11 +16,16 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         sql_expr = source._sql_expr
         for sql_transform in sql_transforms:
             sql_expr = sql_transform.apply(sql_expr)
+            
+        print(sql_expr)
         return type(source)(**dict(source._init_args, sql_expr=sql_expr))
 
     def _get_source(self, table):
         try:
-            source = self.cat[table]
+            if table[-4:]=='@sql':
+                source = self.cat[table[:-4]]
+            else:
+                source = self.cat[table]
         except KeyError:
             raise KeyError(
                 f"'{table}' table could not be found in Intake catalog. "
@@ -27,6 +33,10 @@ class IntakeBaseSQLSource(IntakeBaseSource):
             )
         return source
 
+    def _get_sql(self, source):
+        import pdb; pdb.set_trace()
+        return pd.DataFrame({'sql':[source._sql_expr]})
+    
     @cached()
     def get(self, table, **query):
         '''
@@ -37,6 +47,8 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         sql_transforms = query.pop('sql_transforms', [])
         source = self._get_source(table)
         source = self._apply_transforms(source, sql_transforms)
+        if table[-4:] =='@sql':
+            return self._get_sql(source)
         df = self._read(source)
         return df if dask or not hasattr(df, 'compute') else df.compute()
 

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -34,7 +34,6 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         return source
 
     def _get_sql(self, source):
-        import pdb; pdb.set_trace()
         return pd.DataFrame({'sql':[source._sql_expr]})
     
     @cached()

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -1,9 +1,9 @@
+from pandas import DataFrame
+
 from ..transforms.sql import SQLDistinct, SQLLimit, SQLMinMax
 from ..util import get_dataframe_schema
 from .base import cached
 from .intake import IntakeBaseSource, IntakeSource
-import pandas as pd
-
 
 class IntakeBaseSQLSource(IntakeBaseSource):
 
@@ -34,7 +34,7 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         return source
 
     def _get_sql(self, source):
-        return pd.DataFrame({'sql':[source._sql_expr]})
+        return DataFrame({'sql':[source._sql_expr]})
     
     @cached()
     def get(self, table, **query):

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -17,12 +17,12 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         for sql_transform in sql_transforms:
             sql_expr = sql_transform.apply(sql_expr)
             
-        print(sql_expr)
+        
         return type(source)(**dict(source._init_args, sql_expr=sql_expr))
 
     def _get_source(self, table):
         try:
-            if table[-4:]=='@sql':
+            if table.endswith('@sql'):
                 source = self.cat[table[:-4]]
             else:
                 source = self.cat[table]
@@ -46,7 +46,7 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         sql_transforms = query.pop('sql_transforms', [])
         source = self._get_source(table)
         source = self._apply_transforms(source, sql_transforms)
-        if table[-4:] =='@sql':
+        if table.endswith('@sql'):
             return self._get_sql(source)
         df = self._read(source)
         return df if dask or not hasattr(df, 'compute') else df.compute()

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -604,6 +604,39 @@ class hvPlotView(View):
         self._stream.send(self.get_data())
         return False
 
+class Markdown(View):
+    """
+    Renders a scaler using a Panel Markdown Pane.
+    """
+    
+    view_type = 'markdown'
+    
+#     _extension = 'markdown'
+    
+    def get_panel(self):
+        return pn.pane.Markdown(**self._get_params())
+    
+    def _get_params(self):
+        return dict(object=self.get_value(), extensions=['markdown.extensions.fenced_code'])
+    
+class SQLViewer(Markdown):
+    """
+    Shows syntax highlighted sql via markdown.
+    """
+    
+    view_type = 'sql'
+    
+    def get_value(self):
+        val = super().get_value(field='sql')
+        language_tag = '{ sql }'
+        
+        markdown = f'''
+                   ```sql
+                   {val}
+                   ```
+                   '''
+        return markdown
+    
 
 class Table(View):
     """

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -628,13 +628,14 @@ class SQLViewer(Markdown):
     
     def get_value(self):
         val = super().get_value(field='sql')
-        language_tag = '{ sql }'
         
+        #TODO: make syntax highlighting work.
         markdown = f'''
-                   ```sql
+                   ---sql
                    {val}
-                   ```
+                   ---
                    '''
+        
         return markdown
     
 

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -610,9 +610,7 @@ class Markdown(View):
     """
     
     view_type = 'markdown'
-    
-#     _extension = 'markdown'
-    
+        
     def get_panel(self):
         return pn.pane.Markdown(**self._get_params())
     


### PR DESCRIPTION
This PR does three things:

1. allows user to request the SQL for an intake sql table, `my_table` by setting the table field to `my_table@sql`
2. Creates a `Markdown` base view class for scaler values (similar to existing string view)
3. Attempts to create a subclass of `Markdown` specifically for rendering syntax highlighted sql queries (unsure how to get syntax highlighting to work though).