### PR TITLE
Use fit-content for height

### DIFF
--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -63,8 +63,7 @@ class LumenOutput(Viewer):
         self._tabs = pn.Tabs(
             ("Code", code_col),
             ("Output", placeholder),
-            styles={'min-width': "100%"},
-            min_height=700,
+            styles={'min-width': '100%', 'height': 'fit-content'},
             active=1
         )
         self._tabs.link(self, bidirectional=True, active='active')


### PR DESCRIPTION
This seems to work as long as there is a set height/min_height in the output.

<img width="1098" alt="image" src="https://github.com/user-attachments/assets/8a9edfad-00f4-41d7-8b14-104a86f2d77c">

<img width="1115" alt="image" src="https://github.com/user-attachments/assets/4ac01bf9-e897-4020-80a0-a9a3ed399b46">
