### PR TITLE
Improve rendering of reference docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,11 +53,7 @@ jobs:
           conda activate test-environment
           conda list
           doit develop_install -o doc -o examples
-      - name: install rst-to-myst
-      # with pip as it's not yet available on conda-forge
-        run: |
-          conda activate test-environment
-          pip install rst-to-myst "pydata-sphinx-theme==0.9.0"
+          pip install "pydata-sphinx-theme==0.9.0"
       - name: build docs
         run: |
           conda activate test-environment

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,8 @@ param.parameterized.docstring_describe_params = False
 
 import panel
 
-from nbsite.shared_conf import setup
+from nbsite import nbbuild
+from nbsite.shared_conf import remove_mystnb_static
 from nbsite.util import base_version  # noqa
 from panel.io.convert import BOKEH_VERSION, PY_VERSION
 from panel.io.resources import CDN_DIST, DIST_DIR
@@ -47,6 +48,10 @@ description = 'Declarative data intake, processing, visualization and dashboardi
 version = release = base_version(lumen.__version__)
 
 # -- General configuration ---------------------------------------------------
+
+def setup(app):
+    nbbuild.setup(app)
+    app.connect("builder-inited", remove_mystnb_static)
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -30,7 +30,7 @@ class DataFrame(param.DataFrame):
     """
 
     def __get__(self, obj, objtype):
-        if (obj is not None and obj.__dict__.get(self._internal_name) is None) or (obj._stale and obj.auto_update):
+        if obj is not None and (obj.__dict__.get(self._internal_name) is None or (obj._stale and obj.auto_update)):
             obj._update_data(force=True)
         return super().__get__(obj, objtype)
 

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -851,14 +851,12 @@ class JoinedSource(Source):
 
     As a simple example we may have sources A and B, which contain
     tables 'foo' and 'bar' respectively. We now want to merge these
-    tables on column 'a' in Table A with column 'b' in Table B:
+    tables on column 'a' in Table A with column 'b' in Table B::
 
-    ```
-    {'new_table': [
-        {'source': 'A', 'table': 'foo', 'index': 'a'},
-        {'source': 'B', 'table': 'bar', 'index': 'b'}
-    ]}
-    ```
+        {'new_table': [
+          {'source': 'A', 'table': 'foo', 'index': 'a'},
+          {'source': 'B', 'table': 'bar', 'index': 'b'}
+        ]}
 
     The joined source will now publish the "new_table" with all
     columns from tables "foo" and "bar" except for the index column
@@ -967,40 +965,36 @@ class DerivedSource(Source):
     In 'table' mode the tables can reference any table on any source
     using the reference syntax and declare filters and transforms to
     apply to that specific table, e.g. a table specification might
-    look like this:
+    look like this::
 
-    ```
-    {
-      'derived_table': {
-        'source': 'original_source',
-        'table': 'original_table'
-        'filters': [
-          ...
-        ],
-        'transforms': [
-          ...
-        ]
-      }
-    }
-    ```
+        {
+          'derived_table': {
+            'source': 'original_source',
+            'table': 'original_table'
+            'filters': [
+              ...
+            ],
+            'transforms': [
+              ...
+            ]
+          }
+        }
 
-    **Mirror**
+    **Mirror mode**
 
     When a `source` is declared all tables on that Source are mirrored
     and filtered and transformed according to the supplied `filters`
     and `transforms`. This is referred to as 'mirror' mode.
 
     In mirror mode the DerivedSource may reference an existing source
-    directly, e.g.:
+    directly, e.g.::
 
-    ```
-    {
-        'type': 'derived',
-        'source': 'original_source',
-        'filters': [...],
-        'transforms': [...],
-    }
-    ```
+        {
+            'type': 'derived',
+            'source': 'original_source',
+            'filters': [...],
+            'transforms': [...],
+        }
     """
 
     cache_per_query = param.Boolean(default=False, doc="""


### PR DESCRIPTION
- Uses autodoc to generate anchor (so cross-linking will work)
- Use autodoc to document methods
- Don't render param section if no params are defined