### PR TITLE
Ensure refs are fully synced before Pipeline and View updates

### DIFF
--- a/lumen/base.py
+++ b/lumen/base.py
@@ -106,16 +106,16 @@ class Component(param.Parameterized):
         Component should implement appropriate downstream events
         following a change in a variable.
         """
-        new = value if event is None else event.new
+        new_value = value if event is None else event.new
         if '.' in pname:
             pname, *keys = pname.split('.')
             old = getattr(self, pname)
             current = new = old.copy()
             for k in keys[:-1]:
                 current = current[k]
-            current[keys[-1]] = new
+            current[keys[-1]] = new_value
         else:
-            new = new
+            new = new_value
         self.param.update({pname: new})
 
     def _sync_refs(self, trigger=True):

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -232,6 +232,11 @@ class Pipeline(Component):
             return
 
         self._update_widget.loading = True
+
+        # Ensure all refs are up-to-date before we run the pipeline
+        for f in self.filters+self.transforms+self.sql_transforms:
+            f._sync_refs()
+
         try:
             self.data = self._compute_data()
         except Exception as e:

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -315,6 +315,7 @@ class View(MultiTypeComponent, Viewer):
         Updates the cached Panel object and returns a boolean value
         indicating whether a rerender is required.
         """
+        self._sync_refs(trigger=False)
         if self._panel is not None:
             self._cleanup()
             updates = self._get_params()


### PR DESCRIPTION
Right now if a `Variable` updates this immediately triggers a cascade of events that can update `Pipeline` and `View` components. The problem that can arise is that variables can be linked to multiple different objects and if an update to a Pipeline triggers an update in a View that also references the same `Variable` you'll end up in a situation where the View parameter does not yet reflect the change in the Variable value but the data coming from the Pipeline does.

This PR ensures that when Pipelines and Views are updated we first sync all references to ensure they are all up-to-date.