### PR TITLE
Add functionality to manually apply updates

### DIFF
--- a/docs/how_to/pipeline_python.md
+++ b/docs/how_to/pipeline_python.md
@@ -147,5 +147,8 @@ pn.Row(
 ```
 ![dashboard preview](../_static/pipeline_dash.png)
 
+```{note} If querying data from the Source takes time use set `auto_update=False` on the Pipeline. This will require you to manually trigger an update by clicking a button.
+```
+
 Related Resources:
 * [Branch a pipeline in Python](chain_python)

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -43,6 +43,12 @@ class Config(Component):
     High-level configuration options for the Dashboard.
     """
 
+    auto_update = param.Boolean(default=True, constant=True, doc="""
+        Whether changes in filters, transforms and references automatically
+        trigger updates in the data or whether an update has to be triggered
+        manually using the update event or the update button in the UI."""
+    )
+
     background_load = param.Boolean(default=False, constant=True, doc="""
         Whether to load any targets in the background.""")
 
@@ -63,10 +69,6 @@ class Config(Component):
 
     logo = param.String(default=None, constant=True, doc="""
         A logo to add to the theme.""")
-
-    manual_update = param.Boolean(default=False, doc="""
-        Whether all changes to filters and transforms have to be confirmed
-        with a manual button click.""")
 
     ncols = param.Integer(default=3, bounds=(1, None), constant=True, doc="""
         Number of columns to lay out targets in.""")
@@ -386,8 +388,8 @@ class Dashboard(Component):
         target_spec = dict(target_spec)
         if 'reloadable' not in target_spec:
             target_spec['reloadable'] = self.config.reloadable
-        if self.config.manual_update:
-            target_spec['manual_update'] = True
+        if 'auto_update' not in target_spec:
+            target_spec['auto_update'] = self.config.auto_update
         target = Target.from_spec(target_spec, application=self)
         if isinstance(self._layout, pn.Tabs):
             target.show_title = False
@@ -402,7 +404,7 @@ class Dashboard(Component):
         if force or self._load_global or not state.global_sources:
             state.load_global_sources(clear_cache=force)
         if force or self._load_global or not state.pipelines:
-            state.load_pipelines(manual_update=self.config.manual_update)
+            state.load_pipelines(auto_update=self.config.auto_update)
         if not self.auth.authorized:
             self.targets = []
             return
@@ -594,7 +596,7 @@ class Dashboard(Component):
                          filt.panel is not None) and filt.shared) and filt not in filters:
                         views.append(filt.panel)
                         filters.append(filt)
-        if self.config.manual_update:
+        if not self.config.auto_update:
             button = pn.widgets.Button(name='Apply Update')
             def update_pipelines(event):
                 for target in self.targets:
@@ -613,7 +615,7 @@ class Dashboard(Component):
         filters = [] if global_panel is None else [global_panel]
         global_refs = [ref.split('.')[1] for ref in state.global_refs]
         self._variable_panel = self.variables.panel(global_refs)
-        apply_button = not self.config.manual_update or len(self.targets) == 1
+        apply_button = not self.config.auto_update or len(self.targets) == 1
         if self._variable_panel is not None:
             filters.append(self._variable_panel)
         for i, target in enumerate(self.targets):

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -107,15 +107,19 @@ class Filter(MultiTypeComponent):
             spec['label'] = field.title()
         table = spec.get('table')
         schema = None
+        fields = []
         for key, table_schema in source_schema.items():
             if table is not None and key != table:
                 continue
             schema = table_schema.get(field)
+            fields.extend(list(table_schema))
             if schema is not None:
                 break
         if not schema:
-            raise ValueError("Source did not declare a schema for "
-                             f"'{field}' filter.")
+            raise ValueError(
+                f"Source did not declare a schema for {field!r} filter. "
+                f"Available fields include: {fields!r}."
+            )
         return filter_type(schema={field: schema}, **spec)
 
     @property

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -39,43 +39,38 @@ class Pipeline(Component):
 
     schema = param.Dict(doc="The schema of the input data.")
 
-    manual_update = param.Boolean(
-        default=False, constant=True, doc="""
-        Whether to require user to trigger update manually with a
-        button or by calling update."""
+    auto_update = param.Boolean(default=True, constant=True, doc="""
+        Whether changes in filters, transforms and references automatically
+        trigger updates in the data or whether an update has to be triggered
+        manually using the update event or the update button in the UI."""
     )
 
-    source = param.ClassSelector(
-        class_=Source, constant=True,
-        doc="The Source this pipeline is fed by."
+    source = param.ClassSelector(class_=Source, constant=True, doc="""
+        The Source this pipeline is fed by."""
     )
 
-    pipeline = param.ClassSelector(
-        class_=None,
-        doc="Optionally a pipeline may be chained to another pipeline."
+    pipeline = param.ClassSelector(class_=None, doc="""
+        Optionally a pipeline may be chained to another pipeline."""
     )
 
-    filters = param.List(
-        item_type=Filter,
-        doc="A list of Filters to apply to the source data."
+    filters = param.List(item_type=Filter, doc="""
+        A list of Filters to apply to the source data."""
     )
 
-    sql_transforms = param.List(
-        item_type=SQLTransform,
-        doc="A list of SQLTransforms to apply to the source data."
+    sql_transforms = param.List(item_type=SQLTransform, doc="""
+        A list of SQLTransforms to apply to the source data."""
     )
 
-    transforms = param.List(
-        item_type=Transform,
-        doc="A list of Transforms to apply to the source data."
+    transforms = param.List(item_type=Transform, doc="""
+        A list of Transforms to apply to the source data."""
     )
 
-    table = param.String(
-        doc="The name of the table driving this pipeline."
+    table = param.String(doc="""
+        The name of the table driving this pipeline."""
     )
 
-    update = param.Event(
-        doc="Update event trigger (if manual update is set).", label='Apply update'
+    update = param.Event(label='Apply update', doc="""
+        Update event trigger (if manual update is set)."""
     )
 
     _internal_params = ['data', 'name', 'schema']
@@ -101,7 +96,7 @@ class Pipeline(Component):
             self.pipeline.param.watch(self._update_data, 'data')
 
     def _update_refs(self, *events):
-        if not self.manual_update:
+        if self.auto_update:
             self._update_data()
 
     @property
@@ -120,7 +115,7 @@ class Pipeline(Component):
     @param.depends('update', watch=True)
     @catch_and_notify
     def _update_data(self, *events: param.Event):
-        if self.manual_update and events and not any(
+        if not self.auto_update and events and not any(
                 e.name == 'update' or (e.name == 'data' and isinstance(e.obj, Pipeline)) for e in events):
             return
         query = {}
@@ -389,7 +384,7 @@ class Pipeline(Component):
         if transforms:
             col.append('<div style="font-size: 1.5em; font-weight: bold;">Transforms</div>')
         col.extend(transforms)
-        if self.manual_update:
+        if not self.auto_update:
             col.append(self.param['update'])
         return col
 

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -154,10 +154,10 @@ class _session_state:
                 for fname, filter_spec in filter_specs.items()
             }
 
-    def load_pipelines(self):
+    def load_pipelines(self, **kwargs):
         from .pipeline import Pipeline
         pipelines = {
-            name: Pipeline.from_spec(dict(source_spec, name=name))
+            name: Pipeline.from_spec(dict(source_spec, name=name, **kwargs))
             for name, source_spec in self.spec.get('pipelines', {}).items()
         }
         self._pipelines[pn.state.curdoc or None] = pipelines

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -293,6 +293,12 @@ class Target(Component):
     set of filters and views.
     """
 
+    auto_update = param.Boolean(default=True, constant=True, doc="""
+        Whether changes in filters, transforms and references automatically
+        trigger updates in the data or whether an update has to be triggered
+        manually using the update event or the update button in the UI."""
+    )
+
     download = param.ClassSelector(class_=Download, default=Download(), doc="""
         The download objects determines whether and how the source tables
         can be downloaded.""")
@@ -307,10 +313,6 @@ class Target(Component):
         corresponding to the views, e.g. [[0, 1], [2]] will create
         a Column of one row containing views 0 and 1 and a second Row
         containing view 2.""" )
-
-    manual_update = param.Boolean(default=False, doc="""
-        Whether all changes to filters and transforms have to be confirmed
-        with a manual button click.""")
 
     reloadable = param.Boolean(default=True, doc="""
         Whether to allow reloading data target's source using a button.""")
@@ -487,7 +489,7 @@ class Target(Component):
             views.append(self._view_controls)
 
         # Add update button
-        if self.manual_update and apply_button:
+        if not self.auto_update and apply_button:
             views.append(self._update_button)
 
         # Reload buttons

--- a/lumen/tests/validation/test_target.py
+++ b/lumen/tests/validation/test_target.py
@@ -88,17 +88,12 @@ def test_target_Download(spec, msg):
             {"source": "penguins", "views": []},
             "The Target component requires 'title' parameter to be defined",
         ),
-        (
-            {"title": "Table", "views": []},
-            "Target component requires one of 'pipeline' or 'source' to be defined",
-        ),
     ),
     ids=[
         "correct",
         "missing_source",
         "missing_views",
         "missing_title",
-        "missing_pipeline_or_source",
     ],
 )
 def test_target_Target(spec, msg):


### PR DESCRIPTION
Adds a `manual_update` option to the global config, each Target and Pipeline to be able to manually update the data using a button click. This is useful when applying a filter or transform is very slow.

![apply_update](https://user-images.githubusercontent.com/1550771/192496286-61eafd1a-d91e-47e1-a62e-f3e575250f7f.gif)

- [x] Add tests
- [x] Decide on naming of `manual_update` parameter