### PR TITLE
Ensure that View links and resolves all ParamFilters

### DIFF
--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -361,6 +361,13 @@ class View(MultiTypeComponent, Viewer):
 
         view = view_type(refs=refs, **resolved_spec)
 
+        if filters is None:
+            filters = view.pipeline.traverse('filters')
+            for pipeline in state.pipelines.values():
+                for filt in pipeline.traverse('filters'):
+                    if filt not in filters:
+                        filters.append(filt)
+
         # Resolve ParamFilter parameters
         for filt in (filters or []):
             if isinstance(filt, ParamFilter):


### PR DESCRIPTION
Allows `View.from_spec` to appropriately link all available `ParamFilter` instances.