### PR TITLE
Add min width to ChatStep

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -26,6 +26,7 @@ from ..state import state
 from ..transforms.sql import SQLOverride, SQLTransform, Transform
 from ..views import VegaLiteView, View, hvPlotUIView
 from .analysis import Analysis
+from .config import FUZZY_TABLE_LENGTH
 from .embeddings import Embeddings
 from .llm import Llm
 from .memory import memory
@@ -38,10 +39,6 @@ from .utils import (
     describe_data, get_schema, render_template, retry_llm_output,
 )
 from .views import AnalysisOutput, LumenOutput, SQLOutput
-
-FUZZY_TABLE_LENGTH = 10
-
-pn.chat.ChatStep.min_width = 350
 
 
 class Agent(Viewer):

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -41,6 +41,8 @@ from .views import AnalysisOutput, LumenOutput, SQLOutput
 
 FUZZY_TABLE_LENGTH = 10
 
+pn.chat.ChatStep.min_width = 350
+
 
 class Agent(Viewer):
     """

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -19,28 +19,13 @@ from pydantic.fields import FieldInfo
 from .agents import (
     Agent, AnalysisAgent, ChatAgent, SQLAgent,
 )
+from .config import DEMO_MESSAGES, GETTING_STARTED_SUGGESTIONS
 from .export import export_notebook
 from .llm import Llama, Llm
 from .logs import ChatLogs
 from .memory import memory
 from .models import Validity
 from .utils import get_schema, render_template, retry_llm_output
-
-GETTING_STARTED_SUGGESTIONS = [
-    "What datasets do you have?",
-    "Tell me about the dataset.",
-    "Create a plot of the dataset.",
-    "Find the min and max of the values.",
-]
-
-DEMO_MESSAGES = [
-    "What data is available?",
-    "Can I see the first one?",
-    "Tell me about the dataset.",
-    "What could be interesting to analyze?",
-    "Perform a SQL query on one of these.",
-    "Show it to me as a scatter plot."
-]
 
 
 class Assistant(Viewer):

--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import panel as pn
+
+
+class LlmSetupError(Exception):
+    """
+    Raised when an error occurs during the setup of the LLM.
+    """
+
+
+THIS_DIR = Path(__file__).parent
+
+FUZZY_TABLE_LENGTH = 10
+
+GETTING_STARTED_SUGGESTIONS = [
+    "What datasets do you have?",
+    "Tell me about the dataset.",
+    "Create a plot of the dataset.",
+    "Find the min and max of the values.",
+]
+
+DEMO_MESSAGES = [
+    "What data is available?",
+    "Can I see the first one?",
+    "Tell me about the dataset.",
+    "What could be interesting to analyze?",
+    "Perform a SQL query on one of these.",
+    "Show it to me as a scatter plot.",
+]
+
+DEFAULT_EMBEDDINGS_PATH = Path("embeddings")
+
+UNRECOVERABLE_ERRORS = (
+    ImportError,
+    LlmSetupError,
+    RecursionError,
+)
+
+pn.chat.ChatStep.min_width = 350

--- a/lumen/ai/embeddings.py
+++ b/lumen/ai/embeddings.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-DEFAULT_PATH = Path("embeddings")
+from .config import DEFAULT_EMBEDDINGS_PATH
 
 
 class Embeddings:
@@ -14,7 +14,7 @@ class Embeddings:
 
 class ChromaDb(Embeddings):
 
-    def __init__(self, collection: str, persist_dir: str = DEFAULT_PATH):
+    def __init__(self, collection: str, persist_dir: str = DEFAULT_EMBEDDINGS_PATH):
         import chromadb
         self.client = chromadb.PersistentClient(path=str(persist_dir / collection))
         self.collection = self.client.get_or_create_collection(collection)

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -11,21 +11,7 @@ import pandas as pd
 from lumen.pipeline import Pipeline
 from lumen.sources.base import Source
 
-THIS_DIR = Path(__file__).parent
-
-
-class LlmSetupError(Exception):
-    """
-    Raised when an error occurs during the setup of the LLM.
-    """
-
-
-
-UNRECOVERABLE_ERRORS = (
-    ImportError,
-    LlmSetupError,
-    RecursionError,
-)
+from .config import THIS_DIR, UNRECOVERABLE_ERRORS
 
 
 def render_template(template, **context):


### PR DESCRIPTION
Inspired by https://github.com/holoviz/lumen/issues/626 I noticed our steps are all jagged. By setting a min width, it looks cleaner.
 
<img width="546" alt="image" src="https://github.com/user-attachments/assets/4ff9749e-be36-46dc-9f67-e07c1386c5ca">

But it can expand outward if necessary
<img width="988" alt="image" src="https://github.com/user-attachments/assets/217d9618-3eef-45a0-a6fb-245d5e3ce30c">

Requires https://github.com/holoviz/panel/pull/7049