### PR TITLE
Ensure View reference updates wait on Pipeline

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -41,7 +41,7 @@ class Config(Component):
     `Config` provides high-level configuration options for the Dashboard.
     """
 
-    auto_update = param.Boolean(default=True, constant=True, doc="""
+    auto_update = param.Boolean(default=None, constant=True, doc="""
         Whether changes in filters, transforms and references automatically
         trigger updates in the data or whether an update has to be triggered
         manually using the update event or the update button in the UI."""
@@ -411,7 +411,7 @@ class Dashboard(Component):
         target_spec = dict(target_spec)
         if 'reloadable' not in target_spec:
             target_spec['reloadable'] = self.config.reloadable
-        if 'auto_update' not in target_spec:
+        if 'auto_update' not in target_spec and self.config.auto_update is not None:
             target_spec['auto_update'] = self.config.auto_update
         target = Target.from_spec(target_spec)
         self._rerender_watchers[target] = target.param.watch(
@@ -430,7 +430,10 @@ class Dashboard(Component):
         if force or self._load_global or not state.global_sources:
             state.load_global_sources(clear_cache=force)
         if force or self._load_global or not state.pipelines:
-            state.load_pipelines(auto_update=self.config.auto_update)
+            kwargs = {}
+            if self.config.auto_update is not None:
+                kwargs['auto_update'] = self.config.auto_update
+            state.load_pipelines(**kwargs)
         if not self.auth.authorized:
             self.targets = []
             return

--- a/lumen/tests/sample_dashboard/view_transform_variable.yaml
+++ b/lumen/tests/sample_dashboard/view_transform_variable.yaml
@@ -1,0 +1,28 @@
+variables:
+  rename:
+    type: constant
+    default: Z
+sources:
+  test:
+    type: 'file'
+    tables: ['../sources/test.csv']
+    kwargs:
+      parse_dates: ['D']
+pipelines:
+  test:
+    auto_update: false
+    source: test
+    table: test
+    transforms:
+      - type: rename
+        axis: 1
+        mapper:
+          A: $variables.rename
+targets:
+  - title: "Test"
+    pipeline: test
+    views:
+      - type: hvplot
+        kind: line
+        x: index
+        y: $variables.rename

--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -158,3 +158,23 @@ def test_dashboard_with_view_variable(set_root, document):
     state.variables.page_size = 10
 
     assert table.page_size == 10
+
+def test_dashboard_with_view_and_transform_variable(set_root, document):
+    root = pathlib.Path(__file__).parent / 'sample_dashboard'
+    set_root(str(root))
+    dashboard = Dashboard(str(root / 'view_transform_variable.yaml'))
+    dashboard._render_dashboard()
+    target = dashboard.targets[0]
+    target.update()
+
+    plot = target._cards[0]._card[0][0]
+
+    assert plot.object.vdims == ['Z']
+
+    state.variables.rename = 'Y'
+
+    assert plot.object.vdims == ['Z']
+
+    list(target._pipelines.values())[0].param.trigger('update')
+
+    assert plot.object.vdims == ['Y']

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -52,6 +52,14 @@ class Transform(MultiTypeComponent):
             if is_ref(v):
                 refs[k] = v
                 v = state.resolve_reference(v)
+            elif isinstance(v, dict):
+                resolved = {}
+                for sk, sv in v.items():
+                    if is_ref(sv):
+                        refs[f'{k}.{sk}'] = sv
+                        sv = state.resolve_reference(sv)
+                    resolved[sk] = sv
+                v = resolved
             if (k in transform_type.param and
                 isinstance(transform_type.param[k], param.ListSelector) and
                 not isinstance(v, list)):
@@ -607,7 +615,7 @@ class Rename(Transform):
               level=<level>, axis=<axis>, copy=<copy>)
     """
 
-    axis = param.ClassSelector(default=0, class_=(int, str), doc="""
+    axis = param.ClassSelector(default=None, class_=(int, str), doc="""
         The axis to rename. 0 or 'index', 1 or 'columns'""")
 
     columns = param.Dict(default=None, doc="""

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -171,6 +171,25 @@ class View(MultiTypeComponent, Viewer):
             self.update()
         return pn.panel(pn.bind(lambda e: self.panel, self.param.rerender))
 
+    def _update_ref(self, pname, event=None, value=None):
+        # Note: Do not trigger update in View if Pipeline references
+        # the same variable and is not set up to auto-update
+        if event is not None and not self.pipeline.auto_update:
+            refs = []
+            current = self.pipeline
+            while current is not None:
+                for ref in current.refs:
+                    if ref not in refs:
+                        refs.append(ref)
+                current = current.pipeline
+            print(refs)
+            if any(
+                ref.split('.')[-1] == event.name
+                for ref in refs if ref.startswith('$variables')
+            ):
+                return
+        super()._update_ref(pname, event=event, value=value)
+
     def _init_link_selections(self):
         doc = pn.state.curdoc or self.pipeline
         if self._ls is not None:


### PR DESCRIPTION
Variable can be referenced by both Views and any part of a data pipeline. If the data pipeline is not set to auto_update we can end up in a state where the View does not wait on changes in the Pipeline and the two can get out-of-sync. This fix ensures that a View that references a Variable also used by the Pipeline feeding it waits on the Pipeline update to trigger.