### PR TITLE
Improve support for exporting View and Target to_spec

### DIFF
--- a/lumen/base.py
+++ b/lumen/base.py
@@ -88,6 +88,7 @@ class Component(param.Parameterized):
             if var_type is None:
                 processed[pname] = pval
             else:
+                var_name = var_name.replace(' ', '_')
                 self._refs[pname] = f'$variables.{var_name}'
                 var = var_type(name=var_name, **var_kwargs)
                 state.variables.add_variable(var)

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -128,6 +128,8 @@ class Pipeline(Component):
 
     def to_spec(self, context=None):
         spec = super().to_spec(context=context)
+        if 'pipeline' in spec and 'source' in spec:
+            del spec['source']
         if context is None:
             return spec
         for type_name in ('pipeline', 'source'):

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -127,11 +127,27 @@ class Pipeline(Component):
             self._update_data()
 
     def to_spec(self, context=None):
+        """
+        Exports the full specification to reconstruct this component.
+
+        Parameters
+        ----------
+        context: Dict[str, Any]
+          Context contains the specification of all previously
+          serialized components, e.g. to allow resolving of
+          references.
+
+        Returns
+        -------
+        Declarative specification of this component.
+        """
         spec = super().to_spec(context=context)
         if 'pipeline' in spec and 'source' in spec:
             del spec['source']
         if context is None:
             return spec
+        if 'pipelines' not in context:
+            context['pipelines'] = {}
         for type_name in ('pipeline', 'source'):
             if type_name not in spec:
                 continue
@@ -143,6 +159,7 @@ class Pipeline(Component):
             context[plural][obj_name] = obj
             spec[type_name] = obj_name
             break
+        context['pipelines'][self.name] = spec
         return spec
 
     @property

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -77,11 +77,23 @@ class _session_state:
         variables = variables or self.variables
         context = {}
         if auth:
-            context['auth'] = auth.to_spec()
+            from .dashboard import Auth
+            if isinstance(auth, dict):
+                context['auth'] = Auth.validate(auth)
+            else:
+                context['auth'] = auth.to_spec()
         if config:
-            context['config'] = config.to_spec()
+            from .dashboard import Config
+            if isinstance(config, dict):
+                context['config'] = Config.validate(config)
+            else:
+                context['config'] = config.to_spec()
         if defaults:
-            context['defaults'] = defaults.to_spec()
+            from .dashboard import Defaults
+            if isinstance(defaults, dict):
+                context['defaults'] = Defaults.validate(defaults)
+            else:
+                context['defaults'] = defaults.to_spec()
         if self.variables._vars:
             context['variables'] = {
                 k: v.to_spec() for k, v in self.variables._vars.items()
@@ -94,7 +106,10 @@ class _session_state:
             context['pipelines'] = {}
         for k, pipeline in pipelines.items():
             context['pipelines'][k] = pipeline.to_spec(context=context)
-        context['targets'] = [target.to_spec(context) for target in targets]
+        if targets:
+            context['targets'] = [
+                target.to_spec(context) for target in targets
+            ]
         return context
 
     @property

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -54,7 +54,7 @@ class _session_state:
 
     def to_spec(
         self, auth=None, config=None, defaults=None,
-        pipelines={}, sources={}, variables=None
+        pipelines={}, sources={}, targets=[], variables=None
     ):
         """
         Exports the full specification of the supplied components including
@@ -68,6 +68,7 @@ class _session_state:
         variables: lumen.variables.Variables
         pipelines: Dict[str, Pipeline]
         sources: Dict[str, Source]
+        targets: list[Target]
 
         Returns
         -------
@@ -93,6 +94,7 @@ class _session_state:
             context['pipelines'] = {}
         for k, pipeline in pipelines.items():
             context['pipelines'][k] = pipeline.to_spec(context=context)
+        context['targets'] = [target.to_spec(context) for target in targets]
         return context
 
     @property
@@ -200,9 +202,9 @@ class _session_state:
     def load_pipelines(self, **kwargs):
         from .pipeline import Pipeline
         self._pipelines[pn.state.curdoc or None] = pipelines = {}
-        for name, source_spec in self.spec.get('pipelines', {}).items():
+        for name, pipeline_spec in self.spec.get('pipelines', {}).items():
             pipelines[name] = Pipeline.from_spec(
-                dict(source_spec, name=name, **kwargs)
+                dict(pipeline_spec, name=name, **kwargs)
             )
         return pipelines
 

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -62,11 +62,24 @@ class Card(Viewer):
                 row = pn.Row(sizing_mode='stretch_width')
                 for index in row_spec:
                     if isinstance(index, int):
-                        if index >= view_size:
-                            raise ValueError(
-                                f"Layout specification for '{self.title}' target references "
-                                f"out-of-bounds index ({index}) even though the maximum "
-                                f"available index is {view_size - 1}."
+                        if isinstance(self.views, dict):
+                            raise KeyError(
+                                f'Layout specification for {self.title!r} target used '
+                                f'integer index ({index}) but views were declared as a '
+                                'dictionary.'
+                            )
+                        elif index >= view_size:
+                            raise IndexError(
+                                f'Layout specification for {self.title!r} target references '
+                                f'out-of-bounds index ({index}) even though the maximum '
+                                f'available index is {view_size - 1}.'
+                            )
+                        view = self.views[index]
+                    elif isinstance(self.views, dict):
+                        if index not in self.views:
+                            raise KeyError(
+                                f'Layout specification for {self.title} target references '
+                                'unknown view {index!r}.'
                             )
                         view = self.views[index]
                     else:
@@ -74,7 +87,7 @@ class Card(Viewer):
                         if matches:
                             view = matches[0]
                         else:
-                            raise ValueError(
+                            raise KeyError(
                                 f"Target could not find named view '{index}'."
                             )
                     row.append(view.panel)
@@ -114,7 +127,7 @@ class Card(Viewer):
 
             view_spec = view.copy()
             if 'name' not in view_spec and name:
-                view_spec[name] = name
+                view_spec['name'] = name
             if 'pipeline' in view_spec:
                 pipeline = Pipeline.from_spec(view_spec.pop('pipeline'))
             elif 'table' in view_spec and view_spec['table'] in pipelines:

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -389,6 +389,8 @@ class Target(Component, Viewer):
         self._pipelines = params.pop('pipelines', {})
         self.kwargs = {k: v for k, v in params.items() if k not in self.param}
         super().__init__(**{k: v for k, v in params.items() if k in self.param})
+        if not self.title:
+            self.title = self.name
 
         # Render content
         if self.views:

--- a/lumen/target.py
+++ b/lumen/target.py
@@ -657,8 +657,8 @@ class Target(Component, Viewer):
         view_specs = cls._validate_dict_or_list_subtypes('views', View, view_specs, spec, context)
         if 'source' in spec or 'pipeline' in spec:
             return view_specs
-        view_specs = view_specs.values() if isinstance(view_specs, dict) else view_specs
-        if not all('pipeline' in spec for spec in view_specs):
+        views = list(view_specs.values()) if isinstance(view_specs, dict) else view_specs
+        if not all('pipeline' in spec for spec in views):
             raise ValidationError(
                 'Target (or its views) must declare a source or a pipeline.', spec
             )

--- a/lumen/tests/test_target.py
+++ b/lumen/tests/test_target.py
@@ -189,10 +189,10 @@ def test_transform_controls_facetted(set_root):
     "layout,error",
     [
         ([[0]], None),
-        ([[0], [1]], ValueError),
-        ([[0], [1, 2]], ValueError),
-        ([{"test": 0}], None),
-        ([{"test1": 0}], ValueError),
+        ([[0], [1]], IndexError),
+        ([[0], [1, 2]], IndexError),
+        ([['test']], None),
+        ([['test1']], KeyError),
     ]
 )
 def test_layout_view(set_root, layout, error):
@@ -202,7 +202,7 @@ def test_layout_view(set_root, layout, error):
     views = {
         'test': {
             'type': 'table',
-            'table': 'test',
+            'table': 'test'
         },
     }
     spec = {

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -92,3 +92,109 @@ def test_view_hvplot_download(set_root):
 
     button._on_click()
     assert button.data.startswith('data:text/plain;charset=UTF-8;base64')
+
+def test_view_to_spec(set_root):
+    set_root(str(Path(__file__).parent.parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    view = {
+        'type': 'table',
+        'table': 'test',
+    }
+
+    view = View.from_spec(view, source, [])
+    assert view.to_spec() == {
+        'pipeline': {
+            'source': {
+                'tables': {'test': 'sources/test.csv'},
+                'type': 'file'
+            },
+            'table': 'test'
+        },
+        'type': 'table',
+    }
+
+def test_view_to_spec_with_context(set_root):
+    set_root(str(Path(__file__).parent.parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    view = {
+        'type': 'table',
+        'table': 'test',
+    }
+
+    view = View.from_spec(view, source, [])
+    context = {}
+    spec = view.to_spec(context=context)
+    assert context == {
+        'sources': {
+            source.name: {
+                'tables': {'test': 'sources/test.csv'},
+                'type': 'file'
+            },
+        },
+        'pipelines': {
+            view.pipeline.name: {
+                'source': source.name,
+                'table': 'test'
+            }
+        },
+    }
+    assert spec == {
+        'pipeline': view.pipeline.name,
+        'type': 'table'
+    }
+
+def test_view_to_spec_with_context_existing_context(set_root):
+    set_root(str(Path(__file__).parent.parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    view = {
+        'type': 'table',
+        'table': 'test',
+    }
+
+    view = View.from_spec(view, source, [])
+    context = {}
+    view.pipeline.to_spec(context=context)
+    assert context == {
+        'sources': {
+            source.name: {
+                'tables': {'test': 'sources/test.csv'},
+                'type': 'file'
+            },
+        },
+        'pipelines': {
+            view.pipeline.name: {
+                'source': source.name,
+                'table': 'test'
+            }
+        },
+    }
+    spec = view.to_spec(context=context)
+    assert spec == {
+        'pipeline': view.pipeline.name,
+        'type': 'table'
+    }
+
+def test_hvplot_view_to_spec(set_root):
+    set_root(str(Path(__file__).parent.parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    view = {
+        'type': 'hvplot',
+        'table': 'test',
+        'x': 'A',
+        'y': 'B',
+        'alpha': 0.3
+    }
+    view = View.from_spec(view, source, [])
+    assert view.to_spec() == {
+        'pipeline': {
+            'source': {
+                'tables': {'test': 'sources/test.csv'},
+                'type': 'file'
+            },
+            'table': 'test'
+        },
+        'type': 'hvplot',
+        'x': 'A',
+        'y': 'B',
+        'alpha': 0.3
+    }

--- a/lumen/ui/sources.py
+++ b/lumen/ui/sources.py
@@ -75,6 +75,7 @@ class SourceEditor(FastComponent):
         params.update(**{
             k: v for k, v in spec.items() if k in self.param and k not in params
         })
+        self._source = None
         self._thumbnail = params.pop('thumbnail', None)
         super().__init__(spec=spec, **params)
         self.form = pn.Column(sizing_mode='stretch_width')
@@ -94,6 +95,8 @@ class SourceEditor(FastComponent):
 
     @catch_and_notify
     def _load_table_data(self, event):
+        if self._source is None:
+            self._update_preview()
         self.preview.value = self._source.get(self._select_table.value)
 
     @property

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -52,7 +52,7 @@ class Download(Component, Viewer):
     view = param.Parameter(doc="Holds the current view.")
 
     # Specification configuration
-    _internal_params = ['view']
+    _internal_params = ['view', 'name']
     _required_keys = ['format']
     _validate_params = True
 
@@ -165,8 +165,8 @@ class View(MultiTypeComponent, Viewer):
         return pn.panel(pn.bind(lambda e: self.panel, self.param.rerender))
 
     def _init_link_selections(self):
-        doc = pn.state.curdoc
-        if self._ls is not None or doc is None:
+        doc = pn.state.curdoc or self.pipeline
+        if self._ls is not None:
             return
         if doc not in View._selections and self.selection_group:
             View._selections[doc] = {}
@@ -389,6 +389,7 @@ class View(MultiTypeComponent, Viewer):
         Declarative specification of this component.
         """
         spec = super().to_spec(context)
+        spec.update(self.kwargs)
         if context is None:
             return
         for name, pipeline in context.get('pipelines', {}).items():
@@ -399,6 +400,7 @@ class View(MultiTypeComponent, Viewer):
             if 'pipelines' not in context:
                 context['pipelines'] = {}
             context['pipelines'][self.pipeline.name] = spec['pipeline']
+            spec['pipeline'] = self.pipeline.name
         return spec
 
     def update(self, *events, invalidate_cache=True):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -391,7 +391,7 @@ class View(MultiTypeComponent, Viewer):
         spec = super().to_spec(context)
         spec.update(self.kwargs)
         if context is None:
-            return
+            return spec
         for name, pipeline in context.get('pipelines', {}).items():
             if spec.get('pipeline') == pipeline:
                 spec['pipeline'] = name

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -27,6 +27,7 @@ from ..pipeline import Pipeline
 from ..state import state
 from ..transforms import SQLTransform, Transform
 from ..util import catch_and_notify, is_ref, resolve_module_reference
+from ..validation import ValidationError
 
 DOWNLOAD_FORMATS = ['csv', 'xlsx', 'json', 'parquet']
 
@@ -247,6 +248,12 @@ class View(MultiTypeComponent, Viewer):
                 if isinstance(source, str):
                     source = state.sources[source]
                 pipeline = Pipeline(source=source, **overrides)
+            elif 'table' in overrides and len(overrides) == 1:
+                if pipeline.table != overrides['table']:
+                    raise ValidationError(
+                        'Table declared on view does not match table declared '
+                        'on pipeline.', spec, 'table'
+                    )
             elif overrides:
                 pipeline = pipeline.chain(
                     filters=overrides.get('filters', []),

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -374,6 +374,33 @@ class View(MultiTypeComponent, Viewer):
         """
         return pn.panel(self.get_data())
 
+    def to_spec(self, context=None):
+        """
+        Exports the full specification to reconstruct this component.
+
+        Parameters
+        ----------
+        context: Dict[str, Any]
+          Context contains the specification of all previously serialized components,
+          e.g. to allow resolving of references.
+
+        Returns
+        -------
+        Declarative specification of this component.
+        """
+        spec = super().to_spec(context)
+        if context is None:
+            return
+        for name, pipeline in context.get('pipelines', {}).items():
+            if spec.get('pipeline') == pipeline:
+                spec['pipeline'] = name
+                return spec
+        if 'pipeline' in spec:
+            if 'pipelines' not in context:
+                context['pipelines'] = {}
+            context['pipelines'][self.pipeline.name] = spec['pipeline']
+        return spec
+
     def update(self, *events, invalidate_cache=True):
         """
         Triggers an update in the View.


### PR DESCRIPTION
This rounds out our ability to declare Lumen components programmatically. We can now build `View` and `Target` components programmatically and then export them to a specification.