### PR TITLE
Allow declaring per query caching behavior at Source level

### DIFF
--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -19,6 +19,9 @@ class AE5Source(Source):
     Anaconda Enterprise 5 installation.
     """
 
+    cache_per_query = param.Boolean(default=False, doc="""
+        Whether to query the whole dataset or individual queries.""")
+
     hostname = param.String(doc="URL of the AE5 host.")
 
     username = param.String(doc="Username to authenticate with AE5.")
@@ -279,7 +282,7 @@ class AE5Source(Source):
 
         return allocations[self._allocation_columns]
 
-    @cached(with_query=False)
+    @cached
     def get(self, table, **query):
         if table not in self._tables:
             raise ValueError(f"AE5Source has no '{table}' table, choose from {repr(self._tables)}.")

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -44,6 +44,11 @@ def cached(method, locks=weakref.WeakKeyDictionary()):
     """
     @wraps(method)
     def wrapped(self, table, **query):
+        if self._supports_sql and not self.cache_per_query and 'sql_transforms' in query:
+            raise RuntimeError(
+                'SQLTransforms cannot be used on a Source with cache_per_query '
+                'being disabled. Ensure you set `cache_per_query=True`.'
+            )
         if self in locks:
             main_lock = locks[self]['main']
         else:

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -7,6 +7,9 @@ from .base import Source, cached, cached_schema
 
 class IntakeBaseSource(Source):
 
+    cache_per_query = param.Boolean(default=False, doc="""
+        Whether to query the whole dataset or individual queries.""")
+
     load_schema = param.Boolean(default=True, doc="""
         Whether to load the schema""")
 
@@ -39,7 +42,7 @@ class IntakeBaseSource(Source):
             schemas[entry] = get_dataframe_schema(data)['items']['properties']
         return schemas if table is None else schemas[table]
 
-    @cached(with_query=False)
+    @cached
     def get(self, table, **query):
         dask = query.pop('__dask', self.dask)
         try:

--- a/lumen/sources/intake_dremio.py
+++ b/lumen/sources/intake_dremio.py
@@ -4,6 +4,11 @@ from .intake_sql import IntakeBaseSQLSource
 
 
 class IntakeDremioSource(IntakeBaseSQLSource):
+    """
+    IntakeDremioSource allows querying Dremio tables and views.
+
+    Requires the intake-dremio package to be installed.
+    """
 
     cert = param.String(default="Path to certificate file")
 

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -17,6 +17,8 @@ class IntakeBaseSQLSource(IntakeBaseSource):
     # Declare this source supports SQL transforms
     _supports_sql = True
 
+    __abstract = True
+
     def _apply_transforms(self, source, sql_transforms):
         if not sql_transforms:
             return source
@@ -35,7 +37,7 @@ class IntakeBaseSQLSource(IntakeBaseSource):
             ) from e
         return source
 
-    @cached()
+    @cached
     def get(self, table, **query):
         '''
         Applies SQL Transforms, creating new temp catalog on the fly
@@ -104,8 +106,8 @@ class IntakeBaseSQLSource(IntakeBaseSource):
 
 class IntakeSQLSource(IntakeBaseSQLSource, IntakeSource):
     """
-    Intake source specifically for SQL sources.
-    Allows for sql transformations to be applied prior to querying the source.
+    Intake source specifically for SQL sources. Allows for
+    SQLTransform to be applied prior to querying the source.
     """
 
     source_type = 'intake_sql'

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -12,6 +12,9 @@ from .intake import IntakeBaseSource, IntakeSource
 
 class IntakeBaseSQLSource(IntakeBaseSource):
 
+    cache_per_query = param.Boolean(default=True, doc="""
+        Whether to query the whole dataset or individual queries.""")
+
     filter_in_sql = param.Boolean(default=True, doc="")
 
     # Declare this source supports SQL transforms

--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -22,6 +22,9 @@ class PrometheusSource(Source):
     ae5_source = param.Parameter(doc="""
       An AE5Source instance to use for querying.""")
 
+    cache_per_query = param.Boolean(default=False, doc="""
+        Whether to query the whole dataset or individual queries.""")
+
     ids = param.List(default=[], doc="""
       List of pod IDs to query.""")
 
@@ -230,7 +233,7 @@ class PrometheusSource(Source):
             schema[k] = mdef['schema']
         return {"timeseries": schema} if table is None else schema
 
-    @cached(with_query=False)
+    @cached
     def get(self, table, **query):
         if table not in ('timeseries',):
             raise ValueError(f"PrometheusSource has no '{table}' table, "


### PR DESCRIPTION
Whether to cache all the data or each individual query is, at least in some cases, something that a user might want control over. Therefore we move the declaration from the decorator to a parameter on each Source.