### PR TITLE
Adding how to on caching 

### DIFF
--- a/docs/how_to/data_intake/cache.md
+++ b/docs/how_to/data_intake/cache.md
@@ -2,21 +2,22 @@
 
 :::{admonition} What does this guide solve?
 :class: important
-This guide will go through how to cache large files for easier access.
+This guide will show you how to locally cache data to speed up reloading from a remote source.
 :::
 
 ## Caching file
-When working with large files, it can be very advantageous to cache it and therefore be able to save time when reloading the data.
-To cache a [source](../../reference/source) is done by using `cache_dir` followed by a directory.
+When working with large data in a non-optional file format, creating a local cache can be advantageous to save time when reloading the data.
+Caching a [source](../../reference/source) is done by using `cache_dir` followed by a directory.
 If the directory does not exist, it will be created.
-Below is an example of caching a 370 MB file, and the table consists of almost 12 million rows.
+The data will be saved as [parquet](https://www.databricks.com/glossary/what-is-parquet) files in the cache directory.
+Below is an example of caching a 370 MB file that consists of almost 12 million rows.
 
 :::{warning}
 The initial load can take a couple of minutes as the file needs to be downloaded and cached first.
 :::
 
 ::::{tab-set}
-:::{tab-item} Specification (YAML)
+:::{tab-item} YAML
 :sync: yaml
 ``` {code-block} yaml
 :emphasize-lines: 4
@@ -36,11 +37,9 @@ targets:
       - type: table
         table: large_table
 ```
-_The non-emphasized lines are only there to see the table when running `lumen serve file.yaml`._
-
 :::
 
-:::{tab-item} Pipeline (Python)
+:::{tab-item} Python
 :sync: python
 ``` {code-block} python
 :emphasize-lines: 8
@@ -59,11 +58,10 @@ pipeline = Pipeline.from_spec(
 )
 pipeline.data
 ```
-_The non-emphasized lines are only there to have a table to cache when running the code_
 :::
 ::::
 
 
 :::{note}
-Lumen's [cache]() can be added to all sources found [here](../../reference/source).
+Lumen's [cache]() can be added to all [source types](../../reference/source).
 :::

--- a/docs/how_to/data_intake/cache.md
+++ b/docs/how_to/data_intake/cache.md
@@ -1,0 +1,69 @@
+# How to use cache
+
+:::{admonition} What does this guide solve?
+:class: important
+This guide will go through how to cache large files for easier access.
+:::
+
+## Caching file
+When working with large files, it can be very advantageous to cache it and therefore be able to save time when reloading the data.
+To cache a [source](../../reference/source) is done by using `cache_dir` followed by a directory.
+If the directory does not exist, it will be created.
+Below is an example of caching a 370 MB file, and the table consists of almost 12 million rows.
+
+:::{warning}
+The initial load can take a couple of minutes as the file needs to be downloaded and cached first.
+:::
+
+::::{tab-set}
+:::{tab-item} Specification (YAML)
+:sync: yaml
+``` {code-block} yaml
+:emphasize-lines: 4
+sources:
+  large_source:
+    type: file
+    cache_dir: cache
+    tables:
+      large_table: https://s3.amazonaws.com/datashader-data/nyc_taxi_wide.parq
+    kwargs:
+      engine: fastparquet
+
+targets:
+  - title: Table
+    source: large_source
+    views:
+      - type: table
+        table: large_table
+```
+_The non-emphasized lines are only there to see the table when running `lumen serve file.yaml`._
+
+:::
+
+:::{tab-item} Pipeline (Python)
+:sync: python
+``` {code-block} python
+:emphasize-lines: 8
+from lumen.pipeline import Pipeline
+
+data_url = "https://s3.amazonaws.com/datashader-data/nyc_taxi_wide.parq"
+pipeline = Pipeline.from_spec(
+    {
+        "source": {
+            "type": "file",
+            "cache_dir": "cache",
+            "tables": {"large_table": data_url},
+            "kwargs": {"engine": "fastparquet"},
+        },
+    }
+)
+pipeline.data
+```
+_The non-emphasized lines are only there to have a table to cache when running the code_
+:::
+::::
+
+
+:::{note}
+Lumen's [cache]() can be added to all sources found [here](../../reference/source).
+:::

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import re
 import shutil
-import sys
 import threading
 import warnings
 import weakref
@@ -26,6 +25,11 @@ from ..state import state
 from ..transforms import Filter as FilterTransform, Transform
 from ..util import get_dataframe_schema, is_ref, merge_schemas
 from ..validation import ValidationError, match_suggestion_message
+
+try:
+    import dask.dataframe as dd
+except ImportError:
+    dd = None
 
 
 def cached(with_query=True, locks=weakref.WeakKeyDictionary()):
@@ -291,12 +295,10 @@ class Source(MultiTypeComponent):
             path = self.root / self.cache_dir / filename
             if path.is_file():
                 return pd.read_parquet(path), not bool(query)
-            if 'dask.dataframe' in sys.modules and path.is_dir():
-                import dask.dataframe as dd
+            if dd and path.is_dir():
                 return dd.read_parquet(path), not bool(query)
             path = path.with_suffix('')
-            if 'dask.dataframe' in sys.modules and path.is_dir():
-                import dask.dataframe as dd
+            if dd and path.is_dir():
                 return dd.read_parquet(path), not bool(query)
         return None, not bool(query)
 
@@ -312,8 +314,7 @@ class Source(MultiTypeComponent):
             else:
                 filename = f'{table}.parq'
             filepath = path / filename
-            if 'dask.dataframe' in sys.modules:
-                import dask.dataframe as dd
+            if dd:
                 if isinstance(data, dd.DataFrame):
                     filepath = filepath.with_suffix('')
             try:

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -507,8 +507,8 @@ class FileSource(Source):
         return self._pd_load_fns[ext], kwargs
 
     def _set_cache(self, data, table, **query):
-        _, ext = self._named_files[table]
-        if ext in ('parq', 'parquet'):
+        file, ext = self._named_files[table]
+        if ext in ('parq', 'parquet') and Path(file).exists():
             query['write_to_file'] = False
         super()._set_cache(data, table, **query)
 


### PR DESCRIPTION
Adding a section on how-to on cache.

Found some bugs when setting up the example in the how-to.
1.  `dask.dataframe` was never imported and therefore was not in `sys.modules`. I now try to import `dask.dataframe` and use that through the code.
2. `FileSource` was set up to not save on parquet files, but this should only be the case if the file is local and not remote like the example I use. 
![image](https://user-images.githubusercontent.com/19758978/192336902-0eae81a0-500a-4907-862c-3a5ba9ceebc5.png)
