### PR TITLE
Remove distinct SQL limit

### DIFF
--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -101,9 +101,7 @@ class DuckDBSource(Source):
                 elif 'inclusiveMinimum' in col_schema:
                     min_maxes.append(name)
             for col in enums:
-                distinct_expr = sql_expr
-                for sql_t in (SQLDistinct(columns=[col]), SQLLimit(limit=1000)):
-                    distinct_expr = sql_t.apply(distinct_expr)
+                distinct_expr = sql_expr.apply(SQLDistinct(columns=[col]))
                 distinct_expr = ' '.join(distinct_expr.splitlines())
                 distinct = self._connection.execute(distinct_expr).fetch_df()
                 schema[col]['enum'] = distinct[col].tolist()

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -20,6 +20,8 @@ class IntakeBaseSQLSource(IntakeBaseSource):
     # Declare this source supports SQL transforms
     _supports_sql = True
 
+    _distinct_limit = 5000
+
     __abstract = True
 
     def _apply_transforms(self, source, sql_transforms):
@@ -90,9 +92,7 @@ class IntakeBaseSQLSource(IntakeBaseSource):
                 elif 'inclusiveMinimum' in col_schema:
                     min_maxes.append(name)
             for col in enums:
-                distinct_transforms = [
-                    SQLDistinct(columns=[col]), SQLLimit(limit=1000)
-                ]
+                distinct_transforms = [SQLDistinct(columns=[col])]
                 distinct = self._read(
                     self._apply_transforms(source, distinct_transforms)
                 )


### PR DESCRIPTION
Previously we limited the distinct categories but realistically querying these is relatively cheap.