### PR TITLE
CI: increase tests workflow timeout to 60 min

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: [3.7, 3.8, 3.9]
-    timeout-minutes: 30
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
As per the title, 30 min can be too short at times.