### PR TITLE
LumenAI Views in Sidebar

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -552,9 +552,7 @@ class SQLAgent(LumenBaseAgent):
         pipeline = Pipeline(
             source=sql_expr_source, table=model.expr_name
         )
-        print("pipeline", pipeline)
         df = pipeline.data
-        print(df)
         if len(df) > 0:
             memory["current_data"] = describe_data(df)
         memory["current_pipeline"] = pipeline

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -39,7 +39,7 @@ class DuckDBSource(BaseSQLSource):
 
     uri = param.String(doc="The URI of the DuckDB database")
 
-    sql_expr = param.String(default='SELECT * FROM "{table}"', doc="""
+    sql_expr = param.String(default='SELECT * FROM {table}', doc="""
         The SQL expression to execute.""")
 
     tables = param.ClassSelector(class_=(list, dict), doc="""
@@ -82,6 +82,8 @@ class DuckDBSource(BaseSQLSource):
     def get_sql_expr(self, table: str):
         if isinstance(self.tables, dict):
             table = self.tables[table]
+        if 'read_' not in table:
+            table = f'"{table}"'
         if 'select ' in table.lower():
             sql_expr = table
         else:


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/606

https://github.com/user-attachments/assets/3fde43af-7273-4223-9fa4-7677e29e2b5d

This makes expensive views like plots and tables, pop up one at a time, on the sidebar instead of showing up in the chat feed, to prevent it from becoming laggy.

Logically, these views would make more sense to pop up on the right side, but templates only support sidebar on the left. Perhaps in the future, there can be a right_sidebar.
