### PR TITLE
Provide ability to override Variable label

### DIFF
--- a/lumen/tests/test_variables.py
+++ b/lumen/tests/test_variables.py
@@ -43,6 +43,13 @@ def test_resolve_widget_variable_by_clsname():
     assert isinstance(var._widget, IntSlider)
 
 
+def test_widget_variable_label():
+    var = Variable.from_spec({'type': 'widget', 'kind': 'IntSlider', 'label': 'Custom label'})
+
+    assert isinstance(var._widget, IntSlider)
+    assert var._widget.name == 'Custom label'
+
+
 def test_resolve_widget_variable_by_module_ref():
     var = Variable.from_spec({'type': 'widget', 'kind': 'panel.widgets.IntSlider'})
 

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -86,6 +86,10 @@ class Variable(Component):
     default = param.Parameter(doc="""
        Default value to use if no other value is defined""")
 
+    label = param.String(default=None, doc="""
+       Optional label override for variable. Used wherever the variable
+       shows up in the UI.""")
+
     materialize = param.Boolean(default=False, constant=True, doc="""
        Whether the variable should be inlined as a constant variable
        (in the Lumen Builder).""")
@@ -106,6 +110,8 @@ class Variable(Component):
     def __init__(self, **params):
         if 'value' not in params and 'default' in params:
             params['value'] = params['default']
+        if 'label' not in params and 'name' in params:
+            params['label'] = params['name']
         super().__init__(**params)
         self.param.watch(self._update_value_from_default, 'default')
 
@@ -189,7 +195,10 @@ class Widget(Variable):
         default = params.pop('default', None)
         refs = params.pop('refs', {})
         throttled = params.pop('throttled', True)
-        super().__init__(default=default, refs=refs, name=params.get('name'), throttled=throttled)
+        label = params.pop('label', None)
+        super().__init__(
+            default=default, refs=refs, name=params.get('name'), label=label, throttled=throttled
+        )
         kind = params.pop('kind', None)
         if kind is None:
             raise ValueError("A Widget Variable type must declare the kind of widget.")
@@ -199,6 +208,7 @@ class Widget(Variable):
             widget_type = getattr(pn.widgets, kind)
         if 'value' not in params and default is not None:
             params['value'] = default
+        params['name'] = self.label
         deserialized = {}
         for k, v in params.items():
             if k in widget_type.param:


### PR DESCRIPTION
Lets users provide a custom label for a variable which will be used for variables that surface in the UI.