### PR TITLE
Add more tests to DerivedSource

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -857,7 +857,7 @@ class DerivedSource(Source):
          control over the exact tables to filter and transform is
          available. This is referred to as the 'table' mode.
       2) When a `source` is declared all tables on that Source are
-         mirrored and filtered and transformed acccording to the
+         mirrored and filtered and transformed according to the
          supplied `filters` and `transforms`. This is referred to as
          'mirror' mode.
 

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -57,7 +57,7 @@ def test_source_resolve_module_type():
 @pytest.mark.parametrize("filter_col_B", [(3, 15.9)])
 @pytest.mark.parametrize("filter_col_C", [[1, 'A', 'def']])
 @pytest.mark.parametrize("sql_transforms", [(None, None), (SQLLimit(limit=100), SQLLimit(limit=100))])
-def test_source_table_cache_key(source, filter_col_A, filter_col_B, filter_col_C, sql_transforms):
+def test_file_source_table_cache_key(source, filter_col_A, filter_col_B, filter_col_C, sql_transforms):
     t1, t2 = sql_transforms
     kwargs1 = {}
     kwargs2 = {}
@@ -158,6 +158,11 @@ def test_file_source_get_query_cache_to_file(make_filesource, cachedir):
         df,
         pd._testing.makeMixedDataFrame().iloc[1:3]
     )
+
+
+def test_file_source_get_tables(source):
+    tables = source.get_tables()
+    assert tables == ['test']
 
 
 def test_file_source_variable(make_variable_filesource):

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -123,6 +123,26 @@ def test_file_source_get_query_cache(source, column_value_type, dask, expected_d
     assert cache_key in source._cache
 
 
+@pytest.mark.parametrize(
+    "column_value_type", [
+        ('A', 1, 'single_value'),
+        ('A', [(0, 1), (3, 4)], 'range_list'),
+        ('C', ['foo1', 'foo3'], 'list'),
+        ('D', (dt.datetime(2009, 1, 2), dt.datetime(2009, 1, 5)), 'range'),
+        ('D', dt.datetime(2009, 1, 2), 'date'),
+    ]
+)
+@pytest.mark.parametrize("dask", [True, False])
+def test_file_source_clear_cache(source, column_value_type, dask):
+    column, value, _ = column_value_type
+    kwargs = {column: value}
+    source.get('test', __dask=dask, **kwargs)
+    cache_key = source._get_key('test', **kwargs)
+    assert cache_key in source._cache
+    source.clear_cache()
+    assert len(source._cache) == 0
+
+
 def test_file_source_get_query_cache_to_file(make_filesource, cachedir):
     root = os.path.dirname(__file__)
     source = make_filesource(root, cache_dir=cachedir)

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -1,3 +1,5 @@
+import pytest
+
 import os
 
 import pandas as pd
@@ -5,33 +7,21 @@ import pandas as pd
 from lumen.sources.base import DerivedSource
 
 
-def test_derived_mirror_source(make_filesource):
+@pytest.fixture
+def original(make_filesource):
     root = os.path.dirname(__file__)
-    original = make_filesource(root)
-    derived = DerivedSource.from_spec({
-        'type': 'derived',
-        'source': 'original',
-    })
+    return make_filesource(root)
 
-    assert derived.get_tables() == ['test']
+
+@pytest.fixture
+def expected_table():
     df = pd._testing.makeMixedDataFrame()
-    pd.testing.assert_frame_equal(derived.get('test'), df)
-    assert original.get_schema() == derived.get_schema()
+    return df.iloc[:3]
 
 
-def test_derived_mirror_source_transforms(make_filesource):
-    root = os.path.dirname(__file__)
-    make_filesource(root)
-    derived = DerivedSource.from_spec({
-        'type': 'derived',
-        'source': 'original',
-        'transforms': [{'type': 'iloc', 'end': 3}]
-    })
-
-    assert derived.get_tables() == ['test']
-    df = pd._testing.makeMixedDataFrame().iloc[:3]
-    pd.testing.assert_frame_equal(derived.get('test'), df)
-    assert derived.get_schema('test') == {
+@pytest.fixture
+def expected_schema():
+    schema = {
         'A': {'inclusiveMaximum': 2.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
         'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
         'C': {'enum': ['foo1', 'foo2', 'foo3'], 'type': 'string'},
@@ -42,102 +32,108 @@ def test_derived_mirror_source_transforms(make_filesource):
             'inclusiveMinimum': '2009-01-01T00:00:00'
         }
     }
+    return schema
 
 
-def test_derived_mirror_source_filters(make_filesource):
-    root = os.path.dirname(__file__)
-    make_filesource(root)
+@pytest.fixture
+def mirror_transforms():
+    transforms = [{'type': 'iloc', 'end': 3}]
+    return transforms
+
+
+@pytest.fixture
+def mirror_filters():
+    filters = [{'type': 'constant', 'field': 'A', 'value': (0, 2)}]
+    return filters
+
+
+@pytest.fixture
+def tables_transforms(mirror_transforms):
+    spec = {
+        'type': 'derived',
+        'tables': {
+            'derived': {
+                'source': 'original',
+                'table': 'test',
+                'transforms': mirror_transforms
+            }
+        }
+    }
+    return spec
+
+
+@pytest.fixture
+def tables_filters(mirror_filters):
+    spec = {
+        'type': 'derived',
+        'tables': {
+            'derived': {
+                'source': 'original',
+                'table': 'test',
+                'filters': mirror_filters
+            }
+        }
+    }
+    return spec
+
+
+def test_derived_source_resolve_module_type():
+    assert DerivedSource._get_type('lumen.sources.base.DerivedSource') is DerivedSource
+
+
+def test_derived_mirror_source(original):
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'source': 'original',
-        'filters': [{'type': 'constant', 'field': 'A', 'value': (0, 2)}]
     })
-
-    assert derived.get_tables() == ['test']
-    df = pd._testing.makeMixedDataFrame().iloc[:3]
-    pd.testing.assert_frame_equal(derived.get('test'), df)
-    assert derived.get_schema('test') == {
-        'A': {'inclusiveMaximum': 2.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
-        'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
-        'C': {'enum': ['foo1', 'foo2', 'foo3'], 'type': 'string'},
-        'D': {
-            'format': 'datetime',
-            'type': 'string',
-            'inclusiveMaximum': '2009-01-05T00:00:00',
-            'inclusiveMinimum': '2009-01-01T00:00:00'
-        }
-    }
+    assert derived.get_tables() == original.get_tables()
+    assert derived.get_schema() == original.get_schema()
+    for table in original.get_tables():
+        pd.testing.assert_frame_equal(derived.get(table), original.get(table))
 
 
-def test_derived_tables_source(make_filesource):
-    root = os.path.dirname(__file__)
-    original = make_filesource(root)
+def test_derived_mirror_source_transforms(original, mirror_transforms, expected_table, expected_schema):
+    derived = DerivedSource.from_spec({
+        'type': 'derived',
+        'source': 'original',
+        'transforms': mirror_transforms,
+    })
+    assert derived.get_tables() == original.get_tables()
+    assert derived.get_schema('test') == expected_schema
+    pd.testing.assert_frame_equal(derived.get('test'), expected_table)
+
+
+def test_derived_mirror_source_filters(original, mirror_filters, expected_table, expected_schema):
+    derived = DerivedSource.from_spec({
+        'type': 'derived',
+        'source': 'original',
+        'filters': mirror_filters
+    })
+    assert derived.get_tables() == original.get_tables()
+    assert derived.get_schema('test') == expected_schema
+    pd.testing.assert_frame_equal(derived.get('test'), expected_table)
+
+
+def test_derived_tables_source(original):
     derived = DerivedSource.from_spec({
         'type': 'derived',
         'tables': {'derived': {'source': 'original', 'table': 'test'}}
     })
-
     assert derived.get_tables() == ['derived']
     df = pd._testing.makeMixedDataFrame()
     pd.testing.assert_frame_equal(derived.get('derived'), df)
     assert original.get_schema('test') == derived.get_schema('derived')
 
 
-def test_derived_tables_source_transforms(make_filesource):
-    root = os.path.dirname(__file__)
-    make_filesource(root)
-    derived = DerivedSource.from_spec({
-        'type': 'derived',
-        'tables': {
-            'derived': {
-                'source': 'original',
-                'table': 'test',
-                'transforms': [{'type': 'iloc', 'end': 3}]
-            }
-        }
-    })
-
+def test_derived_tables_source_transforms(original, tables_transforms, expected_table, expected_schema):
+    derived = DerivedSource.from_spec(tables_transforms)
     assert derived.get_tables() == ['derived']
-    df = pd._testing.makeMixedDataFrame().iloc[:3]
-    pd.testing.assert_frame_equal(derived.get('derived'), df)
-    assert derived.get_schema('derived') == {
-        'A': {'inclusiveMaximum': 2.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
-        'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
-        'C': {'enum': ['foo1', 'foo2', 'foo3'], 'type': 'string'},
-        'D': {
-            'format': 'datetime',
-            'type': 'string',
-            'inclusiveMaximum': '2009-01-05T00:00:00',
-            'inclusiveMinimum': '2009-01-01T00:00:00'
-        }
-    }
+    pd.testing.assert_frame_equal(derived.get('derived'), expected_table)
+    assert derived.get_schema('derived') == expected_schema
 
 
-def test_derived_tables_source_filters(make_filesource):
-    root = os.path.dirname(__file__)
-    make_filesource(root)
-    derived = DerivedSource.from_spec({
-        'type': 'derived',
-        'tables': {
-            'derived': {
-                'source': 'original',
-                'table': 'test',
-                'filters': [{'type': 'constant', 'field': 'A', 'value': (0, 2)}]
-            }
-        }
-    })
-
+def test_derived_tables_source_filters(original, tables_filters, expected_table, expected_schema):
+    derived = DerivedSource.from_spec(tables_filters)
     assert derived.get_tables() == ['derived']
-    df = pd._testing.makeMixedDataFrame().iloc[:3]
-    pd.testing.assert_frame_equal(derived.get('derived'), df)
-    assert derived.get_schema('derived') == {
-        'A': {'inclusiveMaximum': 2.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
-        'B': {'inclusiveMaximum': 1.0, 'inclusiveMinimum': 0.0, 'type': 'number'},
-        'C': {'enum': ['foo1', 'foo2', 'foo3'], 'type': 'string'},
-        'D': {
-            'format': 'datetime',
-            'type': 'string',
-            'inclusiveMaximum': '2009-01-05T00:00:00',
-            'inclusiveMinimum': '2009-01-01T00:00:00'
-        }
-    }
+    pd.testing.assert_frame_equal(derived.get('derived'), expected_table)
+    assert derived.get_schema('derived') == expected_schema

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -111,3 +111,10 @@ def test_derived_get_query_cache(original, mirror_mode_spec):
     pd.testing.assert_frame_equal(cached_df, df)
 
 
+def test_derived_clear_cache(original, mirror_mode_spec):
+    derived = DerivedSource.from_spec(mirror_mode_spec)
+    derived.get('test')
+    cache_key = derived._get_key('test')
+    assert cache_key in derived._cache
+    derived.clear_cache()
+    assert len(derived._cache) == 0

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -1,8 +1,7 @@
-import pytest
-
 import os
 
 import pandas as pd
+import pytest
 
 from lumen.sources.base import DerivedSource
 

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -100,3 +100,14 @@ def test_derived_tables_source_apply(
     assert derived.get_tables() == ['derived']
     pd.testing.assert_frame_equal(derived.get('derived'), expected_table)
     assert derived.get_schema('derived') == expected_schema
+
+
+def test_derived_get_query_cache(original, mirror_mode_spec):
+    derived = DerivedSource.from_spec(mirror_mode_spec)
+    df = derived.get('test')
+    cache_key = derived._get_key('test')
+    assert cache_key in derived._cache
+    cached_df = derived._cache[cache_key]
+    pd.testing.assert_frame_equal(cached_df, df)
+
+


### PR DESCRIPTION
This PR refactors `lumen/tests/sources/test_derived.py` and adds more tests to DerivedSource to check if caching and clearing cache work properly.