### PR TITLE
make tabs stretch

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -450,7 +450,7 @@ class LumenBaseAgent(Agent):
             memory["current_spec"] = spec
             try:
                 output = type(component).from_spec(load_yaml(spec)).__panel__()
-                output.sizing_mode = "stretch_both"
+                output.sizing_mode = "stretch_width"
                 yield output
             except Exception as e:
                 import traceback

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -125,6 +125,7 @@ class Agent(Viewer):
         tabs = pn.Tabs(
             ("Code", code_col),
             ("Output", placeholder),
+            styles={'min-width': "100%"}
         )
         placeholder.objects = [
             pn.bind(callback, code_editor.param.value, tabs.param.active)
@@ -448,7 +449,9 @@ class LumenBaseAgent(Agent):
             # store the spec in the cache instead of memory to save tokens
             memory["current_spec"] = spec
             try:
-                yield type(component).from_spec(load_yaml(spec)).__panel__()
+                output = type(component).from_spec(load_yaml(spec)).__panel__()
+                output.sizing_mode = "stretch_both"
+                yield output
             except Exception as e:
                 import traceback
                 traceback.print_exc()

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -450,7 +450,6 @@ class LumenBaseAgent(Agent):
             memory["current_spec"] = spec
             try:
                 output = type(component).from_spec(load_yaml(spec)).__panel__()
-                output.sizing_mode = "stretch_width"
                 yield output
             except Exception as e:
                 import traceback


### PR DESCRIPTION
Not sure why `sizing_mode="stretch_both"` doesn't work so I needed to use `styles={"min-width": "100%"}`...

<img width="998" alt="image" src="https://github.com/holoviz/lumen/assets/15331990/ca7822f7-9254-444d-b26e-616ec183465f">

vs originally:
![image](https://github.com/holoviz/lumen/assets/15331990/3943fecb-45a4-45f0-abff-5d5b9c5f161d)
