### PR TITLE
Notify user of runtime errors

### DIFF
--- a/examples/seattle/weather.yaml
+++ b/examples/seattle/weather.yaml
@@ -24,7 +24,7 @@ targets:
       - type: altair
         marker: rect
         chart:
-          title: 2010 Daily High Temperature (F) in Seattle, WA
+          title: 2012-2015 Daily High Temperature (F) in Seattle, WA
         x:
           shorthand: date(date):O
           title: Day

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -24,7 +24,7 @@ from .sources import RESTSource, Source  # noqa
 from .state import state
 from .target import Target
 from .transforms import Transform  # noqa
-from .util import expand_spec, resolve_module_reference
+from .util import catch_and_notify, expand_spec, resolve_module_reference
 from .validation import ValidationError, match_suggestion_message
 from .variables import Variable, Variables
 from .views import View  # noqa
@@ -525,6 +525,7 @@ class Dashboard(Component):
     # Rendering API
     ##################################################################
 
+    @catch_and_notify
     def _activate_filters(self, event):
         target = self.targets[event.new]
         rendered = self._rendered[event.new]

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -408,7 +408,7 @@ class Dashboard(Component):
         for i, target_spec in enumerate(target_specs):
             if state.loading_msg:
                 state.loading_msg.object = (
-                    f"Loading target {target_spec['title']!r} ({i}/{ntargets})..."
+                    f"Loading target {target_spec['title']!r} ({i + 1}/{ntargets})..."
             )
             if isinstance(self._layout, pn.Tabs) and i != self._layout.active:
                 if self.config.background_load:

--- a/lumen/panel.py
+++ b/lumen/panel.py
@@ -4,6 +4,8 @@ from panel import panel
 from panel.reactive import ReactiveHTML
 from panel.widgets import FileDownload
 
+from .util import catch_and_notify
+
 try:
     # Backward compatibility for panel 0.12.6
     import bokeh.core.properties as bp
@@ -107,6 +109,7 @@ class DownloadButton(ReactiveHTML):
             params['object'] = object
         super().__init__(**params)
 
+    @catch_and_notify(msg="Download failed: {e}")
     def _on_click(self, event=None):
         file_input = FileDownload(callback=self.callback, filename=self.filename)
         file_input._transfer()

--- a/lumen/panel.py
+++ b/lumen/panel.py
@@ -109,7 +109,7 @@ class DownloadButton(ReactiveHTML):
             params['object'] = object
         super().__init__(**params)
 
-    @catch_and_notify(msg="Download failed: {e}")
+    @catch_and_notify("Download failed")
     def _on_click(self, event=None):
         file_input = FileDownload(callback=self.callback, filename=self.filename)
         file_input._transfer()

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -12,7 +12,7 @@ from .filters import Filter, ParamFilter
 from .sources import Source
 from .state import state
 from .transforms import Filter as FilterTransform, SQLTransform, Transform
-from .util import get_dataframe_schema
+from .util import catch_and_notify, get_dataframe_schema
 from .validation import ValidationError, match_suggestion_message
 
 
@@ -106,6 +106,7 @@ class Pipeline(Component):
                     refs.append(ref)
         return refs
 
+    @catch_and_notify
     def _update_data(self, *events: param.Event):
         query = {}
 

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -17,7 +17,7 @@ from .panel import IconButton
 from .pipeline import Pipeline
 from .sources import Source
 from .state import state
-from .util import extract_refs
+from .util import catch_and_notify, extract_refs
 from .validation import ValidationError, match_suggestion_message
 from .views import DOWNLOAD_FORMATS, View
 
@@ -253,6 +253,7 @@ class Download(Component, Viewer):
     def __bool__(self):
         return self.format is not None
 
+    @catch_and_notify("Download failed")
     def _table_data(self):
         if self.format in ('json', 'csv'):
             io = StringIO()

--- a/lumen/ui/sources.py
+++ b/lumen/ui/sources.py
@@ -9,6 +9,7 @@ import yaml
 from panel.reactive import ReactiveHTML
 
 from lumen.sources import Source
+from lumen.util import catch_and_notify
 
 from .base import WizardItem
 from .fast import FastComponent
@@ -284,6 +285,7 @@ class IntakeSourceEditor(SourceEditor):
     def _update_catalog(self):
         self.spec['catalog'] = yaml.safe_load(self.editor.value)
 
+    @catch_and_notify
     @param.depends('uri', watch=True)
     def _load_file(self):
         uri = os.path.expanduser(self.uri)

--- a/lumen/ui/views.py
+++ b/lumen/ui/views.py
@@ -4,6 +4,7 @@ import param
 from panel.reactive import ReactiveHTML
 
 from lumen.sources import Source
+from lumen.util import catch_and_notify
 from lumen.views import View
 
 from .base import WizardItem
@@ -88,6 +89,7 @@ class ViewsEditor(WizardItem):
         self._source = None
         state.sources.param.watch(self._update_sources, 'sources')
 
+    @catch_and_notify
     @param.depends('source', watch=True)
     def _update_tables(self):
         source = state.sources.sources[self.source]

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -41,12 +41,12 @@ def get_dataframe_schema(df, columns=None):
     else:
         is_dask = False
 
+    schema = {'type': 'array', 'items': {'type': 'object', 'properties': {}}}
+    if df is None or df.empty:
+        return schema
+
     if columns is None:
         columns = list(df.columns)
-
-    schema = {'type': 'array', 'items': {'type': 'object', 'properties': {}}}
-    if df.empty:
-        return schema
 
     properties = schema['items']['properties']
     for name in columns:

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -261,7 +261,7 @@ def catch_and_notify(message=None):
         exception message.
 
     """
-    pn.extension(notifications=True)
+    pn.config.notifications = True
 
     # This is to be able to call the decorator
     # like this @catch_and_notify

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -26,7 +26,7 @@ from ..panel import DownloadButton
 from ..pipeline import Pipeline
 from ..state import state
 from ..transforms import SQLTransform, Transform
-from ..util import is_ref, resolve_module_reference
+from ..util import catch_and_notify, is_ref, resolve_module_reference
 
 DOWNLOAD_FORMATS = ['csv', 'xlsx', 'json', 'parquet']
 
@@ -736,7 +736,7 @@ class DownloadView(View):
     def __bool__(self):
         return True
 
-
+    @catch_and_notify("Download failed")
     def _table_data(self):
         if self.format in ('json', 'csv'):
             io = StringIO()

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -289,6 +289,7 @@ class View(MultiTypeComponent, Viewer):
     def __bool__(self):
         return self._cache is not None and len(self._cache) > 0
 
+    @catch_and_notify
     def _update_panel(self, *events):
         """
         Updates the cached Panel object and returns a boolean value


### PR DESCRIPTION
Fixes #321 

The main thing in this PR is the `catch_and_notify` decorator to be able to catch runtime errors, and then both notify the user with a notification and log the exception. 

I'm unsure if I should re-raise the error after this, as the following code could fail because it expects the decorated function to succeed.  

A (staged) example of how this looks.

https://user-images.githubusercontent.com/19758978/189873191-fb7d6a73-a11f-4558-9ff6-377fb82a9e6d.mp4

TODO:
- [x] Check if needed and add a decorator on watched functions.

---
Also, fixing these which are non-related to the original issue:
- The title of the weather example
- Adding +1 to `Loading target ...` so it is one-indexed. This makes sense to me that the last message is `2/2` and not `1/2.  