### PR TITLE
Small improvements

### DIFF
--- a/lumen/command/__init__.py
+++ b/lumen/command/__init__.py
@@ -8,10 +8,10 @@ import sys
 import bokeh.command.util  # type: ignore
 
 from bokeh.application.handlers.code import CodeHandler  # type: ignore
-from bokeh.document import Document
 from bokeh.command.util import (  # type: ignore
     build_single_handler_application as _build_application, die,
 )
+from bokeh.document import Document
 from panel.command import Serve, main as _pn_main, transform_cmds
 from panel.io.server import Application
 from panel.io.state import set_curdoc

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -724,7 +724,7 @@ class Dashboard(Component, Viewer):
 
     def _create_main(self):
         layout_kwargs = {'sizing_mode': 'stretch_width', 'min_height': 400}
-        if self.config.layout is pn.Tabs and bokeh3:
+        if self.config.layout is pn.Tabs and not bokeh3:
             layout_kwargs['dynamic'] = True
         elif self.config.layout is pn.GridBox:
             layout_kwargs['ncols'] = self.config.ncols

--- a/lumen/schema.py
+++ b/lumen/schema.py
@@ -77,8 +77,8 @@ class JSONSchema(pn.pane.PaneBase):
                 wtype = self._bounded_number_range_widget
             else:
                 wtype = self._bounded_number_widget
-            return wtype, {'start': schema['inclusiveMinimum'],
-                           'end': schema['inclusiveMaximum']}
+            return wtype, {'start': float(schema['inclusiveMinimum']),
+                           'end': float(schema['inclusiveMaximum'])}
         else:
             return self._unbounded_number_widget, {}
 
@@ -88,8 +88,8 @@ class JSONSchema(pn.pane.PaneBase):
                 wtype = self._bounded_int_range_widget
             else:
                 wtype = self._bounded_int_widget
-            return wtype, {'start': schema['inclusiveMinimum'],
-                           'end': schema['inclusiveMaximum']}
+            return wtype, {'start': int(schema['inclusiveMinimum']),
+                           'end': int(schema['inclusiveMaximum'])}
         else:
             return self._unbounded_int_widget, {'step': 1}
 


### PR DESCRIPTION
Observed that sometimes `schema['inclusiveMinimum']` and `schema['inclusiveMaximum']` could be a string (sometimes).

Also, correctly set `dynamic` to not be True on Bokeh 3.