### PR TITLE
Fix setting of Widget variable default

### DIFF
--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -192,11 +192,14 @@ class Widget(Variable):
         else:
             widget_type = getattr(pn.widgets, kind)
         if 'value' not in params:
-            params['default'] = default
+            params['value'] = default
         deserialized = {}
         for k, v in params.items():
             if k in widget_type.param:
-                v = widget_type.param[k].deserialize(v)
+                try:
+                    v = widget_type.param[k].deserialize(v)
+                except Exception:
+                    pass
             deserialized[k] = v
         self._widget = widget_type(**deserialized)
         self._widget.link(self, value='value', bidirectional=True)

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -191,7 +191,7 @@ class Widget(Variable):
             widget_type = resolve_module_reference(kind, _PnWidget)
         else:
             widget_type = getattr(pn.widgets, kind)
-        if 'value' not in params:
+        if 'value' not in params and default is not None:
             params['value'] = default
         deserialized = {}
         for k, v in params.items():


### PR DESCRIPTION
Previously we were setting the non-existent default parameter on the Panel widgets resulting in the default being simply ignored.