### PR TITLE
Test workflow dispatch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,3 @@
-# things not included
-# language
-# notifications - no email notifications set up
-
 name: tests
 on:
   push:
@@ -26,17 +22,12 @@ jobs:
       run:
         shell: bash -l {0} 
     env:
-      PYTHON_VERSION: ${{ matrix.python-version }}
       CHANS_DEV: "-c pyviz/label/dev -c bokeh -c conda-forge"
-      CHANS: "-c pyviz -c bokeh"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "100"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -44,15 +35,12 @@ jobs:
         run: git fetch --prune --tags
       - name: conda setup
         run: |
-          conda config --set always_yes True
           conda install -c pyviz "pyctdev>=0.5"
-          doit ecosystem_setup
           doit env_create ${{ env.CHANS_DEV}} --python=${{ matrix.python-version }}
       - name: doit develop_install
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          conda list
           doit develop_install ${{ env.CHANS_DEV}} -o tests
       - name: doit env_capture
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
     - '*'
+  workflow_dispatch:
 
 jobs:
   test_suite:


### PR DESCRIPTION
This allows the test workflow to run after a workflow_dispatch event (launching it from another workflow or from Github's UI). I've also done some minor clean up.