### PR TITLE
fix regressions with icon

### DIFF
--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -110,7 +110,7 @@ class Assistant(Viewer):
         else:
             interface.callback = self._chat_invoke
         interface.callback_exception = "raise"
-        interface.reaction_icons = {"like": "thumb-up", "dislike": "thumb-down"}
+        interface.message_params["reaction_icons"] = {"like": "thumb-up", "dislike": "thumb-down"}
 
         self._session_id = id(self)
 


### PR DESCRIPTION
Noticed that the icons disappeared.

<img width="370" alt="image" src="https://github.com/holoviz/lumen/assets/15331990/9c13fefc-fc91-42a0-a61a-8ef5b858435b">

Fixed here:

<img width="177" alt="image" src="https://github.com/holoviz/lumen/assets/15331990/677e8b89-b786-4471-a48e-89078b077c4d">
