### PR TITLE
fix multi transofrms

### DIFF
--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -81,7 +81,7 @@ class DuckDBSource(Source):
         if self.filter_in_sql:
             sql_transforms = [SQLFilter(conditions=conditions)] + sql_transforms
         for st in sql_transforms:
-            sql_expr = st.apply(sql_expr)
+            sql_expr = st.apply(sql_expr.rstrip(";"))
         df = self._connection.execute(sql_expr).fetch_df(date_as_object=True)
         if not self.filter_in_sql:
             df = Filter.apply_to(df, conditions=conditions)


### PR DESCRIPTION
Subtle bug that could result in incorrect placement of `;`.

For instance:

```
sql_query = "SELECT MAX(depth) AS max_depth FROM earthquakes;"
[SQLOverride(override=sql_query), SQLLimit(limit=1)]
```

Results in:
```
SELECT
    *
FROM ( SELECT MAX(depth) AS max_depth FROM earthquakes;) LIMIT 1
```