### PR TITLE
Ensure data provenance even for synthetic tables

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -20,7 +20,7 @@ def add_source_controls(replace_controls: bool = True):
                 elif upload.filename.endswith(".xlsx"):
                     df = pd.read_excel(io.BytesIO(upload.value))
                 # TODO: add url support
-                duckdb_source = DuckDBSource(uri=":memory:")
+                duckdb_source = DuckDBSource(uri=":memory:", synthetic=True)
                 duckdb_source._connection.from_df(df).to_table(name.value)
                 if duckdb_source.tables is None:
                     duckdb_source.tables = {}

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -20,7 +20,7 @@ def add_source_controls(replace_controls: bool = True):
                 elif upload.filename.endswith(".xlsx"):
                     df = pd.read_excel(io.BytesIO(upload.value))
                 # TODO: add url support
-                duckdb_source = DuckDBSource(uri=":memory:", synthetic=True)
+                duckdb_source = DuckDBSource(uri=":memory:", ephemeral=True)
                 duckdb_source._connection.from_df(df).to_view(name.value)
                 if duckdb_source.tables is None:
                     duckdb_source.tables = {}

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -21,7 +21,7 @@ def add_source_controls(replace_controls: bool = True):
                     df = pd.read_excel(io.BytesIO(upload.value))
                 # TODO: add url support
                 duckdb_source = DuckDBSource(uri=":memory:", synthetic=True)
-                duckdb_source._connection.from_df(df).to_table(name.value)
+                duckdb_source._connection.from_df(df).to_view(name.value)
                 if duckdb_source.tables is None:
                     duckdb_source.tables = {}
                 duckdb_source.tables[name.value] = f"SELECT * FROM {name.value}"

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -156,7 +156,7 @@ class Pipeline(Viewer, Component):
             ]
         elif filters is None:
             filters = []
-        if any(isinstance(t, SQLTransform) for t in params.get('transforms', [])):
+        if any(isinstance(t, SQLTransform) for t in params.get('transforms') or []):
             raise TypeError('Pipeline.transforms must be regular Transform components, not SQLTransform.')
         self._update_widget = None
         super().__init__(source=source, table=table, filters=filters, schema=schema, **params)
@@ -590,7 +590,7 @@ class Pipeline(Viewer, Component):
                     'Cannot chain SQL transforms on a Pipeline without '
                     'DuckDB. Ensure DuckDB is installed.'
                 )
-            sql_src = DuckDBSource(uri=':memory', mirrors={self.name: self})
+            sql_src = DuckDBSource(uri=':memory:', mirrors={self.name: self})
             return Pipeline(
                 source=sql_src,
                 table=self.name,

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -253,7 +253,11 @@ class Source(MultiTypeComponent):
             return source
 
         spec = spec.copy()
-        source_type = Source._get_type(spec.pop('type', None))
+        src_type_name = spec.pop('type', None)
+        source_type = Source._get_type(src_type_name)
+        if cls is Source:
+            spec['type'] = src_type_name
+            return source_type.from_spec(spec)
         resolved_spec, refs = source_type._recursive_resolve(spec, source_type)
         return source_type(refs=refs, **resolved_spec)
 

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -254,7 +254,7 @@ class Source(MultiTypeComponent):
 
         spec = spec.copy()
         source_type = Source._get_type(spec.pop('type', None))
-        resolved_spec, refs = cls._recursive_resolve(spec, source_type)
+        resolved_spec, refs = source_type._recursive_resolve(spec, source_type)
         return source_type(refs=refs, **resolved_spec)
 
     def __init__(self, **params):

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -120,7 +120,7 @@ class DuckDBSource(BaseSQLSource):
         mirrors = {}
         for table, (source, src_table) in spec['mirrors'].items():
             src_spec = source.to_spec(context=context)
-            if source.synthetic:
+            if hasattr(source, "synthetic") and source.synthetic:
                 tables = {}
                 for t in source.get_tables():
                     tdf = source.get(t)

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -35,7 +35,7 @@ def duckdb_source():
 
 @pytest.fixture
 def duckdb_memory_source(mixed_df):
-    source = DuckDBSource(uri=':memory:', synthetic=True)
+    source = DuckDBSource(uri=':memory:', ephemeral=True)
     source._connection.from_df(mixed_df).to_view('mixed')
     return source
 
@@ -155,7 +155,7 @@ def test_duckdb_clear_cache(duckdb_source):
     assert len(duckdb_source._schema_cache) == 0
 
 
-def test_duckdb_source_synthetic_roundtrips(duckdb_memory_source, mixed_df):
+def test_duckdb_source_ephemeral_roundtrips(duckdb_memory_source, mixed_df):
     source = DuckDBSource.from_spec(duckdb_memory_source.to_spec())
     df = source.get('mixed')
     for col in df.columns:

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -36,7 +36,7 @@ def duckdb_source():
 @pytest.fixture
 def duckdb_memory_source(mixed_df):
     source = DuckDBSource(uri=':memory:', synthetic=True)
-    source._connection.from_df(mixed_df).to_table('mixed')
+    source._connection.from_df(mixed_df).to_view('mixed')
     return source
 
 


### PR DESCRIPTION
Ensures that we track the provenance of data so it can be serialized. Specifically this implements:

- `DuckDBSource` can now define `mirrors` which mirror existing tables and pipelines into the `DuckDB` database
- `DuckDBSource` can now be declared as synthetic which means the tables do not have provenance and have to be serialized as part of the spec. 
- Pipelines can now chain SQL expressions on top of an existing non-SQL pipeline by mirroring the existing pipeline into duckdb.

In future we may have to figure out if there's some better way to persist the synthetic tables.