### PR TITLE
Fix tests and CI improvements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,21 +16,11 @@ concurrency:
 
 jobs:
   pre_commit:
-    name: Run pre-commit hooks
+    name: Run pre-commit
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: "1"
-      - name: set PY
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: pre-commit
-        uses: pre-commit/action@v3.0.0
-  test_suite:
+      - uses: holoviz-dev/holoviz_tasks/pre-commit@v0.1a18
+  unit_test_suite:
     name: Pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
     needs: [pre_commit]
     runs-on: ${{ matrix.os }}
@@ -47,9 +37,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
 
-      - uses: holoviz-dev/holoviz_tasks/install@v0.1a15
+      - uses: holoviz-dev/holoviz_tasks/install@v0.1a18
         with:
-          name: test_suite
+          name: unit_test_suite
           python-version: ${{ matrix.python-version }}
           channel-priority: flexible
           channels: pyviz/label/dev,bokeh,conda-forge,nodefaults

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -15,6 +15,7 @@ from subprocess import check_output
 import bokeh
 import pandas as pd
 import panel as pn
+import param
 
 from jinja2 import DebugUndefined, Environment, Undefined
 from packaging.version import Version
@@ -25,6 +26,9 @@ from panel.io.document import unlocked
 log = getLogger(__name__)
 
 bokeh3 = Version(bokeh.__version__) > Version("3.0")
+param2 = Version(param.__version__) > Version("2.0rc1")
+
+disallow_refs = {'allow_refs': False} if param2 else {}
 
 VARIABLE_RE = re.compile(r'\$variables\.([a-zA-Z_]\w*)')
 

--- a/lumen/variables/base.py
+++ b/lumen/variables/base.py
@@ -13,7 +13,7 @@ from typing_extensions import Literal
 
 from ..base import MultiTypeComponent
 from ..state import state
-from ..util import is_ref, resolve_module_reference
+from ..util import disallow_refs, is_ref, resolve_module_reference
 
 if TYPE_CHECKING:
     from panel.viewable import Viewable
@@ -378,7 +378,8 @@ class Parameter(Variable):
     `Parameter` variables reflect the current value of a parameter.
     """
 
-    parameter = param.ClassSelector(class_=param.Parameter, constant=True, doc="""
+    parameter = param.ClassSelector(class_=param.Parameter, constant=True,
+        **disallow_refs, doc="""
         A parameter instance whose current value will be reflected
         on this variable.""")
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ extras_require = {
         'codecov',
         'pre-commit',
         'matplotlib >=3.4',  # Ubuntu + Python 3.9 installs old version matplotlib (3.3.2)
+        'pytest-github-actions-annotate-failures',
     ],
     'doc': [
         'nbsite >=0.8.2',


### PR DESCRIPTION
Update to work with Param 2 and newer version of DuckDB.

Updated to latest install tasks (and align with rest of CI) and added `pytest-github-actions-annotate-failures`.