### PR TITLE
Support wildcard cli

### DIFF
--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -57,7 +57,8 @@ class AIHandler(CodeHandler):
         '''
 
         Keywords:
-            filename (str) : the path to the dataset or the dataset tables
+            filename (str) : the path to the dataset or the paths to multiple datasets
+                used as tables under the same source
             no_data (bool) : if True, do not load data
 
         '''


### PR DESCRIPTION
Was trying to do analysis across multiple CSVs but when I did `lumen-ai serve olympics*.csv`, it opened separate endpoints.

<img width="625" alt="image" src="https://github.com/user-attachments/assets/d221810f-b5f0-47fa-bfe4-f335b7506ef3">

this PR combines them into a single source which I think makes more sense with datasets.

<img width="645" alt="image" src="https://github.com/user-attachments/assets/16faa740-2af8-4fc9-a8a7-0c596861ae73">

<img width="806" alt="image" src="https://github.com/user-attachments/assets/c1c55611-53ad-4833-9286-b00a3f1cb9b8">
