### PR TITLE
Don't sort keys when saving to yaml

### DIFF
--- a/lumen/state.py
+++ b/lumen/state.py
@@ -218,7 +218,7 @@ class _session_state:
         context = self.to_spec(**to_spec_kwargs)
 
         with open(filename, 'w') as f:
-            yaml.dump(context, f)
+            yaml.dump(context, f, sort_keys=False)
 
     @property
     def global_refs(self) -> List[str]:


### PR DESCRIPTION
Observed that when having `Layout(views={"B": B, "A": A})`. The yaml file would have sorted the keys so A was plotted before B. 