### PR TITLE
Update holoviz_tasks/install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
 
-      - uses: pyviz-dev/holoviz_tasks/install@v0.1a5
+      - uses: pyviz-dev/holoviz_tasks/install@v0.1a9
         with:
           name: test_suite
           python-version: ${{ matrix.python-version }}
@@ -51,6 +51,7 @@ jobs:
           channels: pyviz/label/dev,bokeh,conda-forge,nodefaults
           envs: "-o tests -o sql"
           cache: true
+          conda-mamba: mamba
         id: install
       - name: doit test_unit
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channel-priority: flexible
           channels: pyviz/label/dev,bokeh,conda-forge,nodefaults
-          envs: "-o tests -o sql"
+          envs: ${{ contains(matrix.python-version, '3.7') && '-o tests' || '-o tests -o sql' }}
           cache: true
           conda-mamba: mamba
         id: install


### PR DESCRIPTION
Fixing failing CI for python 3.7. 

DuckDB does not work for Python 3.7. Even if it succeeds in installing I can't get the tests to pass:
![image](https://user-images.githubusercontent.com/19758978/212956810-2bf22f6d-f3c9-49bb-99fa-a4dda3d44d6a.png)

So I have removed the `-o sql` option for Python 3.7. 