### PR TITLE
Sync WidgetFilter with url

### DIFF
--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -320,7 +320,7 @@ class WidgetFilter(BaseWidgetFilter):
         self.widget.link(self, bidirectional=True, value='value', visible='visible', disabled='disabled')
         if self._sync_with_url:
             pn.state.location.sync(self.widget, {'value': self.field}, on_error=self._url_sync_error)
-        if self.default is not None and not self.widget.value:
+        if self.default is not None and self.value is None:
             self.widget.value = self.default
 
     @classmethod

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -318,10 +318,10 @@ class WidgetFilter(BaseWidgetFilter):
         self.widget.visible = self.visible
         self.widget.disabled = self.disabled
         self.widget.link(self, bidirectional=True, value='value', visible='visible', disabled='disabled')
-        if self.default is not None:
-            self.widget.value = self.default
         if self._sync_with_url:
             pn.state.location.sync(self.widget, {'value': self.field}, on_error=self._url_sync_error)
+        if self.default is not None and not self.widget.value:
+            self.widget.value = self.default
 
     @classmethod
     def _validate_widget(cls, widget: str, spec: Dict[str, Any], context: Dict[str, Any]) -> str:

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -317,10 +317,11 @@ class WidgetFilter(BaseWidgetFilter):
         self.widget.name = self.label
         self.widget.visible = self.visible
         self.widget.disabled = self.disabled
+        val = self.value
         self.widget.link(self, bidirectional=True, value='value', visible='visible', disabled='disabled')
-        if self._sync_with_url:
-            pn.state.location.sync(self.widget, {'value': self.field}, on_error=self._url_sync_error)
-        if self.default is not None and self.value is None:
+        if val is not None:
+            self.widget.value = val
+        elif self.default is not None:
             self.widget.value = self.default
 
     @classmethod

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -63,8 +63,12 @@ class Filter(MultiTypeComponent):
 
     def __init__(self, **params):
         super().__init__(**params)
-        if state.config and state.config.sync_with_url and self.sync_with_url and pn.state.location:
+        if self._sync_with_url:
             pn.state.location.sync(self, {'value': self.field}, on_error=self._url_sync_error)
+
+    @property
+    def _sync_with_url(self) -> bool:
+        return bool(state.config and state.config.sync_with_url and self.sync_with_url and pn.state.location)
 
     @classproperty
     def _required_keys(cls) -> List[str | Tuple[str, ...]]:  # type: ignore
@@ -316,6 +320,8 @@ class WidgetFilter(BaseWidgetFilter):
         self.widget.link(self, bidirectional=True, value='value', visible='visible', disabled='disabled')
         if self.default is not None:
             self.widget.value = self.default
+        if self._sync_with_url:
+            pn.state.location.sync(self.widget, {'value': self.field}, on_error=self._url_sync_error)
 
     @classmethod
     def _validate_widget(cls, widget: str, spec: Dict[str, Any], context: Dict[str, Any]) -> str:

--- a/lumen/tests/sample_dashboard/sync_query_filters_default.yaml
+++ b/lumen/tests/sample_dashboard/sync_query_filters_default.yaml
@@ -1,0 +1,18 @@
+config:
+  sync_with_url: true
+sources:
+  test:
+    type: 'file'
+    files: ['../sources/test.csv']
+targets:
+  - title: "Test"
+    source: test
+    filters:
+      - type: widget
+        field: A
+      - type: widget
+        field: C
+        default: ['foo1']
+    views:
+      - table: test
+        type: test

--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -82,7 +82,7 @@ def test_dashboard_with_url_sync_filters(set_root, document):
     layout = dashboard.layouts[0]
     f1, f2 = list(layout._pipelines.values())[0].filters
     f1.value = (0.1, 0.7)
-    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D&C=%5B%5D'
+    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D'
     pn.state.location.search = '?A=%5B0.3%2C+0.8%5D'
     assert f1.value == (0.3, 0.8)
     f2.value = ['foo1', 'foo2']
@@ -98,7 +98,7 @@ def test_dashboard_with_url_sync_filters_with_default(set_root, document):
     layout = dashboard.layouts[0]
     f1, f2 = list(layout._pipelines.values())[0].filters
     f1.value = (0.1, 0.7)
-    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D&C=%5B%27foo1%27%5D'
+    assert pn.state.location.search == '?C=%5B%27foo1%27%5D&A=%5B0.1%2C+0.7%5D'
     pn.state.location.search = '?A=%5B0.3%2C+0.8%5D'
     assert f1.value == (0.3, 0.8)
     assert f2.value == ['foo1']
@@ -119,7 +119,7 @@ def test_dashboard_with_url_sync_filters_with_overwritten_default(set_root, docu
     f1, f2 = list(layout._pipelines.values())[0].filters
     f1.value = (0.1, 0.7)
     f2.value = []  # overwriting default with empty list
-    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D&C=%5B%5D'
+    assert pn.state.location.search == '?C=%5B%5D&A=%5B0.1%2C+0.7%5D'
     assert f2.widget.value == []
 
 @sql_available

--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -110,6 +110,18 @@ def test_dashboard_with_url_sync_filters_with_default(set_root, document):
     assert f2.value == ['foo1', 'foo2', 'foo3']
     assert f2.widget.value == ['foo1', 'foo2', 'foo3']
 
+def test_dashboard_with_url_sync_filters_with_overwritten_default(set_root, document):
+    root = pathlib.Path(__file__).parent / 'sample_dashboard'
+    set_root(str(root))
+    dashboard = Dashboard(str(root / 'sync_query_filters_default.yaml'))
+    dashboard._render_dashboard()
+    layout = dashboard.layouts[0]
+    f1, f2 = list(layout._pipelines.values())[0].filters
+    f1.value = (0.1, 0.7)
+    f2.value = []  # overwriting default with empty list
+    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D&C=%5B%5D'
+    assert f2.widget.value == []
+
 @sql_available
 def test_dashboard_with_sql_source_and_transforms(set_root, document, mixed_df_object_type):
     root = pathlib.Path(__file__).parent / 'sample_dashboard'

--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -90,6 +90,25 @@ def test_dashboard_with_url_sync_filters(set_root, document):
     pn.state.location.search = '?A=%5B0.3%2C+0.8%5D&C=%5B%22foo1%22%2C+%22foo2%22%2C+%22foo3%22%5D'
     assert f2.value == ['foo1', 'foo2', 'foo3']
 
+def test_dashboard_with_url_sync_filters_with_default(set_root, document):
+    root = pathlib.Path(__file__).parent / 'sample_dashboard'
+    set_root(str(root))
+    dashboard = Dashboard(str(root / 'sync_query_filters_default.yaml'))
+    dashboard._render_dashboard()
+    layout = dashboard.layouts[0]
+    f1, f2 = list(layout._pipelines.values())[0].filters
+    f1.value = (0.1, 0.7)
+    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D&C=%5B%27foo1%27%5D'
+    pn.state.location.search = '?A=%5B0.3%2C+0.8%5D'
+    assert f1.value == (0.3, 0.8)
+    assert f2.value == ['foo1']
+    assert f1.widget.value == (0.3, 0.8)
+    assert f2.widget.value == ['foo1']
+    f2.value = ['foo1', 'foo2']
+    assert pn.state.location.search == '?A=%5B0.3%2C+0.8%5D&C=%5B%22foo1%22%2C+%22foo2%22%5D'
+    pn.state.location.search = '?A=%5B0.3%2C+0.8%5D&C=%5B%22foo1%22%2C+%22foo2%22%2C+%22foo3%22%5D'
+    assert f2.value == ['foo1', 'foo2', 'foo3']
+    assert f2.widget.value == ['foo1', 'foo2', 'foo3']
 
 @sql_available
 def test_dashboard_with_sql_source_and_transforms(set_root, document, mixed_df_object_type):

--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -82,7 +82,7 @@ def test_dashboard_with_url_sync_filters(set_root, document):
     layout = dashboard.layouts[0]
     f1, f2 = list(layout._pipelines.values())[0].filters
     f1.value = (0.1, 0.7)
-    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D'
+    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D&C=%5B%5D'
     pn.state.location.search = '?A=%5B0.3%2C+0.8%5D'
     assert f1.value == (0.3, 0.8)
     f2.value = ['foo1', 'foo2']

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -143,7 +143,7 @@ class View(MultiTypeComponent, Viewer):
         return pn.panel(pn.bind(lambda e: self.panel, self.param.rerender))
 
     def _update_loading(self, event):
-        if self._panel is not None:
+        if hasattr(self._panel, 'loading'):
             with immediate_dispatch():
                 self._panel.loading = event.new
 


### PR DESCRIPTION
Using the Palmer Penguins example with two updates

``` yaml
config:
  title: Palmer Penguins
  theme: dark
  layout: tabs
  sync_with_url: true   # UPDATED
sources:
  penguins:
    type: file
    cache_dir: ./cache
    tables:
      penguins: https://datasets.holoviz.org/penguins/v1/penguins.csv
pipelines:
  penguins:
    source: penguins
    table: penguins
    filters:
      species:
        type: widget
        field: species
        default: ['Adelie']     # UPDATED
      island:
        type: widget
        field: island
      sex:
        type: widget
        field: sex
      expr:
        type: param
        parameter: scatter.selection_expr
layouts:
  - title: Plots
    pipeline: penguins
    views:
      scatter:
        type: hvplot
        kind: points
        x: bill_length_mm
        y: bill_depth_mm
        color: species
        responsive: true
        height: 350
        selection_group: penguin
      depth_hist:
        type: hvplot
        kind: hist
        y: bill_length_mm
        responsive: true
        height: 350
        selection_group: penguin
      length_hist:
        type: hvplot
        kind: hist
        y: bill_depth_mm
        responsive: true
        height: 350
        selection_group: penguin
      mass_hist:
        type: hvplot
        kind: hist
        y: body_mass_g
        responsive: true
        height: 350
        selection_group: penguin
    layout: [[scatter], [depth_hist, length_hist, mass_hist]]
    sizing_mode: stretch_width
    height: 800
  - title: Table
    pipeline: penguins
    views:
      table:
        type: table
        layout: fit_data_fill
        show_index: false
        theme: midnight
        sizing_mode: stretch_both
    sizing_mode: stretch_width
```