### PR TITLE
Fixes for config.root when rendering multiple dashboards

### DIFF
--- a/lumen/command.py
+++ b/lumen/command.py
@@ -49,7 +49,6 @@ class YamlHandler(CodeHandler):
         with open(filename) as f:
             yaml_spec = f.read()
         state.spec = spec = load_yaml(yaml_spec)
-        config._root = os.path.abspath(os.path.dirname(filename))
         warm = any(flag in sys.argv for flag in ('--dev', '--autoreload', '--warm'))
         Defaults.from_spec(spec.get('defaults', {})).apply()
         if warm:

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -209,7 +209,7 @@ class Dashboard(param.Parameterized):
     def __init__(self, specification=None, **params):
         self._load_global = params.pop('load_global', True)
         self._yaml_file = specification
-        self._root = os.path.abspath(os.path.dirname(self._yaml_file))
+        self._root = config.root = os.path.abspath(os.path.dirname(self._yaml_file))
         self._edited = False
         super().__init__(**params)
 


### PR DESCRIPTION
Ensures that the config.root is set per session (rather than being shared globally). This fixes various issues when serving multiple dashboards.