### PR TITLE
Refator Source tests

### DIFF
--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -94,27 +94,34 @@ def test_file_source_filter(source, column_value_type, dask, expected_df):
     pd.testing.assert_frame_equal(filtered, expected_df)
 
 
-def test_file_source_get_query_cache(source):
-    source.get('test', A=(1, 2))
-    cache_key = source._get_key('test', A=(1, 2))
+@pytest.mark.parametrize(
+    "column_value_type", [
+        ('A', 1, 'single_value'),
+        ('A', (1, 3), 'range'),
+        ('A', (1, 2), 'range'),
+        ('A', [(0, 1), (3, 4)], 'range_list'),
+        ('C', 'foo2', 'single_value'),
+        ('C', ['foo1', 'foo3'], 'list'),
+        ('D', dt.datetime(2009, 1, 2), 'single_value'),
+        ('D', (dt.datetime(2009, 1, 2), dt.datetime(2009, 1, 5)), 'range'),
+        ('D', [dt.datetime(2009, 1, 2), dt.datetime(2009, 1, 5)], 'list'),
+        ('D', dt.datetime(2009, 1, 2), 'date'),
+        ('D', (dt.date(2009, 1, 2), dt.date(2009, 1, 5)), 'date_range'),
+    ]
+)
+@pytest.mark.parametrize("dask", [True, False])
+def test_file_source_get_query_cache(source, column_value_type, dask, expected_df):
+    column, value, _ = column_value_type
+    kwargs = {column: value}
+    source.get('test', __dask=dask, **kwargs)
+    cache_key = source._get_key('test', **kwargs)
     assert cache_key in source._cache
-    pd.testing.assert_frame_equal(
-        source._cache[cache_key],
-        pd._testing.makeMixedDataFrame().iloc[1:3]
-    )
-    cache_key = source._get_key('test', A=(1, 2))
+    cached_df = source._cache[cache_key]
+    if dask:
+        cached_df = cached_df.compute()
+    pd.testing.assert_frame_equal(cached_df, expected_df)
+    cache_key = source._get_key('test', **kwargs)
     assert cache_key in source._cache
-
-
-
-def test_file_source_get_query_dask_cache(source):
-    source.get('test', A=(1, 2), __dask=True)
-    cache_key = source._get_key('test', A=(1, 2))
-    assert cache_key in source._cache
-    pd.testing.assert_frame_equal(
-        source._cache[cache_key].compute(),
-        pd._testing.makeMixedDataFrame().iloc[1:3]
-    )
 
 
 def test_file_source_get_query_cache_to_file(make_filesource, cachedir):

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -1,3 +1,5 @@
+import pytest
+
 import datetime as dt
 import os
 
@@ -10,39 +12,39 @@ from lumen.state import state
 from lumen.transforms.sql import SQLLimit
 
 
+@pytest.fixture
+def source(make_filesource):
+    root = os.path.dirname(__file__)
+    return make_filesource(root)
+
+
 def test_source_resolve_module_type():
     assert Source._get_type('lumen.sources.base.Source') is Source
 
-def test_source_table_cache_key(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_source_table_cache_key(source):
     assert source._get_key('test') == source._get_key('test')
 
-def test_source_table_and_int_query_cache_key(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_source_table_and_int_query_cache_key(source):
     assert source._get_key('test', A=314) == source._get_key('test', A=314)
 
-def test_source_table_and_range_query_cache_key(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_source_table_and_range_query_cache_key(source):
     assert source._get_key('test', A=(13, 314)) == source._get_key('test', A=(13, 314))
 
-def test_source_table_and_list_query_cache_key(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_source_table_and_list_query_cache_key(source):
     assert source._get_key('test', A=['A', 314, 'def']) == source._get_key('test', A=['A', 314, 'def'])
 
-def test_source_table_and_sql_transform_cache_key(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_source_table_and_sql_transform_cache_key(source):
     t1 = SQLLimit(limit=100)
     t2 = SQLLimit(limit=100)
     assert source._get_key('test', sql_transforms=[t1]) == source._get_key('test', sql_transforms=[t2])
 
-def test_source_table_and_multi_query_sql_transform_cache_key(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_source_table_and_multi_query_sql_transform_cache_key(source):
     t1 = SQLLimit(limit=100)
     t2 = SQLLimit(limit=100)
     assert (
@@ -50,12 +52,12 @@ def test_source_table_and_multi_query_sql_transform_cache_key(make_filesource):
         source._get_key('test', A=1, B=(3, 15.9), C=[1, 'A', 'def'], sql_transforms=[t2])
     )
 
-def test_file_source_get_query(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_get_query(source):
     df = source.get('test', A=(1, 2))
     expected = pd._testing.makeMixedDataFrame().iloc[1:3]
     pd.testing.assert_frame_equal(df, expected)
+
 
 def test_file_source_variable(make_variable_filesource):
     root = os.path.dirname(__file__)
@@ -68,9 +70,8 @@ def test_file_source_variable(make_variable_filesource):
     expected = pd._testing.makeMixedDataFrame().iloc[::-1].reset_index(drop=True)
     pd.testing.assert_frame_equal(df, expected)
 
-def test_file_source_get_query_cache(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_get_query_cache(source):
     source.get('test', A=(1, 2))
     cache_key = source._get_key('test', A=(1, 2))
     assert cache_key in source._cache
@@ -80,6 +81,7 @@ def test_file_source_get_query_cache(make_filesource):
     )
     cache_key = source._get_key('test', A=(1, 2))
     assert cache_key in source._cache
+
 
 def test_file_source_get_query_cache_to_file(make_filesource, cachedir):
     root = os.path.dirname(__file__)
@@ -97,16 +99,14 @@ def test_file_source_get_query_cache_to_file(make_filesource, cachedir):
         pd._testing.makeMixedDataFrame().iloc[1:3]
     )
 
-def test_file_source_get_query_dask(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_get_query_dask(source):
     df = source.get('test', A=(1, 2), __dask=True)
     expected = pd._testing.makeMixedDataFrame().iloc[1:3]
     pd.testing.assert_frame_equal(df, expected)
 
-def test_file_source_get_query_dask_cache(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_get_query_dask_cache(source):
     source.get('test', A=(1, 2), __dask=True)
     cache_key = source._get_key('test', A=(1, 2))
     assert cache_key in source._cache
@@ -115,73 +115,64 @@ def test_file_source_get_query_dask_cache(make_filesource):
         pd._testing.makeMixedDataFrame().iloc[1:3]
     )
 
-def test_file_source_filter_int(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_int(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', A=1)
     expected = df[df.A==1]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_str(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_str(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', C='foo2')
     expected = df[df.C=='foo2']
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_int_range(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_int_range(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', A=(1, 3))
     expected = df[(df.A>=1) & (df.A<=3)]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_date(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_date(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', D=dt.date(2009, 1, 2))
     expected = df.iloc[1:2]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_datetime(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_datetime(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', D=dt.datetime(2009, 1, 2))
     expected = df.iloc[1:2]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_datetime_range(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_datetime_range(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', D=(dt.datetime(2009, 1, 2), dt.datetime(2009, 1, 5)))
     expected = df.iloc[1:3]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_date_range(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_date_range(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', D=(dt.date(2009, 1, 2), dt.date(2009, 1, 5)))
     expected = df.iloc[1:3]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_int_range_list(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_int_range_list(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', A=[(0, 1), (3, 4)])
     expected = df[((df.A>=0) & (df.A<=1)) | ((df.A>=3) & (df.A<=4))]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_list(make_filesource):
-    root = os.path.dirname(__file__)
-    source = make_filesource(root)
+
+def test_file_source_filter_list(source):
     df = pd._testing.makeMixedDataFrame()
     filtered = source.get('test', C=['foo1', 'foo3'])
     expected = df[df.C.isin(['foo1', 'foo3'])]

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -10,7 +10,7 @@ from lumen.state import state
 from lumen.transforms.sql import SQLLimit
 
 
-def test_resolve_module_type():
+def test_source_resolve_module_type():
     assert Source._get_type('lumen.sources.base.Source') is Source
 
 def test_source_table_cache_key(make_filesource):
@@ -115,7 +115,7 @@ def test_file_source_get_query_dask_cache(make_filesource):
         pd._testing.makeMixedDataFrame().iloc[1:3]
     )
 
-def test_file_source_filter_int(make_filesource, cachedir):
+def test_file_source_filter_int(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()
@@ -123,7 +123,7 @@ def test_file_source_filter_int(make_filesource, cachedir):
     expected = df[df.A==1]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_str(make_filesource, cachedir):
+def test_file_source_filter_str(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()
@@ -131,7 +131,7 @@ def test_file_source_filter_str(make_filesource, cachedir):
     expected = df[df.C=='foo2']
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_int_range(make_filesource, cachedir):
+def test_file_source_filter_int_range(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()
@@ -139,7 +139,7 @@ def test_file_source_filter_int_range(make_filesource, cachedir):
     expected = df[(df.A>=1) & (df.A<=3)]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_date(make_filesource, cachedir):
+def test_file_source_filter_date(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()
@@ -147,7 +147,7 @@ def test_file_source_filter_date(make_filesource, cachedir):
     expected = df.iloc[1:2]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_datetime(make_filesource, cachedir):
+def test_file_source_filter_datetime(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()
@@ -155,7 +155,7 @@ def test_file_source_filter_datetime(make_filesource, cachedir):
     expected = df.iloc[1:2]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_datetime_range(make_filesource, cachedir):
+def test_file_source_filter_datetime_range(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()
@@ -163,7 +163,7 @@ def test_file_source_filter_datetime_range(make_filesource, cachedir):
     expected = df.iloc[1:3]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_date_range(make_filesource, cachedir):
+def test_file_source_filter_date_range(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()
@@ -171,7 +171,7 @@ def test_file_source_filter_date_range(make_filesource, cachedir):
     expected = df.iloc[1:3]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_int_range_list(make_filesource, cachedir):
+def test_file_source_filter_int_range_list(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()
@@ -179,7 +179,7 @@ def test_file_source_filter_int_range_list(make_filesource, cachedir):
     expected = df[((df.A>=0) & (df.A<=1)) | ((df.A>=3) & (df.A<=4))]
     pd.testing.assert_frame_equal(filtered, expected)
 
-def test_file_source_filter_list(make_filesource, cachedir):
+def test_file_source_filter_list(make_filesource):
     root = os.path.dirname(__file__)
     source = make_filesource(root)
     df = pd._testing.makeMixedDataFrame()

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -1,11 +1,10 @@
-import pytest
-
 import datetime as dt
 import os
 
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from lumen.sources import Source
 from lumen.state import state

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -22,35 +22,21 @@ def test_source_resolve_module_type():
     assert Source._get_type('lumen.sources.base.Source') is Source
 
 
-def test_source_table_cache_key(source):
-    assert source._get_key('test') == source._get_key('test')
-
-
-def test_source_table_and_int_query_cache_key(source):
-    assert source._get_key('test', A=314) == source._get_key('test', A=314)
-
-
-def test_source_table_and_range_query_cache_key(source):
-    assert source._get_key('test', A=(13, 314)) == source._get_key('test', A=(13, 314))
-
-
-def test_source_table_and_list_query_cache_key(source):
-    assert source._get_key('test', A=['A', 314, 'def']) == source._get_key('test', A=['A', 314, 'def'])
-
-
-def test_source_table_and_sql_transform_cache_key(source):
-    t1 = SQLLimit(limit=100)
-    t2 = SQLLimit(limit=100)
-    assert source._get_key('test', sql_transforms=[t1]) == source._get_key('test', sql_transforms=[t2])
-
-
-def test_source_table_and_multi_query_sql_transform_cache_key(source):
-    t1 = SQLLimit(limit=100)
-    t2 = SQLLimit(limit=100)
-    assert (
-        source._get_key('test', A=1, B=(3, 15.9), C=[1, 'A', 'def'], sql_transforms=[t1]) ==
-        source._get_key('test', A=1, B=(3, 15.9), C=[1, 'A', 'def'], sql_transforms=[t2])
-    )
+@pytest.mark.parametrize("filter_col_A", [314, (13, 314), ['A', 314, 'def']])
+@pytest.mark.parametrize("filter_col_B", [(3, 15.9)])
+@pytest.mark.parametrize("filter_col_C", [[1, 'A', 'def']])
+@pytest.mark.parametrize("sql_transforms", [(None, None), (SQLLimit(limit=100), SQLLimit(limit=100))])
+def test_source_table_cache_key(source, filter_col_A, filter_col_B, filter_col_C, sql_transforms):
+    t1, t2 = sql_transforms
+    kwargs1 = {}
+    kwargs2 = {}
+    if t1 is not None:
+        kwargs1['sql_transforms'] = [t1]
+    if t2 is not None:
+        kwargs2['sql_transforms'] = [t2]
+    key1 = source._get_key('test', A=filter_col_A, B=filter_col_B, C=filter_col_C, **kwargs1)
+    key2 = source._get_key('test', A=filter_col_A, B=filter_col_B, C=filter_col_C, **kwargs2)
+    assert key1 == key2
 
 
 def test_file_source_get_query(source):


### PR DESCRIPTION
Use `pytest.fixture` and `pytest.parameterize` to reorganize tests into groups where tests in a group do similar stuffs.