### PR TITLE
Fix chat agent

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -205,7 +205,7 @@ class OpenAI(Llm):
             client = from_openai(llm)
             client_callable = partial(client.chat.completions.create, model=model)
         else:
-            client_callable = llm.chat.completions.create
+            client_callable = partial(llm.chat.completions.create, model=model)
 
         if self.use_logfire:
             import logfire
@@ -245,7 +245,7 @@ class AzureOpenAI(Llm):
             client = from_openai(llm)
             client_callable = partial(client.chat.completions.create, model=model)
         else:
-            client_callable = llm.chat.completions.create
+            client_callable = partial(llm.chat.completions.create, model=model)
         return client_callable
 
 


### PR DESCRIPTION
Left out `model` when `response_model=None`

Not sure why it was working locally for me the entire time though.
```
TypeError: Missing required arguments; Expected either ('messages' and 'model') or ('messages', 'model' and 'stream') arguments to be given
```