### PR TITLE
Keep controls and refs separate

### DIFF
--- a/lumen/layout.py
+++ b/lumen/layout.py
@@ -575,11 +575,14 @@ class Layout(Component, Viewer):
             # Only the controls for the first facet is shown so link
             # the other facets to the controls of the first
             for v1, v2 in zip(linked_views, card.views):
-                v1.param.watch(partial(self._sync_component, v2), v1.refs)
+                if v1.controls:
+                    v1.param.watch(partial(self._sync_component, v2), v1.controls)
                 for t1, t2 in zip(v1.pipeline.transforms, v2.pipeline.transforms):
-                    t1.param.watch(partial(self._sync_component, t2), t1.refs)
+                    if t1.controls:
+                        t1.param.watch(partial(self._sync_component, t2), t1.controls)
                 for t1, t2 in zip(v1.pipeline.sql_transforms, v2.pipeline.sql_transforms):
-                    t1.param.watch(partial(self._sync_component, t2), t1.refs)
+                    if t1.controls:
+                        t1.param.watch(partial(self._sync_component, t2), t1.controls)
         self._view_controls = pn.Column(*controls, sizing_mode='stretch_width')
 
     ##################################################################

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -173,14 +173,6 @@ class Transform(MultiTypeComponent):
             margin=(-10, 0, 5, 0)
         )
 
-    @property
-    def refs(self) -> List[str]:
-        refs = super().refs
-        for c in self.controls:
-            if c not in refs:
-                refs.append(c)
-        return refs
-
 
 class Filter(Transform):
     """

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -476,14 +476,6 @@ class View(MultiTypeComponent, Viewer):
             return pn.Column(title_pane, panel, sizing_mode=panel.sizing_mode)
         return panel
 
-    @property
-    def refs(self) -> List[str]:
-        refs = super().refs
-        for c in self.controls:
-            if c not in refs:
-                refs.append(c)
-        return refs
-
     ##################################################################
     # Component subclassable API
     ##################################################################


### PR DESCRIPTION
Controls and variable references were treated as one concept in the case of `View` and `Transform` components. This is not correct since they have to be watched on completely different entities. This PR ensures they are treated as completely separate concepts.