### PR TITLE
Fix missing navigation bar icons 

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -48,14 +48,6 @@
     }
 }
 
-#navbar-icon-links i.fa-github-square:before {
-    color: white;
-}
-
-.fa-discourse:before {
-    color: white;
-}
-
 button.toggle-button {
     display: none;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "Discourse",
-            "url": "https://discourse.holoviz.org/",
+            "url": "https://discourse.holoviz.org/c/lumen/14",
             "icon": "fab fa-discourse",
         },
     ],


### PR DESCRIPTION
On the [current dev docs](https://pyviz-dev.github.io/lumen/) the navigation bar icons for Github and Discourse is missing:

Current
![image](https://user-images.githubusercontent.com/19758978/200772219-1e4eb24c-b308-423e-9542-d97947a58740.png)

With this PR
![image](https://user-images.githubusercontent.com/19758978/200772086-46612fcc-4ebd-4361-a833-ea5cdba8c4e3.png)

I also updated the Discourse URL to refer to the Lumen category on Discourse, as I could see this is what is Panel does.