### PR TITLE
Align icons and enable editable in header

### DIFF
--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -746,12 +746,19 @@ class Dashboard(Component, Viewer):
             self._layout.param.watch(self._activate_filters, 'active')
 
     def _create_modal(self):
-        self._editor = pn.panel('Editor')
+        if not self.config.editable:
+            self._modal = pn.Column()
+            return
+        self._editor = pn.widgets.Ace(
+            value=self._yaml, filename=self._yaml_file,
+            sizing_mode='stretch_both', min_height=600,
+            theme='monokai'
+        )
         self._edit_button = pn.widgets.Button(
             name='✎', width=50, css_classes=['reload'], margin=0,
             align='center'
         )
-        #self._editor.param.watch(self._edit, 'value')
+        self._editor.param.watch(self._edit, 'value')
         self._edit_button.js_on_click(code="""
         var modal = document.getElementById("pn-Modal")
         modal.style.display = "block"
@@ -767,7 +774,8 @@ class Dashboard(Component, Viewer):
         self._update_button.on_click(self._update_pipelines)
 
     def _populate_template(self):
-        self._template.modal[:] = [self._modal]
+        if self.config.editable:
+            self._template.modal[:] = [self._modal]
         self._template.main[:] = [self._main]
         self._template.header[:] = [self._header]
         self._template.sidebar[:] = [self._sidebar]


### PR DESCRIPTION
This PR aligns the icons in the header and, at the same time, enables the editable option in the header.   

`self.config.editable` seem to me to be disabled by default:

https://github.com/holoviz/lumen/blob/bcd202741a2ce1738ff8a5a03132065513861ae9/lumen/dashboard.py#L68-L70