### PR TITLE
Drop redundant inputs

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -449,7 +449,7 @@ class LumenBaseAgent(Agent):
             if isinstance(df[col].iloc[0], pd.Timestamp):
                 df[col] = pd.to_datetime(df[col])
 
-        df_describe_dict = df.describe(percentiles=[]).to_dict()
+        df_describe_dict = df.describe(percentiles=[], exclude=["min", "max"]).to_dict()
 
         for col in df.select_dtypes(include=["object"]).columns:
             if col not in df_describe_dict:
@@ -483,15 +483,6 @@ class LumenBaseAgent(Agent):
         for col in df.select_dtypes(include=["float64"]).columns:
             df[col] = df[col].apply(format_float)
 
-        df_head_dict = {}
-        for col in df.columns:
-            df_head_dict[col] = df[col].head(10)
-            # if all nan or none, replace with None
-            if df_head_dict[col].isnull().all():
-                df_head_dict[col] = ["all null"]
-            else:
-                df_head_dict[col] = df_head_dict[col].tolist()
-
         data = {
             "summary": {
                 "total_table_cells": size,
@@ -499,7 +490,6 @@ class LumenBaseAgent(Agent):
                 "is_summarized": is_summarized,
             },
             "stats": df_describe_dict,
-            "head": df_head_dict
         }
 
         return data


### PR DESCRIPTION
Doing evals and noticed that min/max are already in the schema; there's no need to waste tokens on it in the summary.

Also, head is wastes a lot of tokens and exists in the `enum` of the schema already. Not so important for numeric values.

"""
Be a helpful chatbot to talk about high-level data exploration like what datasets are available and what each column represents. Provide suggestions to get started if necessary.Be a helpful chatbot to talk about high-level data exploration like what datasets are available and what each column represents. Provide suggestions to get started if necessary.

CONTEXT: windturbines with schema: {'case_id': {'type': 'integer', 'min': 3000001, 'max': 3125948}, 'faa_ors': {'type': 'string', 'enum': ['39-003863', '19-020351', '19-020377', '19-020448', '19-058716', '...']}, 'faa_asn': {'type': 'string', 'enum': ['2016-WTE-5934-OE', '2013-WTE-5497-OE', '2018-WTE-9908-OE', '2018-WTE-9870-OE', '2018-WTE-9867-OE', '...']}, 'usgs_pr_id': {'type': 'number', 'min': 1.0, 'max': 49135.0}, 'eia_id': {'type': 'number', 'min': 90.0, 'max': 65525.0}, 't_state': {'type': 'string', 'enum': ['OH', 'IN', 'CO', 'OR', 'AK', '...']}, 't_county': {'type': 'string', 'enum': ['Adams County', 'Bureau County', 'Brown County', 'Rush County', 'Cambria County', '...']}, 't_fips': {'type': 'integer', 'min': 2013, 'max': 72133}, 'p_name': {'type': 'string', 'enum': ['Agriwind', 'Ainsworth Wind Project (NPPD)', 'Alta III', 'Amazon Wind Farm (Fowler Ridge)', 'Anacacho', '...']}, 'p_year': {'type': 'number', 'min': 1981.0, 'max': 2022.0}, 'p_tnum': {'type': 'integer', 'min': 1, 'max': 731}, 'p_cap': {'type': 'number', 'min': 0.05, 'max': 1055.6}, 't_manu': {'type': 'string', 'enum': ['PowerWind', 'Zond', 'Sinovel', 'Vergnet', 'Guodian', '...']}, 't_model': {'type': 'string', 'enum': ['SWT-2.3-108', 'ECO 86', 'V82-1.65', 'FL1500', 'GE2.85-103', '...']}, 't_cap': {'type': 'number', 'min': 50.0, 'max': 6000.0}, 't_hh': {'type': 'number', 'min': 19.0, 'max': 137.0}, 't_rd': {'type': 'number', 'min': 13.4, 'max': 162.0}, 't_rsa': {'type': 'number', 'min': 141.03, 'max': 20611.99}, 't_ttlh': {'type': 'number', 'min': 30.4, 'max': 205.4}, 'retrofit': {'type': 'integer', 'min': 0, 'max': 1}, 'retrofit_year': {'type': 'number', 'min': 2015.0, 'max': 2021.0}, 't_conf_atr': {'type': 'integer', 'min': 1, 'max': 3}, 't_conf_loc': {'type': 'integer', 'min': 1, 'max': 3}, 't_img_date': {'type': 'string', 'format': 'datetime', 'min': '1993-06-14 00:00:00', 'max': '2022-09-06 00:00:00'}, 't_img_srce': {'type': 'string', 'enum': ['Google Earth', 'NAIP', 'Digital Globe', 'Bing Maps Aerial']}, 'xlong': {'type': 'number', 'min': -171.713074, 'max': 144.722656}, 'ylat': {'type': 'number', 'min': 13.389381, 'max': 66.839905}, 'easting': {'type': 'number', 'min': -19115011.960227706, 'max': 16110452.372170098}, 'northing': {'type': 'number', 'min': 1504253.4146257618, 'max': 10110596.985745305}}
Here's a summary of the dataset the user just asked about:

{'summary': {'total_table_cells': 2098353, 'total_shape': (72357, 29), 'is_summarized': True}, 'stats': {'case_id': {'count': '5000', 'mean': '3.1e+06', 'min': '3000008', '50%': '3.1e+06', 'max': '3125919', 'std': '3.5e+04', 'nulls': '0'}, 'usgs_pr_id': {'count': '2630', 'mean': '2.8e+04', 'min': '19', '50%': '2.9e+04', 'max': '49121', 'std': '1.3e+04', 'nulls': '2370'}, 'eia_id': {'count': '4632', 'mean': '5.8e+04', 'min': '90', '50%': '57834', 'max': '65129', 'std': '6.4e+03', 'nulls': '368'}, 't_fips': {'count': '5000', 'mean': '3.2e+04', 'min': '2050', '50%': '36019', 'max': '72133', 'std': '1.5e+04', 'nulls': '0'}, 'p_year': {'count': '4960', 'mean': '2.0e+03', 'min': '1981', '50%': '2012', 'max': '2022', 'std': '8.1', 'nulls': '40'}, 'p_tnum': {'count': '5000', 'mean': '1.0e+02', 'min': '1', '50%': '84', 'max': '731', 'std': '93.6', 'nulls': '0'}, 'p_cap': {'count': '4780', 'mean': '1.8e+02', 'min': '0.1', '50%': '1.6e+02', 'max': '1.1e+03', 'std': '1.4e+02', 'nulls': '220'}, 't_cap': {'count': '4697', 'mean': '2.0e+03', 'min': '50', '50%': '2000', 'max': '5600', 'std': '7.7e+02', 'nulls': '303'}, 't_hh': {'count': '4662', 'mean': '81.5', 'min': '22.8', '50%': '80', 'max': '137', 'std': '12.5', 'nulls': '338'}, 't_rd': {'count': '4665', 'mean': '97.6', 'min': '15', '50%': '100', 'max': '162', 'std': '24.1', 'nulls': '335'}, 't_rsa': {'count': '4665', 'mean': '7.9e+03', 'min': '1.8e+02', '50%': '7.9e+03', 'max': '2.1e+04', 'std': '3.5e+03', 'nulls': '335'}, 't_ttlh': {'count': '4661', 'mean': '1.3e+02', 'min': '30.4', '50%': '1.3e+02', 'max': '2.1e+02', 'std': '23.1', 'nulls': '339'}, 'retrofit': {'count': '5000', 'mean': '0.1', 'min': '0', '50%': '0', 'max': '1', 'std': '0.3', 'nulls': '0'}, 'retrofit_year': {'count': '446', 'mean': '2.0e+03', 'min': '2017', '50%': '2019', 'max': '2021', 'std': '1.3', 'nulls': '4554'}, 't_conf_atr': {'count': '5000', 'mean': '2.8', 'min': '1', '50%': '3', 'max': '3', 'std': '0.6', 'nulls': '0'}, 't_conf_loc': {'count': '5000', 'mean': '2.9', 'min': '1', '50%': '3', 'max': '3', 'std': '0.4', 'nulls': '0'}, 't_img_date': {'count': '4473', 'mean': '2018-07-05 07:59:40.684104', 'min': '2006-01-01 00:00:00', '50%': '2018-11-03 00:00:00', 'max': '2022-09-06 00:00:00', 'std': 'nan', 'nulls': '527'}, 'xlong': {'count': '5000', 'mean': '-1.0e+02', 'min': '-1.7e+02', '50%': '-99.4', 'max': '1.4e+02', 'std': '11.8', 'nulls': '0'}, 'ylat': {'count': '5000', 'mean': '38.4', 'min': '13.4', '50%': '39.0', 'max': '64.6', 'std': '5.4', 'nulls': '0'}, 'easting': {'count': '5000', 'mean': '-1.1e+07', 'min': '-1.9e+07', '50%': '-1.1e+07', 'max': '1.6e+07', 'std': '1.3e+06', 'nulls': '0'}, 'northing': {'count': '5000', 'mean': '4.7e+06', 'min': '1.5e+06', '50%': '4.7e+06', 'max': '9.5e+06', 'std': '7.7e+05', 'nulls': '0'}, 'faa_ors': {'nunique': 4613, 'lengths': {'max': 9.0, 'min': 9.0, 'mean': 9.0}, 'nulls': 387}, 'faa_asn': {'nunique': 4603, 'lengths': {'max': 17.0, 'min': 13.0, 'mean': 16.03464703334777}, 'nulls': 382}, 't_state': {'nunique': 40, 'lengths': {'max': 2, 'min': 2, 'mean': 2.0}, 'nulls': 0}, 't_county': {'nunique': 419, 'lengths': {'max': 25, 'min': 4, 'mean': 13.5426}, 'nulls': 0}, 'p_name': {'nunique': 1091, 'lengths': {'max': 42, 'min': 3, 'mean': 14.3678}, 'nulls': 0}, 't_manu': {'nunique': 35, 'lengths': {'max': 31.0, 'min': 4.0, 'mean': 7.524541186513018}, 'nulls': 314}, 't_model': {'nunique': 206, 'lengths': {'max': 14.0, 'min': 2.0, 'mean': 8.533561351004703}, 'nulls': 322}, 't_img_srce': {'nunique': 4, 'lengths': {'max': 16, 'min': 4, 'mean': 12.4794}, 'nulls': 0}}, 'head': {'case_id': [3072661, 3046262, 3025813, 3025834, 3025873, 3052618, 3052662, 3053006, 3034125, 3015365], 'faa_ors': [None, '25-025115', '19-020360', '19-020381', '19-020299', '19-027753', '19-027892', '19-027806', '27-021080', '31-001289'], 'faa_asn': [None, '2013-WTE-5497-OE', '2018-WTE-9849-OE', '2018-WTE-9871-OE', '2018-WTE-9912-OE', '2015-WTE-18-OE', '2015-WTE-23-OE', '2015-WTE-44-OE', '2010-WTE-10526-OE', '2005-ACE-2369-OE'], 'usgs_pr_id': ['5149', '26723', '18460', '18404', '18324', nan, nan, nan, '29346', '33992'], 'eia_id': ['52161', '58661', '56810', '56810', '56810', '59637', '59637', '59637', '57375', '56162'], 't_state': ['CA', 'MA', 'IA', 'IA', 'IA', 'IA', 'IA', 'IA', 'MN', 'NE'], 't_county': ['Kern County', 'Barnstable County', 'Adair County', 'Adair County', 'Adair County', 'Adams County', 'Adams County', 'Adams County', 'Meeker County', 'Brown County'], 't_fips': [6029, 25001, 19001, 19001, 19001, 19003, 19003, 19003, 27093, 31017], 'p_name': ['251 Wind', '6th Space Warning Squadron', 'Adair', 'Adair', 'Adair', 'Adams', 'Adams', 'Adams', 'Adams Wind Generations, LLC', 'Ainsworth Wind Project (NPPD)'], 'p_year': ['1987', '2013', '2008', '2008', '2008', '2016', '2016', '2016', '2011', '2005'], 'p_tnum': [194, 2, 76, 76, 76, 64, 64, 64, 12, 36], 'p_cap': ['18.4', '3.4', '1.7e+02', '1.7e+02', '1.7e+02', '1.5e+02', '1.5e+02', '1.5e+02', '19.8', '59.4'], 't_manu': ['Vestas', 'GE Wind', 'Siemens', 'Siemens', 'Siemens', 'Siemens', 'Siemens', 'Siemens', 'Alstom', 'Vestas'], 't_model': [None, 'GE1.68-82.5', 'SWT-2.3-93', 'SWT-2.3-93', 'SWT-2.3-93', 'SWT-2.3-108', 'SWT-2.3-108', 'SWT-2.3-108', 'ECO 86', 'V82-1.65'], 't_cap': ['95', '1680', '2300', '2300', '2300', '2415', '2415', '2415', '1670', '1650'], 't_hh': [nan, '80', '80', '80', '80', '80', '80', '80', '80', '70'], 't_rd': [nan, '82.5', '93', '93', '93', '108', '108', '108', '85.5', '82'], 't_rsa': [nan, '5.3e+03', '6.8e+03', '6.8e+03', '6.8e+03', '9.2e+03', '9.2e+03', '9.2e+03', '5.7e+03', '5.3e+03'], 't_ttlh': [nan, '1.2e+02', '1.3e+02', '1.3e+02', '1.3e+02', '1.3e+02', '1.3e+02', '1.3e+02', '1.2e+02', '1.1e+02'], 'retrofit': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 'retrofit_year': ['all null'], 't_conf_atr': [2, 3, 2, 2, 2, 3, 3, 3, 3, 3], 't_conf_loc': [3, 3, 3, 3, 3, 3, 3, 3, 3, 3], 't_img_date': ['2018-05-08', '2019-09-01', '2018-10-28', '2019-10-31', '2018-10-28', '2017-02-18', '2017-02-18', '2017-02-18', '2019-02-08', '2018-05-09'], 't_img_srce': ['Digital Globe', 'Digital Globe', 'Digital Globe', 'Digital Globe', 'Digital Globe', 'Digital Globe', 'Digital Globe', 'Digital Globe', 'Digital Globe', 'Digital Globe'], 'xlong': ['-1.2e+02', '-70.5', '-94.6', '-94.7', '-94.7', '-94.6', '-94.7', '-94.6', '-94.7', '-99.9'], 'ylat': ['35.1', '41.8', '41.5', '41.5', '41.4', '40.9', '40.9', '40.9', '44.9', '42.5'], 'easting': ['-1.3e+07', '-7.9e+06', '-1.1e+07', '-1.1e+07', '-1.1e+07', '-1.1e+07', '-1.1e+07', '-1.1e+07', '-1.1e+07', '-1.1e+07'], 'northing': ['4.2e+06', '5.1e+06', '5.1e+06', '5.1e+06', '5.1e+06', '5.0e+06', '5.0e+06', '5.0e+06', '5.6e+06', '5.2e+06']}}
"""