### PR TITLE
rename to sql_in for apply_to

### DIFF
--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -20,11 +20,11 @@ class SQLTransform(Transform):
         
         Parameters
         ----------
-        table: `pandas.DataFrame`
+        sql_in: SQL Select statement to input to transformation.
         
         Returns
         -------
-        A DataFrame with the results of the transformation.
+        SQL statement after application of transformation.
         """
         return cls(**kwargs).apply(sql_in)
 

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -12,6 +12,21 @@ class SQLTransform(Transform):
     """
 
     __abstract = True
+    
+    @classmethod
+    def apply_to(cls, sql_in, **kwargs):
+        """
+        Calls the apply method based on keyword arguments passed to define transform.
+        
+        Parameters
+        ----------
+        table: `pandas.DataFrame`
+        
+        Returns
+        -------
+        A DataFrame with the results of the transformation.
+        """
+        return cls(**kwargs).apply(sql_in)
 
     def __hash__(self):
         """


### PR DESCRIPTION
Allows us to use `sql_in` as a keyword arg instead of `table`