### PR TITLE
Do not quote `read_*` identifiers for duckdb

### DIFF
--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -82,7 +82,7 @@ class DuckDBSource(BaseSQLSource):
     def get_sql_expr(self, table: str):
         if isinstance(self.tables, dict):
             table = self.tables[table]
-        if 'read_' not in table:
+        if '(' not in table and ')' not in table:
             table = f'"{table}"'
         if 'select ' in table.lower():
             sql_expr = table

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -39,7 +39,7 @@ class DuckDBSource(BaseSQLSource):
 
     uri = param.String(doc="The URI of the DuckDB database")
 
-    sql_expr = param.String(default='SELECT * FROM "{table}"', doc="""
+    sql_expr = param.String(default='SELECT * FROM {table}', doc="""
         The SQL expression to execute.""")
 
     tables = param.ClassSelector(class_=(list, dict), doc="""
@@ -82,6 +82,8 @@ class DuckDBSource(BaseSQLSource):
     def get_sql_expr(self, table: str):
         if isinstance(self.tables, dict):
             table = self.tables[table]
+        if 'read_' not in table:
+            table = f'"{table}"'
         if 'select ' in table.lower():
             sql_expr = table
         else:

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -24,7 +24,7 @@ def duckdb_source():
             f"SET home_directory='{root}';"
         ],
         root=root,
-        sql_expr='SELECT A, B, C, D::TIMESTAMP_NS AS D FROM {table}',
+        sql_expr="SELECT A, B, C, D::TIMESTAMP_NS AS D FROM {table}",
         tables={
             'test_sql': f"sqlite_scan('{root + '/test.db'}', 'mixed')",
             'test_sql_with_none': f"sqlite_scan('{root + '/test.db'}', 'mixed_none')",


### PR DESCRIPTION
Was wondering why all of a sudden duckdb didn't work anymore and spent a while to figure out the tables were being quoted.

<img width="931" alt="image" src="https://github.com/user-attachments/assets/bc97ffdd-9a68-440d-b9f2-99b33285bcd3">

