### PR TITLE
Fix handling of Variables state in notebook

### DIFF
--- a/lumen/state.py
+++ b/lumen/state.py
@@ -123,9 +123,10 @@ class _session_state:
         from .variables import Variables
         if self._variable is None:
             self._variable = Variables.create_variables()
-        if pn.state.curdoc is None:
+        doc = pn.state.curdoc
+        if doc is None or doc._session_context is None:
             return self._variable  # type: ignore
-        elif pn.state.curdoc not in self._variables:
+        elif doc not in self._variables:
             self._variables[pn.state.curdoc] = variables = Variables.create_variables()
             for var in self._variable._vars.values():  # type: ignore
                 variables.add_variable(var)

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -52,8 +52,11 @@ class Variables(param.Parameterized):
     @classmethod
     def from_spec(cls, spec):
         variables = cls.create_variables()
-        if pn.state.curdoc:
-            state._variables[pn.state.curdoc] = variables
+        doc = pn.state.curdoc
+        if doc and doc._session_context:
+            state._variables[doc] = variables
+        else:
+            state._variable = variables
         for name, var_spec in spec.items():
             if not isinstance(var_spec, dict):
                 var_spec = {


### PR DESCRIPTION
In notebook we would create new `Variables` objects whenever we were running inside a callback. We should only create new objects if we are serving an app from the notebook.