### PR TITLE
Added suggestion for mistyped/wrong parameters

### DIFF
--- a/lumen/base.py
+++ b/lumen/base.py
@@ -4,7 +4,8 @@ import param
 
 from .state import state
 from .util import (
-    match_suggestion_message, resolve_module_reference, validate_parameters,
+    SpecificationError, match_suggestion_message, resolve_module_reference,
+    validate_parameters,
 )
 
 
@@ -44,7 +45,7 @@ class Component(param.Parameterized):
         clsname = cls.__name__
         clslower = clsname.lower()
         if component_type is None:
-            raise ValueError(f"No 'type' was provided during instantiation of '{clsname}' component.")
+            raise SpecificationError(f"No 'type' was provided during instantiation of '{clsname}' component.")
         if '.' in component_type:
             return resolve_module_reference(component_type, cls)
         try:
@@ -63,4 +64,4 @@ class Component(param.Parameterized):
 
         msg = f"No '{clslower}' for {clslower}_type '{component_type}' could be found."
         msg = match_suggestion_message(component_type, cls_types, msg)
-        raise ValueError(msg)
+        raise SpecificationError(msg)

--- a/lumen/base.py
+++ b/lumen/base.py
@@ -1,10 +1,11 @@
-from difflib import get_close_matches
 from functools import partial
 
 import param
 
 from .state import state
-from .util import resolve_module_reference, validate_parameters
+from .util import (
+    match_suggestion_message, resolve_module_reference, validate_parameters,
+)
 
 
 class Component(param.Parameterized):
@@ -61,7 +62,5 @@ class Component(param.Parameterized):
                 return component
 
         msg = f"No '{clslower}' for {clslower}_type '{component_type}' could be found."
-        matches = "', '".join(get_close_matches(component_type, cls_types))
-        if matches:
-            msg += f" Did you mean '{matches}'?"
+        msg = match_suggestion_message(component_type, cls_types, msg)
         raise ValueError(msg)

--- a/lumen/base.py
+++ b/lumen/base.py
@@ -63,5 +63,5 @@ class Component(param.Parameterized):
         msg = f"No '{clslower}' for {clslower}_type '{component_type}' could be found."
         matches = "', '".join(get_close_matches(component_type, cls_types))
         if matches:
-            msg += f" Did you mean: '{matches}'?"
+            msg += f" Did you mean '{matches}'?"
         raise ValueError(msg)

--- a/lumen/base.py
+++ b/lumen/base.py
@@ -44,7 +44,7 @@ class Component(param.Parameterized):
         clsname = cls.__name__
         clslower = clsname.lower()
         if component_type is None:
-            raise ValueError(f"'type' for '{clslower}' is not available.")
+            raise ValueError(f"No 'type' was provided during instantiation of '{clsname}' component.")
         if '.' in component_type:
             return resolve_module_reference(component_type, cls)
         try:

--- a/lumen/config.py
+++ b/lumen/config.py
@@ -10,7 +10,25 @@ from panel.template import DarkTheme, DefaultTheme
 from panel.template.base import BasicTemplate
 from panel.widgets.indicators import Indicator
 
+from .util import match_suggestion_message
+
+
+class ConfigDict(dict):
+    def __init__(self, name, **kwargs):
+        self.name = name
+        super().__init__(**kwargs)
+
+    def __getitem__(self, key):
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            msg = f"{self.name} with name '{key}' was not found."
+            msg = match_suggestion_message(key, list(self), msg)
+            raise ValueError(msg) from None
+
+
 _INDICATORS = {k.lower(): v for k, v in param.concrete_descendents(Indicator).items()}
+_INDICATORS = ConfigDict("Indicator", **_INDICATORS)
 
 _LAYOUTS = {
     'accordion': pn.Accordion,
@@ -25,12 +43,16 @@ try:
 except Exception:
     _DEFAULT_LAYOUT = pn.GridBox
 
+_LAYOUTS = ConfigDict("Layout", **_LAYOUTS)
+
+
 _TEMPLATES = {
     k[:-8].lower(): v for k, v in param.concrete_descendents(BasicTemplate).items()
 }
+_TEMPLATES = ConfigDict("Template", **_TEMPLATES)
 
 _THEMES = {'default': DefaultTheme, 'dark': DarkTheme}
-
+_THEMES = ConfigDict("Theme", **_THEMES)
 
 
 class _config(param.Parameterized):

--- a/lumen/config.py
+++ b/lumen/config.py
@@ -10,7 +10,7 @@ from panel.template import DarkTheme, DefaultTheme
 from panel.template.base import BasicTemplate
 from panel.widgets.indicators import Indicator
 
-from .util import match_suggestion_message
+from .util import SpecificationError, match_suggestion_message
 
 
 class ConfigDict(dict):
@@ -24,7 +24,7 @@ class ConfigDict(dict):
         except KeyError:
             msg = f"{self.name} with name '{key}' was not found."
             msg = match_suggestion_message(key, list(self), msg)
-            raise ValueError(msg) from None
+            raise SpecificationError(msg) from None
 
 
 _INDICATORS = {k.lower(): v for k, v in param.concrete_descendents(Indicator).items()}

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -22,7 +22,7 @@ from .sources import RESTSource, Source  # noqa
 from .state import state
 from .target import Target
 from .transforms import Transform  # noqa
-from .util import expand_spec
+from .util import SpecificationError, expand_spec
 from .variables import Variables
 from .views import View  # noqa
 
@@ -89,7 +89,7 @@ class Config(param.Parameterized):
             if template in _TEMPLATES:
                 params['template'] = _TEMPLATES[template]
             elif '.' not in template:
-                raise ValueError(f'Template must be one of {list(_TEMPLATES)} '
+                raise SpecificationError(f'Template must be one of {list(_TEMPLATES)} '
                                  'or an absolute import path.')
             else:
                 *paths, name = template.split('.')

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -86,7 +86,7 @@ class Filter(Component):
                                  f"available filters on the source include {list(source_filters)}.")
             return source_filters[spec]
         spec = dict(spec)
-        filter_type = Filter._get_type(spec.pop('type'))
+        filter_type = Filter._get_type(spec.pop('type', None))
         if not filter_type._requires_field:
             return filter_type(**spec)
         elif not 'field' in spec:

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -11,6 +11,8 @@ import param
 
 from packaging.version import Version
 
+from lumen.util import SpecificationError
+
 from ..base import Component
 from ..schema import JSONSchema
 from ..state import state
@@ -79,10 +81,10 @@ class Filter(Component):
         """
         if isinstance(spec, str):
             if source_filters is None:
-                raise ValueError(f"Filter spec {repr(spec)} could not be resolved "
+                raise SpecificationError(f"Filter spec {repr(spec)} could not be resolved "
                                  "because source has not declared filters.")
             elif spec not in source_filters:
-                raise ValueError(f"Filter spec {repr(spec)} could not be resolved, "
+                raise SpecificationError(f"Filter spec {repr(spec)} could not be resolved, "
                                  f"available filters on the source include {list(source_filters)}.")
             return source_filters[spec]
         spec = dict(spec)
@@ -90,7 +92,7 @@ class Filter(Component):
         if not filter_type._requires_field:
             return filter_type(**spec)
         elif not 'field' in spec:
-            raise ValueError('Filter specification must declare field to filter on.')
+            raise SpecificationError('Filter specification must declare field to filter on.')
         field = spec['field']
         if 'label' not in spec:
             spec['label'] = field.title()
@@ -103,7 +105,7 @@ class Filter(Component):
             if schema is not None:
                 break
         if not schema:
-            raise ValueError("Source did not declare a schema for "
+            raise SpecificationError("Source did not declare a schema for "
                              f"'{field}' filter.")
         return filter_type(schema={field: schema}, **spec)
 

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -151,6 +151,7 @@ class Pipeline(param.Parameterized):
         cls, spec: Dict[str, Any], source: Optional[Source] = None,
         source_filters: Optional[List[Filter]] = None
     ):
+        spec = spec.copy()
         params = dict(spec)
         expected = list(cls.param.params())
         validate_parameters(params, expected, cls.name)

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from difflib import get_close_matches
 from typing import (
     Any, Dict, List, Optional, Type, Union,
 )
@@ -11,7 +12,7 @@ from .filters import Filter, ParamFilter
 from .sources import Source
 from .state import state
 from .transforms import Filter as FilterTransform, SQLTransform, Transform
-from .util import get_dataframe_schema
+from .util import get_dataframe_schema, validate_parameters
 
 
 class DataFrame(param.DataFrame):
@@ -152,6 +153,8 @@ class Pipeline(param.Parameterized):
         source_filters: Optional[List[Filter]] = None
     ):
         params = dict(spec)
+        expected = list(cls.param.params())
+        validate_parameters(params, expected, cls.name)
 
         # Resolve source
         if 'source' in spec:

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from difflib import get_close_matches
 from typing import (
     Any, Dict, List, Optional, Type, Union,
 )

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -11,7 +11,7 @@ from .filters import Filter, ParamFilter
 from .sources import Source
 from .state import state
 from .transforms import Filter as FilterTransform, SQLTransform, Transform
-from .util import get_dataframe_schema, validate_parameters
+from .util import SpecificationError, get_dataframe_schema, validate_parameters
 
 
 class DataFrame(param.DataFrame):
@@ -118,7 +118,7 @@ class Pipeline(param.Parameterized):
             # Compute SQL transform expression
             if self.sql_transforms:
                 if not self.source._supports_sql:
-                    raise ValueError(
+                    raise SpecificationError(
                         'Can only use sql transforms source that support them. '
                         f'Found source typed {self.source.source_type!r} instead.'
                     )
@@ -171,7 +171,7 @@ class Pipeline(param.Parameterized):
         if table is None:
             tables = source.get_tables()
             if len(tables) > 1:
-                raise ValueError(
+                raise SpecificationError(
                     "The Pipeline specification does not contain a table and the "
                     "supplied Source has multiple tables. Please specify one of the "
                     f"following tables: {tables} in the pipeline specification."

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -196,7 +196,7 @@ class Source(Component):
             return source
 
         spec = dict(spec)
-        source_type = Source._get_type(spec.pop('type'))
+        source_type = Source._get_type(spec.pop('type', None))
         resolved_spec, refs = cls._recursive_resolve(spec, source_type)
         return source_type(refs=refs, **resolved_spec)
 

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -361,12 +361,19 @@ class Source(Component):
             JSON schema(s) for one or all the tables.
         """
         schemas = {}
-        for name in self.get_tables():
+        names = list(self.get_tables())
+        for name in names:
             if table is not None and name != table:
                 continue
             df = self.get(name, __dask=True)
             schemas[name] = get_dataframe_schema(df)['items']['properties']
-        return schemas if table is None else schemas[table]
+
+        try:
+            return schemas if table is None else schemas[table]
+        except KeyError:
+            msg = f"{type(self).name} does not contain '{table}'"
+            msg = match_suggestion_message(table, names, msg)
+            raise ValueError(msg) from None
 
     def get(self, table, **query):
         """

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -490,7 +490,7 @@ class FileSource(Source):
         if isinstance(self.tables, list):
             tables = {}
             for f in self.tables:
-                if f.startswith('http'):
+                if isinstance(f, str) and f.startswith('http'):
                     name = f
                 else:
                     name = '.'.join(basename(f).split('.')[:-1])
@@ -502,7 +502,7 @@ class FileSource(Source):
             if isinstance(table, (list, tuple)):
                 table, ext = table
             else:
-                if table.startswith('http'):
+                if isinstance(table, str) and table.startswith('http'):
                     file = basename(urlparse(table).path)
                 else:
                     file = basename(table)

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -23,7 +23,9 @@ from ..base import Component
 from ..filters import Filter
 from ..state import state
 from ..transforms import Filter as FilterTransform, Transform
-from ..util import get_dataframe_schema, is_ref, merge_schemas
+from ..util import (
+    get_dataframe_schema, is_ref, match_suggestion_message, merge_schemas,
+)
 
 
 def cached(with_query=True, locks=weakref.WeakKeyDictionary()):
@@ -194,7 +196,10 @@ class Source(Component):
             elif spec in state.spec.get('sources', {}):
                 source = state.load_source(spec, state.spec['sources'][spec])
             else:
-                raise ValueError(f"Source with name '{spec}' was not found.")
+                msg = f"Source with name '{spec}' was not found."
+                possibilities = list(state.sources) + list(state.spec.get('sources', {}))
+                msg = match_suggestion_message(spec, possibilities, msg)
+                raise ValueError(msg)
             return source
 
         spec = dict(spec)

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -467,7 +467,7 @@ class FileSource(Source):
                     kwargs['orient'] = None
                 return dd.read_json, kwargs
         if ext not in self._pd_load_fns:
-            raise ValueError("File type '{ext}' not recognized and cannot be loaded.")
+            raise ValueError(f"File type '{ext}' not recognized and cannot be loaded.")
         return self._pd_load_fns[ext], kwargs
 
     def _set_cache(self, data, table, **query):
@@ -512,9 +512,8 @@ class FileSource(Source):
 
     def _load_table(self, table, dask=True):
         df = None
-        for name, filepath in self._named_files.items():
-            filepath, ext = filepath
-            if '://' not in filepath:
+        for name, (filepath, ext) in self._named_files.items():
+            if isinstance(filepath, Path) or '://' not in filepath:
                 filepath = os.path.join(self.root, filepath)
             if name != table:
                 continue

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -1,7 +1,7 @@
 import intake
 import param
 
-from ..util import get_dataframe_schema
+from ..util import SpecificationError, get_dataframe_schema
 from .base import Source, cached, cached_schema
 
 
@@ -69,8 +69,10 @@ class IntakeSource(IntakeBaseSource):
     def __init__(self, **params):
         super().__init__(**params)
         if self.uri and self.catalog:
-            raise ValueError("Either specify a Catalog uri or an "
-                             "inlined catalog, not both.")
+            raise SpecificationError(
+                "Either specify a Catalog uri or an "
+                "inlined catalog, not both."
+            )
         elif self.uri:
             self.cat = intake.open_catalog(self.uri)
         elif self.catalog:

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -4,7 +4,7 @@ from ..transforms.base import Filter
 from ..transforms.sql import (
     SQLDistinct, SQLFilter, SQLLimit, SQLMinMax,
 )
-from ..util import get_dataframe_schema
+from ..util import SpecificationError, get_dataframe_schema
 from .base import cached, cached_schema
 from .intake import IntakeBaseSource, IntakeSource
 
@@ -28,10 +28,10 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         try:
             source = self.cat[table]
         except KeyError:
-            raise KeyError(
+            raise SpecificationError(
                 f"'{table}' table could not be found in Intake catalog. "
                 f"Available tables include: {list(self.cat)}."
-            )
+            ) from None
         return source
 
     @cached()

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -170,7 +170,7 @@ class _session_state:
             if isinstance(views, dict):
                 views = list(views.values())
             for view in views:
-                view_type = View._get_type(view.get('type'))
+                view_type = View._get_type(view.get('type', None))
                 if view_type and view_type._extension:
                     exts.append(view_type._extension)
         for ext in exts:

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -2,7 +2,7 @@ from weakref import WeakKeyDictionary
 
 import panel as pn
 
-from .util import extract_refs, is_ref
+from .util import SpecificationError, extract_refs, is_ref
 
 
 class _session_state:
@@ -192,11 +192,11 @@ class _session_state:
             return source.get(table)
         table_schema = source.get_schema(table)
         if field not in table_schema:
-            raise ValueError(f"Field '{field}' was not found in "
+            raise SpecificationError(f"Field '{field}' was not found in "
                              f"'{sourceref}' table '{table}'.")
         field_schema = table_schema[field]
         if 'enum' not in field_schema:
-            raise ValueError(f"Field '{field}' schema does not "
+            raise SpecificationError(f"Field '{field}' schema does not "
                              "declare an enum.")
         return field_schema['enum']
 

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -520,9 +520,9 @@ class Target(param.Parameterized):
         """
         # Resolve source
         spec = dict(spec)
-        views = spec.get('views', [])
-        if views is None:
+        if 'views' not in spec:
             raise ValueError(f"Ensure that the target '{spec['title']}' declares a 'views' field.")
+        views = spec['views']
 
         pipelines = {}
         source_filters = None

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -322,7 +322,8 @@ class Target(param.Parameterized):
         super().__init__(**{k: v for k, v in params.items() if k in self.param})
 
         # Render content
-        self._construct_cards()
+        if self.views:
+            self._construct_cards()
         self._cards = self.get_cards()
 
         # Set up watchers
@@ -340,8 +341,6 @@ class Target(param.Parameterized):
         controls, all_transforms = [], []
         linked_views = None
         for facet_filters in self.facet.filters:
-            if self.views is None:
-                raise ValueError(f"Ensure that the target '{self.title}' declares a 'views' field.")
             key = tuple(str(f.value) for f in facet_filters)
             self._cache[key] = card = Card.from_spec({
                 'kwargs': self.kwargs,
@@ -522,6 +521,9 @@ class Target(param.Parameterized):
         # Resolve source
         spec = dict(spec)
         views = spec.get('views', [])
+        if views is None:
+            raise ValueError(f"Ensure that the target '{spec['title']}' declares a 'views' field.")
+
         pipelines = {}
         source_filters = None
         filter_specs = spec.pop('filters', [])

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -84,6 +84,10 @@ class Card(Viewer):
     def from_spec(cls, spec, filters=None, pipelines={}):
         spec = dict(spec)
         view_specs = spec.get('views', [])
+        if view_specs is None:
+            # If views is not defined in yaml file
+            raise ValueError("No 'views' was provided during instantiation.")
+
         spec['views'] = views = []
         for view in view_specs:
             if isinstance(view_specs, dict):

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -84,10 +84,6 @@ class Card(Viewer):
     def from_spec(cls, spec, filters=None, pipelines={}):
         spec = dict(spec)
         view_specs = spec.get('views', [])
-        if view_specs is None:
-            # If views is not defined in yaml file
-            raise ValueError("No 'views' was provided during instantiation.")
-
         spec['views'] = views = []
         for view in view_specs:
             if isinstance(view_specs, dict):
@@ -344,6 +340,8 @@ class Target(param.Parameterized):
         controls, all_transforms = [], []
         linked_views = None
         for facet_filters in self.facet.filters:
+            if self.views is None:
+                raise ValueError(f"Ensure that the target '{self.title}' declares a 'views' field.")
             key = tuple(str(f.value) for f in facet_filters)
             self._cache[key] = card = Card.from_spec({
                 'kwargs': self.kwargs,

--- a/lumen/tests/conftest.py
+++ b/lumen/tests/conftest.py
@@ -101,3 +101,19 @@ def cachedir():
     tmp_dir = tempfile.TemporaryDirectory()
     yield tmp_dir.name
     tmp_dir.cleanup()
+
+@pytest.fixture
+def penguins_file(tmp_path):
+    # created with
+    # df = pd.read_csv(url).sample(5).reset_index(drop=True).to_csv()
+    fn = tmp_path / "penguins.csv"
+    penguins = """
+    ,species,island,bill_length_mm,bill_depth_mm,flipper_length_mm,body_mass_g,sex,year
+    0,Gentoo,Biscoe,46.7,15.3,219.0,5200.0,male,2007
+    1,Adelie,Dream,42.2,18.5,180.0,3550.0,female,2007
+    2,Gentoo,Biscoe,51.1,16.3,220.0,6000.0,male,2008
+    3,Adelie,Biscoe,45.6,20.3,191.0,4600.0,male,2009
+    4,Adelie,Torgersen,37.8,17.1,186.0,3300.0,,2007
+    """
+    fn.write_text(penguins)
+    return fn

--- a/lumen/tests/test_target.py
+++ b/lumen/tests/test_target.py
@@ -12,6 +12,7 @@ from lumen.sources import DerivedSource, FileSource
 from lumen.state import state
 from lumen.target import Target
 from lumen.transforms import Astype
+from lumen.util import SpecificationError
 
 
 def test_view_controls(set_root):
@@ -189,10 +190,10 @@ def test_transform_controls_facetted(set_root):
     "layout,error",
     [
         ([[0]], None),
-        ([[0], [1]], ValueError),
-        ([[0], [1, 2]], ValueError),
+        ([[0], [1]], SpecificationError),
+        ([[0], [1, 2]], SpecificationError),
         ([{"test": 0}], None),
-        ([{"test1": 0}], KeyError),
+        ([{"test1": 0}], SpecificationError),
     ]
 )
 def test_layout_view(set_root, layout, error):

--- a/lumen/tests/test_util.py
+++ b/lumen/tests/test_util.py
@@ -1,0 +1,58 @@
+import pytest
+
+from lumen.pipeline import Pipeline
+
+
+def append_s_to_string(spec):
+    """
+    This function recursive add an extra "s" to each string in a nested dict/list
+    """
+    final = []
+    items = []
+
+    if isinstance(spec, list):
+        items = enumerate(spec)
+
+    if isinstance(spec, dict):
+        for k in spec:
+            s = spec.copy()
+            if isinstance(k, str):
+                s[k + "s"] = s[k]
+                del s[k]
+            final.append(s)
+
+        items = spec.items()
+
+    for k, v in items:
+        s = spec.copy()
+        if isinstance(v, str):
+            s[k] = v + "s"
+            final.append(s)
+        elif isinstance(v, (dict, list)):
+            red = append_s_to_string(v)
+            for r in red:
+                s2 = spec.copy()
+                s2[k] = r
+                final.append(s2)
+
+    return final
+
+
+def test_match_suggestion_message(penguins_file):
+    spec = {
+        "source": {"type": "file", "tables": {"penguins": penguins_file}},
+        "filters": [
+            {"type": "widget", "field": "species"},
+        ],
+        "transforms": [{"type": "aggregate", "method": "mean", "by": ["species"]}],
+    }
+
+    expected_error_msg = "(.+? Did you mean .+?|'type' for '.+?' is not available|Filter specification must declare field to filter on)"
+    ignore_words = ["penguinss", "penguins.csvs", "speciess", "means"]
+
+    for s in append_s_to_string(spec):
+        ss = str(s)
+        if any(iw in ss for iw in ignore_words):
+            continue
+        with pytest.raises(ValueError, match=expected_error_msg):
+            Pipeline.from_spec(s)

--- a/lumen/tests/test_util.py
+++ b/lumen/tests/test_util.py
@@ -47,7 +47,7 @@ def test_match_suggestion_message(penguins_file):
         "transforms": [{"type": "aggregate", "method": "mean", "by": ["species"]}],
     }
 
-    expected_error_msg = "(.+? Did you mean .+?|'type' for '.+?' is not available|Filter specification must declare field to filter on)"
+    expected_error_msg = r"(.+? Did you mean .+?|No 'type' was provided|Filter specification must declare field to filter on)"
     ignore_words = ["penguinss", "penguins.csvs", "speciess", "means"]
 
     for s in append_s_to_string(spec):

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 import importlib
 import os
@@ -234,15 +236,24 @@ def extract_refs(spec, ref_type=None):
     filtered = [ref for ref in refs if ref[1:].startswith(ref_type)]
     return filtered
 
-def validate_parameters(params, expected, name):
+def validate_parameters(params: list[str], expected: list[str], name: str):
     for p in params:
         if p not in expected:
-            msg = f"'{p}' not a parameter for '{name}'"
-            match = get_close_matches(p, expected)
-            if match:
-                if len(match) > 1:
-                    match_str = "', '".join(match[:-1]) + f" or '{match[-1]}"
-                else:
-                    match_str = match[0]
-                msg = msg + f". Did you mean '{match_str}'?"
+            first_parth_msg = f"'{p}' not a parameter for '{name}'"
+            msg = match_suggestion_message(p, expected, first_parth_msg)
             raise ValueError(msg)
+
+def match_suggestion_message(word: str, possibilities: list[str], msg: str|None = None):
+    match = get_close_matches(word, possibilities)
+    if match:
+        if len(match) > 1:
+            match = sorted(match)
+            match_str = "', '".join(match[:-1]) + f" or '{match[-1]}"
+        else:
+            match_str = match[0]
+        if msg:
+            msg = msg[-1] if msg.endswith(".") else msg
+            msg = msg + f". Did you mean '{match_str}'?"
+        else:
+            msg = "Did you mean '{match_str}'?"
+    return msg

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -14,6 +14,10 @@ from pandas.core.dtypes.dtypes import CategoricalDtype
 from panel import state
 
 
+class SpecificationError(ValueError):
+    pass
+
+
 def get_dataframe_schema(df, columns=None):
     """
     Returns a JSON schema optionally filtered by a subset of the columns.

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+from difflib import get_close_matches
 
 from jinja2 import DebugUndefined, Environment, Undefined
 from pandas.core.dtypes.dtypes import CategoricalDtype
@@ -231,3 +232,16 @@ def extract_refs(spec, ref_type=None):
         return refs
     filtered = [ref for ref in refs if ref[1:].startswith(ref_type)]
     return filtered
+
+def validate_parameters(params, expected, name):
+    for p in params:
+        if p not in expected:
+            msg = f"'{p}' not a parameter for '{name}'"
+            match = get_close_matches(p, expected)
+            if match:
+                if len(match) > 1:
+                    match_str = "', '".join(match[:-1]) + f" or '{match[-1]}"
+                else:
+                    match_str = match[0]
+                msg = msg + f". Did you mean '{match_str}'?"
+            raise ValueError(msg)

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+
 from difflib import get_close_matches
 
 from jinja2 import DebugUndefined, Environment, Undefined

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -259,5 +259,5 @@ def match_suggestion_message(word: str, possibilities: list[str], msg: str|None 
             msg = msg[:-1] if msg.endswith(".") else msg
             msg = msg + f". Did you mean '{match_str}'?"
         else:
-            msg = "Did you mean '{match_str}'?"
+            msg = f"Did you mean '{match_str}'?"
     return msg

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -236,14 +236,14 @@ def extract_refs(spec, ref_type=None):
     filtered = [ref for ref in refs if ref[1:].startswith(ref_type)]
     return filtered
 
-def validate_parameters(params: list[str], expected: list[str], name: str):
+def validate_parameters(params: list[str], expected: list[str], name: str) -> None:
     for p in params:
         if p not in expected:
             first_parth_msg = f"'{p}' not a parameter for '{name}'"
             msg = match_suggestion_message(p, expected, first_parth_msg)
             raise ValueError(msg)
 
-def match_suggestion_message(word: str, possibilities: list[str], msg: str|None = None):
+def match_suggestion_message(word: str, possibilities: list[str], msg: str|None = None) -> str:
     match = get_close_matches(word, possibilities)
     if match:
         if len(match) > 1:
@@ -252,7 +252,7 @@ def match_suggestion_message(word: str, possibilities: list[str], msg: str|None 
         else:
             match_str = match[0]
         if msg:
-            msg = msg[-1] if msg.endswith(".") else msg
+            msg = msg[:-1] if msg.endswith(".") else msg
             msg = msg + f". Did you mean '{match_str}'?"
         else:
             msg = "Did you mean '{match_str}'?"

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -9,7 +9,7 @@ from panel.widgets import Widget as _PnWidget
 
 from ..base import Component
 from ..state import state
-from ..util import is_ref, resolve_module_reference
+from ..util import SpecificationError, is_ref, resolve_module_reference
 
 _PARAM_MAP = {
     dict : param.Dict,
@@ -203,7 +203,7 @@ class Widget(Variable):
         )
         kind = params.pop('kind', None)
         if kind is None:
-            raise ValueError("A Widget Variable type must declare the kind of widget.")
+            raise SpecificationError("A Widget Variable type must declare the kind of widget.")
         if '.' in kind:
             widget_type = resolve_module_reference(kind, _PnWidget)
         else:

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -26,7 +26,7 @@ from ..panel import DownloadButton
 from ..pipeline import Pipeline
 from ..state import state
 from ..transforms import Transform
-from ..util import is_ref, resolve_module_reference
+from ..util import SpecificationError, is_ref, resolve_module_reference
 
 DOWNLOAD_FORMATS = ['csv', 'xlsx', 'json', 'parquet']
 
@@ -141,7 +141,7 @@ class View(Component, Viewer):
         params = {k: v for k, v in params.items() if k in self.param}
         pipeline = params.pop('pipeline', None)
         if pipeline is None:
-            raise ValueError("Views must declare a Pipeline.")
+            raise SpecificationError("Views must declare a Pipeline.")
         fields = list(pipeline.schema)
         for fp in self._field_params:
             if isinstance(self.param[fp], param.Selector):
@@ -204,7 +204,7 @@ class View(Component, Viewer):
         # Resolve pipeline
         if 'pipeline' in spec:
             if pipeline is not None:
-                raise ValueError(
+                raise SpecificationError(
                     "Either specify the pipeline as part of the specification "
                     "or pass it in explicitly, not both."
                 )

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -579,6 +579,8 @@ class hvPlotView(hvPlotBaseView):
 
     _field_params = ['x', 'y', 'by', 'groupby']
 
+    _ignore_kwargs = ['tables']
+
     _supports_selections = True
 
     def __init__(self, **params):
@@ -589,6 +591,8 @@ class hvPlotView(hvPlotBaseView):
     def get_plot(self, df):
         processed = {}
         for k, v in self.kwargs.items():
+            if k in self._ignore_kwargs:
+                continue
             if k.endswith('formatter') and isinstance(v, str) and '%' not in v:
                 v = NumeralTickFormatter(format=v)
             processed[k] = v


### PR DESCRIPTION
It can be hard to know if something is `transform` or `transforms`. I have tried to take account of this by using `difflib` to come up with suggestions if parameters are mistyped/wrong. 

I have chosen to raise an error when an input parameter does not match the class parameters. My reasoning for this is that the error usually will arrive later, making it harder to debug.  

I have used the following example to see if I can provoke an error by adding or removing an `s`. 

``` python
from lumen.pipeline import Pipeline

data_url = 'https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-07-28/penguins.csv'

pipeline = Pipeline.from_spec({
    'source': {
        'type': 'file',
        'table': {
            'penguins': data_url
        }
    },
    'filters': [
        {'type': 'widget', 'field': 'species'},
        {'type': 'widget', 'field': 'island'},
        {'type': 'widget', 'field': 'sex'},
        {'type': 'widget', 'field': 'year'}
    ],
    'transforms': [
        {'type': 'aggregate', 'method': 'mean', 'by': ['species', 'sex', 'year']}
    ]
})
```

The example will raise an error (try to find out what raises it).

<details>

  <summary>Error message </summary>


Before:

![image](https://user-images.githubusercontent.com/19758978/185180502-6c204e0c-6784-49b6-9774-ae92a02df48e.png)

After:

![image](https://user-images.githubusercontent.com/19758978/185179786-1afe8b3f-46be-4b48-b823-3524957ac6f5.png)


</details>