### PR TITLE
Add a shortcut for setting download format in a view

### DIFF
--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -167,6 +167,8 @@ class View(MultiTypeComponent, Viewer):
         pipeline = params.pop('pipeline', None)
         if pipeline is None:
             raise ValueError("Views must declare a Pipeline.")
+        if isinstance(params.get("download"), str):
+            params["download"] = Download(format=params["download"])
         fields = list(pipeline.schema)
         for fp in self._field_params:
             if isinstance(self.param[fp], param.Selector):


### PR DESCRIPTION
It makes it possible to just paste a string into a View for the download option.

``` python
import lumen
import panel as pn
import yaml
from lumen.layout import Layout
from lumen.pipeline import Pipeline
from lumen.sources import FileSource
from lumen.views import Table

pn.extension("tabulator")

data_url = "https://datasets.holoviz.org/penguins/v1/penguins.csv"

pipeline = Pipeline(source=FileSource(tables={"penguins": data_url}), table="penguins")
pipeline.add_filter("widget", field="species")

view = Table(pipeline=pipeline, download="csv")
# Before: Table(pipeline=pipeline, download=Download(format="csv")) and this import from lumen.views.base import Download

specification = lumen.state.to_spec(
    config={"title": "test"},
    layouts=[Layout(views=[view])],
)

print(yaml.dump(specification))
 