### PR TITLE
Change state to config in catch_and_notifify

### DIFF
--- a/lumen/util.py
+++ b/lumen/util.py
@@ -286,7 +286,7 @@ def catch_and_notify(message=None):
             try:
                 return func(*args, **kwargs)
             except Exception as e:
-                if pn.state.notifications:
+                if pn.config.notifications:
                     log.error(
                         f"{func.__qualname__!r} raised {type(e).__name__}: {e}"
                     )


### PR DESCRIPTION
Mostly for debugging purposes when working in a Notebook.  

``` python
import panel as pn
pn.extension(notifications=True)

pn.config.notifications=False

print(pn.state.notifications)

```

Will output `NotificationArea()` and therefore not raise an error.
