### PR TITLE
Implement thread locking for caches

### DIFF
--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -179,7 +179,7 @@ class Pipeline(param.Parameterized):
         params['filters'] = filters = []
         filter_specs = spec.pop('filters', {})
         if filter_specs:
-            schema = source.get_schema(table)
+            params['schema'] = schema = source.get_schema(table)
         for filt_spec in (filter_specs.items() if isinstance(filter_specs, dict) else filter_specs):
             if isinstance(filt_spec, tuple):
                 filt_spec = dict(filt_spec[1], table=table, name=filt_spec[0])

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -147,7 +147,7 @@ class Facet(param.Parameterized):
         self._sort_widget.options = self.param.sort.objects
 
     @classmethod
-    def from_spec(cls, spec, schema, pipelines={}):
+    def from_spec(cls, spec, schema):
         """
         Creates a Facet object from a schema and a set of fields.
         """
@@ -161,7 +161,7 @@ class Facet(param.Parameterized):
                 f = by_spec
             by.append(f)
         sort = spec.pop('sort', [b.field for b in by])
-        sorter = cls(by=by, pipelines=pipelines, **spec)
+        sorter = cls(by=by, **spec)
         sorter.param.sort.objects = sort
         return sorter
 


### PR DESCRIPTION
Since Lumen dashboards take advantage of both threading and caching **by default** it is quite common for multiple threads to attempt cache lookups at the same time. Since other threads may still be processing the querying the same Source multiple times pointlessly. Here we implement thread locking for caches ensuring that once a single thread attempts to perform a cache lookups other threads won't simultaneously run a query.