### PR TITLE
Ensure loading indicator is displayed even when events are on hold

### DIFF
--- a/lumen/util.py
+++ b/lumen/util.py
@@ -18,6 +18,7 @@ import panel as pn
 from jinja2 import DebugUndefined, Environment, Undefined
 from pandas.core.dtypes.dtypes import CategoricalDtype
 from panel import state
+from panel.io.document import unlocked
 
 log = getLogger(__name__)
 
@@ -333,8 +334,9 @@ def immediate_dispatch(doc=None):
     old_events = doc.callbacks._held_events
     hold = doc.callbacks._hold
     doc.callbacks._held_events = []
-    yield
     doc.callbacks.unhold()
+    with unlocked():
+        yield
     doc.callbacks._hold = hold
     doc.callbacks._held_events = old_events
 

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -33,7 +33,8 @@ from ..state import state
 from ..transforms.base import Transform
 from ..transforms.sql import SQLTransform
 from ..util import (
-    VARIABLE_RE, catch_and_notify, is_ref, resolve_module_reference,
+    VARIABLE_RE, catch_and_notify, immediate_dispatch, is_ref,
+    resolve_module_reference,
 )
 from ..validation import ValidationError
 
@@ -198,7 +199,8 @@ class View(MultiTypeComponent, Viewer):
 
     def _update_loading(self, event):
         if self._panel is not None:
-            self._panel.loading = event.new
+            with immediate_dispatch():
+                self._panel.loading = event.new
 
     def _update_ref(self, pname: str, ref: str, *events: param.parameterized.Event) -> None:
         # Note: Do not trigger update in View if Pipeline references

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -34,7 +34,7 @@ from ..transforms.base import Transform
 from ..transforms.sql import SQLTransform
 from ..util import (
     VARIABLE_RE, catch_and_notify, immediate_dispatch, is_ref,
-    resolve_module_reference, slugify
+    resolve_module_reference, slugify,
 )
 from ..validation import ValidationError
 


### PR DESCRIPTION
The `Pipeline` currently puts all events on hold when it updates ensuring that views are updated in one go. However we want the View loading indicator to render even when the remaining updates are on hold.