### PR TITLE
Decouple Target rerender from Dashboard

### DIFF
--- a/lumen/__init__.py
+++ b/lumen/__init__.py
@@ -4,6 +4,8 @@ from .config import config  # noqa
 from .dashboard import Dashboard  # noqa
 from .filters import Filter  # noqa
 from .sources import Source  # noqa
+from .state import state  # noqa
+from .target import Target  # noqa
 from .transforms import Transform  # noqa
 from .views import View  # noqa
 

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -406,7 +406,8 @@ class Dashboard(Component):
             target_spec['reloadable'] = self.config.reloadable
         if 'auto_update' not in target_spec:
             target_spec['auto_update'] = self.config.auto_update
-        target = Target.from_spec(target_spec, application=self)
+        target = Target.from_spec(target_spec)
+        target.param.watch(self._render_targets, 'rerender')
         if isinstance(self._layout, pn.Tabs):
             target.show_title = False
         target.start()
@@ -646,7 +647,9 @@ class Dashboard(Component):
                 filters.append(panel)
         self._sidebar[:] = filters
 
-    def _render_targets(self):
+    def _render_targets(self, event=None):
+        if event is not None:
+            self._set_loading(event.obj.title)
         items = []
         for target, spec in zip(self.targets, state.spec.get('targets', [])):
             if target is None or isinstance(target, Future):
@@ -655,6 +658,7 @@ class Dashboard(Component):
                 panel = target.panels
             items.append(panel)
         self._layout[:] = items
+        self._layout.loading = False
 
     def _render_unauthorized(self):
         auth_keys = list(state.spec.get('auth'))

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -289,10 +289,9 @@ class Download(Component, Viewer):
         return cls(pipelines=pipelines, **spec)
 
 
-class Target(Component):
+class Target(Component, Viewer):
     """
-    A Target renders the results of a Source query using the defined
-    set of filters and views.
+    A Target renders multiple Views into a layout.
     """
 
     auto_update = param.Boolean(default=True, constant=True, doc="""
@@ -327,6 +326,9 @@ class Target(Component):
     refresh_rate = param.Integer(default=None, doc="""
         How frequently to refresh the monitor by querying the adaptor.""")
 
+    rerender = param.Event(default=False, doc="""
+        An event that is triggered whenever the View requests a re-render.""")
+
     source = param.ClassSelector(class_=Source, doc="""
         The Source queries the data from some data source.""")
 
@@ -348,7 +350,6 @@ class Target(Component):
     def __init__(self, **params):
         if 'facet' not in params:
             params['facet'] = Facet()
-        self._application = params.pop('application', None)
         self._cache = {}
         self._cb = None
         self._scheduled = False
@@ -371,6 +372,10 @@ class Target(Component):
         self.facet.param.watch(self._resort, ['sort', 'reverse'])
         for view in list(self._cache.values())[0].views:
             view.param.watch(self._schedule_rerender, 'rerender')
+
+    @param.depends('rerender')
+    def __panel__(self):
+        return self.panels
 
     def _resort(self, *events):
         self._rerender(update_views=False)
@@ -527,13 +532,9 @@ class Target(Component):
             self._rerender()
 
     def _rerender_cards(self, cards):
-        if self._application:
-            self._application._set_loading(self.title)
         for card in cards:
             if any(view in self._updates for view in card.views):
                 card.rerender()
-        if self._application:
-            self._application._render_targets()
         self._updates = []
 
     def _rerender(self, update_views=True):
@@ -543,10 +544,7 @@ class Target(Component):
             self._rerender_cards(cards)
         if cards != self._cards:
             self._cards[:] = cards
-            if self._application:
-                self._application._render()
-        if self._application:
-            self._application._layout.loading = False
+            self.param.trigger('rerender')
 
     ##################################################################
     # Validation API


### PR DESCRIPTION
Decouples Targets from the overall dashboard in order to allow them to be used programmatically. This uses the same mechanism as we added to `View`s by adding a rerender `param.Event` which the dashboard can watch to when to re-render a target.