### PR TITLE
Allow Variables to reference each other

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -224,8 +224,7 @@ class Dashboard(param.Parameterized):
         self.auth = Auth.from_spec(state.spec.get('auth', {}))
         self.config = Config.from_spec(state.spec.get('config', {}))
         self.defaults = Defaults.from_spec(state.spec.get('defaults', {}))
-        vars = Variables.from_spec(state.spec.get('variables', {}))
-        self.variables = state._variables[pn.state.curdoc] = vars
+        self.variables = Variables.from_spec(state.spec.get('variables', {}))
         self.defaults.apply()
 
         # Load and populate template

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -166,10 +166,14 @@ class _session_state:
     def resolve_reference(self, reference, variables=None):
         if not is_ref(reference):
             raise ValueError('References should be prefixed by $ symbol.')
+        from .variables import Variable
         refs = reference[1:].split('.')
         vars = variables or self.variables
         if refs[0] == 'variables':
-            return vars[refs[1]]
+            value = vars[refs[1]]
+            if isinstance(value, Variable):
+                value = value.value
+            return value
         return self._resolve_source_ref(refs)
 
 

--- a/lumen/ui/dashboard.py
+++ b/lumen/ui/dashboard.py
@@ -140,7 +140,7 @@ class DashboardGallery(WizardItem, Gallery):
         return
 
     def _create_new(self, event):
-        self.spec = {'config': {}, 'sources': {}, 'targets': []}
+        self.spec = {'config': {}, 'sources': {}, 'targets': [], 'variables': {}}
 
     def _selected(self, event):
         self.spec = event.obj.spec


### PR DESCRIPTION
Previously the Variables object was instantiated after each Variable which meant that one Variable could not dynamically reference another because the Variables object required to watch different variable values was not yet available to reference.