### PR TITLE
Initialize value for a Widget even if it is throttled

### DIFF
--- a/lumen/tests/test_variables.py
+++ b/lumen/tests/test_variables.py
@@ -101,12 +101,6 @@ def test_widget_variable_select_to_spec():
     }
 
 
-def test_intslider_value_sync():
-    pval = IntSlider(value=20)
-    var_kwargs = dict(
-        kind=f"{pval.__module__}.{type(pval).__name__}",
-        **{k: v for k, v in pval.param.values().items()},
-    )
-    var = Widget(**var_kwargs)
-
-    assert var.value == pval.value
+def test_intslider_value_initialize():
+    var = Widget(kind="IntSlider", value=20)
+    assert var.value == 20

--- a/lumen/tests/test_variables.py
+++ b/lumen/tests/test_variables.py
@@ -4,7 +4,7 @@ import param
 
 from panel.widgets import IntSlider
 
-from lumen.variables import Variable, Variables
+from lumen.variables import Variable, Variables, Widget
 
 
 def test_variables():
@@ -99,3 +99,14 @@ def test_widget_variable_select_to_spec():
         'options': ['A', 'B', 'C'],
         'value': 'A'
     }
+
+
+def test_intslider_value_sync():
+    pval = IntSlider(value=20)
+    var_kwargs = dict(
+        kind=f"{pval.__module__}.{type(pval).__name__}",
+        **{k: v for k, v in pval.param.values().items()},
+    )
+    var = Widget(**var_kwargs)
+
+    assert var.value == pval.value

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -241,11 +241,11 @@ class Widget(Variable):
             self._widget = widget
         else:
             self._widget = widget_type(**deserialized)
+        self.value = self._widget.value
         if self.throttled and 'value_throttled' in self._widget.param:
             self._widget.link(self, value_throttled='value')
             self.param.watch(lambda e: self._widget.param.update({'value': e.new}), 'value')
         else:
-            self.value = self._widget.value
             self._widget.link(self, value='value', bidirectional=True)
 
     def to_spec(self, context=None):


### PR DESCRIPTION
Noticed that when initializing a Widget variable with `value_throttled` parameter, it would not set the value of the actual widget. 