### PR TITLE
Fixes error handling and optimize SQL prompts

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -682,10 +682,11 @@ class SQLAgent(LumenBaseAgent):
         tabs.active = 1
 
     def _sql_prompt(self, sql: str, table: str, schema: dict) -> str:
-        prompt = f"The SQL expression for the table {table!r} is {sql!r}."
-        if "current_data" in memory:
-            prompt += f"\n\nHere's the head of the dataset:\n```\n{memory['current_data']['head']}\n```"
-        prompt += f"\n\nThe data for table {table!r} follows the following JSON schema:\n\n```{format_schema(schema)}```"
+        prompt = (
+            f"The SQL expression for the table {table!r} is {sql!r}.\n\n"
+            f"The data for table {table!r} follows the following JSON schema:\n\n```{format_schema(schema)}```"
+        )
+        print(prompt)
         return prompt
 
     async def answer(self, messages: list | str):

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -17,10 +17,11 @@ from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
 
 from ..base import Component
-from ..dashboard import load_yaml
+from ..dashboard import Config, load_yaml
 from ..pipeline import Pipeline
 from ..sources import FileSource, InMemorySource, Source
 from ..sources.intake_sql import IntakeBaseSQLSource
+from ..state import state
 from ..transforms.sql import SQLOverride, SQLTransform, Transform
 from ..views import hvPlotUIView
 from .embeddings import Embeddings
@@ -30,7 +31,6 @@ from .models import DataRequired, FuzzyTable, Sql
 from .translate import param_to_pydantic
 
 FUZZY_TABLE_LENGTH = 10
-
 
 def format_schema(schema):
     formatted = {}
@@ -93,6 +93,11 @@ class Agent(Viewer):
         super().__init__(**params)
         if not self.debug:
             pn.config.exception_handler = _exception_handler
+
+        if state.config is None:
+            state.config = Config(raise_with_notifications=True)
+        else:
+            state.config.raise_with_notifications = True
 
     def _link_code_editor(self, value, callback, language):
         code_editor = pn.widgets.CodeEditor(
@@ -499,8 +504,7 @@ class LumenBaseAgent(Agent):
             "head": df_head_dict
         }
 
-        memory["current_columns"] = df.columns.tolist()
-        return str(data)
+        return data
 
     def _render_lumen(self, component: Component, message: pn.chat.ChatMessage = None):
         async def _render_component(spec, active):
@@ -520,7 +524,7 @@ class LumenBaseAgent(Agent):
                 import traceback
                 traceback.print_exc()
                 yield pn.pane.Alert(
-                    f"Error rendering component: {e}. Please press undo, edit the YAML, or continue the conversation.",
+                    f"```\n{e}\n```\nPlease press undo, edit the YAML, or continue chatting.",
                     alert_type="danger",
                 )
                 # maybe offer undo
@@ -668,8 +672,10 @@ class SQLAgent(LumenBaseAgent):
                     memory["current_data"] = self._describe_data(df)
                 yield memory["current_pipeline"].__panel__()
             except Exception as e:
+                import traceback
+                traceback.print_exc()
                 yield pn.pane.Alert(
-                    f"Error executing SQL query: {e}; please press undo, edit the YAML, or continue the conversation",
+                    f"```\n{e}\n```\nPlease press undo, edit the YAML, or continue chatting.",
                     alert_type="danger",
                 )
 
@@ -679,8 +685,8 @@ class SQLAgent(LumenBaseAgent):
 
     def _sql_prompt(self, sql: str, table: str, schema: dict) -> str:
         prompt = f"The SQL expression for the table {table!r} is {sql!r}."
-        if "current_sql" in memory:
-            prompt += f"In case the user is following up on a previous request here is the SQL you just generated: `{memory['current_sql']}`"
+        if "current_data" in memory:
+            prompt += f"\n\nHere's the head of the dataset:\n```\n{memory['current_data']['head']}\n```"
         prompt += f"\n\nThe data for table {table!r} follows the following JSON schema:\n\n```{format_schema(schema)}```"
         return prompt
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -35,8 +35,8 @@ FUZZY_TABLE_LENGTH = 10
 def format_schema(schema):
     formatted = {}
     for field, spec in schema.items():
-        if "enum" in spec:
-            spec["enum"] = spec["enum"][:20] + ["..."]
+        if "enum" in spec and len(spec["enum"]) > 5:
+            spec["enum"] = spec["enum"][:5] + ["..."]
         formatted[field] = spec
     return formatted
 
@@ -164,8 +164,6 @@ class Agent(Viewer):
             schema = source.get_schema(table, limit=100)
         schema = dict(schema)
         for field, spec in schema.items():
-            if "enum" in spec:
-                spec.pop("enum")
             if "inclusiveMinimum" in spec:
                 spec["min"] = spec.pop("inclusiveMinimum")
             if "inclusiveMaximum" in spec:

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -184,7 +184,7 @@ class Assistant(Viewer):
         if not table:
             return
 
-        columns = memory.get("current_columns")
+        columns = list(memory["current_data"]["stats"].keys())
         system = f"""
         Based on the latest user's query, is the table relevant?
         If not, return invalid_key='table'.
@@ -204,7 +204,6 @@ class Assistant(Viewer):
             system=system,
             response_model=Validity,
             allow_partial=False,
-            model_key="reasoning"
         )
         if validity and validity.is_invalid:
             memory.pop("current_table", None)

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -21,7 +21,7 @@ class Llm(param.Parameterized):
     use_logfire = param.Boolean(default=False)
 
     # Allows defining a dictionary of default models.
-    _models_kwargs = {}
+    model_kwargs = param.Dict(default={})
 
     __abstract = True
 
@@ -32,10 +32,10 @@ class Llm(param.Parameterized):
             return patch(create=create, mode=self.mode)
 
     def _get_model_kwargs(self, model_key):
-        if model_key in self._models_kwargs:
-            model_kwargs = self._models_kwargs.get(model_key)
+        if model_key in self.model_kwargs:
+            model_kwargs = self.model_kwargs.get(model_key)
         else:
-            model_kwargs = self._models_kwargs["default"]
+            model_kwargs = self.model_kwargs["default"]
         return dict(model_kwargs)
 
     @property
@@ -132,7 +132,7 @@ class Llama(Llm):
 
     temperature = param.Number(default=0.4, bounds=(0, None), constant=True)
 
-    _models_kwargs = {
+    model_kwargs = param.Dict(default={
         "default": {
             "repo": "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
             "model_file": "mistral-7b-instruct-v0.2.Q5_K_M.gguf",
@@ -143,7 +143,7 @@ class Llama(Llm):
             "model_file": "sqlcoder2.Q5_K_M.gguf",
             "chat_format": "chatml",
         },
-    }
+    })
 
     @property
     def _client_kwargs(self):
@@ -191,10 +191,10 @@ class OpenAI(Llm):
 
     organization = param.String()
 
-    _models_kwargs = {
+    model_kwargs = param.Dict(default={
         "default": {"model": "gpt-3.5-turbo"},
         "reasoning": {"model": "gpt-4-turbo-preview"},
-    }
+    })
 
     @property
     def _client_kwargs(self):
@@ -259,7 +259,7 @@ class AILauncher(OpenAI):
 
     mode = param.Selector(default=Mode.JSON_SCHEMA)
 
-    _models_kwargs = {
+    model_kwargs = param.Dict(default={
         "default": {"model": "gpt-3.5-turbo"},
         "reasoning": {"model": "gpt-4-turbo-preview"},
-    }
+    })

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -101,6 +101,9 @@ class Config(Component):
         Callback that fires when a pipeline is updated. The updated
         pipeline is passed as the first argument.""")
 
+    raise_with_notifications = param.Boolean(default=True, constant=True, doc="""
+        Whether to raise exceptions when notifications are enabled.""")
+
     reloadable = param.Boolean(default=True, constant=True, doc="""
         Whether to allow reloading data from source(s) using a button.""")
 

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -314,6 +314,8 @@ def catch_and_notify(message=None):
                         f"{func.__qualname__!r} raised {type(e).__name__}: {e}"
                     )
                     state.notifications.error(message.format(e=e))
+                    if session_state.config and session_state.config.raise_with_notifications:
+                        raise e
                 else:
                     raise e
         return wrapper


### PR DESCRIPTION
1. Previously when `pn.extension(notifications=True)`, Lumen would absorb all exceptions into notifications. I added `raise_with_notifications` so that it will continue raising errors on notifications so that errors now bubble up properly on edit
<img width="556" alt="image" src="https://github.com/holoviz/lumen/assets/15331990/0fe46b9b-641c-4352-96be-feee13635a0f">
<img width="433" alt="image" src="https://github.com/holoviz/lumen/assets/15331990/196b543f-dfff-4cc6-8cec-1886e51c47c9">

2. As you mentioned, format_spec did do the trick so I added back enum
```
{'case_id': {'type': 'integer', 'min': 3000001, 'max': 3125948}, 'faa_ors': {'type': 'string', 'enum': ['39-003863', '19-020351', '19-020377', '19-020448', '19-058716', '...']}, 'faa_asn': {'type': 'string', 'enum': ['2016-WTE-5934-OE', '2013-WTE-5497-OE', '2018-WTE-9908-OE', '2018-WTE-9870-OE', '2018-WTE-9867-OE', '...']}, 'usgs_pr_id': {'type': 'number', 'min': 1.0, 'max': 49135.0}, 'eia_id': {'type': 'number', 'min': 90.0, 'max': 65525.0}, 't_state': {'type': 'string', 'enum': ['IL', 'TX', 'MI', 'OK', 'ND', '...']}, 't_county': {'type': 'string', 'enum': ['Kern County', 'Poweshiek County', 'Barnstable County', 'Laramie County', 'Blair County', '...']}, 't_fips': {'type': 'integer', 'min': 2013, 'max': 72133}, 'p_name': {'type': 'string', 'enum': ['Agriwind', 'Ainsworth Wind Project (NPPD)', 'Alta III', 'Amazon Wind Farm (Fowler Ridge)', 'Anacacho', '...']}, 'p_year': {'type': 'number', 'min': 1981.0, 'max': 2022.0}, 'p_tnum': {'type': 'integer', 'min': 1, 'max': 731}, 'p_cap': {'type': 'number', 'min': 0.05, 'max': 1055.6}, 't_manu': {'type': 'string', 'enum': ['Suzlon', 'Fuhrlander', 'Leitner Poma', 'REpower', 'Micon', '...']}, 't_model': {'type': 'string', 'enum': ['GE1.5-77', 'GE1.6-82.5', 'GE1.7-100', 'GE1.79-100', 'GE2.3-116', '...']}, 't_cap': {'type': 'number', 'min': 50.0, 'max': 6000.0}, 't_hh': {'type': 'number', 'min': 19.0, 'max': 137.0}, 't_rd': {'type': 'number', 'min': 13.4, 'max': 162.0}, 't_rsa': {'type': 'number', 'min': 141.03, 'max': 20611.99}, 't_ttlh': {'type': 'number', 'min': 30.4, 'max': 205.4}, 'retrofit': {'type': 'integer', 'min': 0, 'max': 1}, 'retrofit_year': {'type': 'number', 'min': 2015.0, 'max': 2021.0}, 't_conf_atr': {'type': 'integer', 'min': 1, 'max': 3}, 't_conf_loc': {'type': 'integer', 'min': 1, 'max': 3}, 't_img_date': {'type': 'string', 'format': 'datetime', 'min': '1993-06-14 00:00:00', 'max': '2022-09-06 00:00:00'}, 't_img_srce': {'type': 'string', 'enum': ['Google Earth', 'Digital Globe', 'Bing Maps Aerial', 'NAIP']}, 'xlong': {'type': 'number', 'min': -171.713074, 'max': 144.722656}, 'ylat': {'type': 'number', 'min': 13.389381, 'max': 66.839905}, 'easting': {'type': 'number', 'min': -19115011.960227706, 'max': 16110452.372170098}, 'northing': {'type': 'number', 'min': 1504253.4146257618, 'max': 10110596.985745305}}
```
 
4. I made `current_data` into a dict instead of a string. That way, there's no need to have `current_columns` in memory, and also I can grab the `head` of the data easily.

5. I removed `current_sql` because I think it's duplicate. Follow-up questions already have the previous messages (SQL YAML within the last 3 chat messages).