### PR TITLE
Tweak hvplot prompt to prevent barh from crashing

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -840,9 +840,11 @@ class hvPlotAgent(BaseViewAgent):
     system_prompt = param.String(
         default="""
         Generate the plot the user requested.
-        Note that `x`, `y`, `by` and `groupby` fields MUST ALL be unique columns.
+        Note that `x`, `y`, `by` and `groupby` fields MUST ALL be unique columns;
+        no repeated columns are allowed.
         Do not arbitrarily set `groupby` and `by` fields unless explicitly requested.
         If a histogram is requested, use `y` instead of `x`.
+        If x is categorical or strings, prefer barh over bar, and use `y` for the values.
         """
     )
 

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -16,7 +16,7 @@ class DataRequired(BaseModel):
 
     chain_of_thought: str = Field(
         description="""
-        Thoughts on whether the user's query requires data loaded;
+        Thoughts on whether the user's query requires data loaded for insights;
         if the user wants to explore a dataset, it's required.
         If only finding a dataset, it's not required.
         """


### PR DESCRIPTION
Previously it choked because hvplot expects barh(x="categorical", y="value"), but it gave it flipped
<img width="575" alt="image" src="https://github.com/user-attachments/assets/00aacfb9-7a43-48f4-88e8-dd6d5a413bde">

<img width="745" alt="image" src="https://github.com/user-attachments/assets/cb1cb26b-15ed-42e9-a804-6d0f0e2680fd">


Now it's better
<img width="845" alt="image" src="https://github.com/user-attachments/assets/f109f4ca-44e5-4b08-ae41-ba3f5dc3d7da">

<img width="801" alt="image" src="https://github.com/user-attachments/assets/b115a0fb-9d9e-4aed-8e9c-3d458d7f04a7">
