### PR TITLE
remove need for sql expr

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -740,7 +740,6 @@ class SQLAgent(LumenBaseAgent):
         tables_sql_schemas = {
             table: {
                 "schema": self._get_schema(source, table, include_min_max=False),
-                 "sql": source.get_sql_expr(table)
             } for table in tables
         }
         sql_prompt = render_template(

--- a/lumen/ai/prompts/sql_query.jinja2
+++ b/lumen/ai/prompts/sql_query.jinja2
@@ -1,15 +1,10 @@
 {% for table, details in tables_sql_schemas.items() %}
-The SQL expression for the table '{{ table }}' is '{{ details.sql }}'.
 
 The data for table '{{ table }}' follows the following JSON schema:
 
 ```json
 {{ details.schema }}
-Only use columns from the schema for '{{ details.sql }}'.
-
-{% if "read_parquet" in details.sql %}
-Be sure to include `FROM read_parquet` in your query.
-{% endif %}
+```
 {% endfor %}
 
 If no limit is specified, specify 10000 as the limit.


### PR DESCRIPTION
The `read_parquet` part is quite finicky since the LLM isn't used to seeing and writing SQL expressions with `read_parquet` included. This led to work on targeted retries such as: https://github.com/holoviz/lumen/pull/572/files#diff-d56253257f94b517eb742b1213dec9b7ccb3fafa7416be4044987ccd54ed3c83R751-R752

However, I discovered, duckdb actually supports reading parquet files directly IF the file extension ends with `.parquet` instead of `.parq` https://duckdb.org/docs/api/python/data_ingestion.html

<img width="736" alt="image" src="https://github.com/holoviz/lumen/assets/15331990/5a0f3111-4afd-4a0a-9ccd-9fd2b987f783">

<img width="1298" alt="image" src="https://github.com/holoviz/lumen/assets/15331990/7c085fac-d9ba-44b0-8b18-75bdfc3df6b9">
