### PR TITLE
limit schema

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -168,6 +168,7 @@ class Agent(Viewer):
                 spec["min"] = spec.pop("inclusiveMinimum")
             if "inclusiveMaximum" in spec:
                 spec["max"] = spec.pop("inclusiveMaximum")
+        schema = format_schema(schema)
         return schema
 
 


### PR DESCRIPTION
I started getting these `error': {'message': 'Request too large for gpt-3.5-turbo in organization org-on tokens per min (TPM): Limit 60000, Requested 567588. The input or output tokens must be reduced in order to run successfully. Visit https://platform.openai.com/account/rate-limits to learn more.', 'type': 'tokens', 'param': None, 'code': 'rate_limit_exceeded'}}` (maybe because my credits expired)

This made me dig into it and I discovered we were passing a schema with many many enums for strings.

<img width="631" alt="image" src="https://github.com/holoviz/lumen/assets/15331990/d6a19458-c5b9-46ac-bcc3-ac580b457be5">