### PR TITLE
Add configurable launcher gallery

### DIFF
--- a/lumen/ui/base.py
+++ b/lumen/ui/base.py
@@ -20,7 +20,7 @@ class Wizard(ReactiveHTML):
 
     _template = """
     <div id="wizard-content" style="display: flex; flex-direction: column; justify-content: space-between; height: 100%;">
-    <div id="wizard">${current}</div>
+    <div id="wizard" style="overflow: clip auto; padding-right: 1em;">${current}</div>
     <div id="wizard-footer" style="margin-top: auto;">
       <fast-divider style="margin: 1em 0;"></fast-divider>
       <div style="display: flex; flex-direction: row; justify-content: space-between; align-items: center;">

--- a/lumen/ui/builder.py
+++ b/lumen/ui/builder.py
@@ -15,7 +15,7 @@ from lumen.state import state as lm_state
 from .base import Wizard
 from .config import ConfigEditor
 from .dashboard import DashboardGallery
-from .launcher import Launcher, YAMLLauncher
+from .launcher import LauncherGallery
 from .sources import SourceGallery
 from .state import state
 from .targets import TargetGallery, TargetEditor, TargetGalleryItem
@@ -53,18 +53,17 @@ class Builder(param.Parameterized):
 
     spec = param.Dict(default={})
 
-    launcher = param.ClassSelector(class_=Launcher, default=YAMLLauncher())
-
     template = param.ClassSelector(class_=BasicTemplate)
 
     modal = param.ClassSelector(class_=ListLike)
 
     def __init__(self, **params):
         path = params['component_dir']
-        dash_params, source_params, target_params, var_params, view_params = (
-            {}, {}, {}, {}, {}
+        dash_params, launcher_params, source_params, target_params, var_params, view_params = (
+            {}, {}, {}, {}, {}, {}
         )
         dash_params['path'] = os.path.join(path, 'dashboards')
+        launcher_params['path'] = os.path.join(path, 'launchers')
         source_params['path'] = os.path.join(path, 'sources')
         target_params['path'] = os.path.join(path, 'targets')
         var_params['path'] = os.path.join(path, 'variables')
@@ -82,6 +81,7 @@ class Builder(param.Parameterized):
         state.sources = self.sources = SourceGallery(spec=self.spec['sources'], **source_params)
         state.views = self.views = ViewGallery(**view_params)
         state.targets = self.targets = TargetGallery(spec=self.spec['targets'], **target_params)
+        self.launcher = LauncherGallery(builder=self, **launcher_params)
         self.wizard = Wizard(items=[
             self.welcome, self.config, self.variables, self.sources,
             self.views, self.targets, self.launcher

--- a/lumen/ui/gallery.py
+++ b/lumen/ui/gallery.py
@@ -83,9 +83,13 @@ class Gallery(ReactiveHTML):
                 kwargs['thumbnail'] = thumbnail
             if self._editor_type:
                 kwargs['editor'] = self._editor_type(**dict(spec, **kwargs))
+            kwargs = self._preprocess_kwargs(kwargs)
             items[name] = item = self._gallery_item(**kwargs)
             item.param.watch(self._selected, ['selected'])
         super().__init__(**params)
+
+    def _preprocess_kwargs(self, kwargs):
+        return kwargs
 
     def _selected(self, event):
         """

--- a/lumen/ui/launcher.py
+++ b/lumen/ui/launcher.py
@@ -1,4 +1,3 @@
-from functools import partial
 import io
 import tempfile
 import yaml

--- a/lumen/ui/launcher.py
+++ b/lumen/ui/launcher.py
@@ -96,7 +96,7 @@ class LauncherGallery(WizardItem, Gallery):
         return kwargs
 
     def _advance(self, event):
-        launcher = event.obj.launcher(self.spec)
+        launcher = event.obj.launcher(**self.spec)
         items = self.builder.wizard.items
         if isinstance(items[-1], Launcher):
             items = items[:-1]
@@ -111,7 +111,7 @@ class LocalLauncher(Launcher):
     Launches the dashboard locally.
     """
 
-    icon = param.String(default='fa-house-signal')
+    icon = param.String(default='fa-window-maximize')
 
     _template = """
     <span style="font-size: 1.5em">Launcher</span>
@@ -139,7 +139,7 @@ class YAMLLauncher(Launcher):
 
     editor = param.ClassSelector(class_=pn.pane.JSON)
 
-    icon = param.String(default='fa-file')
+    icon = param.String(default='fa-file-code')
 
     _template = """
     <span style="font-size: 1.5em">Launcher</span>

--- a/lumen/ui/launcher.py
+++ b/lumen/ui/launcher.py
@@ -1,3 +1,4 @@
+from functools import partial
 import io
 import tempfile
 import yaml
@@ -6,8 +7,42 @@ import panel as pn
 import param
 
 from ..dashboard import Dashboard
+from ..util import resolve_module_reference
 from .base import WizardItem
+from .gallery import Gallery, GalleryItem
 from .state import state
+
+
+class LauncherGalleryItem(GalleryItem):
+    """
+    Gallery Item corresponding to a specific Launcher component.
+    """
+
+    icon = param.String()
+
+    launcher = param.Parameter(precedence=-1)
+
+    selected = param.Boolean(default=False)
+
+    _template = """
+    <div id="launcher-item" onclick="${_select}" style="display: flex; flex-direction: column; height: 100%; justify-content: space-between;">
+      <div style="font-size: 1.25em; font-weight: bold;">{{ name }}</div>
+      <div style="text-align: center; font-size: 5em;">
+        <i id="icon" class="fas {{ launcher.icon }}"></i>
+      </div>
+      <p style="height: 4em;">${description}</p>
+    </div>
+    """
+
+    def __init__(self, launcher, **params):
+        params['name'] = launcher.name.replace('Launcher', '')
+        params['description'] = [
+            l for l in launcher.__doc__.split('\n') if l.strip()
+        ][0]
+        super().__init__(launcher=launcher, **params)
+
+    def _select(self, event):
+        self.selected = True
 
 
 class Launcher(WizardItem):
@@ -16,11 +51,68 @@ class Launcher(WizardItem):
     once it has been built.
     """
 
+    __abstract = True
+
+
+class LauncherGallery(WizardItem, Gallery):
+    "Launch or download your dashboard specification."
+
+    auto_advance = param.Boolean(default=True)
+
+    path = param.Foldername()
+
+    spec = param.Dict(default={}, precedence=-1)
+
+    _template = """
+    <span style="font-size: 2em;">{{ __doc__ }}</span>
+    <fast-divider style="margin: 1em 0;"></fast-divider>
+    <div id="items" style="margin: 1em 0; display: flex; flex-wrap: wrap; gap: 1em;">
+    {% for item in items.values() %}
+      <fast-card id="launcher-container" class="gallery-item" style="height: 290px; width: 350px; padding: 1em;">
+        ${item}
+      </fast-card>
+    {% endfor %}
+    </div>
+    """
+
+    _gallery_item = LauncherGalleryItem
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        if not self.items:
+            self.items['local'] = LauncherGalleryItem(launcher=LocalLauncher)
+            self.items['yaml'] = LauncherGalleryItem(launcher=YAMLLauncher)
+        for item in self.items.values():
+            item.param.watch(self._advance, 'selected')
+
+    def _preprocess_kwargs(self, kwargs):
+        spec = kwargs.get('spec', {})
+        launcher_type = spec.pop('type')
+        launchers = param.concrete_descendents(Launcher)
+        if launcher_type in launchers:
+            cls = launchers[launcher_type]
+        else:
+            cls = resolve_module_reference(launcher_type, Launcher)
+        kwargs['launcher'] = cls
+        return kwargs
+
+    def _advance(self, event):
+        launcher = event.obj.launcher(self.spec)
+        items = self.builder.wizard.items
+        if isinstance(items[-1], Launcher):
+            items = items[:-1]
+        items.append(launcher)
+        self.builder.wizard.items = items
+        self.builder.wizard.next_disable = False
+        self.builder.wizard._next()
+
 
 class LocalLauncher(Launcher):
     """
     Launches the dashboard locally.
     """
+
+    icon = param.String(default='fa-house-signal')
 
     _template = """
     <span style="font-size: 1.5em">Launcher</span>
@@ -47,6 +139,8 @@ class YAMLLauncher(Launcher):
     download = param.ClassSelector(class_=pn.widgets.FileDownload)
 
     editor = param.ClassSelector(class_=pn.pane.JSON)
+
+    icon = param.String(default='fa-file')
 
     _template = """
     <span style="font-size: 1.5em">Launcher</span>

--- a/lumen/ui/main.py
+++ b/lumen/ui/main.py
@@ -13,6 +13,7 @@ def main():
     path.mkdir(parents=True, exist_ok=True)
     params = {'component_dir': str(path)}
     (path / 'dashboards').mkdir(parents=True, exist_ok=True)
+    (path / 'launchers').mkdir(parents=True, exist_ok=True)
     (path / 'sources').mkdir(parents=True, exist_ok=True)
     (path / 'targets').mkdir(parents=True, exist_ok=True)
     (path / 'variables').mkdir(parents=True, exist_ok=True)
@@ -20,11 +21,8 @@ def main():
     state.modal = pn.Column(sizing_mode='stretch_both')
     state.spec = {'config': {}, 'sources': {}, 'targets': [], 'variables': {}}
     state.template = FastListTemplate(theme='dark', title='Lumen Builder')
-    if not state.launcher:
-        state.launcher = LocalLauncher
     builder = Builder(
-        template=state.template, spec=state.spec, modal=state.modal,
-        launcher=state.launcher, **params
+        template=state.template, spec=state.spec, modal=state.modal, **params
     )
     builder.servable()
 

--- a/lumen/ui/main.py
+++ b/lumen/ui/main.py
@@ -5,7 +5,6 @@ import panel as pn
 from panel.template import FastListTemplate
 
 from lumen.ui.builder import Builder
-from lumen.ui.launcher import LocalLauncher
 from lumen.ui.state import state
 
 def main():

--- a/lumen/ui/sources.py
+++ b/lumen/ui/sources.py
@@ -546,6 +546,7 @@ class SourcesEditor(WizardItem):
         sources = param.concrete_descendents(Source)
         self.param.source_type.objects = types = [
             source.source_type for source in sources.values()
+            if source.source_type is not None
         ]+['intake', 'intake_dremio']
         if self.source_type is None and types:
             self.source_type = types[0]

--- a/lumen/ui/state.py
+++ b/lumen/ui/state.py
@@ -8,8 +8,6 @@ class session_state(param.Parameterized):
 
     components = param.String(default='./components')
 
-    launcher = param.Parameter()
-
     _modals = WeakKeyDictionary()
 
     _sources = WeakKeyDictionary()


### PR DESCRIPTION
Previously it was only possible to configure a single launcher via the CLI `--launcher` argument. This did not allow a lot of configurability and often you want to offer users multiple options for launching/deploying/exporting. This PR adds a Launcher gallery which can be configured just like any other components by adding yaml specifications to the `./components/launchers/` directory.

<img width="1692" alt="Screen Shot 2022-05-04 at 15 33 40" src="https://user-images.githubusercontent.com/1550771/166692039-19170d08-1454-4bf2-83a0-4b4388aa304a.png">
