### PR TITLE
Limit number of rows to be rendered once

### DIFF
--- a/lumen/ai/__init__.py
+++ b/lumen/ai/__init__.py
@@ -1,0 +1,12 @@
+import panel as pn
+
+from . import agents, embeddings, llm  # noqa
+from .assistant import Assistant  # noqa
+from .memory import memory  # noqa
+
+pn.chat.message.DEFAULT_AVATARS.update({
+    "lumen": "https://holoviz.org/assets/lumen.png",
+    "dataset": "🗂️",
+    "sql": "🗄️",
+    "router": "🚦",
+})

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -332,19 +332,24 @@ class LumenBaseAgent(Agent):
             else:
                 return f"{num:.1e}"  # Exponential notation with two decimals
 
-        length = len(df)
-        if length < 100:
+        size = df.size
+        shape = df.shape
+        if size < 250:
             out = io.StringIO()
             df.to_csv(out)
             out.seek(0)
             return out.read()
 
         is_summarized = False
-        if length > 5000:
+        if size > 5000:
             is_summarized = True
             df = df.sample(5000)
 
         df = df.sort_index()
+        df_dtypes_dict = {
+            col: str(type(df[col].iloc[:1].astype("object").iloc[0])).split("'")[1]
+            for col in df.columns
+        }
 
         for col in df.columns:
             if isinstance(df[col].iloc[0], pd.Timestamp):
@@ -395,9 +400,10 @@ class LumenBaseAgent(Agent):
 
         data = {
             "summary": {
-                "total_length": length,
+                "total_size": size,
+                "total_shape": shape,
                 "is_summarized": is_summarized,
-                "dtypes": {col: str(dtype) for col, dtype in df.dtypes.to_dict().items()}
+                "dtypes": df_dtypes_dict,
             },
             "stats": df_describe_dict,
             "head": df_head_dict

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -129,7 +129,7 @@ class Agent(Viewer):
     def _get_schema(self, source: Source, table: str):
         try:
             source.load_schema = True
-            return source.get_schema(table)
+            return source.get_schema(table, limit=100)
         finally:
             source.load_schema = False
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -594,8 +594,9 @@ class TableAgent(LumenBaseAgent):
 
 class TableListAgent(LumenBaseAgent):
     """
-    Responsible for listing the available tables if the user's request is vague;
-    do not use this if user wants a specific table.
+    Responsible for listing the available tables or datasets should the
+    user request to know what datasets are available. Do not use this if
+    the user wants a specific table.
     """
 
     system_prompt = param.String(
@@ -620,6 +621,7 @@ class TableListAgent(LumenBaseAgent):
                     "background-color": "white",
                     "padding": "10px",
                 },
+                tags=['catalog']
             )
         else:
             tables = tuple(table.replace('"', "") for table in tables)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -125,6 +125,7 @@ class Agent(Viewer):
         tabs = pn.Tabs(
             ("Code", code_col),
             ("Output", placeholder),
+            styles={'min-width': "100%"}
         )
         placeholder.objects = [
             pn.bind(callback, code_editor.param.value, tabs.param.active)
@@ -448,7 +449,8 @@ class LumenBaseAgent(Agent):
             # store the spec in the cache instead of memory to save tokens
             memory["current_spec"] = spec
             try:
-                yield type(component).from_spec(load_yaml(spec)).__panel__()
+                output = type(component).from_spec(load_yaml(spec)).__panel__()
+                yield output
             except Exception as e:
                 import traceback
                 traceback.print_exc()

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -581,7 +581,7 @@ class TableAgent(LumenBaseAgent):
         memory["current_table"] = table
         memory["current_pipeline"] = pipeline = Pipeline(
             source=memory["current_source"], table=table, sql_transforms=[
-                SQLLimit(limit=500000)
+                SQLLimit(limit=100000)
             ]
         )
 
@@ -667,7 +667,7 @@ class SQLAgent(LumenBaseAgent):
 
             table = memory["current_table"]
 
-            transforms = [SQLOverride(override=query), SQLLimit(limit=500000)]
+            transforms = [SQLOverride(override=query), SQLLimit(limit=100000)]
             try:
                 memory["current_pipeline"] = pipeline = Pipeline(
                     source=source, table=table, sql_transforms=transforms
@@ -759,7 +759,7 @@ class PipelineAgent(LumenBaseAgent):
                 source=memory["current_source"],
                 table=memory["current_table"],
             )
-        pipeline.sql_transforms = [SQLOverride(override=memory["current_sql"]), SQLLimit(limit=500000)]
+        pipeline.sql_transforms = [SQLOverride(override=memory["current_sql"]), SQLLimit(limit=100000)]
         memory["current_pipeline"] = pipeline
         pipeline._update_data(force=True)
         memory["current_data"] = self._describe_data(pipeline.data)
@@ -901,7 +901,7 @@ class TransformPipelineAgent(LumenBaseAgent):
                 source=memory["current_source"],
                 table=memory["current_table"],
             )
-        pipeline.sql_transforms = [SQLOverride(override=memory["current_sql"]), SQLLimit(limit=500000)]
+        pipeline.sql_transforms = [SQLOverride(override=memory["current_sql"]), SQLLimit(limit=100000)]
         memory["current_pipeline"] = pipeline
 
         if not transform_types and pipeline:

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -656,7 +656,7 @@ class PipelineAgent(LumenBaseAgent):
             model="gpt-4",
         )
 
-        if transform.transform_required:
+        if transform and transform.transform_required:
             transform = await self.llm.invoke(
                 f"is the transform, {transform.transform!r} partially relevant to the query {messages!r}",
                 system=(

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -41,9 +41,11 @@ class Agent(Viewer):
 
     system_prompt = param.String()
 
-    response_model = param.ClassSelector(class_=BaseModel, is_instance=False, default=String)
+    response_model = param.ClassSelector(
+        class_=BaseModel, is_instance=False, default=String
+    )
 
-    user = param.String(default='Assistant')
+    user = param.String(default="Assistant")
 
     requires = param.List(default=[], readonly=True)
 
@@ -52,9 +54,49 @@ class Agent(Viewer):
     __abstract = True
 
     def __init__(self, **params):
-        if 'interface' not in params:
-            params['interface'] = ChatInterface(callback=self._chat_invoke)
+        if "interface" not in params:
+            params["interface"] = ChatInterface(callback=self._chat_invoke)
         super().__init__(**params)
+
+    def _link_code_editor(self, value, callback, language):
+        code_editor = pn.widgets.CodeEditor(
+            value=value, language=language, sizing_mode="stretch_both", min_height=300
+        )
+        copy_icon = pn.widgets.ButtonIcon(
+            icon="copy", active_icon="check", toggle_duration=1000
+        )
+        copy_icon.js_on_click(
+            args={"code_editor": code_editor},
+            code="navigator.clipboard.writeText(code_editor.code);",
+        )
+        download_icon = pn.widgets.ButtonIcon(
+            icon="download", active_icon="check", toggle_duration=1000
+        )
+        download_icon.js_on_click(
+            args={"code_editor": code_editor},
+            code="""
+            var text = code_editor.code;
+            var blob = new Blob([text], {type: 'text/plain'});
+            var url = window.URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            a.download = 'lumen_spec.yaml';
+            document.body.appendChild(a); // we need to append the element to the dom -> otherwise it will not work in firefox
+            a.click();
+            a.parentNode.removeChild(a);  //afterwards we remove the element again
+            """,
+        )
+        icons = pn.Row(copy_icon, download_icon)
+        code_col = pn.Column(code_editor, icons, sizing_mode="stretch_both")
+        placeholder = pn.Column()
+        tabs = pn.Tabs(
+            ("Code", code_col),
+            ("Output", placeholder),
+        )
+        placeholder.objects = [
+            pn.bind(callback, code_editor.param.value, tabs.param.active)
+        ]
+        return tabs
 
     def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
         return self.invoke(contents)
@@ -72,7 +114,9 @@ class Agent(Viewer):
     def invoke(self, messages: list | str):
         message = None
         system_prompt = self._system_prompt_with_context(messages)
-        for chunk in self.llm.stream(messages, system=system_prompt, response_model=self.response_model):
+        for chunk in self.llm.stream(
+            messages, system=system_prompt, response_model=self.response_model
+        ):
             if not chunk:
                 continue
             message = self.interface.stream(
@@ -91,59 +135,72 @@ class SourceAgent(Agent):
 
     requires = param.List(default=[], readonly=True)
 
-    provides = param.List(default=['current_source'], readonly=True)
+    provides = param.List(default=["current_source"], readonly=True)
 
     on_init = param.Boolean(default=True)
 
     def invoke(self, messages: list[str] | str):
-        name = pn.widgets.TextInput(name='Name your table', align='center')
-        upload = pn.widgets.FileInput(align='end')
-        url = pn.widgets.TextInput(name='Add a file from a URL')
-        add = pn.widgets.Button(name='Add table', icon='table-plus', disabled=True, align='center', button_type='success')
-        tables = pn.Tabs(sizing_mode='stretch_width')
+        name = pn.widgets.TextInput(name="Name your table", align="center")
+        upload = pn.widgets.FileInput(align="end")
+        url = pn.widgets.TextInput(name="Add a file from a URL")
+        add = pn.widgets.Button(
+            name="Add table",
+            icon="table-plus",
+            disabled=True,
+            align="center",
+            button_type="success",
+        )
+        tables = pn.Tabs(sizing_mode="stretch_width")
         mem_source = InMemorySource()
         file_source = FileSource()
+
         def add_table(event):
             if upload.value:
-                if upload.filename.endswith('csv'):
-                    df = pd.read_csv(io.StringIO(upload.value.decode('utf-8')), parse_dates=True)
-                    for col in ('date', 'Date'):
+                if upload.filename.endswith("csv"):
+                    df = pd.read_csv(
+                        io.StringIO(upload.value.decode("utf-8")), parse_dates=True
+                    )
+                    for col in ("date", "Date"):
                         if col in df.columns:
                             df[col] = pd.to_datetime(df[col])
-                elif upload.filename.endswith(('.parq', '.parquet')):
-                    df = pd.read_parquet(io.BytesIO(upload.value.decode('utf-8')))
+                elif upload.filename.endswith((".parq", ".parquet")):
+                    df = pd.read_parquet(io.BytesIO(upload.value.decode("utf-8")))
                 mem_source.add_table(name.value, df)
-                memory['current_source'] = mem_source
+                memory["current_source"] = mem_source
             elif url.value:
                 file_source.tables[name.value] = url.value
-                memory['current_source'] = file_source
-            name.value = ''
-            url.value = ''
+                memory["current_source"] = file_source
+            name.value = ""
+            url.value = ""
             upload.value = None
-            src = memory['current_source']
-            tables[:] = [(t, pn.widgets.Tabulator(src.get(t))) for t in src.get_tables()]
+            src = memory["current_source"]
+            tables[:] = [
+                (t, pn.widgets.Tabulator(src.get(t))) for t in src.get_tables()
+            ]
 
         def add_name(event):
             if not name.value and event.new:
-                name.value = event.new.split('.')[0]
+                name.value = event.new.split(".")[0]
 
-        upload.param.watch(add_name, 'filename')
+        upload.param.watch(add_name, "filename")
+
         def enable_add(event):
             add.disabled = not bool(name.value and (upload.value or url.value))
-        name.param.watch(enable_add, 'value')
-        upload.param.watch(enable_add, 'value')
-        url.param.watch(enable_add, 'value')
+
+        name.param.watch(enable_add, "value")
+        upload.param.watch(enable_add, "value")
+        url.param.watch(enable_add, "value")
         add.on_click(add_table)
-        menu = pn.Column(pn.Row(
-            name,
-            pn.Tabs(
-                ('Upload', upload),
-                ('URL', url)
+        menu = pn.Column(
+            pn.Row(
+                name,
+                pn.Tabs(("Upload", upload), ("URL", url)),
+                add,
+                sizing_mode="stretch_width",
             ),
-            add,
-            sizing_mode='stretch_width'
-        ), tables)
-        self.interface.send(menu, respond=False, user='SourceAgent')
+            tables,
+        )
+        self.interface.send(menu, respond=False, user="SourceAgent")
 
 
 class ChatAgent(Agent):
@@ -153,12 +210,14 @@ class ChatAgent(Agent):
 
     system_prompt = param.String(default="Be a helpful chatbot.")
 
-    response_model = param.ClassSelector(default=String, class_=BaseModel, is_instance=False)
+    response_model = param.ClassSelector(
+        default=String, class_=BaseModel, is_instance=False
+    )
 
 
 class LumenBaseAgent(Agent):
 
-    user = param.String(default='Lumen')
+    user = param.String(default="Lumen")
 
     def _render_lumen(self, component: Component, message: pn.chat.ChatMessage = None):
         def _render_component(spec, active):
@@ -171,21 +230,8 @@ class LumenBaseAgent(Agent):
             return type(component).from_spec(load_yaml(spec))
 
         # layout widgets
-        spec = component.to_spec()
-        code_editor = pn.widgets.CodeEditor(
-            value=yaml.dump(spec), language="yaml",
-            min_height=300, sizing_mode="stretch_both",
-        )
-        dashboard_placeholder = pn.Column(sizing_mode='stretch_width')
-        tabs = pn.Tabs(
-            ("YAML", code_editor),
-            ("Dashboard", dashboard_placeholder),
-        )
-        dashboard_placeholder[:] = [pn.bind(
-            _render_component, code_editor.param.value, tabs.param.active
-        )]
-        if memory.get("current_spec") is None:
-            tabs.active = 1
+        spec = yaml.safe_dump(component.to_spec())
+        tabs = self._link_code_editor(spec, _render_component, "yaml")
         message_kwargs = dict(value=tabs, user=self.user)
         if message:
             self.interface.stream(message=message, **message_kwargs)
@@ -198,34 +244,44 @@ class TableAgent(LumenBaseAgent):
     The TableAgent is responsible for selecting between a set of tables based on the user prompt.
     """
 
-    system_prompt = param.String(default='You are an agent responsible for finding the correct table based on the user prompt.')
+    system_prompt = param.String(
+        default="You are an agent responsible for finding the correct table based on the user prompt."
+    )
 
-    response_model = param.ClassSelector(default=Table, class_=BaseModel, is_instance=False)
+    response_model = param.ClassSelector(
+        default=Table, class_=BaseModel, is_instance=False
+    )
 
-    requires = param.List(default=['current_source'], readonly=True)
+    requires = param.List(default=["current_source"], readonly=True)
 
-    provides = param.List(default=['current_table', 'current_pipeline'], readonly=True)
+    provides = param.List(default=["current_table", "current_pipeline"], readonly=True)
 
     def answer(self, messages: list | str):
-        tables = tuple(memory['current_source'].get_tables())
+        tables = tuple(memory["current_source"].get_tables())
         if len(tables) == 1:
             table = tables[0]
         else:
             system_prompt = self._system_prompt_with_context(messages)
             if self.debug:
-                print(f'{self.name} is being instructed that it should {system_prompt}')
+                print(f"{self.name} is being instructed that it should {system_prompt}")
             table_model = create_model("Table", table=(Literal[tables], ...))
             table = self.llm.invoke(
-                messages, system=system_prompt, response_model=table_model, allow_partial=False
+                messages,
+                system=system_prompt,
+                response_model=table_model,
+                allow_partial=False,
             ).table
         memory["current_table"] = table
+        memory["current_pipeline"] = Pipeline(
+            source=memory["current_source"], table=table
+        )
         if self.debug:
-            print(f'{self.name} thinks that the user is talking about {table=!r}.')
+            print(f"{self.name} thinks that the user is talking about {table=!r}.")
         return table
 
     def invoke(self, messages: list | str):
         table = self.answer(messages)
-        pipeline = Pipeline(source=memory['current_source'], table=table)
+        pipeline = Pipeline(source=memory["current_source"], table=table)
         self._render_lumen(pipeline)
 
 
@@ -234,12 +290,15 @@ class SQLAgent(LumenBaseAgent):
     The SQLAgent is responsible for modifying SQL queries based on the user prompt.
     """
 
-    system_prompt = param.String(default='You are an agent responsible for writing a SQL query that will perform the data transformations the user requested.')
+    system_prompt = param.String(
+        default="You are an agent responsible for writing a SQL query that will perform the data transformations the user requested."
+    )
 
-    requires = param.List(default=['current_table', 'current_source'], readonly=True)
+    requires = param.List(default=["current_table", "current_source"], readonly=True)
 
     def _render_sql(self, query):
-        source = memory['current_source']
+        source = memory["current_source"]
+
         async def _render_sql_result(query, active):
             print("!!!", query, active)
             if active == 0:
@@ -247,42 +306,35 @@ class SQLAgent(LumenBaseAgent):
                     value=True, name="Executing SQL query...", height=50, width=50
                 )
 
-            table = memory['current_table']
+            table = memory["current_table"]
             source.tables[table] = query
-            memory['current_pipeline'] = pipeline = Pipeline(source=source, table=table)
+            memory["current_pipeline"] = pipeline = Pipeline(source=source, table=table)
             yield pipeline
 
-        code_editor = pn.widgets.CodeEditor(
-            value=query,
-            language="sql",
-            height=200,
-            sizing_mode="stretch_width",
-        )
-        results = pn.Column()
-        tabs = pn.Tabs(
-            ("SQL", code_editor),
-            ("Result", results),
-        )
-        results.objects = [pn.bind(_render_sql_result, code_editor, tabs)]
+        print(query)
+        tabs = self._link_code_editor(query, _render_sql_result, "sql")
         self.interface.stream(tabs, user="SQL", replace=True)
 
     def _sql_prompt(self, sql: str, table: str, schema: dict) -> str:
-        prompt = f'The SQL expression for the table {table!r} is {sql!r}.'
-        prompt += f'\n\nThe data for table {table!r} follows the following JSON schema:\n\n```{str(schema)}```'
+        prompt = f"The SQL expression for the table {table!r} is {sql!r}."
+        prompt += f"\n\nThe data for table {table!r} follows the following JSON schema:\n\n```{str(schema)}```"
         return prompt
 
     def answer(self, messages: list | str):
         message = None
-        source = memory['current_source']
-        table = memory['current_table']
-        if not hasattr(source, 'get_sql_expr'):
+        source = memory["current_source"]
+        table = memory["current_table"]
+        if not hasattr(source, "get_sql_expr"):
             return None
         sql_expr = source.get_sql_expr(table)
         system_prompt = self._system_prompt_with_context(messages)
         schema = source.get_schema(table)
         sql_prompt = self._sql_prompt(sql_expr, table, schema)
         for chunk in self.llm.stream(
-            messages, system=system_prompt+sql_prompt, response_model=Sql, field="query"
+            messages,
+            system=system_prompt + sql_prompt,
+            response_model=Sql,
+            field="query",
         ):
             if chunk:
                 message = self.interface.stream(
@@ -293,16 +345,17 @@ class SQLAgent(LumenBaseAgent):
                 )
         if message.object is None:
             return
-        sql_out = message.object.replace('```sql', '').replace('```', '').strip()
-        if f'FROM {table}' in sql_out:
-            sql_in = sql_expr.replace('SELECT * from ', '')
-            sql_out = sql_out.replace(f'FROM {table}', f'FROM {sql_in}')
+        sql_out = message.object.replace("```sql", "").replace("```", "").strip()
+        if f"FROM {table}" in sql_out:
+            sql_in = sql_expr.replace("SELECT * from ", "")
+            sql_out = sql_out.replace(f"FROM {table}", f"FROM {sql_in}")
             print(table, sql_in, sql_out)
-        memory['current_sql'] = sql_out
+        memory["current_sql"] = sql_out
         return sql_out
 
     def invoke(self, messages: list | str):
         sql = self.answer(messages)
+        raise ValueError(sql)
         self._render_sql(sql)
 
 
@@ -313,77 +366,98 @@ class PipelineAgent(LumenBaseAgent):
     If the user asks to calculate, aggregate, select or perform some other operation on the data this is your best best.
     """
 
-    system_prompt = param.String(default="Generate the appropriate data transformation.")
+    system_prompt = param.String(
+        default="Generate the appropriate data transformation."
+    )
 
-    requires = param.List(default=['current_table'], readonly=True)
+    requires = param.List(default=["current_table"], readonly=True)
 
-    provides = param.List(default=['current_pipeline'], readonly=True)
+    provides = param.List(default=["current_pipeline"], readonly=True)
 
     @property
     def _available_transforms(self) -> dict[str, Type[Transform]]:
         transforms = param.concrete_descendents(Transform)
         return {
-            name: transform for name, transform in transforms.items()
+            name: transform
+            for name, transform in transforms.items()
             if not issubclass(transform, SQLTransform)
         }
 
     def _transform_picker_prompt(self) -> str:
-        prompt = 'This is a description of all available transforms:\n'
+        prompt = "This is a description of all available transforms:\n"
         for name, transform in self._available_transforms.items():
-            if doc:= (transform.__doc__ or '').strip():
-                doc = doc.split('\n\n')[0].strip().replace('\n', '')
+            if doc := (transform.__doc__ or "").strip():
+                doc = doc.split("\n\n")[0].strip().replace("\n", "")
                 prompt += f"- {name}: {doc}\n"
         return prompt
 
-    def _transform_prompt(self, model: BaseModel, transform: Transform, table: str, schema: dict) -> str:
-        prompt = f'{transform.__doc__}'
-        prompt += f'\nThe arguments must conform to the following schema:\n\n```{model.model_json_schema()}```'
-        prompt += f'\n\nThe data follows the following JSON schema:\n\n```{str(schema)}```'
-        if 'current_transform' in memory:
+    def _transform_prompt(
+        self, model: BaseModel, transform: Transform, table: str, schema: dict
+    ) -> str:
+        prompt = f"{transform.__doc__}"
+        prompt += f"\nThe arguments must conform to the following schema:\n\n```{model.model_json_schema()}```"
+        prompt += (
+            f"\n\nThe data follows the following JSON schema:\n\n```{str(schema)}```"
+        )
+        if "current_transform" in memory:
             prompt += f"The previous transform specification was: {memory['current_transform']}"
         return prompt
 
-    def _find_transform(self, messages: list | str, system_prompt: str) -> Type[Transform] | None:
+    def _find_transform(
+        self, messages: list | str, system_prompt: str
+    ) -> Type[Transform] | None:
         picker_prompt = self._transform_picker_prompt()
         transforms = self._available_transforms
-        transform_model = create_model("Transform", transform=(Literal[tuple(transforms)], ...))
+        transform_model = create_model(
+            "Transform", transform=(Literal[tuple(transforms)], ...)
+        )
         transform_name = self.llm.invoke(
-            messages, system=system_prompt+picker_prompt, response_model=transform_model
+            messages,
+            system=system_prompt + picker_prompt,
+            response_model=transform_model,
         ).transform
         if self.debug:
-            print(f'{self.name} thought {transform_name=!r} would be the right thing to do.')
+            print(
+                f"{self.name} thought {transform_name=!r} would be the right thing to do."
+            )
         return transforms[transform_name] if transform_name else None
 
-    def _construct_transform(self, messages: list | str, transform: Type[Transform], system_prompt: str) -> Transform:
-        table = memory['current_table']
-        excluded = transform._internal_params+['controls', 'type']
-        schema = memory['current_source'].get_schema(table)
-        model = param_to_pydantic(transform, excluded=excluded, schema=schema)[transform.__name__]
+    def _construct_transform(
+        self, messages: list | str, transform: Type[Transform], system_prompt: str
+    ) -> Transform:
+        table = memory["current_table"]
+        excluded = transform._internal_params + ["controls", "type"]
+        schema = memory["current_source"].get_schema(table)
+        model = param_to_pydantic(transform, excluded=excluded, schema=schema)[
+            transform.__name__
+        ]
         transform_prompt = self._transform_prompt(model, transform, table, schema)
         if self.debug:
-            print(f'{self.name} recalls that {transform_prompt}.')
+            print(f"{self.name} recalls that {transform_prompt}.")
         kwargs = self.llm.invoke(
-            messages, system=system_prompt+transform_prompt, response_model=model, allow_partial=False
+            messages,
+            system=system_prompt + transform_prompt,
+            response_model=model,
+            allow_partial=False,
         )
         return transform(**dict(kwargs))
 
     def answer(self, messages: list | str) -> Transform:
         system_prompt = self._system_prompt_with_context(messages)
         transform_type = self._find_transform(messages, system_prompt)
-        if 'current_pipeline' in memory:
-            pipeline = memory['current_pipeline']
+        if "current_pipeline" in memory:
+            pipeline = memory["current_pipeline"]
         else:
             pipeline = Pipeline(
-                source=memory['current_source'],
-                table=memory['current_table']
+                source=memory["current_source"], table=memory["current_table"]
             )
-        memory['current_pipeline'] = pipeline
+        memory["current_pipeline"] = pipeline
         if not transform_type:
             return pipeline
         transform = self._construct_transform(messages, transform_type, system_prompt)
-        memory['current_transform'] = spec = transform.to_spec()
+        memory["current_transform"] = spec = transform.to_spec()
         if self.debug:
-            print(f'{self.name} settled on {spec=!r}.')
+            print(f"{self.name} settled on {spec=!r}.")
         if pipeline.transforms and type(pipeline.transforms[-1]) is type(transform):
             pipeline.transforms[-1] = transform
         else:
@@ -392,8 +466,8 @@ class PipelineAgent(LumenBaseAgent):
             pipeline._update_data(force=True)
         except Exception as e:
             self.interface.send(
-                f'Generated invalid transform resulting in following error: {e}',
-                user=self.name
+                f"Generated invalid transform resulting in following error: {e}",
+                user=self.name,
             )
             pipeline.transforms = pipeline.transforms[:-1]
             pipeline._stale = True
@@ -411,48 +485,66 @@ class hvPlotAgent(LumenBaseAgent):
     If the user asks to plot, visualize or render the data this is your best best.
     """
 
-    system_prompt = param.String(default="Generate the plot the user requested. Note that x, y, by and groupby arguments may not reference the same columns.")
+    system_prompt = param.String(
+        default="Generate the plot the user requested. Note that x, y, by and groupby arguments may not reference the same columns."
+    )
 
-    requires = param.List(default=['current_pipeline'], readonly=True)
+    requires = param.List(default=["current_pipeline"], readonly=True)
 
-    provides = param.List(default=['current_plot'], readonly=True)
+    provides = param.List(default=["current_plot"], readonly=True)
 
-    def _view_prompt(self, model: BaseModel, view: hvPlotUIView, table: str, schema: dict) -> str:
-        doc = view.__doc__.split('\n\n')[0]
-        prompt = f'{doc}'
-        prompt += f'\nThe arguments must conform to the following schema:\n\n```{model.model_json_schema()}```'
-        prompt += f'\n\nThe data follows the following JSON schema:\n\n```{str(schema)}```'
-        if 'current_view' in memory:
+    def _view_prompt(
+        self, model: BaseModel, view: hvPlotUIView, table: str, schema: dict
+    ) -> str:
+        doc = view.__doc__.split("\n\n")[0]
+        prompt = f"{doc}"
+        prompt += f"\nThe arguments must conform to the following schema:\n\n```{model.model_json_schema()}```"
+        prompt += (
+            f"\n\nThe data follows the following JSON schema:\n\n```{str(schema)}```"
+        )
+        if "current_view" in memory:
             prompt += f"The previous view specification was: {memory['current_view']}"
         return prompt
 
     def answer(self, messages: list | str) -> Transform:
-        pipeline = memory['current_pipeline']
-        table = memory['current_table']
+        pipeline = memory["current_pipeline"]
+        table = memory["current_table"]
         system_prompt = self._system_prompt_with_context(messages)
 
         # Find parameters
         view = hvPlotUIView
         schema = pipeline.get_schema()
-        excluded = view._internal_params+[
-            'controls', 'type', 'source', 'pipeline', 'transforms',
-            'sql_transforms', 'download', 'field', 'groupby', 'by',
-            'selection_group', 'limit'
+        excluded = view._internal_params + [
+            "controls",
+            "type",
+            "source",
+            "pipeline",
+            "transforms",
+            "sql_transforms",
+            "download",
+            "field",
+            "groupby",
+            "by",
+            "selection_group",
+            "limit",
         ]
         model = param_to_pydantic(view, excluded=excluded, schema=schema)[view.__name__]
         view_prompt = self._view_prompt(model, view, table, schema)
         if self.debug:
-            print(f'{self.name} is being instructed that {view_prompt}.')
+            print(f"{self.name} is being instructed that {view_prompt}.")
         kwargs = self.llm.invoke(
-            messages, system=system_prompt+view_prompt, response_model=model, allow_partial=False
+            messages,
+            system=system_prompt + view_prompt,
+            response_model=model,
+            allow_partial=False,
         )
 
         # Instantiate
         spec = dict(kwargs)
-        spec['responsive'] = True
-        memory['current_view'] = dict(spec, type=view.view_type)
+        spec["responsive"] = True
+        memory["current_view"] = dict(spec, type=view.view_type)
         if self.debug:
-            print(f'{self.name} settled on {spec=!r}.')
+            print(f"{self.name} settled on {spec=!r}.")
         return view(pipeline=pipeline, **spec)
 
     def invoke(self, messages: list | str):

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -330,12 +330,14 @@ class LumenBaseAgent(Agent):
             df_describe_dict[col]["nunique"] = df[col].nunique()
             # df_describe_dict[col]["top_5_counts"] = df[col].value_counts().head().to_dict()
             # length stats
-            df_describe_dict[col]["lengths"] = {
-                "max": df[col].str.len().max(),
-                "min": df[col].str.len().min(),
-                "mean": float(df[col].str.len().mean()),
-                # "std": df[col].str.len().std(),
-            }
+            try:
+                df_describe_dict[col]["lengths"] = {
+                    "max": df[col].str.len().max(),
+                    "min": df[col].str.len().min(),
+                    "mean": float(df[col].str.len().mean()),
+                }
+            except AttributeError:
+                pass
 
         for col in df.columns:
             if col not in df_describe_dict:

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -281,7 +281,7 @@ class ChatAgent(Agent):
         required_model = create_model("DataRequired", data_required=(bool, FieldInfo(
             description="Whether the user is asking about a specific dataset."
         )))
-        for _ in range(3):
+        for i in range(3):
             result = await self.llm.invoke(
                 messages,
                 system=(
@@ -296,6 +296,8 @@ class ChatAgent(Agent):
                 continue
             elif result.data_required:
                 return self.requires + ['current_table']
+            else:
+                break
         return self.requires
 
     def _system_prompt_with_context(
@@ -862,7 +864,7 @@ class hvPlotAgent(LumenBaseAgent):
         )
 
         # Instantiate
-        spec = dict(kwargs)
+        spec = {key: val for key, val in dict(kwargs).items() if val is not None}
         spec["responsive"] = True
 
         spec["type"] = "hvplot_ui"

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -186,7 +186,7 @@ class Agent(Viewer):
 
         # make case insensitive, but keep original case to transform back
         if not fuzzy_table.keywords:
-            return []
+            return tables[:n]
 
         table_keywords = [keyword.lower() for keyword in fuzzy_table.keywords]
         tables_lower = {table.lower(): table for table in tables}
@@ -196,17 +196,28 @@ class Agent(Viewer):
         for keyword in table_keywords:
             closest_tables |= set(difflib.get_close_matches(keyword, list(tables_lower), n=5, cutoff=0.3))
         closest_tables = [tables_lower[table] for table in closest_tables]
-        return tuple(closest_tables)
+        if len(closest_tables) == 0:
+            # if no tables are found, ask the user to select ones and load it
+            tables = await self._select_table(tables)
+        memory["closest_tables"] = tables
+        return tuple(tables)
 
     async def _select_table(self, tables):
         input_widget = pn.widgets.AutocompleteInput(
-            placeholder="Start typing the table name you are looking for",
+            placeholder="Start typing parts of the table name",
             case_sensitive=False,
             options=list(tables),
             search_strategy="includes",
             min_characters=1,
         )
-        self.interface.send(input_widget, user="Assistant", respond=False)
+        self.interface.send(
+            pn.chat.ChatMessage(
+                "No tables were found based on the user query. Please select the table you are looking for.",
+                footer_objects=[input_widget],
+                user="Assistant",
+            ),
+            respond=False
+        )
         while not input_widget.value:
             await asyncio.sleep(0.05)
         tables = [input_widget.value]
@@ -332,17 +343,6 @@ class ChatAgent(Agent):
         if 'current_data' in memory:
             return self.requires
 
-        source = memory.get("current_source")
-        tables = source.get_tables() if source else []
-        if len(tables) > FUZZY_TABLE_LENGTH:
-            closest_tables = await self._get_closest_tables(messages, tables, n=5)
-            if len(closest_tables) == 0:
-                # if no tables are found, ask the user to select ones and load it
-                tables = await self._select_table(tables)
-                return self.requires + ['current_table']
-            elif len(closest_tables) == 1:
-                return self.requires + ['current_table']
-
         for i in range(3):
             result = await self.llm.invoke(
                 messages,
@@ -368,9 +368,11 @@ class ChatAgent(Agent):
         source = memory.get("current_source")
         tables = source.get_tables() if source else []
         if len(tables) > 1:
-            if len(tables) > FUZZY_TABLE_LENGTH:
-                tables = await self._get_closest_tables(messages, tables, n=5)
-            context = f"Available tables: {', '.join(tables)}"
+            if len(tables) > FUZZY_TABLE_LENGTH and "closest_tables" not in memory:
+                closest_tables = await self._get_closest_tables(messages, tables, n=5)
+            else:
+                closest_tables = memory.get("closest_tables", None)
+            context = f"Available tables: {', '.join(closest_tables)}"
         else:
             memory["current_table"] = table = memory.get("current_table", tables[0])
             schema = self._get_schema(memory["current_source"], table)
@@ -533,7 +535,7 @@ class LumenBaseAgent(Agent):
 
 class TableAgent(LumenBaseAgent):
     """
-    Responsible for only displaying or choosing between a set of tables / datasets, no discussion.
+    Responsible for only displaying a set of tables / datasets, no discussion.
     """
 
     system_prompt = param.String(
@@ -549,22 +551,27 @@ class TableAgent(LumenBaseAgent):
         if len(tables) == 1:
             table = tables[0]
         else:
-            if len(tables) > FUZZY_TABLE_LENGTH:
+            closest_tables = memory.pop("closest_tables", None)
+            if closest_tables:
+                tables = closest_tables
+            elif len(tables) > FUZZY_TABLE_LENGTH:
                 tables = await self._get_closest_tables(messages, tables)
             system_prompt = await self._system_prompt_with_context(messages)
             if self.debug:
                 print(f"{self.name} is being instructed that it should {system_prompt}")
-            # needed or else something with grammar issue
-            table_model = create_model("Table", table=(Literal[tables], FieldInfo(
-                description="The most relevant table based on the user query; if none are relevant, select the first."
-            )))
-            result = await self.llm.invoke(
-                messages,
-                system=system_prompt,
-                response_model=table_model,
-                allow_partial=False,
-            )
-            table = result.table
+            if len(tables) > 1:
+                table_model = create_model("Table", table=(Literal[tables], FieldInfo(
+                    description="The most relevant table based on the user query; if none are relevant, select the first."
+                )))
+                result = await self.llm.invoke(
+                    messages,
+                    system=system_prompt,
+                    response_model=table_model,
+                    allow_partial=False,
+                )
+                table = result.table
+            else:
+                table = tables[0]
         memory["current_table"] = table
         memory["current_pipeline"] = pipeline = Pipeline(
             source=memory["current_source"], table=table

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -20,7 +20,6 @@ from ..pipeline import Pipeline
 from ..sources import FileSource, InMemorySource, Source
 from ..sources.intake_sql import IntakeBaseSQLSource
 from ..transforms.sql import SQLOverride, SQLTransform, Transform
-from ..validation import ValidationError
 from ..views import hvPlotUIView
 from .embeddings import Embeddings
 from .llm import Llm
@@ -66,16 +65,24 @@ class Agent(Viewer):
     __abstract = True
 
     def __init__(self, **params):
+        self._retries_left = 1
         def _exception_handler(exception):
             import traceback
+            tb = traceback.format_exc()
+            print(tb)
+            if self._retries_left > 0:
+                self._retries_left -= 1
+                self.interface.send(
+                    f"Attempting to fix: {exception}.",
+                    user="Exception",
+                )
+            else:
+                self.interface.send(
+                    f"Error cannot be resolved: {exception}.",
+                    user="System",
+                    respond=False
+                )
 
-            traceback.print_exc()
-            last_message = self.interface.objects[-1]
-            self.interface.send(
-                f"Sorry I'm unable to {last_message.object!r}: {exception!r}",
-                user="Exception",
-                respond=False,
-            )
 
         if "interface" not in params:
             params["interface"] = ChatInterface(callback=self._chat_invoke)
@@ -123,9 +130,9 @@ class Agent(Viewer):
         ]
         return tabs
 
-    def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
-        print("-" * 25)
-        self.invoke(contents)
+    async def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
+        await self.invoke(contents)
+        self._retries_left = 1
 
     def __panel__(self):
         return self.interface
@@ -243,14 +250,16 @@ class SourceAgent(Agent):
 
 class ChatAgent(Agent):
     """
-    Responsible for chatting about high level or simple data exploration and suggesting
-    ways to get started with data exploration.
+    Responsible for chatting about high level data stuff, like
+    what datasets are available and what each column represents.
+    Is capable of providing suggestions to get started.
+    If data is available, it can also talk about the data itself.
     """
 
     system_prompt = param.String(
         default=(
             "Be a helpful chatbot to talk about high-level data exploration "
-            "like their types or suggestions to get started."
+            "like what datasets are available and what each column represents."
         )
     )
 
@@ -271,6 +280,12 @@ class ChatAgent(Agent):
             if schema:
                 context = f"{table} with schema: {schema}"
 
+        if "current_data" in memory:
+            context += (
+                f"\nHere's an overview of a *RANDOM* SAMPLE of "
+                f"the last available dataset, up to 5000 rows:\n```\n{memory['current_data']}\n```"
+            )
+
         system_prompt = self.system_prompt
         if context:
             system_prompt += f"{system_prompt}\n### CONTEXT: {context}".strip()
@@ -280,6 +295,85 @@ class ChatAgent(Agent):
 class LumenBaseAgent(Agent):
 
     user = param.String(default="Lumen")
+
+    def _describe_data(self, df: pd.DataFrame) -> str:
+        def format_float(num):
+            if pd.isna(num):
+                return num
+            # if is integer, round to 0 decimals
+            if num == int(num):
+                return f"{int(num)}"
+            elif 0.01 <= abs(num) < 100:
+                return f"{num:.1f}"  # Regular floating-point notation with two decimals
+            else:
+                return f"{num:.1e}"  # Exponential notation with two decimals
+
+        df = pd.read_parquet("windturbines.parq")
+        df = df.sample(len(df) if len(df) < 5000 else 5000).sort_index()
+
+        for col in df.columns:
+            if isinstance(df[col].iloc[0], pd.Timestamp):
+                df[col] = pd.to_datetime(df[col])
+
+        # df_dtypes_dict = {
+        #     col: str(type(df[col].iloc[:1].astype("object").iloc[0])).split("'")[1]
+        #     for col in df.columns
+        # }
+        df_describe_dict = df.describe(percentiles=[]).to_dict()
+
+        for col in df.select_dtypes(include=["object"]).columns:
+            if col not in df_describe_dict:
+                df_describe_dict[col] = {}
+            df_describe_dict[col]["nunique"] = df[col].nunique()
+            # df_describe_dict[col]["top_5_counts"] = df[col].value_counts().head().to_dict()
+            # length stats
+            df_describe_dict[col]["lengths"] = {
+                "max": df[col].str.len().max(),
+                "min": df[col].str.len().min(),
+                "mean": float(df[col].str.len().mean()),
+                # "std": df[col].str.len().std(),
+            }
+
+        for col in df.columns:
+            if col not in df_describe_dict:
+                df_describe_dict[col] = {}
+            df_describe_dict[col]["nulls"] = int(df[col].isnull().sum())
+
+        # select datetime64 columns
+        for col in df.select_dtypes(include=["datetime64"]).columns:
+            for key in df_describe_dict[col]:
+                df_describe_dict[col][key] = str(df_describe_dict[col][key])
+            df[col] = df[col].astype(str)  # shorten output
+
+        # select all numeric columns and round
+        for col in df.select_dtypes(include=["int64", "float64"]).columns:
+            for key in df_describe_dict[col]:
+                df_describe_dict[col][key] = format_float(df_describe_dict[col][key])
+
+        for col in df.select_dtypes(include=["float64"]).columns:
+            df[col] = df[col].apply(format_float)
+
+        df_head_dict = {}
+        for col in df.columns:
+            df_head_dict[col] = df[col].head(5)
+            # if all nan or none, replace with None
+            if df_head_dict[col].isnull().all():
+                df_head_dict[col] = ["all null"]
+            else:
+                df_head_dict[col] = df_head_dict[col].tolist()
+
+        data = {"stats": df_describe_dict, "head": df_head_dict}
+        # if len(df) > 5:
+        #     df_tail_dict = {}
+        #     for col in df.columns:
+        #         df_tail_dict[col] = df[col].tail(5)
+        #         # if all nan or none, replace with None
+        #         if df_tail_dict[col].isnull().all():
+        #             df_tail_dict[col] = ["all null"]
+        #         else:
+        #             df_tail_dict[col] = df_tail_dict[col].tolist()
+        data_string = str(data)
+        return data_string
 
     def _render_lumen(self, component: Component, message: pn.chat.ChatMessage = None):
         async def _render_component(spec, active):
@@ -302,7 +396,6 @@ class LumenBaseAgent(Agent):
                 # maybe offer undo
 
         # layout widgets
-
         component_spec = component.to_spec()
         spec = yaml.safe_dump(component_spec)
         spec = f"# Here's the generated Lumen spec; modify if needed\n{spec}"
@@ -350,16 +443,18 @@ class TableAgent(LumenBaseAgent):
             )
             table = result.table
         memory["current_table"] = table
-        memory["current_pipeline"] = Pipeline(
+        memory["current_pipeline"] = pipeline = Pipeline(
             source=memory["current_source"], table=table
         )
+        df = pipeline.__panel__()[-1].value
+        if len(df) > 0:
+            memory["current_data"] = self._describe_data(df)
         if self.debug:
             print(f"{self.name} thinks that the user is talking about {table=!r}.")
-        return table
+        return pipeline
 
     async def invoke(self, messages: list | str):
-        table = await self.answer(messages)
-        pipeline = Pipeline(source=memory["current_source"], table=table)
+        pipeline = await self.answer(messages)
         self._render_lumen(pipeline)
 
 
@@ -406,7 +501,7 @@ class TableListAgent(LumenBaseAgent):
 class SQLAgent(LumenBaseAgent):
     """
     Responsible for generating and modifying SQL queries to answer user queries about the data,
-    like stats or insights about the dataset.
+    like disucssing stats, such as min & max, or other insights about the dataset.
     """
 
     system_prompt = param.String(
@@ -433,6 +528,9 @@ class SQLAgent(LumenBaseAgent):
                 )
                 # Need this separate or else create random memory entry
                 pipeline = memory["current_pipeline"].__panel__()
+                df = pipeline.objects[-1].value
+                if len(df) > 0:
+                    memory["current_data"] = self._describe_data(df)
                 yield pipeline
             except Exception as e:
                 memory.pop("current_pipeline")
@@ -529,9 +627,7 @@ class PipelineAgent(LumenBaseAgent):
         prompt = f"{transform.__doc__}"
         if not schema:
             raise ValueError(f"No schema found for table {table!r}")
-        else:
-            print(f"Used schema: {schema}")
-        prompt += f"\n\nThe data follows the following JSON schema:\n\n```json\n{format_schema(schema)}\n```"
+        prompt += f"\n\nThe data columns follows the following JSON schema:\n\n```json\n{format_schema(schema)}\n```"
         if "current_transform" in memory:
             prompt += f"The previous transform specification was: {memory['current_transform']}"
         return prompt
@@ -618,7 +714,7 @@ class PipelineAgent(LumenBaseAgent):
                 source=memory["current_source"], table=memory["current_table"]
             )
         memory["current_pipeline"] = pipeline
-        if not transform_type:
+        if not transform_type and pipeline:
             return pipeline
         transform = await self._construct_transform(
             messages, transform_type, system_prompt
@@ -630,13 +726,7 @@ class PipelineAgent(LumenBaseAgent):
             pipeline.transforms[-1] = transform
         else:
             pipeline.add_transform(transform)
-        try:
-            pipeline._update_data(force=True)
-        except Exception:
-            pipeline.transforms = pipeline.transforms[:-1]
-            memory.pop("current_transform")
-            print(f"{memory=}")
-            pipeline._stale = True
+        pipeline._update_data(force=True)
         return pipeline
 
     async def invoke(self, messages: list | str):
@@ -652,7 +742,12 @@ class hvPlotAgent(LumenBaseAgent):
     """
 
     system_prompt = param.String(
-        default="Generate the plot the user requested. Note that x, y, by and groupby arguments may not reference the same columns. Be sure to add `download: csv`"
+        default="""
+        Generate the plot the user requested.
+        Note that `x`, `y`, `by` and `groupby` fields MUST ALL be unique columns.
+        Do not arbitrarily set `groupby` and `by` fields unless explicitly requested.
+        If a histogram is requested, use `y` instead of `x`.
+        """
     )
 
     requires = param.List(default=["current_pipeline"], readonly=True)
@@ -664,12 +759,12 @@ class hvPlotAgent(LumenBaseAgent):
     ) -> str:
         doc = view.__doc__.split("\n\n")[0]
         prompt = f"{doc}"
-        prompt += f"\n\nThe data follows the following JSON schema:\n\n```json\n{format_schema(schema)}\n```"
+        # prompt += f"\n\nThe data follows the following JSON schema:\n\n```json\n{format_schema(schema)}\n```"
         if "current_view" in memory:
             prompt += f"The previous view specification was: {memory['current_view']}"
         return prompt
 
-    async def answer(self, messages: list | str, retry: bool = True) -> Transform:
+    async def answer(self, messages: list | str) -> Transform:
         pipeline = memory["current_pipeline"]
         table = memory["current_table"]
         system_prompt = self._system_prompt_with_context(messages)
@@ -683,13 +778,9 @@ class hvPlotAgent(LumenBaseAgent):
             "source",
             "pipeline",
             "transforms",
-            "sql_transforms",
             "download",
             "field",
-            "groupby",
-            "by",
             "selection_group",
-            "limit",
         ]
         model = param_to_pydantic(view, excluded=excluded, schema=schema)[view.__name__]
         view_prompt = self._view_prompt(model, view, table, schema)
@@ -706,21 +797,8 @@ class hvPlotAgent(LumenBaseAgent):
         spec = dict(kwargs)
         spec["responsive"] = True
 
-        try:
-            spec["type"] = "hvplot_ui"
-            view.validate(spec)
-        except ValidationError as e:
-            if retry:
-                new_messages = [
-                    {"role": "assistant", "content": f"{spec=}"},
-                    {
-                        "role": "user",
-                        "content": f"\nThat didn't work; please note: {e}",
-                    },
-                ]
-                messages.extend(new_messages)
-                print(f"RETRYING...\n\n\n{messages}")
-                return await self.answer(messages, retry=False)
+        spec["type"] = "hvplot_ui"
+        view.validate(spec)
 
         spec.pop("type", None)
         if len(pipeline.data) > 20000 and spec["kind"] in ("line", "scatter", "points"):

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -418,7 +418,7 @@ class LumenBaseAgent(Agent):
 
     user = param.String(default="Lumen")
 
-    sql_limit = param.Integer(default=200000)
+    sql_limit = param.Integer(default=50000)
 
     def __init__(self, **params):
         super().__init__(**params)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -1,0 +1,308 @@
+from typing import Literal
+
+import panel as pn
+import param
+import yaml
+
+from panel.chat import ChatInterface
+from panel.viewable import Viewer
+from pydantic import BaseModel, create_model
+
+from ..base import Component
+from ..dashboard import load_yaml
+from ..pipeline import Pipeline
+from ..transforms.sql import SQLTransform, Transform
+from ..views import hvPlotUIView
+from .embeddings import Embeddings
+from .llm import Llm
+from .memory import memory
+from .models import String, Table
+from .translate import param_to_pydantic
+
+
+class Agent(Viewer):
+    """
+    An Agent in Panel is responsible for handling a specific type of
+    query. Each agent consists of an LLM and optionally a set of
+    embeddings.
+    """
+
+    debug = param.Boolean(default=True)
+
+    embeddings = param.ClassSelector(class_=Embeddings)
+
+    interface = param.ClassSelector(class_=ChatInterface)
+
+    llm = param.ClassSelector(class_=Llm)
+
+    system_prompt = param.String()
+
+    response_model = param.ClassSelector(class_=BaseModel, is_instance=False, default=String)
+
+    user = param.String(default='Assistant')
+
+    requires = param.List(default=[], readonly=True)
+
+    provides = param.List(default=[], readonly=True)
+
+    __abstract = True
+
+    def __init__(self, **params):
+        if 'interface' not in params:
+            params['interface'] = ChatInterface(callback=self._chat_invoke)
+        super().__init__(**params)
+
+    def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
+        return self.invoke(contents)
+
+    def __panel__(self):
+        return self.interface
+
+    def _system_prompt_with_context(self, messages: list | str) -> str:
+        system_prompt = self.system_prompt
+        if self.embeddings:
+            context = self.embeddings.query(messages)
+            system_prompt += f"{system_prompt}\n### CONTEXT: {context}".strip()
+        return system_prompt
+
+    def invoke(self, messages: list | str):
+        message = None
+        system_prompt = self._system_prompt_with_context(messages)
+        for chunk in self.llm.stream(messages, system=system_prompt, response_model=self.response_model):
+            if not chunk:
+                continue
+            message = self.interface.stream(
+                chunk, user=self.user, message=message, replace=True
+            )
+        return message
+
+
+class ChatAgent(Agent):
+    """
+    The ChatAgent is a general chat agent unrelated to other roles.
+    """
+
+    system_prompt = param.String(default="Be a helpful chatbot.")
+
+    response_model = param.ClassSelector(default=String, class_=BaseModel, is_instance=False)
+
+
+class LumenBaseAgent(Agent):
+
+    user = param.String(default='Lumen')
+
+    def _render_lumen(self, component: Component, message: pn.chat.ChatMessage = None):
+        def _render_component(spec, active):
+            if active == 0:
+                return pn.indicators.LoadingSpinner(
+                    value=True, name="Rendering component...", height=50, width=50
+                )
+            # store the spec in the cache instead of memory to save tokens
+            memory["current_spec"] = spec
+            return type(component).from_spec(load_yaml(spec))
+
+        # layout widgets
+        spec = component.to_spec()
+        code_editor = pn.widgets.CodeEditor(
+            value=yaml.dump(spec), language="yaml",
+            min_height=300, sizing_mode="stretch_both",
+        )
+        dashboard_placeholder = pn.Column()
+        tabs = pn.Tabs(
+            ("YAML", code_editor),
+            ("Dashboard", dashboard_placeholder),
+        )
+        dashboard_placeholder[:] = [pn.bind(
+            _render_component, code_editor.param.value, tabs.param.active
+        )]
+        if memory.get("current_spec") is None:
+            tabs.active = 1
+        message_kwargs = dict(value=tabs, user=self.user)
+        if message:
+            self.interface.stream(message=message, **message_kwargs)
+        else:
+            self.interface.send(respond=False, **message_kwargs)
+
+
+class TableAgent(LumenBaseAgent):
+    """
+    The TableAgent is responsible for selecting between a set of tables based on the user prompt.
+    """
+
+    system_prompt = param.String(default='Find the closest match to one of the available tables.')
+
+    response_model = param.ClassSelector(default=Table, class_=BaseModel, is_instance=False)
+
+    requires = param.List(default=['current_source'], readonly=True)
+
+    provides = param.List(default=['current_table', 'current_pipeline'], readonly=True)
+
+    def answer(self, messages: list | str):
+        tables = tuple(memory['current_source'].get_tables())
+        if len(tables) == 1:
+            table = tables[0]
+        else:
+            system_prompt = self._system_prompt_with_context(messages)
+            if self.debug:
+                print(f'{self.name} is being instructed that it should {system_prompt}')
+            table_model = create_model("Table", table=(Literal[tables], ...))
+            table = self.llm.invoke(
+                messages, system=system_prompt, response_model=table_model
+            ).table
+        memory["current_table"] = table
+        if self.debug:
+            print(f'{self.name} thinks that the user is talking about {table=!r}.')
+        return table
+
+    def invoke(self, messages: list | str):
+        table = self.answer(messages)
+        pipeline = Pipeline(source=memory['current_source'], table=table)
+        self._render_lumen(pipeline)
+
+
+class PipelineAgent(LumenBaseAgent):
+    """
+    The Pipeline agent generates a data pipeline by applying transformations to the data.
+
+    If the user asks to calculate or aggregate the data this is your best best.
+    """
+
+    system_prompt = param.String(default="Generate the appropriate data transformation.")
+
+    requires = param.List(default=['current_table'], readonly=True)
+
+    provides = param.List(default=['current_pipeline'], readonly=True)
+
+    @property
+    def _available_transforms(self):
+        transforms = param.concrete_descendents(Transform)
+        return {
+            name: transform for name, transform in transforms.items()
+            if not isinstance(transform, SQLTransform)
+        }
+
+    def _transform_picker_prompt(self) -> str:
+        prompt = 'This is a description of all available transforms:\n'
+        for name, transform in self._available_transforms.items():
+            if doc:= (transform.__doc__ or '').strip():
+                doc = doc.split('\n\n')[0].strip().replace('\n', '')
+                prompt += f"- {name}: {doc}\n"
+        return prompt
+
+    def _transform_prompt(self, model: BaseModel, transform: Transform, table: str, schema: dict) -> str:
+        doc = transform.__doc__.split('\n\n')[0]
+        prompt = f'{doc}'
+        prompt += f'\nThe arguments must conform to the following schema:\n\n```{model.model_json_schema()}```'
+        prompt += f'\n\nThe data follows the following JSON schema:\n\n```{str(schema)}```'
+        if 'current_transform' in memory:
+            prompt += f"The previous transform specification was: {memory['current_transform']}"
+        return prompt
+
+    def answer(self, messages: list | str) -> Transform:
+        table = memory['current_table']
+        system_prompt = self._system_prompt_with_context(messages)
+        picker_prompt = self._transform_picker_prompt()
+        if self.debug:
+            print(f'{self.name} is being instructed that it should {picker_prompt}')
+
+        # Find the transform type
+        transforms = self._available_transforms
+        transform_model = create_model("Transform", transform=(Literal[tuple(transforms)], ...))
+        transform_type = self.llm.invoke(
+            messages, system=system_prompt+picker_prompt, response_model=transform_model
+        ).transform
+        if self.debug:
+            print(f'{self.name} thought {transform_type=!r} would be the right thing to do.')
+
+        # Find parameters
+        transform = transforms[transform_type]
+        excluded = transform._internal_params+['controls', 'type']
+        schema = memory['current_source'].get_schema(table)
+        model = param_to_pydantic(transform, excluded=excluded, schema=schema)[transform.__name__]
+        transform_prompt = self._transform_prompt(model, transform, table, schema)
+        if self.debug:
+            print(f'{self.name} recalls that {transform_prompt}.')
+        kwargs = self.llm.invoke(
+            messages, system=system_prompt+transform_prompt, response_model=model, allow_partial=False
+        )
+
+        # Instantiate
+        spec = dict(kwargs)
+        memory['current_transform'] = dict(
+            spec, type=transform.transform_type
+        )
+        if self.debug:
+            print(f'{self.name} settled on {spec=!r}.')
+        transform = transform(**spec)
+        if 'current_pipeline' in memory:
+            pipeline = memory['current_pipeline']
+            if pipeline.transforms and type(pipeline.transforms[-1]) is type(transform):
+                pipeline.transforms[-1] = transform
+            else:
+                pipeline.add_transform(transform)
+        else:
+            memory['current_pipeline'] = pipeline = Pipeline(
+                source=memory['current_source'],
+                table=memory['current_table'],
+                transforms=[transform]
+            )
+        return pipeline
+
+    def invoke(self, messages: list | str):
+        pipeline = self.answer(messages)
+        self._render_lumen(pipeline)
+
+
+class hvPlotAgent(LumenBaseAgent):
+    """
+    The hvPlot agent generates a plot of the data given a user prompt.
+
+    If the user asks to plot, visualize or render the data this is your best best.
+    """
+
+    system_prompt = param.String(default="Generate the plot the user requested. Note that x, y, by and groupby arguments may not reference the same columns.")
+
+    requires = param.List(default=['current_pipeline'], readonly=True)
+
+    provides = param.List(default=['current_plot'], readonly=True)
+
+    def _view_prompt(self, model: BaseModel, view: hvPlotUIView, table: str, schema: dict) -> str:
+        doc = view.__doc__.split('\n\n')[0]
+        prompt = f'{doc}'
+        prompt += f'\nThe arguments must conform to the following schema:\n\n```{model.model_json_schema()}```'
+        prompt += f'\n\nThe data follows the following JSON schema:\n\n```{str(schema)}```'
+        if 'current_view' in memory:
+            prompt += f"The previous view specification was: {memory['current_view']}"
+        return prompt
+
+    def answer(self, messages: list | str) -> Transform:
+        pipeline = memory['current_pipeline']
+        table = memory['current_table']
+        system_prompt = self._system_prompt_with_context(messages)
+
+        # Find parameters
+        view = hvPlotUIView
+        schema = memory['current_source'].get_schema(table)
+        excluded = view._internal_params+[
+            'controls', 'type', 'source', 'pipeline', 'transforms',
+            'sql_transforms', 'download', 'field', 'groupby', 'by',
+            'selection_group'
+        ]
+        model = param_to_pydantic(view, excluded=excluded, schema=schema)[view.__name__]
+        view_prompt = self._view_prompt(model, view, table, schema)
+        if self.debug:
+            print(f'{self.name} is being instructed that {view_prompt}.')
+        kwargs = self.llm.invoke(
+            messages, system=system_prompt+view_prompt, response_model=model, allow_partial=False
+        )
+
+        # Instantiate
+        spec = dict(kwargs)
+        memory['current_view'] = dict(spec, type=view.view_type)
+        if self.debug:
+            print(f'{self.name} settled on {spec=!r}.')
+        return view(pipeline=pipeline, **spec)
+
+    def invoke(self, messages: list | str):
+        view = self.answer(messages)
+        self._render_lumen(view)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -25,17 +25,18 @@ from ..views import hvPlotUIView
 from .embeddings import Embeddings
 from .llm import Llm
 from .memory import memory
-from .models import Sql, String, Table
+from .models import Sql, Table
 from .translate import param_to_pydantic
 
 
 def format_schema(schema):
     formatted = {}
     for field, spec in schema.items():
-        if 'enum' in spec:
-            spec['enum'] = spec['enum'][:20] + ['...']
+        if "enum" in spec:
+            spec["enum"] = spec["enum"][:20] + ["..."]
         formatted[field] = spec
     return formatted
+
 
 class Agent(Viewer):
     """
@@ -54,9 +55,7 @@ class Agent(Viewer):
 
     system_prompt = param.String()
 
-    response_model = param.ClassSelector(
-        class_=BaseModel, is_instance=False, default=String
-    )
+    response_model = param.ClassSelector(class_=BaseModel, is_instance=False)
 
     user = param.String(default="Assistant")
 
@@ -68,9 +67,13 @@ class Agent(Viewer):
 
     def __init__(self, **params):
         def _exception_handler(exception):
+            import traceback
+
+            traceback.print_exc()
+            last_message = self.interface.objects[-1]
             self.interface.send(
-                f"Sorry I'm unable to handle this: {exception!r}",
-                user="System",
+                f"Sorry I'm unable to {last_message.object!r}: {exception!r}",
+                user="Exception",
                 respond=False,
             )
 
@@ -121,8 +124,8 @@ class Agent(Viewer):
         return tabs
 
     def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
-        print("-" * 50)
-        return self.invoke(contents)
+        print("-" * 25)
+        self.invoke(contents)
 
     def __panel__(self):
         return self.interface
@@ -144,22 +147,20 @@ class Agent(Viewer):
             schema = source.get_schema(table, limit=100)
         schema = dict(schema)
         for field, spec in schema.items():
-            if 'enum' in spec:
-                schema[field] = dict(spec, enum=spec['enum'][:5])
+            if "enum" in spec:
+                schema[field] = dict(spec, enum=spec["enum"][:5])
         return schema
 
-    def invoke(self, messages: list | str):
-        message = None
+    async def invoke(self, messages: list | str):
         system_prompt = self._system_prompt_with_context(messages)
-        for chunk in self.llm.stream(
+
+        message = None
+        async for chunk in self.llm.stream(
             messages, system=system_prompt, response_model=self.response_model
         ):
-            if not chunk:
-                continue
             message = self.interface.stream(
-                chunk, user=self.user, message=message, replace=True
+                chunk, replace=True, message=message, user=self.user
             )
-        return message
 
 
 class SourceAgent(Agent):
@@ -176,7 +177,7 @@ class SourceAgent(Agent):
 
     on_init = param.Boolean(default=True)
 
-    def invoke(self, messages: list[str] | str):
+    async def invoke(self, messages: list[str] | str):
         name = pn.widgets.TextInput(name="Name your table", align="center")
         upload = pn.widgets.FileInput(align="end")
         url = pn.widgets.TextInput(name="Add a file from a URL")
@@ -253,9 +254,7 @@ class ChatAgent(Agent):
         )
     )
 
-    response_model = param.ClassSelector(
-        default=String, class_=BaseModel, is_instance=False
-    )
+    response_model = param.ClassSelector(class_=BaseModel, is_instance=False)
 
     requires = param.List(default=["current_source"], readonly=True)
 
@@ -306,12 +305,10 @@ class LumenBaseAgent(Agent):
 
         component_spec = component.to_spec()
         spec = yaml.safe_dump(component_spec)
+        spec = f"# Here's the generated Lumen spec; modify if needed\n{spec}"
         tabs = self._link_code_editor(spec, _render_component, "yaml")
         message_kwargs = dict(value=tabs, user=self.user)
-        if message:
-            self.interface.stream(message=message, **message_kwargs)
-        else:
-            self.interface.send(respond=False, **message_kwargs)
+        self.interface.stream(message=message, **message_kwargs, replace=True)
         tabs.active = 1
 
 
@@ -332,7 +329,7 @@ class TableAgent(LumenBaseAgent):
 
     provides = param.List(default=["current_table", "current_pipeline"], readonly=True)
 
-    def answer(self, messages: list | str):
+    async def answer(self, messages: list | str):
         tables = tuple(memory["current_source"].get_tables())
         if len(tables) == 1:
             table = tables[0]
@@ -342,13 +339,16 @@ class TableAgent(LumenBaseAgent):
                 print(f"{self.name} is being instructed that it should {system_prompt}")
             # needed or else something with grammar issue
             tables = tuple(table.replace('"', "") for table in tables)
-            table_model = create_model("Table", table=(Literal[tables], ...))
-            table = self.llm.invoke(
+            table_model = create_model("Table", table=(Literal[tables], FieldInfo(
+                description="The most relevant table based on the user query; if none are relevant, select the first."
+            )))
+            result = await self.llm.invoke(
                 messages,
                 system=system_prompt,
                 response_model=table_model,
                 allow_partial=False,
-            ).table
+            )
+            table = result.table
         memory["current_table"] = table
         memory["current_pipeline"] = Pipeline(
             source=memory["current_source"], table=table
@@ -357,8 +357,8 @@ class TableAgent(LumenBaseAgent):
             print(f"{self.name} thinks that the user is talking about {table=!r}.")
         return table
 
-    def invoke(self, messages: list | str):
-        table = self.answer(messages)
+    async def invoke(self, messages: list | str):
+        table = await self.answer(messages)
         pipeline = Pipeline(source=memory["current_source"], table=table)
         self._render_lumen(pipeline)
 
@@ -375,15 +375,23 @@ class TableListAgent(LumenBaseAgent):
 
     requires = param.List(default=["current_source"], readonly=True)
 
-    def answer(self, messages: list | str):
+    async def answer(self, messages: list | str):
         source = memory["current_source"]
         tables = memory["current_source"].get_tables()
         if not tables:
             return
-        if isinstance(source, IntakeBaseSQLSource) and hasattr(source.cat, '_repr_html_'):
-            table_listing = HTML(textwrap.dedent(source.cat._repr_html_()), margin=10, styles={
-                'overflow': 'auto', 'background-color': 'white', 'padding': '10px'
-            })
+        if isinstance(source, IntakeBaseSQLSource) and hasattr(
+            source.cat, "_repr_html_"
+        ):
+            table_listing = HTML(
+                textwrap.dedent(source.cat._repr_html_()),
+                margin=10,
+                styles={
+                    "overflow": "auto",
+                    "background-color": "white",
+                    "padding": "10px",
+                },
+            )
         else:
             tables = tuple(table.replace('"', "") for table in tables)
             table_bullets = "\n".join(f"- {table}" for table in tables)
@@ -391,13 +399,14 @@ class TableListAgent(LumenBaseAgent):
         self.interface.send(table_listing, user=self.name, respond=False)
         return tables
 
-    def invoke(self, messages: list | str):
-        self.answer(messages)
+    async def invoke(self, messages: list | str):
+        await self.answer(messages)
 
 
 class SQLAgent(LumenBaseAgent):
     """
-    Responsible for generating and modifying SQL queries to answer user questions about statistics like min/max/average.
+    Responsible for generating and modifying SQL queries to answer user queries about the data,
+    like stats or insights about the dataset.
     """
 
     system_prompt = param.String(
@@ -419,7 +428,9 @@ class SQLAgent(LumenBaseAgent):
 
             transforms = [SQLOverride(override=query)]
             try:
-                memory["current_pipeline"] = Pipeline(source=source, table=table, sql_transforms=transforms)
+                memory["current_pipeline"] = Pipeline(
+                    source=source, table=table, sql_transforms=transforms
+                )
                 # Need this separate or else create random memory entry
                 pipeline = memory["current_pipeline"].__panel__()
                 yield pipeline
@@ -441,7 +452,7 @@ class SQLAgent(LumenBaseAgent):
         prompt += f"\n\nThe data for table {table!r} follows the following JSON schema:\n\n```{format_schema(schema)}```"
         return prompt
 
-    def answer(self, messages: list | str):
+    async def answer(self, messages: list | str):
         message = None
         source = memory["current_source"]
         table = memory["current_table"]
@@ -451,30 +462,31 @@ class SQLAgent(LumenBaseAgent):
         system_prompt = self._system_prompt_with_context(messages)
         schema = self._get_schema(source, table)
         sql_prompt = self._sql_prompt(sql_expr, table, schema)
-        for chunk in self.llm.stream(
+        async for chunk in self.llm.stream(
             messages,
             system=system_prompt + sql_prompt,
             response_model=Sql,
             field="query",
         ):
-            if chunk:
-                message = self.interface.stream(
-                    f"```sql\n{chunk}\n```",
-                    user="SQL",
-                    message=message,
-                    replace=True,
-                )
+            message = self.interface.stream(
+                f"```sql\n{chunk}\n```",
+                user="SQL",
+                message=message,
+                replace=True,
+            )
         if message.object is None:
             return
         sql_out = message.object.replace("```sql", "").replace("```", "").strip()
         if f"FROM {table}" in sql_out:
-            sql_in = sql_expr.replace("SELECT * FROM ", "").replace("SELECT * from ", "")
+            sql_in = sql_expr.replace("SELECT * FROM ", "").replace(
+                "SELECT * from ", ""
+            )
             sql_out = sql_out.replace(f"FROM {table}", f"FROM {sql_in}")
         memory["current_sql"] = sql_out
         return sql_out
 
-    def invoke(self, messages: list | str):
-        sql = self.answer(messages)
+    async def invoke(self, messages: list | str):
+        sql = await self.answer(messages)
         self._render_sql(sql)
 
 
@@ -524,7 +536,7 @@ class PipelineAgent(LumenBaseAgent):
             prompt += f"The previous transform specification was: {memory['current_transform']}"
         return prompt
 
-    def _find_transform(
+    async def _find_transform(
         self, messages: list | str, system_prompt: str
     ) -> Type[Transform] | None:
         picker_prompt = self._transform_picker_prompt()
@@ -547,7 +559,7 @@ class PipelineAgent(LumenBaseAgent):
             transform=(Optional[Literal[tuple(transforms)]], None),
         )
 
-        transform = self.llm.invoke(
+        transform = await self.llm.invoke(
             messages,
             system=f"{system_prompt}\n{picker_prompt}",
             response_model=transform_model,
@@ -555,7 +567,7 @@ class PipelineAgent(LumenBaseAgent):
         )
 
         if transform.transform_required:
-            transform = self.llm.invoke(
+            transform = await self.llm.invoke(
                 f"is the transform, {transform.transform!r} partially relevant to the query {messages!r}",
                 system=(
                     f"You are a world class validation model. "
@@ -576,7 +588,7 @@ class PipelineAgent(LumenBaseAgent):
             )
         return transforms[transform_name.strip("'")] if transform_name else None
 
-    def _construct_transform(
+    async def _construct_transform(
         self, messages: list | str, transform: Type[Transform], system_prompt: str
     ) -> Transform:
         excluded = transform._internal_params + ["controls", "type"]
@@ -588,7 +600,7 @@ class PipelineAgent(LumenBaseAgent):
         transform_prompt = self._transform_prompt(model, transform, table, schema)
         if self.debug:
             print(f"{self.name} recalls that {transform_prompt}.")
-        kwargs = self.llm.invoke(
+        kwargs = await self.llm.invoke(
             messages,
             system=system_prompt + transform_prompt,
             response_model=model,
@@ -596,9 +608,9 @@ class PipelineAgent(LumenBaseAgent):
         )
         return transform(**dict(kwargs))
 
-    def answer(self, messages: list | str) -> Transform:
+    async def answer(self, messages: list | str) -> Transform:
         system_prompt = self._system_prompt_with_context(messages)
-        transform_type = self._find_transform(messages, system_prompt)
+        transform_type = await self._find_transform(messages, system_prompt)
         if "current_pipeline" in memory:
             pipeline = memory["current_pipeline"]
         else:
@@ -608,7 +620,9 @@ class PipelineAgent(LumenBaseAgent):
         memory["current_pipeline"] = pipeline
         if not transform_type:
             return pipeline
-        transform = self._construct_transform(messages, transform_type, system_prompt)
+        transform = await self._construct_transform(
+            messages, transform_type, system_prompt
+        )
         memory["current_transform"] = spec = transform.to_spec()
         if self.debug:
             print(f"{self.name} settled on {spec=!r}.")
@@ -625,8 +639,8 @@ class PipelineAgent(LumenBaseAgent):
             pipeline._stale = True
         return pipeline
 
-    def invoke(self, messages: list | str):
-        pipeline = self.answer(messages)
+    async def invoke(self, messages: list | str):
+        pipeline = await self.answer(messages)
         self._render_lumen(pipeline)
 
 
@@ -655,7 +669,7 @@ class hvPlotAgent(LumenBaseAgent):
             prompt += f"The previous view specification was: {memory['current_view']}"
         return prompt
 
-    def answer(self, messages: list | str, retry: bool = True) -> Transform:
+    async def answer(self, messages: list | str, retry: bool = True) -> Transform:
         pipeline = memory["current_pipeline"]
         table = memory["current_table"]
         system_prompt = self._system_prompt_with_context(messages)
@@ -681,7 +695,7 @@ class hvPlotAgent(LumenBaseAgent):
         view_prompt = self._view_prompt(model, view, table, schema)
         if self.debug:
             print(f"{self.name} is being instructed that {view_prompt}.")
-        kwargs = self.llm.invoke(
+        kwargs = await self.llm.invoke(
             messages,
             system=system_prompt + view_prompt,
             response_model=model,
@@ -699,21 +713,24 @@ class hvPlotAgent(LumenBaseAgent):
             if retry:
                 new_messages = [
                     {"role": "assistant", "content": f"{spec=}"},
-                    {"role": "user", "content": f"\nThat didn't work; please note: {e}"}
+                    {
+                        "role": "user",
+                        "content": f"\nThat didn't work; please note: {e}",
+                    },
                 ]
                 messages.extend(new_messages)
                 print(f"RETRYING...\n\n\n{messages}")
-                return self.answer(messages, retry=False)
+                return await self.answer(messages, retry=False)
 
         spec.pop("type", None)
-        if len(pipeline.data) > 20000 and spec['kind'] in ('line', 'scatter', 'points'):
+        if len(pipeline.data) > 20000 and spec["kind"] in ("line", "scatter", "points"):
             spec["rasterize"] = True
-            spec["cnorm"] = 'log'
+            spec["cnorm"] = "log"
         memory["current_view"] = dict(spec, type=view.view_type)
         if self.debug:
             print(f"{self.name} settled on {spec=!r}.")
         return view(pipeline=pipeline, **spec)
 
-    def invoke(self, messages: list | str):
-        view = self.answer(messages)
+    async def invoke(self, messages: list | str):
+        view = await self.answer(messages)
         self._render_lumen(view)

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -8,7 +8,7 @@ from typing import Literal, Type
 import param
 
 from panel import bind
-from panel.chat import ChatInterface, ChatMessage, ChatReactionIcons
+from panel.chat import ChatInterface, ChatMessage
 from panel.layout import Column, FlexBox, Tabs
 from panel.pane import Markdown
 from panel.viewable import Viewer
@@ -55,7 +55,7 @@ class Assistant(Viewer):
         llm: Llm | None = None,
         interface: ChatInterface | None = None,
         agents: list[Agent | Type[Agent]] | None = None,
-        logs_filename: str | None = None,
+        logs_filename: str = "",
         **params,
     ):
 
@@ -107,12 +107,12 @@ class Assistant(Viewer):
             interface = ChatInterface(
                 callback=self._chat_invoke,
                 # remove this once dynamic reaction icons is merged
-                reaction_icons=ChatReactionIcons(options={"like": "thumb-up", "dislike": "thumb-down"}).clone()
+                reaction_icons={"like": "thumb-up", "dislike": "thumb-down"}
             )
         else:
             interface.callback = self._chat_invoke
         interface.callback_exception = "raise"
-        interface.reaction_icons = ChatReactionIcons(options={"like": "thumb-up", "dislike": "thumb-down"}).clone()
+        interface.reaction_icons = {"like": "thumb-up", "dislike": "thumb-down"}
 
         self._session_id = id(self)
 

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -250,7 +250,7 @@ class Assistant(Viewer):
         return prompt
 
     async def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
-        print("NEW" + "-" * 100)
+        print("\033[94mNEW\033[0m" + "-" * 100)
         await self.invoke(contents)
 
     async def _choose_agent(self, messages: list | str, agents: list[Agent]):

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -182,8 +182,9 @@ class Assistant(Viewer):
     async def _invalidate_memory(self, messages):
         table = memory.get("current_table")
         sql = memory.get("current_sql")
-        if not sql:
+        if not table and not sql:
             return
+
         system = f"""
         Based on the latest user's query, is the table relevant?
         If not, return invalid_key='table'.
@@ -213,6 +214,9 @@ class Assistant(Viewer):
             invalid_key = validity.invalid_key
             if invalid_key == "table":
                 memory.pop("current_table", None)
+                memory.pop("current_data", None)
+                memory.pop("current_pipeline", None)
+                memory.pop("closest_tables", None)
             elif invalid_key == "sql":
                 memory.pop("current_sql", None)
             print(f"\033[91mInvalidated {invalid_key!r} from memory.\033[0m")
@@ -263,7 +267,7 @@ class Assistant(Viewer):
                 FieldInfo(
                     description=(
                         "Think step by step out loud, focused on application and how it could be useful to the "
-                        "tying into the available agents. Provide up to two sentence description. "
+                        "tying into the available agents. Provide up to two sentence description; be concise."
                     )
                 ),
             ),

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -57,8 +57,8 @@ class Assistant(Viewer):
         self.invoke('Initializing chat')
 
     def _generate_picker_prompt(self, agents):
-        prompt = 'Current you have the following items in memory: {list(memory)}'
-        prompt += "\nSelect most relevant agent for the user's query:\n" + "\n".join(
+        # prompt = f'Current you have the following items in memory: {list(memory)}'
+        prompt = "\nSelect most relevant agent for the user's query:\n" + "\n".join(
             f"- {agent.name}: {agent.__doc__.strip()}" for agent in agents
         )
         return prompt
@@ -99,6 +99,8 @@ class Assistant(Viewer):
                 agent for agent in self.agents if any(ur in agent.provides for ur in unmet_dependencies)
             ]
             subagent_name = self._choose_agent(messages, subagents)
+            if subagent_name is None:
+                continue
             subagent = agents[subagent_name]
             agent_chain.append((subagent, unmet_dependencies))
             if not (unmet_dependencies:= tuple(r for r in subagent.requires if r not in memory)):

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -206,7 +206,7 @@ class Assistant(Viewer):
                     )
                 ),
             ),
-            agents=(Literal[agent_names], ...),
+            agent=(Literal[agent_names], ...),
         )
         self._current_agent.object = "## **Current Agent**: Lumen.ai"
         for _ in range(3):

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -52,7 +52,6 @@ class Assistant(Viewer):
                 ('Memory', memory)
             )
         )
-        self._invoke_on_init()
 
     def _invoke_on_init(self):
         self.invoke('Initializing chat')

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -233,7 +233,7 @@ class Assistant(Viewer):
         selected = subagent = agents[agent]
         agent_chain = []
         while unmet_dependencies := tuple(
-            r for r in subagent.requires if r not in memory
+            r for r in await subagent.requirements(messages) if r not in memory
         ):
             print(f"Unmet dependencies: {unmet_dependencies}")
             subagents = [
@@ -246,12 +246,6 @@ class Assistant(Viewer):
                 continue
             subagent = agents[subagent_name]
             agent_chain.append((subagent, unmet_dependencies))
-            if not (
-                unmet_dependencies := tuple(
-                    r for r in subagent.requires if r not in memory
-                )
-            ):
-                break
         for subagent, deps in agent_chain[::-1]:
             print(f"Assistant decided the {subagent} will provide {deps}.")
             self._current_agent.object = f"## **Current Agent**: {subagent.name[:-5]}"

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -7,7 +7,8 @@ from typing import Literal, Type
 
 import param
 
-from panel.chat import ChatInterface, ChatMessage
+from panel import bind
+from panel.chat import ChatInterface, ChatMessage, ChatReactionIcons
 from panel.layout import Column, FlexBox, Tabs
 from panel.pane import Markdown
 from panel.viewable import Viewer
@@ -17,6 +18,7 @@ from pydantic.fields import FieldInfo
 
 from .agents import Agent, ChatAgent
 from .llm import Llama, Llm
+from .logs import ChatLogs
 from .memory import memory
 from .models import Validity
 
@@ -42,17 +44,52 @@ class Assistant(Viewer):
 
     agents = param.List(default=[ChatAgent])
 
-    llm = param.ClassSelector(class_=Llm, default=Llama(model="default"))
+    llm = param.ClassSelector(class_=Llm, default=Llama())
 
     interface = param.ClassSelector(class_=ChatInterface)
+
+    logs_filename = param.String()
 
     def __init__(
         self,
         llm: Llm | None = None,
         interface: ChatInterface | None = None,
         agents: list[Agent | Type[Agent]] | None = None,
+        logs_filename: str | None = None,
         **params,
     ):
+
+        def on_message(message, instance):
+            def update_on_reaction(reactions):
+                self._logs.update_status(
+                    message_id=message_id,
+                    liked="like" in reactions,
+                    disliked="dislike" in reactions,
+                )
+
+            bind(update_on_reaction, message.param.reactions, watch=True)
+            message_id = id(message)
+            message_index = len(instance) - 1
+            self._logs.upsert(
+                session_id=self._session_id,
+                message_id=message_id,
+                message_index=message_index,
+                message_user=message.user,
+                message_content=message.object,
+            )
+
+        def on_undo(instance, _):
+            count = instance._get_last_user_entry_index()
+            messages = instance[-count:]
+            for message in messages:
+                self._logs.update_status(message_id=id(message), removed=True)
+
+        def on_rerun(instance, _):
+            count = instance._get_last_user_entry_index() - 1
+            messages = instance[-count:]
+            for message in messages:
+                self._logs.update_status(message_id=id(message), removed=True)
+
         def download_messages():
             def filter_by_reactions(messages):
                 return [
@@ -67,10 +104,21 @@ class Assistant(Viewer):
             return StringIO(json.dumps(messages))
 
         if interface is None:
-            interface = ChatInterface(callback=self._chat_invoke)
+            interface = ChatInterface(
+                callback=self._chat_invoke,
+                # remove this once dynamic reaction icons is merged
+                reaction_icons=ChatReactionIcons(options={"like": "thumb-up", "dislike": "thumb-down"}).clone()
+            )
         else:
             interface.callback = self._chat_invoke
         interface.callback_exception = "raise"
+        interface.reaction_icons = ChatReactionIcons(options={"like": "thumb-up", "dislike": "thumb-down"}).clone()
+
+        self._session_id = id(self)
+
+        if logs_filename is not None:
+            self._logs = ChatLogs(filename=logs_filename)
+            interface.post_hook = on_message
 
         llm = llm or self.llm
         instantiated = []
@@ -79,12 +127,16 @@ class Assistant(Viewer):
                 kwargs = {"llm": llm} if agent.llm is None else {}
                 agent = agent(interface=interface, **kwargs)
             instantiated.append(agent)
-        super().__init__(llm=llm, agents=instantiated, interface=interface, **params)
+
+        super().__init__(llm=llm, agents=instantiated, interface=interface, logs_filename=logs_filename, **params)
         interface.send(
-            "Welcome to LumenAI; get started by clicking a suggestion or type your own query below!", user="Help", respond=False
+            "Welcome to LumenAI; get started by clicking a suggestion or type your own query below!",
+            user="Help", respond=False,
         )
         interface.button_properties={
-            "suggest": {"callback": self._create_suggestion, "icon": "wand"}
+            "suggest": {"callback": self._create_suggestion, "icon": "wand"},
+            "undo": {"callback": on_undo},
+            "rerun": {"callback": on_rerun},
         }
         self._add_suggestions_to_footer(GETTING_STARTED_SUGGESTIONS)
 
@@ -226,6 +278,7 @@ class Assistant(Viewer):
                 messages=messages,
                 system=self._generate_picker_prompt(agents),
                 response_model=agent_model,
+                model_key="reasoning",
                 allow_partial=False
             )
             if out:

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -22,7 +22,7 @@ class Assistant(Viewer):
 
     agents = param.List(default=[ChatAgent])
 
-    llm = param.ClassSelector(class_=Llm, default=Llama(model='default'))
+    llm = param.ClassSelector(class_=Llm, default=Llama(model="default"))
 
     interface = param.ClassSelector(class_=ChatInterface)
 
@@ -31,30 +31,27 @@ class Assistant(Viewer):
         llm: Llm | None = None,
         interface: ChatInterface | None = None,
         agents: list[Agent | Type[Agent]] | None = None,
-        **params
+        **params,
     ):
         if interface is None:
-            interface = ChatInterface(callback=self._chat_invoke, callback_exception='verbose')
+            interface = ChatInterface(
+                callback=self._chat_invoke, callback_exception="verbose"
+            )
         else:
             interface.callback = self._chat_invoke
         llm = llm or self.llm
         instantiated = []
-        for agent in (agents or self.agents):
+        for agent in agents or self.agents:
             if not isinstance(agent, Agent):
-                kwargs = {'llm': llm} if agent.llm is None else {}
+                kwargs = {"llm": llm} if agent.llm is None else {}
                 agent = agent(interface=interface, **kwargs)
             instantiated.append(agent)
         super().__init__(llm=llm, agents=instantiated, interface=interface, **params)
-        self._current_agent = Markdown('## No agent active', margin=0)
-        self._controls = Column(
-            self._current_agent,
-            Tabs(
-                ('Memory', memory)
-            )
-        )
+        self._current_agent = Markdown("## No agent active", margin=0)
+        self._controls = Column(self._current_agent, Tabs(("Memory", memory)))
 
     def _invoke_on_init(self):
-        self.invoke('Initializing chat')
+        self.invoke("Initializing chat")
 
     def _generate_picker_prompt(self, agents):
         # prompt = f'Current you have the following items in memory: {list(memory)}'
@@ -68,16 +65,20 @@ class Assistant(Viewer):
 
     def _choose_agent(self, messages: list | str, agents: list[Agent]):
         agent_names = tuple(sagent.name for sagent in agents)
+        if len(agent_names) == 0:
+            raise ValueError("No agents available to choose from.")
         if len(agent_names) == 1:
             return agent_names[0]
-        agent_model = create_model("Agent", agent=(Literal[agent_names], ...))
-        self._current_agent.object = '## **Current Agent**: Lumen.ai'
+        agent_model = create_model(
+            "Agent", chain_of_thought=(str, ...), agent=(Literal[agent_names], ...)
+        )
+        self._current_agent.object = "## **Current Agent**: Lumen.ai"
         for _ in range(3):
             out = self.llm.invoke(
                 messages=messages,
                 system=self._generate_picker_prompt(agents),
                 response_model=agent_model,
-                allow_partial=False
+                allow_partial=False,
             )
             if out:
                 return out.agent
@@ -91,31 +92,41 @@ class Assistant(Viewer):
             agent = agent_types[0]
         else:
             agent = self._choose_agent(messages, self.agents)
-        print(f'Assistant decided on {agent} between the available options: {agent_types}')
+        print(
+            f"Assistant decided on {agent} between the available options: {agent_types}"
+        )
         selected = subagent = agents[agent]
         agent_chain = []
-        while (unmet_dependencies:=tuple(r for r in subagent.requires if r not in memory)):
+        while unmet_dependencies := tuple(
+            r for r in subagent.requires if r not in memory
+        ):
             subagents = [
-                agent for agent in self.agents if any(ur in agent.provides for ur in unmet_dependencies)
+                agent
+                for agent in self.agents
+                if any(ur in agent.provides for ur in unmet_dependencies)
             ]
             subagent_name = self._choose_agent(messages, subagents)
             if subagent_name is None:
                 continue
             subagent = agents[subagent_name]
             agent_chain.append((subagent, unmet_dependencies))
-            if not (unmet_dependencies:= tuple(r for r in subagent.requires if r not in memory)):
+            if not (
+                unmet_dependencies := tuple(
+                    r for r in subagent.requires if r not in memory
+                )
+            ):
                 break
-        for (subagent, deps) in agent_chain[::-1]:
+        for subagent, deps in agent_chain[::-1]:
             print(f"Assistant decided the {subagent} will provide {deps}.")
-            self._current_agent.object = f'## **Current Agent**: {subagent.name}'
+            self._current_agent.object = f"## **Current Agent**: {subagent.name}"
             subagent.answer(messages)
         return selected
 
     def invoke(self, messages: list | str) -> str:
         agent = self._get_agent(messages)
-        self._current_agent.object = f'## **Current Agent**: {agent.name}'
+        self._current_agent.object = f"## **Current Agent**: {agent.name}"
         result = agent.invoke(messages)
-        self._current_agent.object = '## No agent active'
+        self._current_agent.object = "## No agent active"
         return result
 
     def controls(self):

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Literal, Type
+
+import param
+
+from panel.chat import ChatInterface
+from panel.viewable import Viewer
+from pydantic import create_model
+
+from .agents import Agent, ChatAgent
+from .llm import Llama, Llm
+from .memory import memory
+
+
+class Assistant(Viewer):
+    """
+    An Assistant handles multiple agents.
+    """
+
+    agents = param.List(default=[ChatAgent])
+
+    llm = param.ClassSelector(class_=Llm, default=Llama(model='default'))
+
+    interface = param.ClassSelector(class_=ChatInterface)
+
+    def __init__(
+        self,
+        llm: Llm | None = None,
+        interface: ChatInterface | None = None,
+        agents: list[Agent | Type[Agent]] | None = None,
+        **params
+    ):
+        if interface is None:
+            interface = ChatInterface(callback=self._chat_invoke, callback_exception='verbose')
+        else:
+            interface.callback = self._chat_invoke
+        instantiated = []
+        for agent in (agents or self.agents):
+            if not isinstance(agent, Agent):
+                kwargs = {'llm': self.llm} if agent.llm is None else {}
+                agent = agent(interface=interface, **kwargs)
+            instantiated.append(agent)
+        super().__init__(llm=llm, agents=instantiated, interface=interface, **params)
+
+    def _generate_picker_prompt(self, agents):
+        prompt = "Select most relevant agent for the user's query:\n" + "\n".join(
+            f"- {agent.name}: {agent.__doc__.strip()}" for agent in self.agents
+        )
+        print(prompt)
+        return prompt
+
+    def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
+        return self.invoke(contents)
+
+    def _choose_agent(self, messages: list | str, agents: list[Agent]):
+        agent_names = tuple(sagent.name for sagent in agents)
+        agent_model = create_model("Agent", agent=(Literal[agent_names], ...))
+        return self.llm.invoke(
+            messages=messages,
+            system=self._generate_picker_prompt(agents),
+            response_model=agent_model,
+        ).agent
+
+    def _get_agent(self, messages: list | str):
+        if len(self.agents) == 1:
+            return self.agents[0]
+        agent_types = tuple(agent.name for agent in self.agents)
+        agents = {agent.name: agent for agent in self.agents}
+        if len(agent_types) == 1:
+            agent = agent_types[0]
+        else:
+            agent = self._choose_agent(messages, self.agents)
+        print(f'Assistant decided on {agent} between the available options: {agent_types}')
+        selected = subagent = agents[agent]
+        agent_chain = []
+        while (unmet_dependencies:=tuple(r for r in subagent.requires if r not in memory)):
+            # Improve logic to allow multi-level resolution
+            subagents = [
+                agent for agent in self.agents if any(ur in agent.provides for ur in unmet_dependencies)
+            ]
+            subagent_name = self._choose_agent(messages, subagents)
+            subagent = agents[subagent_name]
+            agent_chain.append((subagent, unmet_dependencies))
+            if not (unmet_dependencies:= tuple(r for r in subagent.requires if r not in memory)):
+                break
+        for (subagent, deps) in agent_chain[::-1]:
+            print(f"Assistant decided the {agent} will provide {deps}.")
+            subagent.answer(messages)
+        return selected
+
+    def invoke(self, messages: list | str) -> str:
+        return self._get_agent(messages).invoke(messages)
+
+    def __panel__(self):
+        return self.interface

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -148,9 +148,8 @@ class Assistant(Viewer):
             system=system,
             response_model=PipelineValidity,
             allow_partial=False,
-            model="gpt-4-turbo-preview",
         )
-        if not validity.valid:
+        if validity and not validity.valid:
             memory.pop("current_pipeline", None)
             memory.pop("current_sql", None)
             memory.pop("current_transform", None)

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -7,17 +7,24 @@ from typing import Literal, Type
 
 import param
 
-from panel.chat import ChatInterface
-from panel.layout import Column, Tabs
+from panel.chat import ChatInterface, ChatMessage
+from panel.layout import Column, FlexBox, Tabs
 from panel.pane import Markdown
 from panel.viewable import Viewer
-from panel.widgets import FileDownload
+from panel.widgets import Button, FileDownload
 from pydantic import create_model
 from pydantic.fields import FieldInfo
 
 from .agents import Agent, ChatAgent
 from .llm import Llama, Llm
 from .memory import memory
+
+GETTING_STARTED_SUGGESTIONS = [
+    "What datasets do you have?",
+    "Tell me about the dataset.",
+    "Create a plot of the dataset.",
+    "Find the min and max of the values.",
+]
 
 
 class Assistant(Viewer):
@@ -56,6 +63,7 @@ class Assistant(Viewer):
         else:
             interface.callback = self._chat_invoke
         interface.callback_exception = "raise"
+
         llm = llm or self.llm
         instantiated = []
         for agent in agents or self.agents:
@@ -64,6 +72,14 @@ class Assistant(Viewer):
                 agent = agent(interface=interface, **kwargs)
             instantiated.append(agent)
         super().__init__(llm=llm, agents=instantiated, interface=interface, **params)
+        interface.send(
+            "Welcome to LumenAI; get started by clicking a suggestion or type your own query below!", user="Help", respond=False
+        )
+        interface.button_properties={
+            "suggest": {"callback": self._create_suggestion, "icon": "wand"}
+        }
+        self._add_suggestions_to_footer(GETTING_STARTED_SUGGESTIONS)
+
         self._current_agent = Markdown("## No agent active", margin=0)
         self._controls = Column(
             FileDownload(
@@ -76,22 +92,67 @@ class Assistant(Viewer):
         )
         # self._controls = Column(self._current_agent, Tabs(("Memory", memory)))
 
+    def _add_suggestions_to_footer(self, suggestions: list[str], inplace: bool = True):
+        def use_suggestion(event):
+            contents = event.obj.name
+            suggestion_buttons.visible = False
+            self.interface.send(contents)
+
+        suggestion_buttons = FlexBox(
+            *[
+                Button(
+                    name=suggestion,
+                    button_style="outline",
+                    on_click=use_suggestion,
+                    margin=5,
+                )
+                for suggestion in suggestions
+            ],
+            margin=(5, 5),
+        )
+
+        message = self.interface.objects[-1]
+        message = ChatMessage(
+            footer_objects=[suggestion_buttons],
+            user=message.user,
+            object=message.object,
+        )
+        if inplace:
+            self.interface.objects[-1] = message
+        return message
+
+    def _create_suggestion(self, instance, event):
+        messages = self.interface.serialize(custom_serializer=self._serialize)[-3:-1]
+        string = self.llm.stream(
+            messages,
+            system="Generate a follow-up question that a user might ask; ask from the user POV",
+            model="gpt-3.5-turbo",
+            allow_partial=True,
+        )
+        try:
+            self.interface.disabled = True
+            for chunk in string:
+                self.interface.active_widget.value_input = chunk
+        finally:
+            self.interface.disabled = False
+
     def _generate_picker_prompt(self, agents):
         # prompt = f'Current you have the following items in memory: {list(memory)}'
         prompt = (
-            "\nSelect most relevant agent for the user's query:\n'''"
+            "\nYou are a world-class leader who has a lot of agents at your disposal. "
+            "Select most relevant agent for the user's query:\n'''"
             + "\n".join(
                 f"- '{agent.name[:-5]}': {agent.__doc__.strip()}" for agent in agents
             )
-            + "\n'''"
+            + f"\n'''\nIf possible, build off the prior agent: {memory.get('current_agent')!r}"
         )
         return prompt
 
-    def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
+    async def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
         print("-" * 50)
-        return self.invoke(contents)
+        await self.invoke(contents)
 
-    def _choose_agent(self, messages: list | str, agents: list[Agent]):
+    async def _choose_agent(self, messages: list | str, agents: list[Agent]):
         agent_names = tuple(sagent.name[:-5] for sagent in agents)
         if len(agent_names) == 0:
             raise ValueError("No agents available to choose from.")
@@ -102,14 +163,17 @@ class Assistant(Viewer):
             chain_of_thought=(
                 str,
                 FieldInfo(
-                    description="Thoughts focused on application and how it could be useful to the user."
+                    description=(
+                        "Thoughts focused on application and how it could be useful to the user, "
+                        "specifically focusing on the prior messages and the user's query."
+                    )
                 ),
             ),
             agent=(Literal[agent_names], ...),
         )
         self._current_agent.object = "## **Current Agent**: Lumen.ai"
         for _ in range(3):
-            out = self.llm.invoke(
+            out = await self.llm.invoke(
                 messages=messages,
                 system=self._generate_picker_prompt(agents),
                 response_model=agent_model,
@@ -119,7 +183,7 @@ class Assistant(Viewer):
             if out:
                 return out.agent
 
-    def _get_agent(self, messages: list | str):
+    async def _get_agent(self, messages: list | str):
         if len(self.agents) == 1:
             return self.agents[0]
         agent_types = tuple(agent.name[:-5] for agent in self.agents)
@@ -127,7 +191,7 @@ class Assistant(Viewer):
         if len(agent_types) == 1:
             agent = agent_types[0]
         else:
-            agent = self._choose_agent(messages, self.agents)
+            agent = await self._choose_agent(messages, self.agents)
         print(
             f"Assistant decided on {agent} between the available options: {agent_types}"
         )
@@ -141,7 +205,7 @@ class Assistant(Viewer):
                 for agent in self.agents
                 if any(ur in agent.provides for ur in unmet_dependencies)
             ]
-            subagent_name = self._choose_agent(messages, subagents)
+            subagent_name = await self._choose_agent(messages, subagents)
             if subagent_name is None:
                 continue
             subagent = agents[subagent_name]
@@ -155,36 +219,29 @@ class Assistant(Viewer):
         for subagent, deps in agent_chain[::-1]:
             print(f"Assistant decided the {subagent} will provide {deps}.")
             self._current_agent.object = f"## **Current Agent**: {subagent.name[:-5]}"
-            subagent.answer(messages)
+            await subagent.answer(messages)
         return selected
 
-    def invoke(self, messages: list | str) -> str:
-        def _custom_serializer(obj):
-            if isinstance(obj, (Tabs, Column)):
-                return _custom_serializer(obj[0])
-            if hasattr(obj, "object"):
-                return obj.object
-            elif hasattr(obj, "value"):
-                return obj.value
-            return str(obj)
+    def _serialize(self, obj):
+        if isinstance(obj, (Tabs, Column)):
+            return self._serialize(obj[0])
+        if hasattr(obj, "object"):
+            return obj.object
+        elif hasattr(obj, "value"):
+            return obj.value
+        return str(obj)
 
-        agent = self._get_agent(messages)
+    async def invoke(self, messages: list | str) -> str:
+        agent = await self._get_agent(messages)
         self._current_agent.object = f"## **Current Agent**: {agent.name[:-5]}"
-        messages = self.interface.serialize(custom_serializer=_custom_serializer)[-5:-1]
+        memory["current_agent"] = agent
+        messages = self.interface.serialize(custom_serializer=self._serialize)[-5:]
 
-        # something weird with duplicate assistant messages;
-        # TODO: remove later
-        if len(messages) > 1:
-            messages = [
-                message
-                for message, next_message in zip(messages, messages[1:])
-                if message != next_message
-            ][-3:] + [messages[-1]]
-            for message in messages:
-                print(f"{message['role']!r}: {message['content']}")
-                print("---")
+        for message in messages:
+            print(f"{message['role']!r}: {message['content']}")
+            print("---")
 
-        result = agent.invoke(messages)
+        result = await agent.invoke(messages)
         self._current_agent.object = "## No agent active"
         return result
 

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -35,10 +35,11 @@ class Assistant(Viewer):
             interface = ChatInterface(callback=self._chat_invoke, callback_exception='verbose')
         else:
             interface.callback = self._chat_invoke
+        llm = llm or self.llm
         instantiated = []
         for agent in (agents or self.agents):
             if not isinstance(agent, Agent):
-                kwargs = {'llm': self.llm} if agent.llm is None else {}
+                kwargs = {'llm': llm} if agent.llm is None else {}
                 agent = agent(interface=interface, **kwargs)
             instantiated.append(agent)
         super().__init__(llm=llm, agents=instantiated, interface=interface, **params)
@@ -75,7 +76,6 @@ class Assistant(Viewer):
         selected = subagent = agents[agent]
         agent_chain = []
         while (unmet_dependencies:=tuple(r for r in subagent.requires if r not in memory)):
-            # Improve logic to allow multi-level resolution
             subagents = [
                 agent for agent in self.agents if any(ur in agent.provides for ur in unmet_dependencies)
             ]

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -333,13 +333,12 @@ class Assistant(Viewer):
         messages = self.interface.serialize(custom_serializer=self._serialize)[-4:]
         await self._invalidate_memory(messages[-2:])
         agent = await self._get_agent(messages[-3:])
-        agent = None
         if agent is None:
             msg = (
                 "Assistant could not settle on an agent to perform the requested query. "
                 "Please restate your request."
             )
-            self.interface.send(msg, user='Lumen')
+            self.interface.stream(msg, user='Lumen')
             return msg
 
         self._current_agent.object = f"## **Current Agent**: {agent.name[:-5]}"

--- a/lumen/ai/embeddings.py
+++ b/lumen/ai/embeddings.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+DEFAULT_PATH = Path("embeddings")
+
+
+class Embeddings:
+
+    def add_directory(self, data_dir: Path):
+        raise NotImplementedError
+
+    def query(self, query_texts: str) -> list:
+        raise NotImplementedError
+
+
+class ChromaDb(Embeddings):
+
+    def __init__(self, collection: str, persist_dir: str = DEFAULT_PATH):
+        import chromadb
+        self.client = chromadb.PersistentClient(path=str(persist_dir / collection))
+        self.collection = self.client.get_or_create_collection(collection)
+
+    def add_directory(self, data_dir: Path, file_type='json'):
+        add_kwargs = {
+            "ids": [],
+            "documents": [],
+        }
+        for i, path in enumerate(data_dir.glob(f"**/*.{file_type}")):
+            add_kwargs["ids"].append(f"{i}")
+            add_kwargs["documents"].append(path.read_text())
+        self.collection.add(**add_kwargs)
+
+    def query(self, query_texts: str) -> list:
+        return self.collection.query(query_texts=query_texts)["documents"]

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -70,10 +70,13 @@ class Llm(param.Parameterized):
                 output = await self.run_client(model_key, messages, **kwargs)
                 break
             except Exception as e:
+                import traceback
+                traceback.print_exc()
                 print(f"Error encountered: {e}")
                 if 'response_model' in kwargs:
                     kwargs['response_model'] = response_model
-                messages = messages + [{"role": "system", "content": f"You just encountered the following error, make sure you don't repeat it: {e}" }]
+                messages = [{"role": "system", "content": f"You just encountered the following error, make sure you don't repeat it: {e}" }] + messages
+                print("MESSAGES", messages)
         print(f"\033[33mInvoked LLM output: {output!r}\033[0m")
         return output
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1,0 +1,169 @@
+from functools import partial
+
+import panel as pn
+import param
+
+from instructor.dsl.partial import Partial
+from instructor.patch import Mode, patch
+from pydantic import BaseModel
+
+from .models import String
+
+
+class Llm(param.Parameterized):
+
+    # Allows defining a dictionary of default models.
+    _models = {}
+
+    __abstract = True
+
+    def __init__(self, model: str | None = None, **params):
+        if model is not None:
+            if model in self._models:
+                params = dict(self._models[model], **params)
+            else:
+                raise ValueError(
+                    "No model named {model!r} available. Known models include "
+                    "{', '.join(LLM_METADATA)}."
+                )
+        super().__init__(**params)
+        self._client = None
+
+    def _create_client(self, create):
+        return patch(create=create, mode=Mode.JSON_SCHEMA)
+
+    @property
+    def _client_kwargs(self):
+        return {}
+
+    def invoke(
+        self,
+        messages: list | str,
+        system: str = "",
+        response_model: BaseModel = String,
+        allow_partial: bool = True,
+        **kwargs
+    ) -> BaseModel:
+        if self._client is None:
+            self._init_model()
+        if isinstance(messages, str):
+            messages = [{"role": "user", "content": messages}]
+        if system:
+            messages = [{"role": "system", "content": system}] + messages
+
+        kwargs = dict(self._client_kwargs, **kwargs)
+        if response_model is String:
+            client = self._raw_client
+        else:
+            client = self._client
+            if allow_partial:
+                response_model = Partial[response_model]
+            kwargs['response_model'] = response_model
+
+        output = client(messages=messages, **kwargs)
+        if response_model is String:
+            output = String(output=output)
+        return output
+
+    def stream(
+        self,
+        messages: list | str,
+        system: str = "",
+        response_model: BaseModel = String,
+        field: str = "output",
+        **kwargs
+    ):
+        if self._client is None:
+            self._init_model()
+        for chunk in self.invoke(
+            messages,
+            system=system,
+            response_model=response_model,
+            stream=True,
+            **dict(self._client_kwargs, **kwargs)
+        ):
+            yield getattr(chunk, field)
+
+
+class Llama(Llm):
+
+    chat_format = param.String(constant=True)
+
+    repo = param.String(constant=True)
+
+    model_file = param.String(constant=True)
+
+    temperature = param.Number(default=0.3, bounds=(0, None), constant=True)
+
+    _models = {
+        "default": {
+            "repo": "TheBloke/OpenHermes-2.5-Mistral-7B-GGUF",
+            "model_file": "openhermes-2.5-mistral-7b.Q4_K_M.gguf",
+            "chat_format": "chatml",
+        },
+        "mistral": {
+            "repo": "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
+            "model_file": "mistral-7b-instruct-v0.2.Q5_K_M.gguf",
+            "chat_format": "mistral-instruct",
+        },
+        "sql": {
+            "repo": "TheBloke/sqlcoder2-GGUF",
+            "model_file": "sqlcoder2.Q5_K_M.gguf",
+            "chat_format": "chatml",
+        },
+    }
+
+    @property
+    def _client_kwargs(self):
+        return {'temperature': self.temperature}
+
+    def _init_model(self):
+        from huggingface_hub import hf_hub_download
+        from llama_cpp import Llama
+        from llama_cpp.llama_speculative import LlamaPromptLookupDecoding
+        draft_model = LlamaPromptLookupDecoding(num_pred_tokens=10)
+        self._model = pn.state.as_cached(
+            'Llama',
+            partial(Llama, draft_model=draft_model),
+            model_path=hf_hub_download(self.repo, self.model_file),
+            n_gpu_layers=-1,
+            n_ctx=8192,
+            chat_format=self.chat_format,
+            logits_all=False,
+            verbose=False
+        )
+        self._raw_client = self._model.create_chat_completion_openai_v1
+        self._client = self._create_client(self._raw_client)
+
+
+class OpenAI(Llm):
+
+    api_key = param.String()
+
+    base_url = param.String()
+
+    model_name = param.String()
+
+    _models = {
+        'gpt-4': {
+            'model_name': 'gpt-4'
+        },
+        'gpt-3.5-turbo': {
+            'model_name': 'gpt-3.5-turbo'
+        }
+    }
+
+    @property
+    def _client_kwargs(self):
+        return {'model': self.model_name}
+
+    def _init_model(self):
+        import openai
+        model_kwargs = {}
+        if self.base_url:
+            model_kwargs['base_url'] = self.base_url
+        if self.api_key:
+            model_kwargs['api_key'] = self.api_key
+        self._model = openai.OpenAI(**model_kwargs)
+        self._raw_client = self._model.chat.completions.create
+        self._client = self._create_client(self._raw_client)

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -197,6 +197,38 @@ class OpenAI(Llm):
         self._client = self._create_client(self._raw_client)
 
 
+class AzureOpenAI(Llm):
+
+    api_key = param.String()
+
+    api_version = param.String()
+
+    azure_endpoint = param.String()
+
+    model_name = param.String()
+
+    temperature = param.Number(default=0.2, bounds=(0, None), constant=True)
+
+    @property
+    def _client_kwargs(self):
+        return {"model": self.model_name, "temperature": self.temperature}
+
+    def _init_model(self):
+        import openai
+
+        model_kwargs = {}
+        if self.api_version:
+            model_kwargs["api_version"] = self.api_version
+        if self.api_key:
+            model_kwargs["api_key"] = self.api_key
+        if self.azure_endpoint:
+            model_kwargs["azure_endpoint"] = self.azure_endpoint
+        self._model = openai.AsyncAzureOpenAI(**model_kwargs)
+        self._raw_client = self._model.chat.completions.create
+        self._client = self._create_client(self._raw_client)
+
+
+
 class AILauncher(OpenAI):
 
     base_url = param.String(default="http://localhost:8080/v1")

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -116,7 +116,7 @@ class Llama(Llm):
 
     model_file = param.String(constant=True)
 
-    temperature = param.Number(default=0.3, bounds=(0, None), constant=True)
+    temperature = param.Number(default=0.4, bounds=(0, None), constant=True)
 
     _models = {
         "default": {

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 class Llm(param.Parameterized):
 
     mode = param.Selector(
-        default=Mode.JSON_SCHEMA, objects=[Mode.JSON_SCHEMA, Mode.JSON]
+        default=Mode.JSON_SCHEMA, objects=[Mode.JSON_SCHEMA, Mode.JSON, Mode.FUNCTIONS]
     )
 
     retry = param.Integer(default=2)
@@ -164,9 +164,7 @@ class OpenAI(Llm):
 
     model_name = param.String()
 
-    mode = param.Selector(
-        default=Mode.FUNCTIONS, objects=[Mode.JSON_SCHEMA, Mode.JSON, Mode.FUNCTIONS]
-    )
+    mode = param.Selector(default=Mode.FUNCTIONS)
 
     temperature = param.Number(default=0.2, bounds=(0, None), constant=True)
 
@@ -205,6 +203,8 @@ class AzureOpenAI(Llm):
 
     azure_endpoint = param.String()
 
+    mode = param.Selector(default=Mode.FUNCTIONS)
+
     model_name = param.String()
 
     temperature = param.Number(default=0.2, bounds=(0, None), constant=True)
@@ -226,7 +226,6 @@ class AzureOpenAI(Llm):
         self._model = openai.AsyncAzureOpenAI(**model_kwargs)
         self._raw_client = self._model.chat.completions.create
         self._client = self._create_client(self._raw_client)
-
 
 
 class AILauncher(OpenAI):

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -75,7 +75,7 @@ class Llm(param.Parameterized):
                 if 'response_model' in kwargs:
                     kwargs['response_model'] = response_model
                 messages = messages + [{"role": "system", "content": f"You just encountered the following error, make sure you don't repeat it: {e}" }]
-        print(f"Invoked LLM output: {output!r}")
+        print(f"\033[33mInvoked LLM output: {output!r}\033[0m")
         return output
 
     @classmethod

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from functools import partial
+
 import panel as pn
 import param
 
@@ -17,24 +19,22 @@ class Llm(param.Parameterized):
     retry = param.Integer(default=2)
 
     # Allows defining a dictionary of default models.
-    _models = {}
+    _models_kwargs = {}
 
     __abstract = True
 
-    def __init__(self, model: str | None = None, **params):
-        if model is not None:
-            if model in self._models:
-                params = dict(self._models[model], **params)
-            else:
-                raise ValueError(
-                    f"No model named {model!r} available. Known models include "
-                    f"{', '.join(self._models)}."
-                )
-        super().__init__(**params)
-        self._client = None
+    def _create_client(self, create, model: str | None = None):
+        if model:
+            return partial(patch(create=create, mode=self.mode), model=model)
+        else:
+            return patch(create=create, mode=self.mode)
 
-    def _create_client(self, create):
-        return patch(create=create, mode=self.mode)
+    def _get_model_kwargs(self, model_key):
+        if model_key in self._models_kwargs:
+            model_kwargs = self._models_kwargs.get(model_key)
+        else:
+            model_kwargs = self._models_kwargs["default"]
+        return dict(model_kwargs)
 
     @property
     def _client_kwargs(self):
@@ -46,11 +46,9 @@ class Llm(param.Parameterized):
         system: str = "",
         response_model: BaseModel | None = None,
         allow_partial: bool = True,
+        model_key: str = "default",
         **input_kwargs,
     ) -> BaseModel:
-        if self._client is None:
-            self._init_model()
-
         if isinstance(messages, str):
             messages = [{"role": "user", "content": messages}]
         if system:
@@ -58,7 +56,6 @@ class Llm(param.Parameterized):
 
         kwargs = dict(self._client_kwargs)
         kwargs.update(input_kwargs)
-        client = self._client
 
         if response_model is not None:
             if allow_partial:
@@ -68,7 +65,7 @@ class Llm(param.Parameterized):
         output = None
         for r in range(self.retry):
             try:
-                output = await client(messages=messages, **kwargs)
+                output = await self.run_client(model_key, messages, **kwargs)
                 break
             except Exception as e:
                 print(f"Error encountered: {e}")
@@ -90,44 +87,48 @@ class Llm(param.Parameterized):
         system: str = "",
         response_model: BaseModel | None = None,
         field: str = "output",
+        model_key: str = "default",
         **kwargs,
     ):
-        if self._client is None:
-            self._init_model()
-
         string = ""
-        async for chunk in await self.invoke(
+        chunks = await self.invoke(
             messages,
             system=system,
             response_model=response_model,
             stream=True,
-            **dict(self._client_kwargs, **kwargs),
-        ):
-            if response_model is None:
-                delta = self._get_delta(chunk)
-                string += delta
-                yield string
-            else:
-                yield getattr(chunk, field)
+            model_key=model_key,
+            **kwargs,
+        )
+        try:
+            async for chunk in chunks:
+                if response_model is None:
+                    delta = self._get_delta(chunk)
+                    string += delta
+                    yield string
+                else:
+                    yield getattr(chunk, field)
+        except TypeError:
+            for chunk in chunks:
+                if response_model is None:
+                    delta = self._get_delta(chunk)
+                    string += delta
+                    yield string
+                else:
+                    yield getattr(chunk, field)
+
+    async def run_client(self, model_key, messages, **kwargs):
+        client = self.get_client(model_key)
+        return await client(messages=messages, **kwargs)
 
 
 class Llama(Llm):
 
     chat_format = param.String(constant=True)
 
-    repo = param.String(constant=True)
-
-    model_file = param.String(constant=True)
-
     temperature = param.Number(default=0.4, bounds=(0, None), constant=True)
 
-    _models = {
+    _models_kwargs = {
         "default": {
-            "repo": "TheBloke/OpenHermes-2.5-Mistral-7B-GGUF",
-            "model_file": "openhermes-2.5-mistral-7b.Q4_K_M.gguf",
-            "chat_format": "chatml",
-        },
-        "mistral": {
             "repo": "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
             "model_file": "mistral-7b-instruct-v0.2.Q5_K_M.gguf",
             "chat_format": "mistral-instruct",
@@ -143,23 +144,34 @@ class Llama(Llm):
     def _client_kwargs(self):
         return {"temperature": self.temperature}
 
-    def _init_model(self):
+    def get_client(self, model_key: str):
+        if client := pn.state.cache.get(model_key):
+            return client
         from huggingface_hub import hf_hub_download
         from llama_cpp import Llama
-        self._model = pn.state.as_cached(
-            'Llama',
-            Llama,
-            model_path=hf_hub_download(self.repo, self.model_file),
+
+        model_kwargs = self._get_model_kwargs(model_key)
+        repo = model_kwargs["repo"]
+        model_file = model_kwargs["model_file"]
+        chat_format = model_kwargs["chat_format"]
+        llm = Llama(
+            model_path=hf_hub_download(repo, model_file),
             n_gpu_layers=-1,
             n_ctx=8192,
             seed=128,
-            chat_format=self.chat_format,
+            chat_format=chat_format,
             logits_all=False,
             use_mlock=True,
             verbose=False
         )
-        self._raw_client = self._model.create_chat_completion_openai_v1
-        self._client = self._create_client(self._raw_client)
+        raw_client = llm.create_chat_completion_openai_v1
+        client = self._create_client(raw_client, model_key)
+        pn.state.cache[model_key] = client
+        return client
+
+    async def run_client(self, model_key, messages, **kwargs):
+        client = self.get_client(model_key)
+        return client(messages=messages, **kwargs)
 
 
 class OpenAI(Llm):
@@ -168,38 +180,36 @@ class OpenAI(Llm):
 
     base_url = param.String()
 
-    model_name = param.String()
-
     mode = param.Selector(default=Mode.FUNCTIONS)
 
     temperature = param.Number(default=0.2, bounds=(0, None), constant=True)
 
     organization = param.String()
 
-    _models = {
-        "gpt-3.5-turbo": {"model_name": "gpt-3.5-turbo"},
-        "gpt-4": {"model_name": "gpt-4"},
-        "gpt-4-turbo-preview": {"model_name": "gpt-4-turbo-preview"},
+    _models_kwargs = {
+        "default": {"model": "gpt-3.5-turbo"},
+        "reasoning": {"model": "gpt-4-turbo-preview"},
     }
 
     @property
     def _client_kwargs(self):
-        return {"model": self.model_name, "temperature": self.temperature}
+        return {"temperature": self.temperature}
 
-    def _init_model(self):
+    def get_client(self, model_key: str):
         import openai
 
-        model_kwargs = {}
+        model_kwargs = self._get_model_kwargs(model_key)
+        model = model_kwargs.pop("model")
         if self.base_url:
             model_kwargs["base_url"] = self.base_url
         if self.api_key:
             model_kwargs["api_key"] = self.api_key
         if self.organization:
             model_kwargs["organization"] = self.organization
-        self._model = openai.AsyncOpenAI(**model_kwargs)
-        self._raw_client = self._model.chat.completions.create
-        self._client = self._create_client(self._raw_client)
-
+        llm = openai.AsyncOpenAI(**model_kwargs)
+        raw_client = llm.chat.completions.create
+        client = self._create_client(raw_client, model)
+        return client
 
 class AzureOpenAI(Llm):
 
@@ -211,27 +221,27 @@ class AzureOpenAI(Llm):
 
     mode = param.Selector(default=Mode.FUNCTIONS)
 
-    model_name = param.String()
-
     temperature = param.Number(default=0.2, bounds=(0, None), constant=True)
 
     @property
     def _client_kwargs(self):
-        return {"model": self.model_name, "temperature": self.temperature}
+        return {"temperature": self.temperature}
 
-    def _init_model(self):
+    def get_client(self, model_key: str):
         import openai
 
-        model_kwargs = {}
+        model_kwargs = self._get_model_kwargs(model_key)
+        model = model_kwargs.pop("model")
         if self.api_version:
             model_kwargs["api_version"] = self.api_version
         if self.api_key:
             model_kwargs["api_key"] = self.api_key
         if self.azure_endpoint:
             model_kwargs["azure_endpoint"] = self.azure_endpoint
-        self._model = openai.AsyncAzureOpenAI(**model_kwargs)
-        self._raw_client = self._model.chat.completions.create
-        self._client = self._create_client(self._raw_client)
+        llm = openai.AsyncAzureOpenAI(**model_kwargs)
+        raw_client = llm.chat.completions.create
+        client = self._create_client(raw_client, model)
+        return client
 
 
 class AILauncher(OpenAI):
@@ -240,4 +250,7 @@ class AILauncher(OpenAI):
 
     mode = param.Selector(default=Mode.JSON_SCHEMA)
 
-    _models = {"default": {"model_name": "gpt-3.5-turbo"}}
+    _models_kwargs = {
+        "default": {"model": "gpt-3.5-turbo"},
+        "reasoning": {"model": "gpt-4-turbo-preview"},
+    }

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1,7 +1,5 @@
 from functools import partial
 
-from llama_cpp import ChatCompletionChunk
-
 import panel as pn
 import param
 
@@ -30,8 +28,8 @@ class Llm(param.Parameterized):
                 params = dict(self._models[model], **params)
             else:
                 raise ValueError(
-                    "No model named {model!r} available. Known models include "
-                    "{', '.join(LLM_METADATA)}."
+                    f"No model named {model!r} available. Known models include "
+                    f"{', '.join(self._models)}."
                 )
         super().__init__(**params)
         self._client = None
@@ -68,20 +66,18 @@ class Llm(param.Parameterized):
                 response_model = Partial[response_model]
             kwargs['response_model'] = response_model
 
-        errored = False
+        print(messages, "\n\n")
+        output = None
         for r in range(self.retry):
             try:
                 output = client(messages=messages, **kwargs)
                 break
             except Exception as e:
+                print(f"Error encountered: {e}")
                 if 'response_model' in kwargs:
-                    errored = True
                     kwargs['response_model'] = Maybe(response_model)
                 messages = messages + [{"role": "system", "content": f"You just encountered the following error, make sure you don't repeat it: {e}" }]
-
-        if errored:
-            output = output.result
-
+        print(f"Invoked output: {output!r}")
         return output
 
     def stream(

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import panel as pn
 import param
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -12,8 +12,12 @@ from .models import String
 
 class Llm(param.Parameterized):
 
+    mode = param.Selector(default=Mode.JSON_SCHEMA, objects=[Mode.JSON_SCHEMA, Mode.JSON])
+
     # Allows defining a dictionary of default models.
     _models = {}
+
+    retry = param.Integer(default=2)
 
     __abstract = True
 
@@ -30,7 +34,7 @@ class Llm(param.Parameterized):
         self._client = None
 
     def _create_client(self, create):
-        return patch(create=create, mode=Mode.JSON_SCHEMA)
+        return patch(create=create, mode=self.mode)
 
     @property
     def _client_kwargs(self):
@@ -60,7 +64,14 @@ class Llm(param.Parameterized):
                 response_model = Partial[response_model]
             kwargs['response_model'] = response_model
 
-        output = client(messages=messages, **kwargs)
+        for r in range(self.retry):
+            try:
+                output = client(messages=messages, **kwargs)
+                break
+            except Exception as e:
+                if r == (self.retry-1):
+                    raise e
+                messages = messages + [{"role": "system", "content": f"You just encountered the following error, make sure you don't repeat it: {e}" }]
         if response_model is String:
             output = String(output=output)
         return output
@@ -144,6 +155,8 @@ class OpenAI(Llm):
 
     model_name = param.String()
 
+    organization = param.String()
+
     _models = {
         'gpt-4': {
             'model_name': 'gpt-4'
@@ -164,6 +177,21 @@ class OpenAI(Llm):
             model_kwargs['base_url'] = self.base_url
         if self.api_key:
             model_kwargs['api_key'] = self.api_key
+        if self.organization:
+            model_kwargs['organization'] = self.organization
         self._model = openai.OpenAI(**model_kwargs)
         self._raw_client = self._model.chat.completions.create
         self._client = self._create_client(self._raw_client)
+
+
+class AILauncher(OpenAI):
+
+    base_url = param.String(default="http://localhost:8080/v1")
+
+    mode = param.Selector(default=Mode.JSON_SCHEMA)
+
+    _models = {
+        'default': {
+            'model_name': 'gpt-3.5-turbo'
+        }
+    }

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -18,6 +18,8 @@ class Llm(param.Parameterized):
 
     retry = param.Integer(default=2)
 
+    use_logfire = param.Boolean(default=False)
+
     # Allows defining a dictionary of default models.
     _models_kwargs = {}
 
@@ -209,6 +211,10 @@ class OpenAI(Llm):
         llm = openai.AsyncOpenAI(**model_kwargs)
         raw_client = llm.chat.completions.create
         client = self._create_client(raw_client, model)
+
+        if self.use_logfire:
+            import logfire
+            logfire.instrument_openai(llm)
         return client
 
 class AzureOpenAI(Llm):

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -78,6 +78,12 @@ class Llm(param.Parameterized):
         print(f"Invoked LLM output: {output!r}")
         return output
 
+    @classmethod
+    def _get_delta(cls, chunk):
+        if chunk.choices:
+            return chunk.choices[0].delta.content or ""
+        return ""
+
     async def stream(
         self,
         messages: list | str,
@@ -98,7 +104,7 @@ class Llm(param.Parameterized):
             **dict(self._client_kwargs, **kwargs),
         ):
             if response_model is None:
-                delta = chunk.choices[0].delta.content or ""
+                delta = self._get_delta(chunk)
                 string += delta
                 yield string
             else:

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -21,7 +21,7 @@ class Llm(param.Parameterized):
     use_logfire = param.Boolean(default=False)
 
     # Allows defining a dictionary of default models.
-    _models_kwargs = {}
+    model_kwargs = param.Dict(default={})
 
     __abstract = True
 
@@ -32,10 +32,10 @@ class Llm(param.Parameterized):
             return patch(create=create, mode=self.mode)
 
     def _get_model_kwargs(self, model_key):
-        if model_key in self._models_kwargs:
-            model_kwargs = self._models_kwargs.get(model_key)
+        if model_key in self.model_kwargs:
+            model_kwargs = self.model_kwargs.get(model_key)
         else:
-            model_kwargs = self._models_kwargs["default"]
+            model_kwargs = self.model_kwargs["default"]
         return dict(model_kwargs)
 
     @property
@@ -132,7 +132,7 @@ class Llama(Llm):
 
     temperature = param.Number(default=0.4, bounds=(0, None), constant=True)
 
-    _models_kwargs = {
+    model_kwargs = param.Dict(default={
         "default": {
             "repo": "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
             "model_file": "mistral-7b-instruct-v0.2.Q5_K_M.gguf",
@@ -143,7 +143,7 @@ class Llama(Llm):
             "model_file": "sqlcoder2.Q5_K_M.gguf",
             "chat_format": "chatml",
         },
-    }
+    })
 
     @property
     def _client_kwargs(self):
@@ -191,10 +191,10 @@ class OpenAI(Llm):
 
     organization = param.String()
 
-    _models_kwargs = {
+    model_kwargs = param.Dict(default={
         "default": {"model": "gpt-3.5-turbo"},
         "reasoning": {"model": "gpt-4-turbo-preview"},
-    }
+    })
 
     @property
     def _client_kwargs(self):
@@ -259,7 +259,7 @@ class AILauncher(OpenAI):
 
     mode = param.Selector(default=Mode.JSON_SCHEMA)
 
-    _models_kwargs = {
+    model_kwargs = param.Dict(default={
         "default": {"model": "gpt-3.5-turbo"},
         "reasoning": {"model": "gpt-4-turbo-preview"},
-    }
+    })

--- a/lumen/ai/logs.py
+++ b/lumen/ai/logs.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import sqlite3
+
+import param
+
+
+class ChatLogs(param.Parameterized):
+
+    filename = param.String(default="chat_logs.db")
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        self.conn = sqlite3.connect(self.filename)
+        self.cursor = self.conn.cursor()
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS logs (
+                session_id TEXT,
+                message_id TEXT PRIMARY KEY,
+                message_index INTEGER,
+                message_user TEXT,
+                message_content TEXT,
+                liked BOOLEAN DEFAULT FALSE,
+                disliked BOOLEAN DEFAULT FALSE,
+                removed BOOLEAN DEFAULT FALSE,
+                timestamp TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        self.conn.commit()
+
+    def upsert(
+        self,
+        session_id,
+        message_id,
+        message_index,
+        message_user,
+        message_content,
+    ):
+        self.cursor.execute(
+            """
+            INSERT INTO logs (session_id, message_id, message_index, message_user, message_content)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (message_id)
+            DO UPDATE SET
+            session_id = excluded.session_id,
+            message_id = excluded.message_id,
+            message_index = excluded.message_index,
+            message_user = excluded.message_user,
+            message_content = excluded.message_content
+            """,
+            (
+                session_id,
+                message_id,
+                message_index,
+                message_user,
+                message_content,
+            ),
+        )
+        self.conn.commit()
+
+    def update_status(self, message_id, liked=None, disliked=None, removed=None):
+        self.cursor.execute(
+            """
+            UPDATE logs
+            SET liked = COALESCE(?, liked), disliked = COALESCE(?, disliked), removed = COALESCE(?, removed)
+            WHERE message_id = ?
+            """,
+            (liked, disliked, removed, message_id),
+        )
+        self.conn.commit()

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -58,8 +58,6 @@ class _Memory(Viewer):
 
     def _render_item(self, key, item):
         if isinstance(item, Component):
-            if hasattr(item, "password"):
-                item.password = "$variables.PASSWORD"
             item = item.to_spec()
         if isinstance(item, str):
             item = f'```yaml\n{item}\n```'

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+from weakref import WeakKeyDictionary
+
+import panel as pn
+
+from panel import state
+from panel.viewable import Viewer
+
+from ..base import Component
+
+if TYPE_CHECKING:
+    from bokeh.document import Document
+
+
+class _Memory(Viewer):
+
+    _session_contexts: ClassVar[WeakKeyDictionary[Document, Any]] = WeakKeyDictionary()
+
+    _views: ClassVar[WeakKeyDictionary[Document, Any]] = WeakKeyDictionary()
+
+    _global_context = {}
+
+    @property
+    def _curcontext(self):
+        if state.curdoc:
+            if state.curdoc in self._session_contexts:
+                context = self._session_contexts[state.curdoc]
+            else:
+                self._session_contexts[state.curdoc] = context = {}
+            return context
+        else:
+            return self._global_context
+
+    def __contains__(self, key):
+        return key in self._curcontext
+
+    def __getitem__(self, key):
+        return self._curcontext[key]
+
+    def __setitem__(self, key, value):
+        self._curcontext[key] = value
+        if state.curdoc in self._views:
+            self._views[state.curdoc][:] = [self._create_view()]
+
+    def get(self, key, default=None):
+        return self._curcontext.get(key, default)
+
+    def _render_item(self, item):
+        if isinstance(item, Component):
+            item = item.to_spec()
+        if isinstance(item, str):
+            item = f'```yaml\n{item}\n```'
+        return pn.panel(item, sizing_mode='stretch_width')
+
+    def _create_view(self):
+        return pn.Accordion(*(
+            (name, self._render_item(item))
+            for name, item in self._curcontext.items()
+        ), sizing_mode='stretch_width', active=list(range(len(self._curcontext))))
+
+    def __panel__(self):
+        self._views[state.curdoc] = view = pn.Column(self._create_view())
+        return view
+
+
+memory = _Memory()

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -47,8 +47,13 @@ class _Memory(Viewer):
     def get(self, key, default=None):
         return self._curcontext.get(key, default)
 
+    def pop(self, key, default=None):
+        return self._curcontext.pop(key, default)
+
     def _render_item(self, key, item):
         if isinstance(item, Component):
+            if hasattr(item, "password"):
+                item.password = "$variables.PASSWORD"
             item = item.to_spec()
         if isinstance(item, str):
             item = f'```yaml\n{item}\n```'

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -45,7 +45,10 @@ class _Memory(Viewer):
             self._update_view(key, value)
 
     def get(self, key, default=None):
-        return self._curcontext.get(key, default)
+        obj = self._curcontext.get(key, default)
+        if hasattr(obj, "copy"):
+            obj = obj.copy()
+        return obj
 
     def pop(self, key, default=None):
         return self._curcontext.pop(key, default)

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -42,26 +42,39 @@ class _Memory(Viewer):
     def __setitem__(self, key, value):
         self._curcontext[key] = value
         if state.curdoc in self._views:
-            self._views[state.curdoc][:] = [self._create_view()]
+            self._update_view(key, value)
 
     def get(self, key, default=None):
         return self._curcontext.get(key, default)
 
-    def _render_item(self, item):
+    def _render_item(self, key, item):
         if isinstance(item, Component):
             item = item.to_spec()
         if isinstance(item, str):
             item = f'```yaml\n{item}\n```'
-        return pn.panel(item, sizing_mode='stretch_width')
+        return pn.panel(item, name=key, sizing_mode='stretch_width', styles={'overflow': 'scroll'})
 
-    def _create_view(self):
+    def _render_memories(self):
         return pn.Accordion(*(
-            (name, self._render_item(item))
+            self._render_item(name, item)
             for name, item in self._curcontext.items()
         ), sizing_mode='stretch_width', active=list(range(len(self._curcontext))))
 
+    def _update_view(self, key, value):
+        view = self._views[state.curdoc]
+        accordion = view[0]
+        new_item = self._render_item(key, value)
+        i = 0
+        for i, item in enumerate(accordion):
+            if item.name == key:
+                accordion[i] = new_item
+                break
+        else:
+            accordion.append(new_item)
+            accordion.active = accordion.active + [i+1]
+
     def __panel__(self):
-        self._views[state.curdoc] = view = pn.Column(self._create_view())
+        self._views[state.curdoc] = view = pn.Column(self._render_memories())
         return view
 
 

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -59,6 +59,8 @@ class _Memory(Viewer):
     def _render_item(self, key, item):
         if isinstance(item, Component):
             item = item.to_spec()
+            if 'password' in item:
+                item['password'] = '•'*len(item['password'])
         if isinstance(item, str):
             item = f'```yaml\n{item}\n```'
         return pn.panel(item, name=key, sizing_mode='stretch_width', styles={'overflow': 'scroll'})

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -53,6 +53,9 @@ class _Memory(Viewer):
     def pop(self, key, default=None):
         return self._curcontext.pop(key, default)
 
+    def keys(self):
+        return self._curcontext.keys()
+
     def _render_item(self, key, item):
         if isinstance(item, Component):
             if hasattr(item, "password"):

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -3,9 +3,7 @@ from pydantic import BaseModel, Field
 
 class Table(BaseModel):
 
-    table: str = Field(
-        description="The full path name"
-    )
+    table: str = Field(description="The full path name")
 
 
 class Sql(BaseModel):
@@ -18,6 +16,21 @@ class Yaml(BaseModel):
     spec: str = Field(description="Lumen spec YAML to reflect user query")
 
 
-class Decision(BaseModel):
+class PipelineValidity(BaseModel):
 
-    required: bool = Field(description="Whether a transformation is required to achieve the user's request")
+    chain_of_thought: str = Field(
+        description="""
+        Focus only on whether the pipeline contain all the necessary columns
+        to answer the user's query? FOCUS only on the columns, and **disregard** everything else,
+        like whether the pipeline contains visualization or not.
+        For example, if it's "visualize this", then it's still valid.
+        However, if the pipeline contains `MAX(t_cap) as turbine_capacity`, and the user
+        asks to plot a map of `lat and lon`, then it's invalid!
+        Please only provide up to two sentences at most; be concise and to the point.
+        """
+    )
+
+    valid: bool = Field(
+        default=...,
+        description="Whether a transformation is required to achieve the user's request"
+    )

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel, Field
+
+
+class String(BaseModel):
+
+    output: str
+
+
+class Table(BaseModel):
+
+    table: str = Field(
+        description="The full path name"
+    )
+
+
+class Sql(BaseModel):
+
+    query: str = Field(description="SQL query to be executed")
+
+
+class Yaml(BaseModel):
+
+    spec: str = Field(description="Lumen spec YAML to reflect user query")

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -16,12 +20,17 @@ class Yaml(BaseModel):
     spec: str = Field(description="Lumen spec YAML to reflect user query")
 
 
-class PipelineValidity(BaseModel):
+class Validity(BaseModel):
 
     chain_of_thought: str = Field(
         description="""
-        Focus only on whether the pipeline contain all the necessary columns
-        to answer the user's query? FOCUS only on the columns, and **disregard** everything else,
+        Focus only on whether the table and/or pipeline contain all the necessary columns
+        to answer the user's query.
+
+        Based on the latest user's query, is the table relevant?
+        If not, return invalid_key='table'.
+
+        Then for pipeline, focus only on the columns, and **disregard** everything else,
         like whether the pipeline contains visualization or not.
         For example, if it's "visualize this", then it's still valid.
         However, if the pipeline contains `MAX(t_cap) as turbine_capacity`, and the user
@@ -30,7 +39,11 @@ class PipelineValidity(BaseModel):
         """
     )
 
-    valid: bool = Field(
-        default=...,
-        description="Whether a transformation is required to achieve the user's request"
+    is_invalid: bool = Field(
+        description="Whether one of the table and/or pipeline is invalid."
+    )
+
+    invalid_key: Literal["pipeline", "table"] | None = Field(
+        default=None,
+        description="Whether a pipeline or table is invalid. None if valid."
     )

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -12,38 +12,37 @@ class Table(BaseModel):
 
 class Sql(BaseModel):
 
-    query: str = Field(description="SQL query to be executed")
+    chain_of_thought: str = Field(
+        description="""
+        You are a world-class SQL expert, and your fame is on the line so don't mess up.
+        Then, think step by step on how you might approach this problem in an optimal way.
+        If it's simple, just provide one sentence.
+        """
+    )
 
-
-class Yaml(BaseModel):
-
-    spec: str = Field(description="Lumen spec YAML to reflect user query")
+    query: str = Field(description="Expertly optimized, valid SQL query to be executed; do NOT add extraneous comments.")
 
 
 class Validity(BaseModel):
 
     chain_of_thought: str = Field(
         description="""
-        Focus only on whether the table and/or pipeline contain all the necessary columns
+        Focus only on whether the table and/or / SQL contain all the necessary columns
         to answer the user's query.
 
         Based on the latest user's query, is the table relevant?
         If not, return invalid_key='table'.
 
-        Then for pipeline, focus only on the columns, and **disregard** everything else,
-        like whether the pipeline contains visualization or not.
-        For example, if it's "visualize this", then it's still valid.
-        However, if the pipeline contains `MAX(t_cap) as turbine_capacity`, and the user
-        asks to plot a map of `lat and lon`, then it's invalid!
-        Please only provide up to two sentences at most; be concise and to the point.
+        Then, do all the necessary columns exist?
+        If not, return invalid_key='sql'.
         """
     )
 
     is_invalid: bool = Field(
-        description="Whether one of the table and/or pipeline is invalid."
+        description="Whether one of the table and/or pipeline is invalid or needs a refresh."
     )
 
-    invalid_key: Literal["pipeline", "table"] | None = Field(
+    invalid_key: Literal["table", "sql"] | None = Field(
         default=None,
-        description="Whether a pipeline or table is invalid. None if valid."
+        description="Whether a table or sql is invalid. None if valid."
     )

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -5,9 +5,24 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-class Table(BaseModel):
+class FuzzyTable(BaseModel):
 
-    table: str = Field(description="The full path name")
+    required: bool = Field(description="Whether the user's query requires looking for a new table.")
+
+    keywords: list[str] | None = Field(default=None, description="The most likely keywords related to a table name that the user might be referring to.")
+
+
+class DataRequired(BaseModel):
+
+    chain_of_thought: str = Field(
+        description="""
+        Thoughts on whether the user's query requires data loaded;
+        if the user wants to explore a dataset, it's required.
+        If only finding a dataset, it's not required.
+        """
+    )
+
+    data_required: bool = Field(description="Whether the user wants to load a specific dataset; if only searching for one, it's not required.")
 
 
 class Sql(BaseModel):

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -1,11 +1,6 @@
 from pydantic import BaseModel, Field
 
 
-class String(BaseModel):
-
-    output: str
-
-
 class Table(BaseModel):
 
     table: str = Field(

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -21,3 +21,8 @@ class Sql(BaseModel):
 class Yaml(BaseModel):
 
     spec: str = Field(description="Lumen spec YAML to reflect user query")
+
+
+class Decision(BaseModel):
+
+    required: bool = Field(description="Whether a transformation is required to achieve the user's request")

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Literal
-
 from pydantic import BaseModel, Field
 
 
@@ -42,22 +40,11 @@ class Validity(BaseModel):
 
     chain_of_thought: str = Field(
         description="""
-        Focus only on whether the table and/or / SQL contain all the necessary columns
+        Focus only on whether the table contain all the necessary columns
         to answer the user's query.
-
-        Based on the latest user's query, is the table relevant?
-        If not, return invalid_key='table'.
-
-        Then, do all the necessary columns exist?
-        If not, return invalid_key='sql'.
         """
     )
 
     is_invalid: bool = Field(
         description="Whether one of the table and/or pipeline is invalid or needs a refresh."
-    )
-
-    invalid_key: Literal["table", "sql"] | None = Field(
-        default=None,
-        description="Whether a table or sql is invalid. None if valid."
     )

--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -110,6 +110,8 @@ def parameter_to_field(
     elif param_type in [param.Selector, param.ObjectSelector]:
         if literals:
             type_ = _create_literal(literals)
+        elif parameter.objects:
+            type_ = _create_literal(parameter.objects)
         else:
             type_ = str
     elif issubclass(param_type, param.DataFrame):

--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -93,9 +93,7 @@ def parameter_to_field(
             field_info.default_factory = default_factory
     elif param_type in [param.List, param.ListSelector]:
         type_ = List
-        if parameter.default == [] or parameter.default is None:
-            field_info.default_factory = list
-        elif parameter.default is not None:
+        if parameter.default is not None:
             field_info.default_factory = parameter.default
         if param_type is param.List and parameter.item_type:
             type_ = List[_get_model(parameter.item_type, created_models)]
@@ -108,6 +106,7 @@ def parameter_to_field(
         elif parameter.default is not None:
             field_info.default_factory = parameter.default
     elif param_type in [param.Selector, param.ObjectSelector]:
+        field_info.default = parameter.default
         if literals:
             type_ = _create_literal(literals)
         elif parameter.objects:

--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -84,11 +84,8 @@ def parameter_to_field(
         field_info.default = parameter.default
     elif param_type is param.ClassSelector:
         type_ = _get_model(parameter.class_, created_models)
-        # if isinstance(type_, tuple):
-        #     type_ = Union[tuple([PARAM_TYPE_MAPPING.get(t, t) for t in type_])]
         if isinstance(type_, tuple):
-            # Union currently unsupported.
-            type_ = type_[0]
+            type_ = Union[tuple([PARAM_TYPE_MAPPING.get(t, t) for t in type_])]
         if parameter.default is not None:
             default_factory = parameter.default
             if not callable(default_factory):
@@ -251,10 +248,5 @@ def pydantic_to_param(model: BaseModel) -> param.Parameterized:
         else:
             kwargs[key] = value
 
-    # work around for not being able to provide a list of filters
-    filters = kwargs.pop("filters", None)
     parameterized = model.__parameterized__(**kwargs)
-    if filters:
-        for filter in filters:
-            parameterized.add_filter("widget", field=filter.field)
     return parameterized

--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -1,0 +1,260 @@
+import datetime
+import inspect
+import warnings
+
+from typing import (
+    Any, Callable, Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union,
+)
+
+import param
+
+from pydantic import BaseConfig, BaseModel, create_model
+from pydantic.color import Color
+from pydantic.fields import FieldInfo, PydanticUndefined
+
+DATE_TYPE = Union[datetime.datetime, datetime.date]
+PARAM_TYPE_MAPPING: Dict[param.Parameter, Type] = {
+    param.String: str,
+    param.Integer: int,
+    param.Number: float,
+    param.Boolean: bool,
+    param.Event: bool,
+    param.Date: DATE_TYPE,
+    param.DateRange: Tuple[DATE_TYPE],
+    param.CalendarDate: DATE_TYPE,
+    param.CalendarDateRange: Tuple[DATE_TYPE],
+    param.Parameter: object,
+    param.Color: Color,
+    param.Callable: Callable,
+}
+PandasDataFrame = TypeVar("pandas.core.frame.DataFrame")
+
+
+class ArbitraryTypesModel(BaseModel):
+    """
+    A Pydantic model that allows arbitrary types.
+    """
+
+    class Config(BaseConfig):
+        arbitrary_types_allowed = True
+
+
+def _create_literal(obj: List[Union[str, Type]]) -> Type:
+    """
+    Create a literal type from a list of objects.
+    """
+    enum = []
+    for item in obj:
+        if item is None:
+            continue
+        elif isinstance(item, str):
+            enum.append(item)
+        else:
+            enum.append(item.__name__)
+    if enum:
+        return Literal[tuple(enum)]
+    else:
+        return str
+
+
+def _get_model(type_, created_models: Dict[str, BaseModel]) -> Any:
+    try:
+        if issubclass(type_, param.Parameterized):
+            type_ = created_models.get(type_.__name__, type_.__name__)
+    except TypeError:
+        pass
+    return type_
+
+
+def parameter_to_field(
+    parameter: param.Parameter, created_models: Dict[str, BaseModel],
+    literals: list[str] | None
+) -> (Type, FieldInfo):
+    """
+    Translate a parameter to a pydantic field.
+    """
+    param_type = parameter.__class__
+    description = " ".join(parameter.doc.split()) if parameter.doc else None
+    field_info = FieldInfo(description=description)
+    if not literals and hasattr(parameter, 'get_range'):
+        literals = list(parameter.get_range())
+
+    if param_type in PARAM_TYPE_MAPPING:
+        type_ = PARAM_TYPE_MAPPING[param_type]
+        field_info.default = parameter.default
+    elif param_type is param.ClassSelector:
+        type_ = _get_model(parameter.class_, created_models)
+        # if isinstance(type_, tuple):
+        #     type_ = Union[tuple([PARAM_TYPE_MAPPING.get(t, t) for t in type_])]
+        if isinstance(type_, tuple):
+            # Union currently unsupported.
+            type_ = type_[0]
+        if parameter.default is not None:
+            default_factory = parameter.default
+            if not callable(default_factory):
+                default_factory = type(default_factory)
+            field_info.default_factory = default_factory
+    elif param_type in [param.List, param.ListSelector]:
+        type_ = List
+        if parameter.default == [] or parameter.default is None:
+            field_info.default_factory = list
+        elif parameter.default is not None:
+            field_info.default_factory = parameter.default
+        if param_type is param.List and parameter.item_type:
+            type_ = List[_get_model(parameter.item_type, created_models)]
+        elif param_type is param.ListSelector:
+            type_ = List[_create_literal(literals)]
+    elif param_type is param.Dict:
+        type_ = Dict
+        if parameter.default == {}:
+            field_info.default_factory = dict
+        elif parameter.default is not None:
+            field_info.default_factory = parameter.default
+    elif param_type in [param.Selector, param.ObjectSelector]:
+        if literals:
+            type_ = _create_literal(literals)
+        else:
+            type_ = str
+    elif issubclass(param_type, param.DataFrame):
+        type_ = PandasDataFrame
+    elif parameter.name == "align":
+        type_ = _create_literal(["auto", "start", "center", "end"])
+    elif parameter.name == "aspect_ratio":
+        type_ = Union[Literal["auto"], float]
+    elif parameter.name == "margin":
+        type_ = Union[float, Tuple[float, float], Tuple[float, float, float, float]]
+    else:
+        raise NotImplementedError(
+            f"Parameter {parameter.name!r} of {param_type.__name__!r} not supported"
+        )
+
+    if hasattr(parameter, "bounds") and parameter.bounds and type_ in [int, float]:
+        try:
+            field_info.ge = parameter.bounds[0]
+            field_info.le = parameter.bounds[1]
+        except Exception:
+            pass
+
+    if parameter.allow_None:
+        type_ = Optional[type_]
+
+    return type_, field_info
+
+
+def param_to_pydantic(
+    parameterized: Type[param.Parameterized],
+    base_model: Type[BaseModel] = ArbitraryTypesModel,
+    created_models: Optional[Dict[str, BaseModel]] = None,
+    schema: Optional[Dict[str, Any]] = None,
+    excluded: Union[str, List[str]] = "_internal_params",
+) -> Dict[str, BaseModel]:
+    """
+    Translate a param Parameterized to a Pydantic BaseModel.
+
+    Parameters
+    ----------
+    parameterized : Type[param.Parameterized]
+        The parameterized class to translate.
+    base_model : Type[BaseModel], optional
+        The base model to use, by default ArbitraryTypesModel
+    created_models : Optional[Dict[str, BaseModel]], optional
+        A dictionary of already created models, by default None
+    excluded : Union[str, List[str]], optional
+        A list of parameters to exclude. If a string is provided,
+        it looks up the parameter on the parameterized class and
+        excludes the parameter's value, by default "_internal_params".
+    """
+    parameterized_name = parameterized.__name__
+    if created_models is None:
+        created_models = {}
+    if parameterized_name in created_models:
+        return created_models
+
+    if isinstance(excluded, str) and hasattr(parameterized, excluded):
+        excluded = getattr(parameterized, excluded)
+
+    parameterized_signature = inspect.signature(parameterized.__init__)
+    required_args = [
+        arg.name
+        for arg in parameterized_signature.parameters.values()
+        if arg.name not in ["self", "params"] and arg.default == inspect._empty
+    ]
+    field_params = list(getattr(parameterized, '_field_params', []))
+
+    fields = {}
+    for parameter_name in parameterized.param:
+        if parameter_name in excluded or parameterized_name.lower() == parameter_name.lower():
+            continue
+        parameter = parameterized.param[parameter_name]
+        if hasattr(parameter, "class_") and hasattr(parameter.class_, "param"):
+            parameter_class_name = parameter.class_.__name__
+            if parameterized_name != parameter_class_name:
+                param_to_pydantic(parameter.class_, created_models=created_models)
+
+        literals = list(schema) if schema and parameter_name in field_params else None
+
+        type_, field_info = parameter_to_field(parameter, created_models, literals)
+        if parameter_name == "schema":
+            field_info.alias = "schema"
+            parameter_name = "schema_"
+        elif parameter_name == "copy":
+            field_info.alias = "copy"
+            parameter_name = "copy_"
+        elif parameter_name[0] == "_":
+            field_info.alias = parameter_name
+            parameter_name = parameter_name.lstrip("_")
+
+        if parameter_name in required_args:
+            field_info.default = PydanticUndefined
+        elif field_info.default == PydanticUndefined and not field_info.default_factory:
+            field_info.default = None
+        fields[parameter_name] = (type_, field_info)
+
+    fields["__parameterized__"] = (Type, parameterized)
+    # ignore RuntimeWarning: fields may not start with an underscore
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        pydantic_model = create_model(
+            parameterized.__name__, __base__=base_model, **fields
+        )
+    created_models[pydantic_model.__name__] = pydantic_model
+    return created_models
+
+
+def pydantic_to_param(model: BaseModel) -> param.Parameterized:
+    """
+    Serialize a Pydantic model to a Parameterized instance.
+
+    Parameters
+    ----------
+    model : BaseModel
+        The model to serialize.
+    """
+    kwargs = {}
+    for key, value in dict(model).items():
+        if isinstance(value, BaseModel):
+            kwargs[key] = pydantic_to_param(value)
+        elif isinstance(value, Color):
+            kwargs[key] = value.as_hex()
+        elif isinstance(value, dict):
+            sub_kwargs = {}
+            for k, v in value.items():
+                if isinstance(v, BaseModel):
+                    sub_kwargs[k] = pydantic_to_param(v)
+                else:
+                    sub_kwargs[k] = v
+            kwargs[key] = sub_kwargs
+        elif key == "table":
+            # couldn't convince AI to provide path to file for `tables`
+            # but remove the extension for `table`
+            kwargs[key] = value.split(".")[0]
+        else:
+            kwargs[key] = value
+
+    # work around for not being able to provide a list of filters
+    filters = kwargs.pop("filters", None)
+    parameterized = model.__parameterized__(**kwargs)
+    if filters:
+        for filter in filters:
+            parameterized.add_filter("widget", field=filter.field)
+    return parameterized

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -123,6 +123,9 @@ class Config(Component):
     show_traceback = param.Boolean(default=True, doc="""
         Whether to show the traceback if an error happens.""")
 
+    sql_limit = param.Integer(default=None, bounds=(1, None), doc="""
+        The max number of rows to return in all SQL queries.""")
+
     _valid_keys: ClassVar[Literal['params']] = 'params'
     _validate_params: ClassVar[bool] = True
 

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -101,6 +101,9 @@ class Config(Component):
         Callback that fires when a pipeline is updated. The updated
         pipeline is passed as the first argument.""")
 
+    raise_with_notifications = param.Boolean(default=True, constant=True, doc="""
+        Whether to raise exceptions when notifications are enabled.""")
+
     reloadable = param.Boolean(default=True, constant=True, doc="""
         Whether to allow reloading data from source(s) using a button.""")
 

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -523,12 +523,15 @@ class Pipeline(Viewer, Component):
         filt: Transform
            The Transform instance to add.
         """
+        fields = list(self.schema)
         if isinstance(transform, str):
             transform = Transform._get_type(transform)(**kwargs)
-            fields = list(self.schema)
             for fparam in transform._field_params:
                 transform.param[fparam].objects = fields
                 transform.param.update(**{fparam: kwargs.get(fparam, fields)})
+        else:
+            for fparam in transform._field_params:
+                transform.param[fparam].objects = fields
         if isinstance(transform, SQLTransform):
             self.sql_transforms.append(transform)
         else:

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -191,7 +191,7 @@ class Pipeline(Viewer, Component):
         self._update_data()
 
     def __panel__(self) -> pn.Row:
-        return pn.Row(self.control_panel, self.param.data)
+        return pn.Row(self.control_panel, pn.widgets.Tabulator(self.param.data, pagination='remote'))
 
     def to_spec(self, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
         """
@@ -287,6 +287,11 @@ class Pipeline(Viewer, Component):
         for transform in self.transforms:
             data = transform.apply(data)
         return data
+
+    def get_schema(self):
+        if self._stale:
+            self._update_data(force=True)
+        return get_dataframe_schema(self.data)['items']['properties']
 
     @catch_and_notify
     def _update_data(self, *events: param.parameterized.Event, force: bool = False):

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -525,14 +525,14 @@ class Pipeline(Viewer, Component):
         """
         if isinstance(transform, str):
             transform = Transform._get_type(transform)(**kwargs)
+            fields = list(self.schema)
+            for fparam in transform._field_params:
+                transform.param[fparam].objects = fields
+                transform.param.update(**{fparam: kwargs.get(fparam, fields)})
         if isinstance(transform, SQLTransform):
             self.sql_transforms.append(transform)
         else:
             self.transforms.append(transform)
-        fields = list(self.schema)
-        for fparam in transform._field_params:
-            transform.param[fparam].objects = fields
-            transform.param.update(**{fparam: kwargs.get(fparam, fields)})
         transform.param.watch(self._update_data, list(transform.param))
         self._stale = True
 

--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -1,5 +1,7 @@
 import datetime as dt
 
+from typing import Any, Dict
+
 import numpy as np
 import pandas as pd
 import param  # type: ignore
@@ -290,7 +292,9 @@ class AE5Source(Source):
         return getattr(self, f'_get_{table}')()
 
     @cached_schema
-    def get_schema(self, table=None):
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         schemas = {}
         for t in self._tables:
             if table is None or t == table:

--- a/lumen/sources/ae5.py
+++ b/lumen/sources/ae5.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 
 from typing import Any, Dict

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -417,16 +417,20 @@ class Source(MultiTypeComponent):
         """
 
     @cached_schema
-    def get_schema(self, table: str | None = None) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         """
         Returns JSON schema describing the tables returned by the
         Source.
 
         Parameters
         ----------
-        table : str or None
+        table : str | None
             The name of the table to return the schema for. If None
             returns schema for all available tables.
+        limit : int | None
+            Limits the number of rows considered for the schema calculation
 
         Returns
         -------
@@ -479,7 +483,9 @@ class RESTSource(Source):
     source_type: ClassVar[str] = 'rest'
 
     @cached_schema
-    def get_schema(self, table: str | None = None) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         query = {} if table is None else {'table': table}
         response = requests.get(self.url+'/schema', params=query)
         return {table: schema['items']['properties'] for table, schema in
@@ -503,7 +509,9 @@ class InMemorySource(Source):
     def get_tables(self) -> list[str]:
         return list(self.tables)
 
-    def get_schema(self, table: str | None = None) -> Dict[str, Any]:
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         if table:
             df = self.get(table)
             return get_dataframe_schema(df)['items']['properties']
@@ -765,7 +773,9 @@ class WebsiteSource(Source):
     source_type: ClassVar[str] = 'live'
 
     @cached_schema
-    def get_schema(self, table: str | None = None) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         schema = {
             "status": {
                 "url": {"type": "string", 'enum': self.urls},
@@ -812,7 +822,9 @@ class PanelSessionSource(Source):
     source_type: ClassVar[str] = 'session_info'
 
     @cached_schema
-    def get_schema(self, table: str | None = None) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         schema = {
             "summary": {
                 "url": {"type": "string", "enum": self.urls},
@@ -952,7 +964,9 @@ class JoinedSource(Source):
         return list(self.tables)
 
     @cached_schema
-    def get_schema(self, table: str | None = None) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         schemas: Dict[str, Dict[str, Any]] = {}
         for name, specs in self.tables.items():
             if table is not None and name != table:

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -440,7 +440,6 @@ class Source(MultiTypeComponent):
                 continue
             df = self.get(name, __dask=True)
             schemas[name] = get_dataframe_schema(df)['items']['properties']
-
         try:
             return schemas if table is None else schemas[table]
         except KeyError as e:
@@ -507,9 +506,9 @@ class InMemorySource(Source):
     def get_schema(self, table: str | None = None) -> Dict[str, Any]:
         if table:
             df = self.get(table)
-            return get_dataframe_schema(df)
+            return get_dataframe_schema(df)['items']['properties']
         else:
-            return {t: get_dataframe_schema(self.get(t)) for t in self.get_tables()}
+            return {t: get_dataframe_schema(self.get(t))['items']['properties'] for t in self.get_tables()}
 
     def get(self, table: str, **query) -> pd.DataFrame:
         dask = query.pop('__dask', False)

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -120,9 +120,12 @@ class DuckDBSource(Source):
                 distinct = self._connection.execute(distinct_expr).fetch_df()
                 schema[col]['enum'] = distinct[col].tolist()
 
-            minmax_expr = SQLMinMax(columns=min_maxes).apply(sql_expr)
-            minmax_expr = ' '.join(minmax_expr.splitlines())
-            minmax_data = self._connection.execute(minmax_expr).fetch_df()
+            if min_maxes:
+                minmax_expr = SQLMinMax(columns=min_maxes).apply(sql_expr)
+                minmax_expr = ' '.join(minmax_expr.splitlines())
+                minmax_data = self._connection.execute(minmax_expr).fetch_df()
+            else:
+                minmax_data = None
             for col in min_maxes:
                 kind = data[col].dtype.kind
                 if kind in 'iu':

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -107,6 +107,7 @@ class DuckDBSource(Source):
                     min_maxes.append(name)
             for col in enums:
                 distinct_expr = SQLDistinct(columns=[col]).apply(sql_expr)
+                distinct_expr = SQLLimit(limit=5).apply(distinct_expr)  # TODO REMOVE THIS
                 distinct_expr = ' '.join(distinct_expr.splitlines())
                 distinct = self._connection.execute(distinct_expr).fetch_df()
                 schema[col]['enum'] = distinct[col].tolist()

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict
 
 import duckdb

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -28,7 +28,6 @@ class IntakeBaseSource(Source):
                     self.param.warning(
                         f"Could not load {entry.name!r} table with dask."
                     )
-        print(entry)
         return entry.read()
 
     def get_tables(self):

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -20,7 +20,6 @@ class IntakeBaseSource(Source):
     __abstract = True
 
     def _read(self, entry, dask=True):
-        print(entry)
         if self.dask or dask:
             try:
                 return entry.to_dask()

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -39,6 +39,7 @@ class IntakeBaseSource(Source):
     ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         schemas = {}
         for entry in list(self.cat):
+            print(entry)
             if table is not None and entry != table:
                 continue
             elif not self.load_schema:

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -28,6 +28,7 @@ class IntakeBaseSource(Source):
                     self.param.warning(
                         f"Could not load {entry.name!r} table with dask."
                     )
+        print(entry)
         return entry.read()
 
     def get_tables(self):
@@ -39,7 +40,6 @@ class IntakeBaseSource(Source):
     ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         schemas = {}
         for entry in list(self.cat):
-            print(entry)
             if table is not None and entry != table:
                 continue
             elif not self.load_schema:

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -20,6 +20,7 @@ class IntakeBaseSource(Source):
     __abstract = True
 
     def _read(self, entry, dask=True):
+        print(entry)
         if self.dask or dask:
             try:
                 return entry.to_dask()

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import intake  # type: ignore
 import param  # type: ignore
 
@@ -30,7 +32,9 @@ class IntakeBaseSource(Source):
         return list(self.cat)
 
     @cached_schema
-    def get_schema(self, table=None):
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         schemas = {}
         for entry in list(self.cat):
             if table is not None and entry != table:

--- a/lumen/sources/intake.py
+++ b/lumen/sources/intake.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict
 
 import intake  # type: ignore

--- a/lumen/sources/intake_dremio.py
+++ b/lumen/sources/intake_dremio.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import param  # type: ignore
 
 from .intake_sql import IntakeBaseSQLSource

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import param  # type: ignore
 
 from ..transforms.base import Filter
@@ -68,14 +70,16 @@ class IntakeBaseSQLSource(IntakeBaseSource):
         return df if dask or not hasattr(df, 'compute') else df.compute()
 
     @cached_schema
-    def get_schema(self, table=None):
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         if table is None:
             tables = self.get_tables()
         else:
             tables = [table]
 
         schemas = {}
-        limit = SQLLimit(limit=1)
+        sql_limit = SQLLimit(limit=limit or 1)
         for entry in tables:
             if not self.load_schema:
                 schemas[entry] = {}
@@ -84,8 +88,11 @@ class IntakeBaseSQLSource(IntakeBaseSource):
             if not hasattr(source, '_sql_expr'):
                 schemas[entry] = super().get_schema(table)
                 continue
-            data = self._read(self._apply_transforms(source, [limit]))
+            data = self._read(self._apply_transforms(source, [sql_limit]))
             schema = get_dataframe_schema(data)['items']['properties']
+            if limit:
+                schemas[entry] = schema
+                continue
             enums, min_maxes = [], []
             for name, col_schema in schema.items():
                 if 'enum' in col_schema:

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict
 
 import param  # type: ignore

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -40,6 +40,9 @@ class IntakeBaseSQLSource(IntakeBaseSource):
             ) from e
         return source
 
+    def get_sql_expr(self, table):
+        return self._get_source(table)._sql_expr
+
     @cached
     def get(self, table, **query):
         '''

--- a/lumen/sources/intake_sql.py
+++ b/lumen/sources/intake_sql.py
@@ -107,9 +107,12 @@ class IntakeBaseSQLSource(IntakeBaseSource):
                     self._apply_transforms(source, distinct_transforms)
                 )
                 schema[col]['enum'] = distinct[col].to_list()
-            minmax_data = self._read(
-                self._apply_transforms(source, [SQLMinMax(columns=min_maxes)])
-            )
+            if min_maxes:
+                minmax_data = self._read(
+                    self._apply_transforms(source, [SQLMinMax(columns=min_maxes)])
+                )
+            else:
+                minmax_data = None
             for col in min_maxes:
                 kind = data[col].dtype.kind
                 if kind in 'iu':

--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 import urllib.parse as urlparse
 

--- a/lumen/sources/prometheus.py
+++ b/lumen/sources/prometheus.py
@@ -3,6 +3,7 @@ import urllib.parse as urlparse
 
 from collections import defaultdict
 from concurrent import futures
+from typing import Any, Dict
 
 import pandas as pd
 import panel as pn
@@ -218,7 +219,9 @@ class PrometheusSource(Source):
         else:
             return pd.DataFrame(columns=list(self.get_schema('timeseries')))
 
-    def get_schema(self, table=None):
+    def get_schema(
+        self, table: str | None = None, limit: int | None = None
+    ) -> Dict[str, Dict[str, Any]] | Dict[str, Any]:
         dt_start, dt_end = self._format_timestamps()
         schema = {
             "id": {

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -309,7 +309,7 @@ class Aggregate(Transform):
     by = param.ListSelector(doc="""
         Columns or indexes to group by.""")
 
-    columns = param.ListSelector(doc="""
+    columns = param.ListSelector(allow_None=True, doc="""
         Columns to aggregate.""")
 
     with_index = param.Boolean(default=True, doc="""
@@ -327,7 +327,6 @@ class Aggregate(Transform):
 
     def apply(self, table: DataFrame) -> DataFrame:
         grouped = table.groupby(self.by)
-        [c for c in table.select_dtypes(include='number').columns if c not in self.by]
         if self.columns:
             cols = self.columns
         else:
@@ -502,7 +501,9 @@ class Compute(Transform):
     transform_type: ClassVar[str] = 'compute'
 
     def apply(self, table: DataFrame) -> DataFrame:
-        return table.compute()
+        if hasattr(table, 'compute'):
+            return table.compute()
+        return table
 
 
 class Pivot(Transform):

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -456,7 +456,7 @@ class Unstack(Transform):
 
 class Iloc(Transform):
     """
-    `Iloc` applies integer slicing to the data, see `pandas.DataFrame.iloc`.
+    `Iloc` allows selecting the data with integer indexing, see `pandas.DataFrame.iloc`.
 
     `df.iloc[<start>:<end>]`
     """

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -303,6 +303,8 @@ class Aggregate(Transform):
     """
     `Aggregate` one or more columns or indexes, see `pandas.DataFrame.groupby`.
 
+    `by` must be provided.
+
     `df.groupby(<by>)[<columns>].<method>()[.reset_index()]`
     """
 
@@ -315,8 +317,8 @@ class Aggregate(Transform):
     with_index = param.Boolean(default=True, doc="""
         Whether to make the groupby columns indexes.""")
 
-    method = param.String(default=None, doc="""
-        Name of aggregation method.""")
+    method = param.String(default="mean", doc="""
+        Name of the pandas aggregation method, e.g. max, min, count.""")
 
     kwargs = param.Dict(default={}, doc="""
         Keyword arguments to the aggregation method.""")

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -102,13 +102,13 @@ class SQLLimit(SQLTransform):
             template = """
                 SELECT
                     *
-                FROM ( {sql_in} )
-                LIMIT {limit}
+                FROM ( {{sql_in}} )
+                LIMIT {{limit}}
             """
             return self._render_template(template, sql_in=sql_in, limit=self.limit)
         else:
             # more efficiently apply limit directly to the query
-            template = "{sql_in} LIMIT {limit}"
+            template = "{{sql_in}} LIMIT {{limit}}"
             return self._render_template(template, sql_in=sql_in, limit=self.limit)
 
 

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import re
 import textwrap
 
 from typing import Any, ClassVar
@@ -98,18 +97,13 @@ class SQLLimit(SQLTransform):
     transform_type: ClassVar[str] = 'sql_limit'
 
     def apply(self, sql_in):
-        if re.search(r'\bLIMIT\b', sql_in, re.IGNORECASE):
-            template = """
-                SELECT
-                    *
-                FROM ( {{sql_in}} )
-                LIMIT {{limit}}
-            """
-            return self._render_template(template, sql_in=sql_in, limit=self.limit)
-        else:
-            # more efficiently apply limit directly to the query
-            template = "{{sql_in}} LIMIT {{limit}}"
-            return self._render_template(template, sql_in=sql_in, limit=self.limit)
+        template = """
+            SELECT
+                *
+            FROM ( {{sql_in}} )
+            LIMIT {{limit}}
+        """
+        return self._render_template(template, sql_in=sql_in, limit=self.limit)
 
 
 class SQLDistinct(SQLTransform):

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -227,4 +227,12 @@ class SQLFilter(SQLTransform):
         return self._render_template(template, sql_in=sql_in, conditions=' AND '.join(conditions))
 
 
+class SQLOverride(SQLTransform):
+
+    override = param.String()
+
+    def apply(self, sql_expr):
+        return self.override
+
+
 __all__ = [name for name, obj in locals().items() if isinstance(obj, type) and issubclass(obj, SQLTransform)]

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -314,6 +314,8 @@ def catch_and_notify(message=None):
                         f"{func.__qualname__!r} raised {type(e).__name__}: {e}"
                     )
                     state.notifications.error(message.format(e=e))
+                    if session_state.config and session_state.config.raise_with_notifications:
+                        raise e
                 else:
                     raise e
         return wrapper

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -660,7 +660,7 @@ class IndicatorView(View):
 class hvPlotBaseView(View):
 
     kind = param.Selector(
-        default=None, doc="The kind of plot, e.g. 'scatter' or 'line'.",
+        default="scatter", doc="The kind of plot, e.g. 'scatter' or 'line'.",
         objects=[
             'area', 'bar', 'barh', 'bivariate', 'box', 'contour', 'contourf',
             'errorbars', 'hist', 'image', 'kde', 'labels',
@@ -672,9 +672,9 @@ class hvPlotBaseView(View):
 
     y = param.Selector(doc="The column to render on the y-axis.")
 
-    by = param.ListSelector(doc="The column(s) to facet the plot by.")
+    by = param.ListSelector(doc="The column(s) to facet the plot by.", allow_None=True)
 
-    groupby = param.ListSelector(doc="The column(s) to group by.")
+    groupby = param.ListSelector(doc="The column(s) to group by.", allow_None=True)
 
     _field_params = ['x', 'y', 'by', 'groupby']
 

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -672,9 +672,9 @@ class hvPlotBaseView(View):
 
     y = param.Selector(doc="The column to render on the y-axis.")
 
-    by = param.ListSelector(doc="The column(s) to facet the plot by.", allow_None=True)
+    by = param.ListSelector(doc="The column(s) to facet the plot by.")
 
-    groupby = param.ListSelector(doc="The column(s) to group by.", allow_None=True)
+    groupby = param.ListSelector(doc="The column(s) to group by.")
 
     _field_params = ['x', 'y', 'by', 'groupby']
 

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -669,6 +669,8 @@ class hvPlotBaseView(View):
 
     groupby = param.ListSelector(doc="The column(s) to group by.")
 
+    _field_params = ['x', 'y', 'by', 'groupby']
+
     __abstract = True
 
     def __init__(self, **params):
@@ -736,8 +738,6 @@ class hvPlotView(hvPlotBaseView):
         on the plot.""")
 
     view_type = 'hvplot'
-
-    _field_params = ['x', 'y', 'by', 'groupby']
 
     _ignore_kwargs = ['tables']
 

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -659,7 +659,14 @@ class IndicatorView(View):
 
 class hvPlotBaseView(View):
 
-    kind = param.String(default=None, doc="The kind of plot, e.g. 'scatter' or 'line'.")
+    kind = param.Selector(
+        default=None, doc="The kind of plot, e.g. 'scatter' or 'line'.",
+        objects=[
+            'area', 'bar', 'barh', 'bivariate', 'box', 'contour', 'contourf',
+            'errorbars', 'hist', 'image', 'kde', 'labels',
+            'line', 'scatter', 'heatmap', 'hexbin', 'ohlc', 'points', 'step', 'violin'
+        ]
+    )
 
     x = param.Selector(doc="The column to render on the x-axis.")
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ dependencies = [
     "hvplot",
     "holoviews >=1.17.0",
     "packaging",
-    "intake",
+    "intake <2",
     "jinja2 >3.0"
 ]
 


### PR DESCRIPTION
Took me a while to pin this down to prevent the interface from freezing.

It was hanging in `pipeline.to_spec`. Specifically, when it calls `self.param.values()`, that calls `wrapped` in `lumen/sources/base.py`, which calls the underlying `df = method(self, table, **cache_query)` which loads the data.

My reproduction basically re-samples a dataset n-times, concatenates, and exports as parquet, but I noticed if it's not duckdb, potentially we could `use_dask` for other cases?