### PR TITLE
Add title option to view

### DIFF
--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -109,7 +109,8 @@ class Download(Component, Viewer):
 
 class View(MultiTypeComponent, Viewer):
     """
-    `View` components provide a visual representation for the data returned by a :class:`lumen.source.base.Source` or :class:`lumen.pipeline.Pipeline`.
+    `View` components provide a visual representation for the data returned
+    by a :class:`lumen.source.base.Source` or :class:`lumen.pipeline.Pipeline`.
 
     The `View` must return a Panel object or an object that can be
     rendered by Panel. The base class provides methods which query the
@@ -135,6 +136,9 @@ class View(MultiTypeComponent, Viewer):
     selection_group = param.String(default=None, doc="""
         Declares a selection group the plot is part of. This feature
         requires the separate HoloViews library.""")
+
+    title = param.String(default=None, doc="""
+        The title of the view.""")
 
     field = param.Selector(doc="The field being visualized.")
 
@@ -489,8 +493,19 @@ class View(MultiTypeComponent, Viewer):
                 panel = panel.layout[0]
             else:
                 panel = panel._layout
-        if self.download:
-            return pn.Column(self.download, panel, sizing_mode='stretch_width')
+        if self.title:
+            title_pane = pn.pane.HTML(
+                f'<h3 align="center", style="margin-top: 0; margin-bottom: 0;">{self.title}</h3>',
+                sizing_mode="stretch_width"
+            )
+        if self.download and self.title:
+            download_pane = pn.panel(self.download)
+            download_pane.sizing_mode = "fixed"
+            return pn.Column(pn.Row(title_pane, download_pane), panel)
+        elif self.download:
+            return pn.Column(self.download, panel, sizing_mode="stretch_both")
+        elif self.title:
+            return pn.Column(title_pane, panel)
         return panel
 
     @property

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -501,11 +501,13 @@ class View(MultiTypeComponent, Viewer):
         if self.download and self.title:
             download_pane = pn.panel(self.download)
             download_pane.sizing_mode = "fixed"
-            return pn.Column(pn.Row(title_pane, download_pane), panel)
+            return pn.Column(
+                pn.Row(title_pane, download_pane), panel, sizing_mode=panel.sizing_mode
+            )
         elif self.download:
             return pn.Column(self.download, panel, sizing_mode="stretch_both")
         elif self.title:
-            return pn.Column(title_pane, panel)
+            return pn.Column(title_pane, panel, sizing_mode=panel.sizing_mode)
         return panel
 
     @property


### PR DESCRIPTION
``` python
import panel as pn
from lumen.layout import Layout
from lumen.pipeline import Pipeline
from lumen.sources import FileSource
from lumen.views import Table

pn.extension("tabulator")

data_url = "https://datasets.holoviz.org/penguins/v1/penguins.csv"

pipeline = Pipeline(source=FileSource(tables={"penguins": data_url}), table="penguins")
pipeline.add_transform("iloc", end=5)

table1 = Table(pipeline=pipeline, title="Title 1", download="csv")
table2 = Table(pipeline=pipeline, title="Title 2")
table3 = Table(pipeline=pipeline)
table4 = Table(pipeline=pipeline, download="csv")

Layout(views=[table1, table2, table3, table4], title="Tables")
````

![image](https://user-images.githubusercontent.com/19758978/212929964-0d2a640f-edd5-470d-b7a4-72f6e1abf810.png)


- [x] Need to write some unit tests
- [ ] Document it somewhere in the docs
