### PR TITLE
Improve Download with Index and Filename parameters

### DIFF
--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -238,3 +238,32 @@ def test_view_title_download(set_root, view_type):
 
     button._on_click()
     assert button.data.startswith('data:text/plain;charset=UTF-8;base64')
+
+    assert view.download.filename is None
+    assert view.download.format == 'csv'
+
+
+@pytest.mark.parametrize("view_type", ("table", "hvplot"))
+def test_view_title_download_filename(set_root, view_type):
+    set_root(str(Path(__file__).parent.parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    view = {
+        'type': view_type,
+        'table': 'test',
+        'title': 'Test title',
+        'download': 'example.csv',
+    }
+
+    view = View.from_spec(view, source)
+
+    title = view.panel[0][0]
+    assert isinstance(title, pn.pane.HTML)
+
+    button = view.panel[0][1]
+    assert isinstance(button, DownloadButton)
+
+    button._on_click()
+    assert button.data.startswith('data:text/plain;charset=UTF-8;base64')
+
+    assert view.download.filename == 'example'
+    assert view.download.format == 'csv'

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -5,6 +5,7 @@ import importlib
 import os
 import re
 import sys
+import unicodedata
 
 from functools import wraps
 from logging import getLogger
@@ -314,3 +315,25 @@ def catch_and_notify(message=None):
         return decorator(function)
 
     return decorator
+
+
+def slugify(value, allow_unicode=False) -> str:
+    """
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
+    dashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+
+    From: https://docs.djangoproject.com/en/4.0/_modules/django/utils/text/#slugify
+    """
+    value = str(value)
+    if allow_unicode:
+        value = unicodedata.normalize("NFKC", value)
+    else:
+        value = (
+            unicodedata.normalize("NFKD", value)
+            .encode("ascii", "ignore")
+            .decode("ascii")
+        )
+    value = re.sub(r"[^\w\s-]", "", value.lower())
+    return re.sub(r"[-\s]+", "-", value).strip("-_")

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -33,7 +33,7 @@ from ..state import state
 from ..transforms.base import Transform
 from ..transforms.sql import SQLTransform
 from ..util import (
-    VARIABLE_RE, catch_and_notify, is_ref, resolve_module_reference,
+    VARIABLE_RE, catch_and_notify, is_ref, resolve_module_reference, slugify,
 )
 from ..validation import ValidationError
 
@@ -51,6 +51,12 @@ class Download(Component, Viewer):
 
     color = param.Color(default='grey', allow_None=True, doc="""
       The color of the download button.""")
+
+    filename = param.String(default=None, doc="""filenamefil
+      The filename of the downloaded table.
+      File extension is added automatic based on the format.
+      If filename is not added, it will be based on the name of the view.
+      """)
 
     format = param.ObjectSelector(default=None, objects=DOWNLOAD_FORMATS, doc="""
       The format to download the data in.""")
@@ -103,7 +109,11 @@ class Download(Component, Viewer):
         return io
 
     def __panel__(self) -> DownloadButton:
-        filename = f'{self.view.pipeline.table}.{self.format}'
+        if self.filename:
+            filename = self.filename
+        else:
+            filename = slugify(self.view.title or self.view.pipeline.table)
+        filename = f'{filename}.{self.format}'
         return DownloadButton(
             callback=self._table_data, filename=filename, color=self.color,
             size=18, hide=self.hide

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -52,11 +52,14 @@ class Download(Component, Viewer):
     color = param.Color(default='grey', allow_None=True, doc="""
       The color of the download button.""")
 
+    format = param.ObjectSelector(default=None, objects=DOWNLOAD_FORMATS, doc="""
+      The format to download the data in.""")
+
     hide = param.Boolean(default=False, doc="""
       Whether the download button hides when not in focus.""")
 
-    format = param.ObjectSelector(default=None, objects=DOWNLOAD_FORMATS, doc="""
-      The format to download the data in.""")
+    index = param.Boolean(default=True, doc="""
+      Whether the downloaded table has an index.""")
 
     kwargs = param.Dict(default={}, doc="""
       Keyword arguments passed to the serialization function, e.g.
@@ -89,13 +92,13 @@ class Download(Component, Viewer):
             io = BytesIO()
         data = self.view.get_data()
         if self.format == 'csv':
-            data.to_csv(io, **self.kwargs)
+            data.to_csv(io, index=self.index, **self.kwargs)
         elif self.format == 'json':
-            data.to_json(io, **self.kwargs)
+            data.to_json(io, index=self.index, **self.kwargs)
         elif self.format == 'xlsx':
-            data.to_excel(io, **self.kwargs)
+            data.to_excel(io, index=self.index, **self.kwargs)
         elif self.format == 'parquet':
-            data.to_parquet(io, **self.kwargs)
+            data.to_parquet(io, index=self.index, **self.kwargs)
         io.seek(0)
         return io
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
     'sql': [
         'duckdb',
         'intake-sql',
+        'sqlalchemy <2',  # Don't work with pandas yet
     ],
     'tests': [
         'pytest',


### PR DESCRIPTION
This PR does two things:

- Add the ability to save or not to save the Index
   - Was possible before with `kwargs={'index': False}`.
   - I have kept it as `True` to follow the default used by pandas `to_xxx` methods. 
- Add Filename
   -  If this is not defined, it will try `self.view.title` and thereafter `self.view.pipeline.table` and clean either of them up to be a valid filename. I have chosen not to do this with the parameter, as a user will expect the actually input to be the filename. 

Code used for the filename:
``` python
import numpy as np
import pandas as pd
import panel as pn
from lumen.pipeline import Pipeline
from lumen.sources import FileSource
from lumen.views import Table
from lumen.views.base import Download

pn.extension("tabulator")

np.random.seed(1)
df = pd.DataFrame({"revenue": np.random.uniform(0, 10000, 30)})
df.to_parquet("data.parq")

source = FileSource(files=["data.parq"])
pipeline = Pipeline(source=source, table="data", name="Pipeline")

table = Table(
    pipeline=pipeline,
    download=Download(format="csv", index=False, filename="test"),
    # download=Download(format="csv", index=False),
    title="This is my ??test!!!!",
)
table
```