### PR TITLE
Fix the conda build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,6 @@ jobs:
     env:
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
       PKG_TEST_PYTHON: "--test-python=py37"
-      PYTHON_VERSION: "3.7"
-      CHANS: "-c pyviz"
       MPLBACKEND: "Agg"
       PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
     steps:
@@ -62,7 +60,6 @@ jobs:
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
       PKG_TEST_PYTHON: "--test-python=py37"
       PYTHON_VERSION: "3.7"
-      CHANS: "-c pyviz"
       MPLBACKEND: "Agg"
       PPU: ${{ secrets.PPU }}
       PPP: ${{ secrets.PPP }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.8
+          python-version: 3.9
       - name: Set output
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,6 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py37"
       MPLBACKEND: "Agg"
       PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
     steps:
@@ -43,7 +42,7 @@ jobs:
           conda install -c pyviz/label/dev "pyctdev>=0.5"
           doit ecosystem_setup
       - name: conda build
-        run: doit package_build $CHANS_DEV $PKG_TEST_PYTHON
+        run: doit package_build $CHANS_DEV
       - name: conda dev upload
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: doit package_upload --token=${{ secrets.CONDA_UPLOAD_TOKEN }} --label=dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
           conda install -c pyviz/label/dev "pyctdev>=0.5"
           doit ecosystem_setup
       - name: conda build
-        run: doit package_build $CHANS_DEV
+        run: doit package_build $CHANS_DEV --no-pkg-tests
       - name: conda dev upload
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: doit package_upload --token=${{ secrets.CONDA_UPLOAD_TOKEN }} --label=dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py39"
+      PKG_TEST_PYTHON: "--test-python=py37"
       MPLBACKEND: "Agg"
       PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
     steps:
@@ -58,7 +58,7 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py39"
+      PKG_TEST_PYTHON: "--test-python=py37"
       PYTHON_VERSION: "3.7"
       MPLBACKEND: "Agg"
       PPU: ${{ secrets.PPU }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.8
+          python-version: 3.7
       - name: Set output
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
           conda install -c pyviz/label/dev "pyctdev>=0.5"
           doit ecosystem_setup
       - name: conda build
-        run: doit package_build $CHANS_DEV $PKG_TEST_PYTHON --test-group=all
+        run: doit package_build $CHANS_DEV $PKG_TEST_PYTHON
       - name: conda dev upload
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: doit package_upload --token=${{ secrets.CONDA_UPLOAD_TOKEN }} --label=dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh -c conda-forge"
+      CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
       PKG_TEST_PYTHON: "--test-python=py37"
       PYTHON_VERSION: "3.7"
       CHANS: "-c pyviz"
@@ -59,7 +59,7 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh -c conda-forge"
+      CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
       PKG_TEST_PYTHON: "--test-python=py37"
       PYTHON_VERSION: "3.7"
       CHANS: "-c pyviz"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.9
+          python-version: 3.8
       - name: Set output
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py37"
+      PKG_TEST_PYTHON: "--test-python=py39"
       MPLBACKEND: "Agg"
       PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
     steps:
@@ -58,7 +58,7 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py37"
+      PKG_TEST_PYTHON: "--test-python=py39"
       PYTHON_VERSION: "3.7"
       MPLBACKEND: "Agg"
       PPU: ${{ secrets.PPU }}


### PR DESCRIPTION
For some unknown reason the conda build has started to fail with an 137 error code, i.e. an OOM error. I tried various things but ended up unblocking the build by totally removing the tests that run after the build. Well, to be honest I'm not sure it was running any test, the flags passed to `doit package_build` did declare some required test dependencies but didn't declare which tests to run, so I'm not sure if they were running (pyctdev is doing a lot of magic in this command, maybe it runs them, I'm not sure).

It'd be nice to re-add the tests, even just a simple `import lumen` is better than nothing. Let's keep in mind to try to re-enable them before the next non-dev release.