### PR TITLE
Avoid leaking panel config settings

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -10,6 +10,7 @@ import panel as pn
 import param
 import yaml
 
+from panel.io.resources import CSS_URLS
 from panel.template.base import BasicTemplate
 
 from .auth import AuthPlugin
@@ -29,9 +30,6 @@ from .validation import ValidationError, match_suggestion_message
 from .variables import Variable, Variables
 from .views import View  # noqa
 
-pn.config.css_files.append(
-    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css'
-)
 
 def load_yaml(yaml_spec, **kwargs):
     expanded = expand_spec(yaml_spec, config.template_vars, **kwargs)
@@ -325,6 +323,7 @@ class Dashboard(Component):
         self._edited = False
         self._debug = params.pop('debug', False)
         super().__init__(**params)
+        self._init_config()
 
         # Initialize from spec
         config.load_local_modules()
@@ -352,6 +351,11 @@ class Dashboard(Component):
 
         state._apps[pn.state.curdoc] = self
         pn.state.onload(self._render_dashboard)
+
+    def _init_config(self):
+        pn.config.notifications = True
+        if CSS_URLS['font-awesome'] not in pn.config.css_files:
+            pn.config.css_files.append(CSS_URLS['font-awesome'])
 
     ##################################################################
     # Load specification

--- a/lumen/ui/builder.py
+++ b/lumen/ui/builder.py
@@ -24,30 +24,6 @@ from .targets import TargetEditor, TargetGallery, TargetGalleryItem
 from .variables import VariablesEditor
 from .views import ViewEditor, ViewGallery, ViewGalleryItem
 
-CSS_RAW = """
-i.fa.fa-plus:hover {
-  color: var(--neutral-fill-color) !important;
-}
-
-.gallery-item:hover {
-  box-shadow: 0 1px 5px;
-}
-
-.gallery-item {
-  cursor: pointer;
-}
-
-.card-margin {
-  height: calc(100% - 40px);
-}
-
-.bk-root {
-  height: 100% !important;
-}
-"""
-
-pn.extension('ace', 'perspective', 'tabulator', raw_css=[CSS_RAW])
-
 
 class Builder(param.Parameterized):
 

--- a/lumen/ui/main.py
+++ b/lumen/ui/main.py
@@ -2,11 +2,38 @@ from pathlib import Path
 
 import panel as pn
 
+from panel.io.resources import CSS_URLS
 from panel.template import FastListTemplate
 
 from lumen.ui.builder import Builder
 from lumen.ui.state import state
 
+CSS_RAW = """
+i.fa.fa-plus:hover {
+  color: var(--neutral-fill-color) !important;
+}
+
+.gallery-item:hover {
+  box-shadow: 0 1px 5px;
+}
+
+.gallery-item {
+  cursor: pointer;
+}
+
+.card-margin {
+  height: calc(100% - 40px);
+}
+
+.bk-root {
+  height: 100% !important;
+}
+"""
+
+pn.extension(
+    'ace', 'perspective', 'tabulator', raw_css=[CSS_RAW],
+    css_files=[CSS_URLS['font-awesome']]
+)
 
 def main():
     path = Path(state.components)

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -261,8 +261,6 @@ def catch_and_notify(message=None):
         exception message.
 
     """
-    pn.config.notifications = True
-
     # This is to be able to call the decorator
     # like this @catch_and_notify
     function = None


### PR DESCRIPTION
Some `pn.config` settings were leaking to the global Panel configuration because Lumen is registered as an entrypoint which means that it would get imported automatically and modified the global configuration.