### PR TITLE
Add support for exporting notebooks from Lumen.ai

### DIFF
--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -18,6 +18,7 @@ from pydantic import create_model
 from pydantic.fields import FieldInfo
 
 from .agents import Agent, ChatAgent
+from .export import export_notebook
 from .llm import Llama, Llm
 from .logs import ChatLogs
 from .memory import memory
@@ -111,6 +112,10 @@ class Assistant(Viewer):
                 raise ValueError("No messages to download.")
             return StringIO(json.dumps(messages))
 
+        def download_notebook():
+            nb = export_notebook(self)
+            return StringIO(nb)
+
         if interface is None:
             interface = ChatInterface(
                 callback=self._chat_invoke, load_buffer=5,
@@ -154,7 +159,16 @@ class Assistant(Viewer):
             filename="favorited_messages.json",
             sizing_mode="stretch_width",
         )
-        self._controls = Column(download_button, self._current_agent, Tabs(("Memory", memory)))
+        notebook_button = FileDownload(
+            icon="notebook",
+            button_type="success",
+            callback=download_notebook,
+            filename="Lumen_ai.ipynb",
+            sizing_mode="stretch_width",
+        )
+        self._controls = Column(
+            download_button, notebook_button, self._current_agent, Tabs(("Memory", memory))
+        )
 
     def _add_suggestions_to_footer(self, suggestions: list[str], inplace: bool = True):
         async def hide_suggestions(_=None):

--- a/lumen/ai/export.py
+++ b/lumen/ai/export.py
@@ -1,0 +1,58 @@
+import datetime as dt
+import json
+
+import nbformat
+
+from lumen.ai.views import LumenOutput
+from lumen.pipeline import Pipeline
+from lumen.views import View
+
+
+def make_preamble():
+    now = dt.datetime.now()
+    header = nbformat.v4.new_markdown_cell(source=f'# Lumen.ai - Chat Logs {now}')
+    imports = nbformat.v4.new_code_cell(source="""\
+import lumen as lm
+import panel as pn
+
+pn.extension('tabulator')""")
+    return [header, imports]
+
+def format_markdown(msg):
+    if msg.avatar.startswith('https://'):
+        avatar = f'<img src="{msg.avatar}" width=45 height=45></img>'
+    else:
+        avatar = f'<span>{msg.avatar}</span>'
+    header = f'<div style="display: flex; flex-direction: row; font-weight: bold; font-size: 2em;">{avatar}<span style="margin-left: 0.5em">{msg.user}</span></div>'
+    prefix = '\n' if msg.user == 'User' else '\n> '
+    content = prefix.join(msg.serialize().split('\n'))
+    return [nbformat.v4.new_markdown_cell(source=f'{header}\n{prefix}{content}')]
+
+def format_output(msg):
+    output = msg.object
+    code = []
+    spec = json.dumps(output.component.to_spec(), indent=2).replace('true', 'True').replace('false', 'False')
+    if isinstance(output.component, Pipeline):
+        code.extend([
+            f'pipeline = lm.Pipeline.from_spec({spec})',
+            'pipeline'
+        ])
+    elif isinstance(output.component, View):
+        code.extend([
+            f'view = lm.View.from_spec({spec})',
+            'view'
+        ])
+    return [nbformat.v4.new_code_cell(source='\n'.join(code))]
+
+def export_notebook(assistant):
+    cells = make_preamble()
+    for msg in assistant.interface.objects:
+        if msg.user == 'Help':
+            continue
+        elif isinstance(msg.object, str):
+            cells += format_markdown(msg)
+        elif isinstance(msg.object, LumenOutput):
+            cells += format_output(msg)
+
+    nb = nbformat.v4.new_notebook(cells=cells)
+    return nbformat.v4.writes(nb)

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -20,6 +20,8 @@ class _Memory(Viewer):
 
     _views: ClassVar[WeakKeyDictionary[Document, Any]] = WeakKeyDictionary()
 
+    _global_view = None
+
     _global_context = {}
 
     @property
@@ -34,18 +36,18 @@ class _Memory(Viewer):
             return self._global_context
 
     def __contains__(self, key):
-        return key in self._curcontext
+        return key in self._curcontext or key in self._global_context
 
     def __getitem__(self, key):
         return self._curcontext[key]
 
     def __setitem__(self, key, value):
         self._curcontext[key] = value
-        if state.curdoc in self._views:
+        if state.curdoc in self._views or (state.curdoc is None and self._global_view is not None):
             self._update_view(key, value)
 
     def get(self, key, default=None):
-        obj = self._curcontext.get(key, default)
+        obj = dict(self._global_context, **self._curcontext).get(key, default)
         if hasattr(obj, "copy"):
             obj = obj.copy()
         return obj
@@ -54,7 +56,7 @@ class _Memory(Viewer):
         return self._curcontext.pop(key, default)
 
     def keys(self):
-        return self._curcontext.keys()
+        return dict(self._global_context, **self._curcontext).keys()
 
     def _render_item(self, key, item):
         if isinstance(item, Component):
@@ -72,7 +74,7 @@ class _Memory(Viewer):
         ), sizing_mode='stretch_width', active=list(range(len(self._curcontext))))
 
     def _update_view(self, key, value):
-        view = self._views[state.curdoc]
+        view = self._views[state.curdoc] if state.curdoc else self._global_view
         accordion = view[0]
         new_item = self._render_item(key, value)
         i = 0
@@ -85,7 +87,11 @@ class _Memory(Viewer):
             accordion.active = accordion.active + [i+1]
 
     def __panel__(self):
-        self._views[state.curdoc] = view = pn.Column(self._render_memories())
+        view = pn.Column(self._render_memories())
+        if state.curdoc is None:
+            self._global_view = view
+        else:
+            self._views[state.curdoc] = view
         return view
 
 

--- a/lumen/ai/prompts/check_validity.jinja2
+++ b/lumen/ai/prompts/check_validity.jinja2
@@ -1,7 +1,4 @@
-Based on the latest user's query, decide whether the
-current table and data contain all the required info to
-provide a reliable, accurate answer to the user's query.
-Return `is_invalid=True` if not; else return `is_invalid=False`.
+Based on the latest user's query, decide whether the current table and data contains the the required data. If the user is referencing "this data" or "that" they probably are referring to the current data. Pay particular attention to whether the data actually contains the columns required to answer the query, e.g. if they are asking for a location but there are no location related column the data is invalid.
 
 ### Current Table:
 ```

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -6,6 +6,7 @@ from functools import wraps
 from pathlib import Path
 
 import jinja2
+import pandas as pd
 
 from lumen.pipeline import Pipeline
 from lumen.sources.base import Source
@@ -104,3 +105,76 @@ def get_schema(
                 spec.pop("inclusiveMaximum")
     schema = format_schema(schema)
     return schema
+
+
+def describe_data(df: pd.DataFrame) -> str:
+    def format_float(num):
+        if pd.isna(num):
+            return num
+        # if is integer, round to 0 decimals
+        if num == int(num):
+            return f"{int(num)}"
+        elif 0.01 <= abs(num) < 100:
+            return f"{num:.1f}"  # Regular floating-point notation with two decimals
+        else:
+            return f"{num:.1e}"  # Exponential notation with two decimals
+
+    size = df.size
+    shape = df.shape
+    if size < 250:
+        return df
+
+    is_summarized = False
+    if shape[0] > 5000:
+        is_summarized = True
+        df = df.sample(5000)
+
+    df = df.sort_index()
+
+    for col in df.columns:
+        if isinstance(df[col].iloc[0], pd.Timestamp):
+            df[col] = pd.to_datetime(df[col])
+
+    df_describe_dict = df.describe(percentiles=[]).drop(["min", "max"]).to_dict()
+
+    for col in df.select_dtypes(include=["object"]).columns:
+        if col not in df_describe_dict:
+            df_describe_dict[col] = {}
+        df_describe_dict[col]["nunique"] = df[col].nunique()
+        try:
+            df_describe_dict[col]["lengths"] = {
+                "max": df[col].str.len().max(),
+                "min": df[col].str.len().min(),
+                "mean": float(df[col].str.len().mean()),
+            }
+        except AttributeError:
+            pass
+
+    for col in df.columns:
+        if col not in df_describe_dict:
+            df_describe_dict[col] = {}
+        df_describe_dict[col]["nulls"] = int(df[col].isnull().sum())
+
+    # select datetime64 columns
+    for col in df.select_dtypes(include=["datetime64"]).columns:
+        for key in df_describe_dict[col]:
+            df_describe_dict[col][key] = str(df_describe_dict[col][key])
+        df[col] = df[col].astype(str)  # shorten output
+
+    # select all numeric columns and round
+    for col in df.select_dtypes(include=["int64", "float64"]).columns:
+        for key in df_describe_dict[col]:
+            df_describe_dict[col][key] = format_float(df_describe_dict[col][key])
+
+    for col in df.select_dtypes(include=["float64"]).columns:
+        df[col] = df[col].apply(format_float)
+
+    data = {
+        "summary": {
+            "total_table_cells": size,
+            "total_shape": shape,
+            "is_summarized": is_summarized,
+        },
+        "stats": df_describe_dict,
+    }
+    return data

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -1,0 +1,155 @@
+import panel as pn
+import param
+import yaml
+
+from panel.viewable import Viewer
+
+from ..base import Component
+from ..dashboard import load_yaml
+from ..downloads import Download
+from ..pipeline import Pipeline
+from ..views.base import Table
+from .memory import memory
+from .utils import describe_data
+
+
+class LumenOutput(Viewer):
+
+    active = param.Integer(default=1)
+
+    component = param.ClassSelector(class_=Component)
+
+    spec = param.String()
+
+    language = "yaml"
+
+    def __init__(self, **params):
+        if 'spec' not in params and 'component' in params:
+            component_spec = params['component'].to_spec()
+            params['spec'] = yaml.safe_dump(component_spec)
+        super().__init__(**params)
+        code_editor = pn.widgets.CodeEditor(
+            value=self.spec, language=self.language, sizing_mode="stretch_both", min_height=300
+        )
+        code_editor.link(self, bidirectional=True, value='spec')
+        copy_icon = pn.widgets.ButtonIcon(
+            icon="copy", active_icon="check", toggle_duration=1000
+        )
+        copy_icon.js_on_click(
+            args={"code_editor": code_editor},
+            code="navigator.clipboard.writeText(code_editor.code);",
+        )
+        download_icon = pn.widgets.ButtonIcon(
+            icon="download", active_icon="check", toggle_duration=1000
+        )
+        download_icon.js_on_click(
+            args={"code_editor": code_editor},
+            code="""
+            var text = code_editor.code;
+            var blob = new Blob([text], {type: 'text/plain'});
+            var url = window.URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            a.download = 'lumen_spec.yaml';
+            document.body.appendChild(a); // we need to append the element to the dom -> otherwise it will not work in firefox
+            a.click();
+            a.parentNode.removeChild(a);  //afterwards we remove the element again
+            """,
+        )
+        icons = pn.Row(copy_icon, download_icon)
+        code_col = pn.Column(code_editor, icons, sizing_mode="stretch_both")
+        placeholder = pn.Column(sizing_mode="stretch_width")
+        self._tabs = pn.Tabs(
+            ("Code", code_col),
+            ("Output", placeholder),
+            styles={'min-width': "100%"}, active=1
+        )
+        self._tabs.link(self, bidirectional=True, active='active')
+        placeholder.objects = [
+            pn.pane.ParamMethod(self._render_component, inplace=True)
+        ]
+
+    @param.depends('spec', 'active')
+    async def _render_component(self):
+        yield pn.indicators.LoadingSpinner(
+            value=True, name="Rendering component...", height=50, width=50
+        )
+
+        if self.active != 1:
+            return
+
+        # store the spec in the cache instead of memory to save tokens
+        memory["current_spec"] = self.spec
+        try:
+            self.component = type(self.component).from_spec(load_yaml(self.spec))
+            if isinstance(self.component, Pipeline):
+                table = Table(
+                    pipeline=self.component, pagination='remote',
+                    height=458, page_size=12
+                )
+                download = Download(
+                    view=table, hide=False, filename=f'{self.component.table}',
+                    format='csv'
+                )
+                download_pane = download.__panel__()
+                download_pane.sizing_mode = 'fixed'
+                download_pane.styles = {'position': 'absolute', 'right': '-50px'}
+                output = pn.Column(download_pane, table)
+            else:
+                output = self.component.__panel__()
+            yield output
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            yield pn.pane.Alert(
+                f"```\n{e}\n```\nPlease press undo, edit the YAML, or continue chatting.",
+                alert_type="danger",
+            )
+
+    def __panel__(self):
+        return self._tabs
+
+
+class SQLOutput(LumenOutput):
+
+    language = "sql"
+
+    @param.depends('spec', 'active')
+    async def _render_component(self):
+        if self.active == 0:
+            yield pn.indicators.LoadingSpinner(
+                value=True, name="Executing SQL query...", height=50, width=50
+            )
+
+        source = memory["current_source"]
+        memory["current_table"] = self.name
+        source.add_table(self.name, self.spec)
+        try:
+            pipeline = Pipeline(source=source, table=self.name)
+            df = pipeline.data
+            if len(df) > 0:
+                memory["current_data"] = describe_data(df)
+            table = Table(
+                pipeline=pipeline, pagination='remote',
+                height=458, page_size=12
+            )
+            download = Download(
+                view=table, hide=False, filename=f'{self.component.table}',
+                format='csv'
+            )
+            download_pane = download.__panel__()
+            download_pane.sizing_mode = 'fixed'
+            download_pane.styles = {'position': 'absolute', 'right': '-50px'}
+            output = pn.Column(download_pane, table)
+            yield output
+            memory["current_pipeline"] = self.component = pipeline
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            yield pn.pane.Alert(
+                f"```\n{e}\n```\nPlease press undo, edit the YAML, or continue chatting.",
+                alert_type="danger",
+            )
+
+    def __panel__(self):
+        return self._tabs

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -58,6 +58,13 @@ class DuckDBSource(Source):
         for init in self.initializers:
             self._connection.execute(init)
 
+    def add_table(self, name, sql_expr):
+        if isinstance(self.tables, list):
+            self.tables = {
+                table: table for table in self.tables
+            }
+        self.tables[name] = sql_expr
+
     def get_tables(self):
         if isinstance(self.tables, (dict, list)):
             return list(self.tables)


### PR DESCRIPTION
This PR does a few things to make it possible to easily export Lumen.ai output to a notebook:

- Factor out the logic for rendering Lumen and SQL outputs into separate `Viewer` classes to make it easier to serialize the outputs
- Add support for using `lumen.ai.memory` in notebooks
- Add functions that take a `ChatInterface` and generate a notebook file from the list of messages.
- Add ability to dynamically define tables on a Source.  