### PR TITLE
Mention use verbatim names in SQL prompts

### DIFF
--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -40,10 +40,9 @@ class TableJoins(BaseModel):
 
     tables: list[str] = Field(
         description=(
-            "List of tables that need to be joined to answer the user's query; "
-            "be sure to match the table names exactly as they appear. "
-            "e.g. `read_parquet('table.parquet')` should be read_parquet('table.parquet') "
-            "NOT just 'table'"
+            "List of tables that need to be joined to answer the user's query. "
+            "Use table names verbatim; e.g. if table is `read_csv('table.csv')` "
+            "then use `read_csv('table.csv')` and not `table`"
         ),
     )
 

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -38,10 +38,15 @@ class JoinRequired(BaseModel):
 
 class TableJoins(BaseModel):
 
-    tables: list[str] | None = Field(
-        default=None,
-        description="List of tables that need to be joined to answer the user's query.",
+    tables: list[str] = Field(
+        description=(
+            "List of tables that need to be joined to answer the user's query; "
+            "be sure to match the table names exactly as they appear. "
+            "e.g. `read_parquet('table.parquet')` should be read_parquet('table.parquet') "
+            "NOT just 'table'"
+        ),
     )
+
 
 class Sql(BaseModel):
 

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -29,7 +29,8 @@ class JoinRequired(BaseModel):
 
     chain_of_thought: str = Field(
         description="""
-        Explain whether a table join is required to answer the user's query.
+        Explain whether a table join is required to answer the user's query, or
+        if the user is requesting a join or merge.
         """
     )
 
@@ -71,7 +72,8 @@ class Validity(BaseModel):
     correct_assessment: str = Field(
         description="""
         Thoughts on whether the current table meets the requirement
-        to answer the user's query, i.e. table contains all necessary columns
+        to answer the user's query, i.e. table contains all necessary columns,
+        unless user explicitly asks for a refresh.
         """
     )
 

--- a/lumen/ai/prompts/sql_query.jinja2
+++ b/lumen/ai/prompts/sql_query.jinja2
@@ -9,4 +9,5 @@ The data for table '{{ table }}' follows the following JSON schema:
 Checklist
 - If it's a date column (excluding individual year/month/day integers), cast as date
 - If no limit is specified, specify 10000 as the limit.
+- Use table names verbatim; e.g. if table is `read_csv('table.csv')` then use `read_csv('table.csv')` and not `table`
 - Use only `{{ dialect }}` syntax


### PR DESCRIPTION
`FROM read_parquet('olympics.parquet')` sometimes became `FROM olympics`; slight prompt change and it works.

Before:
<img width="893" alt="image" src="https://github.com/user-attachments/assets/08271a1e-29a2-403d-9607-342810127979">

I guess not just joins, but SQL in general; takes two tries:
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/ffac27e6-30f5-4610-a758-15f8ab5a9918">

After:
<img width="1233" alt="image" src="https://github.com/user-attachments/assets/66914cb9-a3f3-4d3e-9db4-18ef6cec73b7">
