### PR TITLE
Fix and speed up builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.7
+          python-version: 3.8
       - name: Set output
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
@@ -57,8 +57,8 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py37"
-      PYTHON_VERSION: "3.7"
+      PKG_TEST_PYTHON: "--test-python=py38"
+      PYTHON_VERSION: "3.8"
       MPLBACKEND: "Agg"
       PPU: ${{ secrets.PPU }}
       PPP: ${{ secrets.PPP }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,12 +76,12 @@ jobs:
           miniconda-version: "latest"
       - name: conda setup
         run: |
-          conda create -n test-environment
+          conda install -c pyviz/label/dev "pyctdev>=0.5"
+          doit ecosystem_setup
+          doit env_create $CHANS_DEV --python=$PYTHON_VERSION
           conda activate test-environment
-          conda config --remove channels defaults
           conda config --env --remove channels defaults
           conda config --env --append channels pyviz/label/dev --append channels conda-forge
-          conda install "python=$PYTHON_VERSION" "pyctdev>=0.5"
       - name: env setup
         run: |
           conda activate test-environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channel-priority: flexible
           channels: pyviz/label/dev,bokeh,conda-forge,nodefaults
-          envs: "-o tests"
+          envs: "-o tests -o sql"
           cache: true
         id: install
       - name: doit test_unit

--- a/lumen/tests/sources/test_intake_sql.py
+++ b/lumen/tests/sources/test_intake_sql.py
@@ -4,6 +4,11 @@ import os
 import pandas as pd
 import pytest
 
+try:
+    import intake_sql  # noqa
+except Exception:
+    pytest.skip('intake-sql not available.')
+
 from lumen.sources.intake_sql import IntakeSQLSource
 from lumen.transforms.sql import SQLGroupBy
 

--- a/lumen/tests/sources/test_intake_sql.py
+++ b/lumen/tests/sources/test_intake_sql.py
@@ -7,7 +7,7 @@ import pytest
 try:
     import intake_sql  # noqa
 except Exception:
-    pytest.skip('intake-sql not available.')
+    pytest.skip('intake-sql not available.', allow_module_level=True)
 
 from lumen.sources.intake_sql import IntakeSQLSource
 from lumen.transforms.sql import SQLGroupBy

--- a/lumen/tests/test_pipeline.py
+++ b/lumen/tests/test_pipeline.py
@@ -1,6 +1,12 @@
 import pathlib
 
 import pandas as pd
+import pytest
+
+try:
+    import intake_sql  # noqa
+except Exception:
+    intake_sql = None
 
 from panel.widgets import Select
 
@@ -10,6 +16,8 @@ from lumen.sources.intake_sql import IntakeSQLSource
 from lumen.state import state
 from lumen.transforms.base import Columns
 from lumen.transforms.sql import SQLColumns, SQLGroupBy
+
+sql_available = pytest.mark.skipif(intake_sql is None, reason="intake-sql is not installed")
 
 
 def test_pipeline_source_only(make_filesource, mixed_df):
@@ -99,6 +107,7 @@ def test_pipeline_manual_with_transform(make_filesource, mixed_df):
     expected = mixed_df[['B', 'C']]
     pd.testing.assert_frame_equal(pipeline.data, expected)
 
+@sql_available
 def test_pipeline_with_sql_transform(mixed_df):
     root = pathlib.Path(__file__).parent / 'sources'
     source = IntakeSQLSource(
@@ -188,6 +197,7 @@ def test_pipeline_chained_with_transform(make_filesource, mixed_df):
     expected = mixed_df.iloc[2:4][['B', 'C']]
     pd.testing.assert_frame_equal(pipeline2.data, expected)
 
+@sql_available
 def test_pipeline_collapsed_with_sql_transform(mixed_df):
     root = pathlib.Path(__file__).parent / 'sources'
     source = IntakeSQLSource(
@@ -211,6 +221,7 @@ def test_pipeline_collapsed_with_sql_transform(mixed_df):
     expected = mixed_df.iloc[2:4][['B', 'C']].reset_index(drop=True)
     pd.testing.assert_frame_equal(pipeline2.data, expected)
 
+@sql_available
 def test_pipeline_chained_with_sql_transform(mixed_df):
     root = pathlib.Path(__file__).parent / 'sources'
     source = IntakeSQLSource(
@@ -236,6 +247,7 @@ def test_pipeline_chained_with_sql_transform(mixed_df):
     expected = mixed_df[['B', 'C']]
     pd.testing.assert_frame_equal(pipeline2.data, expected)
 
+@sql_available
 def test_pipeline_chained_manual_update_with_sql_transform(mixed_df):
     root = pathlib.Path(__file__).parent / 'sources'
     source = IntakeSQLSource(
@@ -314,6 +326,7 @@ def test_load_chained_pipeline(penguins_file):
     assert 'penguins_chained' in pipelines
     assert pipelines['penguins_chained'].pipeline is pipelines['penguins']
 
+@sql_available
 def test_pipeline_with_sql_transform_nested_widget_vars(mixed_df):
     root = pathlib.Path(__file__).parent / 'sources'
     source = IntakeSQLSource(

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,16 @@ dependencies = [
 ]
 
 extras_require = {
+    'sql': [
+        'duckdb',
+        'intake-sql',
+    ],
     'tests': [
         'pytest',
         'flake8',
         'intake',
-        'intake-sql',
         'fastparquet',
         'msgpack-python',
-        'duckdb',
         'toolz',
         'pytest-cov',
         'codecov',


### PR DESCRIPTION
- Run builds on py3.8
- Install pyctdev in base env (not build env)
- Do not test sql in build (due to DuckDB issues in build env)