### PR TITLE
Only insert once for select widget

### DIFF
--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -237,7 +237,8 @@ class WidgetFilter(BaseWidgetFilter):
             schema=self.schema, sizing_mode='stretch_width', multi=self.multi
         )._widgets[self.field]
         if isinstance(self.widget, pn.widgets.Select) and self.empty_select:
-            self.widget.options.insert(0, ' ')
+            if self.widget.options[0] != ' ':
+                self.widget.options.insert(0, ' ')
             self.widget.value = ' '
         self.widget.name = self.label
         self.widget.visible = self.visible


### PR DESCRIPTION
Notices that for select widget, multiple empty fields were inserted. 


![image](https://user-images.githubusercontent.com/19758978/187917429-69b9dfdb-1196-403a-8390-91f288a3d78e.png)


<details>

<summary> YAML </summary>


```yaml
sources:
  penguins:
    type: file
    tables:
      penguins: https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-07-28/penguins.csv

targets:
  - title: Penguins
    source: penguins
    layout: [[0], [1, 2, 3], [4]]
    filters:
      - type: widget
        field: species
        multi: false
        default: Adelia
    views:
      - type: hvplot
        tables: penguins
        kind: scatter
        x: bill_length_mm
        y: bill_depth_mm
        selection_group: a
        height: 350
      - type: hvplot
        tables: penguins
        kind: scatter
        x: bill_length_mm
        y: bill_depth_mm
        selection_group: a
        height: 350
      - type: hvplot
        tables: penguins
        kind: scatter
        x: bill_length_mm
        y: bill_depth_mm
        selection_group: a
        height: 350
      - type: hvplot
        tables: penguins
        kind: scatter
        x: bill_length_mm
        y: bill_depth_mm
        selection_group: a
        height: 350
      - type: hvplot
        tables: penguins
        kind: scatter
        x: bill_length_mm
        y: bill_depth_mm
        selection_group: a
        height: 350

```

</details>