### PR TITLE
Ensure WidgetFilter sync_with_url uses Widget parameter to serialize values

### DIFF
--- a/lumen/tests/test_dashboard.py
+++ b/lumen/tests/test_dashboard.py
@@ -82,11 +82,11 @@ def test_dashboard_with_url_sync_filters(set_root, document):
     layout = dashboard.layouts[0]
     f1, f2 = list(layout._pipelines.values())[0].filters
     f1.value = (0.1, 0.7)
-    assert pn.state.location.search == '?A=%5B0.1%2C+0.7%5D'
+    assert pn.state.location.query_params == {'A': [0.1, 0.7], 'C': []}
     pn.state.location.search = '?A=%5B0.3%2C+0.8%5D'
     assert f1.value == (0.3, 0.8)
     f2.value = ['foo1', 'foo2']
-    assert pn.state.location.search == '?A=%5B0.3%2C+0.8%5D&C=%5B%22foo1%22%2C+%22foo2%22%5D'
+    assert pn.state.location.query_params == {'A': [0.3, 0.8], 'C': ['foo1', 'foo2']}
     pn.state.location.search = '?A=%5B0.3%2C+0.8%5D&C=%5B%22foo1%22%2C+%22foo2%22%2C+%22foo3%22%5D'
     assert f2.value == ['foo1', 'foo2', 'foo3']
 
@@ -98,14 +98,14 @@ def test_dashboard_with_url_sync_filters_with_default(set_root, document):
     layout = dashboard.layouts[0]
     f1, f2 = list(layout._pipelines.values())[0].filters
     f1.value = (0.1, 0.7)
-    assert pn.state.location.search == '?C=%5B%27foo1%27%5D&A=%5B0.1%2C+0.7%5D'
+    assert pn.state.location.query_params == {'C': ['foo1'], 'A': [0.1, 0.7]}
     pn.state.location.search = '?A=%5B0.3%2C+0.8%5D'
     assert f1.value == (0.3, 0.8)
     assert f2.value == ['foo1']
     assert f1.widget.value == (0.3, 0.8)
     assert f2.widget.value == ['foo1']
     f2.value = ['foo1', 'foo2']
-    assert pn.state.location.search == '?A=%5B0.3%2C+0.8%5D&C=%5B%22foo1%22%2C+%22foo2%22%5D'
+    assert pn.state.location.query_params == {'C': ['foo1', 'foo2'], 'A': [0.3, 0.8]}
     pn.state.location.search = '?A=%5B0.3%2C+0.8%5D&C=%5B%22foo1%22%2C+%22foo2%22%2C+%22foo3%22%5D'
     assert f2.value == ['foo1', 'foo2', 'foo3']
     assert f2.widget.value == ['foo1', 'foo2', 'foo3']
@@ -119,7 +119,7 @@ def test_dashboard_with_url_sync_filters_with_overwritten_default(set_root, docu
     f1, f2 = list(layout._pipelines.values())[0].filters
     f1.value = (0.1, 0.7)
     f2.value = []  # overwriting default with empty list
-    assert pn.state.location.search == '?C=%5B%5D&A=%5B0.1%2C+0.7%5D'
+    assert pn.state.location.query_params == {'C': [], 'A': [0.1, 0.7]}
     assert f2.widget.value == []
 
 @sql_available


### PR DESCRIPTION
Since `Filter.value` is of type Parameter it does not define the correct serialize methods for the Location sync to correct serialize and deserialize the data values. Therefore we now sync the `Widget.value` rather than the `Filter.value` allowing the value type of the parameter to provide the correct serialization. In future `Location.sync` in Panel should provide a dictionary of serializers and deserializers so we can override these directly.

Fixes https://github.com/holoviz/lumen/issues/455