### PR TITLE
Improve passing context

### DIFF
--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -414,10 +414,8 @@ class Assistant(Viewer):
 
     async def invoke(self, messages: list | str) -> str:
         messages = self.interface.serialize(custom_serializer=self._serialize)[-4:]
-        print(messages, "BEFORE")
         await self._invalidate_memory(messages[-2:])
         agent = await self._get_agent(messages[-3:])
-        print(messages, "AFTER")
         if agent is None:
             msg = (
                 "Assistant could not settle on an agent to perform the requested query. "

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -121,6 +121,9 @@ class LumenOutput(Viewer):
     def __repr__(self):
         return self.spec
 
+    def __str__(self):
+        return self.spec
+
 
 class SQLOutput(LumenOutput):
 


### PR DESCRIPTION
The context wasn't propagated properly before.

Before:

I wanted it to group by medal type as a follow up, but it didn't see that I grouped by country first.

<img width="487" alt="image" src="https://github.com/user-attachments/assets/a69518c3-419f-4de0-a2c6-2aa4f1619f83">

<img width="831" alt="image" src="https://github.com/user-attachments/assets/b21c7af1-efb7-4c6f-b978-8f067783b4ff">

After:

Now the context is properly propagated.

```python
[

{'role': 'system', 'content': '\nYou are an agent responsible for writing a SQL query that will\nperform the data transformations the user requested.\nThe data for table \'read_parquet(\'/Users/ahuang/repos/lumen/olympic_medals.parquet\')\' follows the following JSON schema:\n```json\n{\'discipline_title\': {\'type\': \'string\', \'enum\': [\'Freestyle Skiing\', \'Luge\', \'Bobsleigh\', \'Boxing\', \'Handball\', \'...\']}, \'slug_game\': {\'type\': \'string\', \'enum\': [\'sochi-2014\', \'atlanta-1996\', \'lillehammer-1994\', \'rome-1960\', \'oslo-1952\', \'...\']}, \'event_title\': {\'type\': \'string\', \'enum\': ["Women\'s Freeski Halfpipe", "Men\'s 5000m Relay", "Men\'s Parallel Giant Slalom", "Women\'s Snowboard Big Air", "Women\'s NH Individual", \'...\']}, \'event_gender\': {\'type\': \'string\', \'enum\': [\'Mixed\', \'Women\', \'Men\', \'Open\']}, \'medal_type\': {\'type\': \'string\', \'enum\': [\'GOLD\', \'BRONZE\', \'SILVER\']}, \'participant_type\': {\'type\': \'string\', \'enum\': [\'Athlete\', \'GameTeam\']}, \'participant_title\': {\'type\': \'string\', \'enum\': [\'Japan\', \'Slovenia\', "People\'s Republic of China 1", \'Ukraine\', \'Poland\', \'...\']}, \'athlete_url\': {\'type\': \'string\', \'enum\': [\'https://olympics.com/en/athletes/ikuma-horishima\', \'https://olympics.com/en/athletes/henrik-harlaut\', \'https://olympics.com/en/athletes/colby-stevenson\', \'https://olympics.com/en/athletes/gu-ailing-eileen\', \'https://olympics.com/en/athletes/marielle-thompson\', \'...\']}, \'athlete_full_name\': {\'type\': \'string\', \'enum\': [\'Stefania CONSTANTINI\', None, \'Walter WALLBERG\', \'Nico PORTEOUS\', \'Jakara ANTHONY\', \'...\']}, \'country_name\': {\'type\': \'string\', \'enum\': [\'Japan\', \'Switzerland\', \'Ukraine\', \'Slovenia\', \'Poland\', \'...\']}, \'country_code\': {\'type\': \'string\', \'enum\': [\'NO\', \'SK\', \'SM\', \'DK\', \'PH\', \'...\']}, \'country_3_letter_code\': {\'type\': \'string\', \'enum\': [\'JPN\', \'GER\', \'NED\', \'SRB\', \'POR\', \'...\']}}\n```\n\n\nChecklist\n- If it\'s a date column (excluding individual year/month/day integers), cast as date\n- If no limit is specified, specify 10000 as the limit.\n- Use only `duckdb` syntax'},

{'role': 'assistant', 'content': 'The user is asking for information about countries that have won the most medals, which likely involves querying a dataset related to medals won by countries. The SQLAgent is the best choice to generate a query that can retrieve this specific information from the relevant dataset.'},

{'role': 'assistant', 'content': "SELECT country_name, COUNT(medal_type) AS total_medals \nFROM read_parquet('/Users/ahuang/repos/lumen/olympic_medals.parquet') \nGROUP BY country_name \nORDER BY total_medals DESC \nLIMIT 10000;"},

{'role': 'user', 'content': 'By medal type?'}]
```

<img width="402" alt="image" src="https://github.com/user-attachments/assets/af37d1b5-9f0b-437b-b223-cd5f0456e3a2">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7c17ad68-6590-4d32-8c38-0a4e2d381189">
