### PR TITLE
Fix for all obj type df

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -135,7 +135,8 @@ def describe_data(df: pd.DataFrame) -> str:
         if isinstance(df[col].iloc[0], pd.Timestamp):
             df[col] = pd.to_datetime(df[col])
 
-    df_describe_dict = df.describe(percentiles=[]).drop(["min", "max"]).to_dict()
+    df_describe_dict = df.describe(percentiles=[]).drop(
+        ["min", "max"], errors="ignore").to_dict()
 
     for col in df.select_dtypes(include=["object"]).columns:
         if col not in df_describe_dict:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -135,8 +135,10 @@ def describe_data(df: pd.DataFrame) -> str:
         if isinstance(df[col].iloc[0], pd.Timestamp):
             df[col] = pd.to_datetime(df[col])
 
-    df_describe_dict = df.describe(percentiles=[]).drop(
-        ["min", "max"], errors="ignore").to_dict()
+    describe_df = df.describe(percentiles=[])
+    columns_to_drop = ["min", "max"] # present if any numeric
+    columns_to_drop = [col for col in columns_to_drop if col in describe_df.columns]
+    df_describe_dict = describe_df.drop(columns=columns_to_drop).to_dict()
 
     for col in df.select_dtypes(include=["object"]).columns:
         if col not in df_describe_dict:


### PR DESCRIPTION
If all the types are strings, then min/max will not appear and this will error.
![image](https://github.com/holoviz/lumen/assets/15331990/562221df-5fe2-462f-a5b4-81a2b50f363c)


```
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 6992, in drop
    raise KeyError(f"{labels[mask].tolist()} not found in axis")
KeyError: "['min', 'max'] not found in axis"
```