### PR TITLE
Apply Filters in SQL where applicable

### DIFF
--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -1,10 +1,14 @@
-from ..transforms.sql import SQLDistinct, SQLLimit, SQLMinMax
+import param
+
+from ..transforms.sql import SQLDistinct, SQLFilter, SQLLimit, SQLMinMax
 from ..util import get_dataframe_schema
 from .base import cached
 from .intake import IntakeBaseSource, IntakeSource
 
 
 class IntakeBaseSQLSource(IntakeBaseSource):
+
+    filter_in_sql = param.Boolean(default=True, doc="")
 
     # Declare this source supports SQL transforms
     _supports_sql = True
@@ -36,8 +40,12 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         dask = query.pop('__dask', self.dask)
         sql_transforms = query.pop('sql_transforms', [])
         source = self._get_source(table)
+        if self.filter_in_sql:
+            sql_transforms = [SQLFilter(conditions=list(query.items()))] + sql_transforms
         source = self._apply_transforms(source, sql_transforms)
         df = self._read(source)
+        if not self.filter_in_sql:
+            self._filter_dataframe(df, **query)
         return df if dask or not hasattr(df, 'compute') else df.compute()
 
     def get_schema(self, table=None):

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import os
 import hashlib
 
@@ -72,3 +73,75 @@ def test_file_source_get_query_dask_cache(make_filesource):
         source._cache[('test', 'A', (1, 2))].compute(),
         pd._testing.makeMixedDataFrame().iloc[1:3]
     )
+
+def test_file_source_filter_int(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', A=1)
+    expected = df[df.A==1]
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_file_source_filter_str(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', C='foo2')
+    expected = df[df.C=='foo2']
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_file_source_filter_int_range(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', A=(1, 3))
+    expected = df[(df.A>=1) & (df.A<=3)]
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_file_source_filter_date(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', D=dt.date(2009, 1, 2))
+    expected = df.iloc[1:2]
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_file_source_filter_datetime(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', D=dt.datetime(2009, 1, 2))
+    expected = df.iloc[1:2]
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_file_source_filter_datetime_range(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', D=(dt.datetime(2009, 1, 2), dt.datetime(2009, 1, 5)))
+    expected = df.iloc[1:3]
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_file_source_filter_date_range(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', D=(dt.date(2009, 1, 2), dt.date(2009, 1, 5)))
+    expected = df.iloc[1:3]
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_file_source_filter_int_range_list(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', A=[(0, 1), (3, 4)])
+    expected = df[((df.A>=0) & (df.A<=1)) | ((df.A>=3) & (df.A<=4))]
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_file_source_filter_list(make_filesource, cachedir):
+    root = os.path.dirname(__file__)
+    source = make_filesource(root)
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test', C=['foo1', 'foo3'])
+    expected = df[df.C.isin(['foo1', 'foo3'])]
+    pd.testing.assert_frame_equal(filtered, expected)

--- a/lumen/tests/sources/test_intake_sql.py
+++ b/lumen/tests/sources/test_intake_sql.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import os
 
 import pandas as pd
@@ -42,6 +43,96 @@ def test_intake_sql_transforms():
     transformed = source.get('test_sql', sql_transforms=transforms)
     expected = df.groupby('B')['A'].sum().reset_index()
     pd.testing.assert_frame_equal(transformed, expected)
+
+def test_intake_sql_filter_int():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', A=1)
+    expected = df[df.A==1].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_intake_sql_filter_str():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', C='foo2')
+    expected = df[df.C=='foo2'].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_intake_sql_filter_int_range():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', A=(1, 3))
+    expected = df[(df.A>=1) & (df.A<=3)].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_intake_sql_filter_date():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', D=dt.date(2009, 1, 2))
+    expected = df.iloc[1:2].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_intake_sql_filter_datetime():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', D=dt.datetime(2009, 1, 2))
+    expected = df.iloc[1:2].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_intake_sql_filter_datetime_range():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', D=(dt.datetime(2009, 1, 2), dt.datetime(2009, 1, 3)))
+    expected = df.iloc[1:3].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_intake_sql_filter_date_range():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', D=(dt.date(2009, 1, 2), dt.date(2009, 1, 3)))
+    expected = df.iloc[1:3].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_intake_sql_filter_int_range_list():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', A=[(0, 1), (3, 4)])
+    expected = df[((df.A>=0) & (df.A<=1)) | ((df.A>=3) & (df.A<=4))].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
+
+def test_intake_sql_filter_list():
+    root = os.path.dirname(__file__)
+    source = IntakeSQLSource(
+        uri=os.path.join(root, 'catalog.yml'), root=root
+    )
+    df = pd._testing.makeMixedDataFrame()
+    filtered = source.get('test_sql', C=['foo1', 'foo3'])
+    expected = df[df.C.isin(['foo1', 'foo3'])].reset_index(drop=True)
+    pd.testing.assert_frame_equal(filtered, expected)
 
 def test_intake_sql_transforms_cache():
     root = os.path.dirname(__file__)

--- a/lumen/tests/sources/test_intake_sql.py
+++ b/lumen/tests/sources/test_intake_sql.py
@@ -100,7 +100,7 @@ def test_intake_sql_filter_datetime_range():
         uri=os.path.join(root, 'catalog.yml'), root=root
     )
     df = pd._testing.makeMixedDataFrame()
-    filtered = source.get('test_sql', D=(dt.datetime(2009, 1, 2), dt.datetime(2009, 1, 3)))
+    filtered = source.get('test_sql', D=(dt.datetime(2009, 1, 2), dt.datetime(2009, 1, 5)))
     expected = df.iloc[1:3].reset_index(drop=True)
     pd.testing.assert_frame_equal(filtered, expected)
 
@@ -110,7 +110,7 @@ def test_intake_sql_filter_date_range():
         uri=os.path.join(root, 'catalog.yml'), root=root
     )
     df = pd._testing.makeMixedDataFrame()
-    filtered = source.get('test_sql', D=(dt.date(2009, 1, 2), dt.date(2009, 1, 3)))
+    filtered = source.get('test_sql', D=(dt.date(2009, 1, 2), dt.date(2009, 1, 5)))
     expected = df.iloc[1:3].reset_index(drop=True)
     pd.testing.assert_frame_equal(filtered, expected)
 

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -201,6 +201,12 @@ class Filter(Transform):
                 mask = column.isin(val)
             elif isinstance(val, tuple):
                 mask = self._range_filter(column, *val)
+            else:
+                self.param.warning(
+                    'Condition {val!r} on {col!r} column not understood. '
+                    'Filter query will not be applied.'
+                )
+                continue
             if mask is not None:
                 filters.append(mask)
         if filters:

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -153,7 +153,9 @@ class SQLFilter(SQLTransform):
     Translates Lumen Filter query into a SQL WHERE statement.
     """
 
-    conditions = param.List()
+    conditions = param.List(doc="""
+      List of filter conditions expressed as tuples of the column
+      name and the filter value.""")
 
     @classmethod
     def _range_filter(cls, col, v1, v2):

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -173,7 +173,7 @@ class SQLFilter(SQLTransform):
             if np.isscalar(val):
                 condition = f'{col} = {val!r}'
             elif isinstance(val, dt.datetime):
-                 condition = f'{col} = {str(val)!r}'
+                condition = f'{col} = {str(val)!r}'
             elif isinstance(val, dt.date):
                 condition = f"{col} BETWEEN '{str(val)} 00:00:00' AND '{str(val)} 23:59:59'"
             elif (isinstance(val, list) and all(

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -1,3 +1,6 @@
+import datetime as dt
+
+import numpy as np
 import param
 
 from jinja2 import Template
@@ -142,4 +145,65 @@ class SQLMinMax(SQLTransform):
         """
         return Template(template, trim_blocks=True, lstrip_blocks=True).render(
             columns=', '.join(aggs), sql_in=sql_in
+        )
+
+
+class SQLFilter(SQLTransform):
+    """
+    Translates Lumen Filter query into a SQL WHERE statement.
+    """
+
+    conditions = param.List()
+
+    @classmethod
+    def _range_filter(cls, col, v1, v2):
+        start = str(v1) if isinstance(v1, dt.date) else v1
+        end = str(v2) if isinstance(v2, dt.date) else v2
+        if isinstance(v1, dt.date) and not isinstance(v1, dt.datetime):
+            start += ' 00:00:00'
+        if isinstance(v2, dt.date) and not isinstance(v2, dt.datetime):
+            end += ' 00:00:00'
+        return f'{col} BETWEEN {start!r} AND {end!r}'
+
+    def apply(self, sql_in):
+        conditions = []
+        for col, val in self.conditions:
+            if np.isscalar(val):
+                condition = f'{col} = {val!r}'
+            elif isinstance(val, dt.datetime):
+                 condition = f'{col} = {str(val)!r}'
+            elif isinstance(val, dt.date):
+                condition = f"{col} BETWEEN '{str(val)} 00:00:00' AND '{str(val)} 23:59:59'"
+            elif (isinstance(val, list) and all(
+                    isinstance(v, tuple) and len(v) == 2 for v in val
+            )):
+                val = [v for v in val if v is not None]
+                if not val:
+                    continue
+                condition = ' OR '.join([
+                    self._range_filter(col, v1, v2) for v1, v2 in val
+                ])
+            elif isinstance(val, list):
+                if not val:
+                    continue
+                condition = f'{col} IN {tuple(val)!r}'
+            elif isinstance(val, tuple):
+                condition = self._range_filter(col, *val)
+            else:
+                self.param.warning(
+                    'Condition {val!r} on {col!r} column not understood.'
+                )
+                continue
+            conditions.append(condition)
+        if not self.conditions:
+            return sql_in
+        print(conditions)
+        template = """
+            SELECT
+                *
+            FROM ( {{sql_in}} )
+            WHERE ( {{conditions}} )
+        """
+        return Template(template, trim_blocks=True, lstrip_blocks=True).render(
+            conditions=' AND '.join(conditions), sql_in=sql_in
         )

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -193,7 +193,8 @@ class SQLFilter(SQLTransform):
                 condition = self._range_filter(col, *val)
             else:
                 self.param.warning(
-                    'Condition {val!r} on {col!r} column not understood.'
+                    'Condition {val!r} on {col!r} column not understood. '
+                    'Filter query will not be applied.'
                 )
                 continue
             conditions.append(condition)

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -25,7 +25,7 @@ from ..filters import ParamFilter
 from ..panel import DownloadButton
 from ..sources import Source
 from ..state import state
-from ..transforms import Transform
+from ..transforms import Filter, Transform
 from ..util import is_ref
 
 DOWNLOAD_FORMATS = ['csv', 'xlsx', 'json', 'parquet']
@@ -301,7 +301,7 @@ class View(Component):
         for transform in self.transforms:
             data = transform.apply(data)
         if len(data):
-            data = self.source._filter_dataframe(data, **query)
+            data = Filter.apply_to(data, conditions=list(query.items()))
         for filt in self.filters:
             if not isinstance(filt, ParamFilter):
                 continue


### PR DESCRIPTION
So far SQL based sources have always performed full queries and then filtered the data in Python. This means that we have to query all the data all the time which is significantly more expensive than simply querying the subset of the data we actually need.