### PR TITLE
Add throttled options to Widget Variable and Filter

### DIFF
--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -213,6 +213,11 @@ class WidgetFilter(BaseWidgetFilter):
         e.g. for a numeric value this could be a regular slider or a
         range slider.""")
 
+    throttled = param.Boolean(default=True, doc="""
+       If the widget has a value_throttled parameter use that instead,
+       ensuring that no intermediate events are generated, e.g. when
+       dragging a slider.""")
+
     widget = param.ClassSelector(class_=pn.widgets.Widget)
 
     filter_type = 'widget'
@@ -228,7 +233,10 @@ class WidgetFilter(BaseWidgetFilter):
         self.widget.name = self.label
         self.widget.visible = self.visible
         self.widget.disabled = self.disabled
-        self.widget.link(self, value='value', visible='visible', disabled='disabled', bidirectional=True)
+        links = dict(value='value', visible='visible', disabled='disabled')
+        if self.throttled and 'value_throttled' in self.widget.param:
+            links['value_throttled'] = links.pop('value')
+        self.widget.link(self, bidirectional=True, **links)
         if self.default is not None:
             self.widget.value = self.default
 

--- a/lumen/tests/filters/test_base.py
+++ b/lumen/tests/filters/test_base.py
@@ -1,3 +1,5 @@
+import param
+
 from lumen.filters import Filter
 
 
@@ -5,9 +7,9 @@ def test_resolve_module_type():
     assert Filter._get_type('lumen.filters.base.Filter') is Filter
 
 
-def test_widget_filter_link():
+def test_widget_filter_link_unthrottled():
     wfilter = Filter.from_spec(
-        {'type': 'widget', 'field': 'test'},
+        {'type': 'widget', 'field': 'test', 'throttled': False},
         {'example': {
             'test': {
                 'type': 'integer',
@@ -19,7 +21,7 @@ def test_widget_filter_link():
     widget = wfilter.panel
 
     assert widget.value == (0, 2)
-    
+
     widget.value = (1, 2)
 
     assert wfilter.value == (1, 2)
@@ -35,3 +37,28 @@ def test_widget_filter_link():
     widget.disabled = False
 
     assert widget.disabled == False
+
+
+def test_widget_filter_link_throttled():
+    wfilter = Filter.from_spec(
+        {'type': 'widget', 'field': 'test'},
+        {'example': {
+            'test': {
+                'type': 'integer',
+                'inclusiveMinimum': 0,
+                'inclusiveMaximum': 2
+            }
+        }}
+    )
+    widget = wfilter.panel
+
+    assert widget.value == (0, 2)
+
+    with param.edit_constant(widget):
+        widget.value_throttled = (1, 2)
+
+    assert wfilter.value == (1, 2)
+
+    wfilter.value = (2, 2)
+
+    assert widget.value == (2, 2)

--- a/lumen/tests/test_variables.py
+++ b/lumen/tests/test_variables.py
@@ -1,5 +1,7 @@
 import os
 
+import param
+
 from panel.widgets import IntSlider
 
 from lumen.variables import Variables, Variable
@@ -47,10 +49,21 @@ def test_resolve_widget_variable_by_module_ref():
     assert isinstance(var._widget, IntSlider)
 
 
-def test_widget_variable_linking():
-    var = Variable.from_spec({'type': 'widget', 'kind': 'IntSlider'})
+def test_widget_variable_linking_unthrottled():
+    var = Variable.from_spec({'type': 'widget', 'kind': 'IntSlider', 'throttled': False})
 
     var._widget.value = 3
+    assert var.value == 3
+
+    var.value = 4
+    assert var._widget.value == 4
+
+
+def test_widget_variable_linking_unthrottled():
+    var = Variable.from_spec({'type': 'widget', 'kind': 'IntSlider'})
+
+    with param.edit_constant(var._widget):
+        var._widget.value_throttled = 3
     assert var.value == 3
 
     var.value = 4

--- a/lumen/tests/test_variables.py
+++ b/lumen/tests/test_variables.py
@@ -59,11 +59,12 @@ def test_widget_variable_linking_unthrottled():
     assert var._widget.value == 4
 
 
-def test_widget_variable_linking_unthrottled():
+def test_widget_variable_linking_throttled():
     var = Variable.from_spec({'type': 'widget', 'kind': 'IntSlider'})
 
     with param.edit_constant(var._widget):
         var._widget.value_throttled = 3
+
     assert var.value == 3
 
     var.value = 4

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -208,7 +208,8 @@ class Widget(Variable):
             deserialized[k] = v
         self._widget = widget_type(**deserialized)
         if self.throttled and 'value_throttled' in self._widget.param:
-            self._widget.link(self, value_throttled='value', bidirectional=True)
+            self._widget.link(self, value_throttled='value')
+            self.param.watch(lambda e: self._widget.param.update({'value': e.new}), 'value')
         else:
             self._widget.link(self, value='value', bidirectional=True)
 

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -208,7 +208,7 @@ class Widget(Variable):
             deserialized[k] = v
         self._widget = widget_type(**deserialized)
         if self.throttled and 'value_throttled' in self._widget.param:
-            self._widget.link(self, value='value_throttled', bidirectional=True)
+            self._widget.link(self, value_throttled='value', bidirectional=True)
         else:
             self._widget.link(self, value='value', bidirectional=True)
 

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -188,7 +188,8 @@ class Widget(Variable):
     def __init__(self, **params):
         default = params.pop('default', None)
         refs = params.pop('refs', {})
-        super().__init__(default=default, refs=refs, name=params.get('name'))
+        throttled = params.pop('throttled', True)
+        super().__init__(default=default, refs=refs, name=params.get('name'), throttled=throttled)
         kind = params.pop('kind', None)
         if kind is None:
             raise ValueError("A Widget Variable type must declare the kind of widget.")

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -178,6 +178,11 @@ class Widget(Variable):
     A Widget variable that updates when the widget value changes.
     """
 
+    throttled = param.Boolean(default=True, doc="""
+       If the widget has a value_throttled parameter use that instead,
+       ensuring that no intermediate events are generated, e.g. when
+       dragging a slider.""")
+
     variable_type = 'widget'
 
     def __init__(self, **params):
@@ -202,7 +207,10 @@ class Widget(Variable):
                     pass
             deserialized[k] = v
         self._widget = widget_type(**deserialized)
-        self._widget.link(self, value='value', bidirectional=True)
+        if self.throttled and 'value_throttled' in self._widget.param:
+            self._widget.link(self, value='value_throttled', bidirectional=True)
+        else:
+            self._widget.link(self, value='value', bidirectional=True)
 
     @property
     def panel(self):


### PR DESCRIPTION
In most cases in Lumen you do not want sliders (or other widgets with continuous updates) to trigger updates continuously. Therefore we add a throttled parameter to Widget variables and filters that enables throttled updates by default.