### PR TITLE
Add lock closed issues/pr workflow

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -1,0 +1,21 @@
+name: "Lock Threads"
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          issue-inactive-days: "100"

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -19,3 +19,12 @@ jobs:
       - uses: dessant/lock-threads@v4
         with:
           issue-inactive-days: "100"
+          pr-inactive-days: "100"
+          issue-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-comment: >
+            This pull request has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.


### PR DESCRIPTION
Using https://github.com/marketplace/actions/lock-threads, which clearly states it is only for closed issues/PR:

![image](https://github.com/holoviz/lumen/assets/19758978/c5c35c23-7bf8-4044-8ea7-8dedcc1836dd)

They advise having the cron job set up to once every hour to start with and then reduce it to a day:
![image](https://github.com/holoviz/lumen/assets/19758978/4bff823e-841e-4367-b797-a0b5027cced9)
 