### PR TITLE
Wait until variable refs are fully updated to rerender target

### DIFF
--- a/lumen/state.py
+++ b/lumen/state.py
@@ -53,7 +53,10 @@ class _session_state:
 
     @property
     def variables(self):
-        return self._variables.get(pn.state.curdoc, {})
+        if pn.state.curdoc in self._variables:
+            return self._variables[pn.state.curdoc]
+        from .variables import Variables
+        return Variables()
 
     @property
     def loading_msg(self):


### PR DESCRIPTION
Previously updating a variable reference on a Transform or View would directly lead to a re-render of the target. However we need to ensure that all variable references are updated before a re-render is triggered, therefore we watch the Variables object instead of the individual views/transforms.