### PR TITLE
Fix SQLAgent

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -549,6 +549,8 @@ class SQLAgent(LumenBaseAgent):
         if not message:
             return
         sql_query = message.replace("```sql", "").replace("```", "").strip()
+        if not sql_query:
+            raise ValueError("No SQL query was generated.")
 
         # check whether the SQL query is valid
         transforms = [SQLOverride(override=sql_query), SQLLimit(limit=1)]
@@ -556,6 +558,7 @@ class SQLAgent(LumenBaseAgent):
             source=source, table=tables[0], sql_transforms=transforms
         )
         pipeline.data
+        memory["current_pipeline"] = pipeline
         return sql_query
 
     async def answer(self, messages: list | str):

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -56,19 +58,15 @@ class Sql(BaseModel):
 
 class Validity(BaseModel):
 
-    chain_of_thought: str = Field(
+    correct_assessment: str = Field(
         description="""
         Thoughts on whether the current table meets the requirement
         to answer the user's query, i.e. table contains all necessary columns
         """
     )
 
-    missing_table_or_columns: list[str] = Field(
-        description="List out all the tables or columns requested by the user that are currently missing in the spec."
-    )
-
-    is_invalid: bool = Field(
-        description="Whether the table needs a refresh."
+    is_invalid: Literal["table", "sql"] | None = Field(
+        description="Whether the table or sql is invalid or no longer relevant. None if valid."
     )
 
 

--- a/lumen/ai/prompts/check_validity.jinja2
+++ b/lumen/ai/prompts/check_validity.jinja2
@@ -5,6 +5,11 @@ Based on the latest user's query, decide whether the current table and data cont
 {{ table }}
 ```
 
+### Current SQL:
+```
+{{ sql }}
+```
+
 ### Current Data `{column: stat}`:
 ```
 {{ spec }}

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -10,7 +10,6 @@ from ..downloads import Download
 from ..pipeline import Pipeline
 from ..views.base import Table
 from .memory import memory
-from .utils import describe_data
 
 
 class LumenOutput(Viewer):
@@ -123,14 +122,8 @@ class SQLOutput(LumenOutput):
                 value=True, name="Executing SQL query...", height=50, width=50
             )
 
-        source = memory["current_source"]
-        memory["current_table"] = self.name
-        source.add_table(self.name, self.spec)
+        pipeline = memory["current_pipeline"]
         try:
-            pipeline = Pipeline(source=source, table=self.name)
-            df = pipeline.data
-            if len(df) > 0:
-                memory["current_data"] = describe_data(df)
             table = Table(
                 pipeline=pipeline, pagination='remote',
                 height=458, page_size=12
@@ -144,7 +137,6 @@ class SQLOutput(LumenOutput):
             download_pane.styles = {'position': 'absolute', 'right': '-50px'}
             output = pn.Column(download_pane, table)
             yield output
-            memory["current_pipeline"] = self.component = pipeline
         except Exception as e:
             import traceback
             traceback.print_exc()


### PR DESCRIPTION
I'm slightly sure that the following...
```
        source = memory["current_source"]
        memory["current_table"] = self.name
        source.add_table(self.name, self.spec)
```
was added for a reason, but it was implemented incorrectly because `self.name` is `SQLOutput02697` so subsequent calls to SQL broke (no table is named `SQLOutput02697`)

This reverts those changes by retrieving the pipeline stored in memory from earlier.

Also, even though the table is still valid, in cases where the Assistant chooses `PipelineAgent`, we need to check if the SQL statement is still valid, and if not refresh it.

