### PR TITLE
Either have source or pipeline as option for a target

### DIFF
--- a/lumen/target.py
+++ b/lumen/target.py
@@ -581,6 +581,12 @@ class Target(Component):
         return cls._validate_str_or_spec('pipeline', Pipeline, *args, **kwargs)
 
     @classmethod
+    def validate(cls, spec, context=None):
+        if "source" in spec and "pipeline" in spec:
+            raise ValueError(f"{cls.name} should either have a source or a pipeline.")
+        return super().validate(spec, context)
+
+    @classmethod
     def _validate_filters(cls, filter_specs, spec, context):
         filters = cls._validate_list_subtypes('filters', Filter, filter_specs, spec, context)
         for filter_spec in filter_specs:


### PR DESCRIPTION
It makes sense to me that a target should either be connected to a source or a pipeline, but not both. 

Before:
![image](https://user-images.githubusercontent.com/19758978/195045608-f7d6408f-e9d2-4ec3-8296-8a55065d5903.png)


After:
![image](https://user-images.githubusercontent.com/19758978/195045373-03e9fbfe-3450-4fd9-8d4d-7155954a8ec6.png)



Example:

``` yaml
sources:
  stock_data:
    type: file
    tables:
      ticker: https://raw.githubusercontent.com/matplotlib/sample_data/master/aapl.csv

pipelines:
  ticker_pipe:
    source: stock_data
    table: ticker
    transforms:
      - type: columns
        columns: [Date, Open]

targets:
- title: Table
  source: stock_data
  pipeline: ticker_pipe
  views:
    - type: table
      table: ticker
```