### PR TITLE
Sort enumerated values from schema in Select widgets

### DIFF
--- a/lumen/schema.py
+++ b/lumen/schema.py
@@ -134,7 +134,7 @@ class JSONSchema(pn.pane.PaneBase):
 
     def _enum(self, schema):
         wtype = self._multi_select_widget if self.multi else self._select_widget
-        return wtype, {'options': schema['enum']}
+        return wtype, {'options': sorted(schema['enum'])}
 
     def __init__(self, object=None, schema=None, **params):
         if schema is not None:


### PR DESCRIPTION
Since the schema is obtained by querying the data and is therefore in random order it is better to sort the enumerated values when creating a select widget.