### PR TITLE
Improve alert message when no data is available because of too hard filtering

### DIFF
--- a/lumen/target.py
+++ b/lumen/target.py
@@ -744,9 +744,10 @@ class Target(Component):
         else:
             content = (
                 pn.pane.Alert(
-                    '**All views are empty since no data is available. '
+                    f'**All views are empty for {self.title!r} since no data is available. '
                     'Try relaxing the filter constraints.**',
-                    sizing_mode='stretch_width'
+                    sizing_mode='stretch_width',
+                    margin=(0, 0, 50, 0),
                 ),
             )
         return layout_type(*content, **kwargs)

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -38,6 +38,9 @@ def get_dataframe_schema(df, columns=None):
         columns = list(df.columns)
 
     schema = {'type': 'array', 'items': {'type': 'object', 'properties': {}}}
+    if df.empty:
+        return schema
+
     properties = schema['items']['properties']
     for name in columns:
         dtype = df.dtypes[name]


### PR DESCRIPTION
This PR fixes two things:
1) Return an "empty" schema if the dataframe is empty.  
2) Add more margin so that a possible table does not overlap the alert and give the title to the view alert. 

### Before:
![image](https://user-images.githubusercontent.com/19758978/188857966-4dce054d-9a9b-490b-ac7e-f8b93f0c2615.png)

### No alert update:
![image](https://user-images.githubusercontent.com/19758978/188858783-858ce5dd-942d-4efb-8a50-f7241a589da1.png)

### After:
![image](https://user-images.githubusercontent.com/19758978/188858283-caa5f73a-ea7b-417c-a925-0fa7181dc811.png)


``` yaml
sources:
  penguins:
    type: file
    tables:
      penguins: https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-07-28/penguins.csv

targets:
  - title: Table
    source: penguins
    filters:
      - type: constant
        field: bill_length_mm
        value: 2.10
    views:
      - type: table
        table: penguins
  - title: Table2
    source: penguins
    filters:
      - type: constant
        field: island
        value: Torgersen
    views:
      - type: table
        table: penguins
```