### PR TITLE
Ensure views are rendered lazily

### DIFF
--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -164,9 +164,11 @@ class View(MultiTypeComponent, Viewer):
         self.download.view = self
         if self.selection_group:
             self._init_link_selections()
-        self.update()
+        self._initialized = False
 
     def __panel__(self):
+        if not self._initialized:
+            self.update()
         return pn.panel(pn.bind(lambda e: self.panel, self.param.rerender))
 
     def _init_link_selections(self):
@@ -429,6 +431,7 @@ class View(MultiTypeComponent, Viewer):
         if invalidate_cache:
             self._cache = None
         stale = self._update_panel()
+        self._initialized = True
         if stale:
             self.param.trigger('rerender')
 
@@ -443,6 +446,8 @@ class View(MultiTypeComponent, Viewer):
 
     @property
     def panel(self):
+        if not self._initialized:
+            self.update()
         panel = self._panel
         if isinstance(panel, PaneBase):
             if len(panel.layout) == 1 and panel._unpack:


### PR DESCRIPTION
When we made View components usable in a notebook we started rendering them on instantiation. Since many subclasses relied on the fact that they could initialize variables after instantiation of the superclass this meant we broke some of these. Therefore we now return to a scheme where a View is not rendered on instantiation but only when rendering is required.