### PR TITLE
Serialize Widget Variable parameters

### DIFF
--- a/lumen/tests/test_variables.py
+++ b/lumen/tests/test_variables.py
@@ -76,3 +76,26 @@ def test_widget_variable_linking_throttled():
 
     var.value = 4
     assert var._widget.value == 4
+
+
+def test_widget_variable_intslider_to_spec():
+    var = Variable.from_spec({'type': 'widget', 'kind': 'IntSlider', 'throttled': False, 'start': 10, 'end': 53})
+
+    assert var.to_spec() == {
+        'type': 'widget',
+        'kind': 'IntSlider',
+        'throttled': False,
+        'start': 10,
+        'end': 53,
+        'value': 10
+    }
+
+def test_widget_variable_select_to_spec():
+    var = Variable.from_spec({'type': 'widget', 'kind': 'Select', 'options': ['A', 'B', 'C']})
+
+    assert var.to_spec() == {
+        'type': 'widget',
+        'kind': 'Select',
+        'options': ['A', 'B', 'C'],
+        'value': 'A'
+    }

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -259,8 +259,19 @@ class Widget(Variable):
         spec = super().to_spec(context=context)
         pvals = self._widget.param.values()
         for pname, pobj in self._widget.param.objects().items():
-            if pvals[pname] is not pobj.default and pname not in spec:
-                spec[pname] = pvals[pname]
+            pval = pvals[pname]
+            if (
+                pval is pobj.default or pname in spec or
+                (pname == 'name' and not pval) or pname == 'value_throttled'
+            ):
+                continue
+            try:
+                # Gracefully handle failed equality checks
+                if pval == pobj.default:
+                    continue
+            except Exception:
+                pass
+            spec[pname] = pvals[pname]
         return spec
 
     @property

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -226,6 +226,7 @@ class Widget(Variable):
             widget_type = getattr(pn.widgets, self.kind)
         if 'value' not in params and default is not None:
             params['value'] = default
+
         if self.label:
             params['name'] = self.label
         deserialized = {}
@@ -246,6 +247,21 @@ class Widget(Variable):
         else:
             self.value = self._widget.value
             self._widget.link(self, value='value', bidirectional=True)
+
+    def to_spec(self, context=None):
+        """
+        Exports the full specification to reconstruct this component.
+
+        Returns
+        -------
+        Resolved and instantiated Component object
+        """
+        spec = super().to_spec(context=context)
+        pvals = self._widget.param.values()
+        for pname, pobj in self._widget.param.objects().items():
+            if pvals[pname] is not pobj.default and pname not in spec:
+                spec[pname] = pvals[pname]
+        return spec
 
     @property
     def panel(self):


### PR DESCRIPTION
Ensures that all non-default `Widget` `Variable` parameters are correctly serialized.