### PR TITLE
Don't set the widget name if None

### DIFF
--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -209,7 +209,7 @@ class Widget(Variable):
         if 'value' not in params and default is not None:
             params['value'] = default
         params['name'] = self.label
-        deserialized = {}
+            params['name'] = self.label
         for k, v in params.items():
             if k in widget_type.param:
                 try:

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -208,8 +208,9 @@ class Widget(Variable):
             widget_type = getattr(pn.widgets, kind)
         if 'value' not in params and default is not None:
             params['value'] = default
-        params['name'] = self.label
+        if self.label:
             params['name'] = self.label
+        deserialized = {}
         for k, v in params.items():
             if k in widget_type.param:
                 try:


### PR DESCRIPTION
Panel widgets `name` don't accept `None`.