### PR TITLE
Remove usage of the deprecated `.param.params()`

### DIFF
--- a/lumen/base.py
+++ b/lumen/base.py
@@ -61,7 +61,7 @@ class Component(param.Parameterized):
 
     def __init__(self, **params):
         self._refs = params.pop('refs', {})
-        expected = list(self.param.params())
+        expected = list(self.param)
         validate_parameters(params, expected, type(self).name)
         if self._allows_refs:
             params = self._extract_refs(params, self._refs)

--- a/lumen/command/__init__.py
+++ b/lumen/command/__init__.py
@@ -8,10 +8,10 @@ import sys
 import bokeh.command.util  # type: ignore
 
 from bokeh.application.handlers.code import CodeHandler  # type: ignore
-from bokeh.document import Document
 from bokeh.command.util import (  # type: ignore
     build_single_handler_application as _build_application, die,
 )
+from bokeh.document import Document
 from panel.command import Serve, main as _pn_main, transform_cmds
 from panel.io.server import Application
 from panel.io.state import set_curdoc

--- a/lumen/layout.py
+++ b/lumen/layout.py
@@ -175,7 +175,7 @@ class Card(Viewer):
             if layout == 'grid' and 'ncols' not in kwargs:
                 kwargs['ncols'] = 2
             layout_type = _LAYOUTS[layout]
-            layout_params = list(layout_type.param.params())
+            layout_params = list(layout_type.param)
             kwargs = {k: v for k, v in kwargs.items() if k in layout_params}
             item = layout_type(*(view.panel for view in self.views), **kwargs)
         return item

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def get_setup_version(reponame):
 dependencies = [
     "numpy",
     "bokeh",
-    "param",
+    "param >=1.9.0",
     "panel >=0.14.2",
     "pandas",
     "hvplot",


### PR DESCRIPTION
`param.params()` has been deprecated. This PR sets the minimum version of Param required to `1.9.0`, which was released on the 3rd of April 2019, about 3 years ago. It replaces `list(obj.param.params())` by `list(obj.param)`.
