### PR TITLE
Ensure cache key hashes SQLTransform

### DIFF
--- a/lumen/tests/sources/test_intake_sql.py
+++ b/lumen/tests/sources/test_intake_sql.py
@@ -200,6 +200,10 @@ def test_intake_sql_transforms_cache():
     transforms = [SQLGroupBy(by=['B'], aggregates={'SUM': 'A'})]
     source.get('test_sql', sql_transforms=transforms)
     expected = df.groupby('B')['A'].sum().reset_index()
-    cache_key = ('test_sql', 'sql_transforms', tuple(transforms))
+    cache_key = source._get_key('test_sql', sql_transforms=transforms)
     assert cache_key in source._cache
     pd.testing.assert_frame_equal(source._cache[cache_key], expected)
+
+    transforms = [SQLGroupBy(by=['B'], aggregates={'SUM': 'A'})]
+    cache_key = source._get_key('test_sql', sql_transforms=transforms)
+    assert cache_key in source._cache


### PR DESCRIPTION
Bakes hashing into the `Source._get_key` function to separate concerns and to ensure that SQLTransforms are hashed before being used as a key (otherwise identical instances of a SQLTransform will generate different hashes).