### PR TITLE
Fix quoting and `read(file.ext)` queries

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -518,9 +518,12 @@ class SQLAgent(LumenBaseAgent):
                 relation = source._connection.from_df(df)
                 try:
                     # DREMIO.SOMETHING turns into DREMIO_SOMETHING
-                    renamed_table = a_table.replace(".", "_")
-                    sql_query = sql_query.replace(a_table, renamed_table)
-                    relation.to_table(renamed_table)
+                    if not ("(" in a_table and ")" in a_table):
+                        renamed_table = a_table.replace(".", "_")
+                        sql_query = sql_query.replace(a_table, renamed_table)
+                        relation.to_table(renamed_table)
+                    else:
+                        relation.to_table(a_table)
                 except duckdb.CatalogException as e:
                     print(f"Could not add to catalog {e}")
         else:

--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -75,7 +75,7 @@ class Join(Analysis):
     async def __call__(self, pipeline) -> Component:
         if self.table_name:
             agent = next((agent for agent in self.agents if type(agent).__name__ == "SQLAgent"), None)
-            content = f"Join these tables: `//{self._previous_source}//{self._previous_table}` and `//{memory['current_source']}//{self.table_name}`"
+            content = f"Join these tables: '//{self._previous_source}//{self._previous_table}' and '//{memory['current_source']}//{self.table_name}'"
             if self.index_col:
                 content += f" on {self.index_col}"
             if self.context:

--- a/lumen/ai/prompts/join_required.jinja2
+++ b/lumen/ai/prompts/join_required.jinja2
@@ -1,6 +1,6 @@
 Determine whether a table join is required to answer the user's query.
 
-The current table `{{ table }}` follows this JSON schema:
+The current table '{{ table }}' follows this JSON schema:
 
 ```json
 {{ schema }}

--- a/lumen/ai/prompts/sql_query.jinja2
+++ b/lumen/ai/prompts/sql_query.jinja2
@@ -8,12 +8,15 @@ The data for table '{{ table }}' follows the following JSON schema:
 
 {% if not join_required %}
 It was already determined that no join is required, so only use the existing
-table `{{ table }}` to calculate the result.
+table '{{ table }}' to calculate the result.
 {% endif %}
 
 Checklist
 - Do not write a join if the table already contains all the columns that are needed
 - If it's a date column (excluding individual year/month/day integers), cast as date
 - If no limit is specified, specify 10000 as the limit.
-- Use table names verbatim; e.g. if table is `read_csv('table.csv')` then use `read_csv('table.csv')` and not `table`
+- Use table names verbatim; e.g. if table is read_csv('table.csv') then use read_csv('table.csv') and not 'table'
 - Use only `{{ dialect }}` syntax
+{% if dialect == 'duckdb' %}
+- String literals are delimited using single quotes (', apostrophe) and result in STRING_LITERAL values. Note that double quotes (") cannot be used as string delimiter character: instead, double quotes are used to delimit quoted identifiers.
+{% endif %}

--- a/lumen/ai/prompts/sql_query.jinja2
+++ b/lumen/ai/prompts/sql_query.jinja2
@@ -16,6 +16,7 @@ Checklist
 - If it's a date column (excluding individual year/month/day integers), cast as date
 - If no limit is specified, specify 10000 as the limit.
 - Use table names verbatim; e.g. if table is read_csv('table.csv') then use read_csv('table.csv') and not 'table'
+- If `read_*` is used, use with alias, e.g. read_parquet('table.parq') as table_parq
 - Use only `{{ dialect }}` syntax
 {% if dialect == 'duckdb' %}
 - String literals are delimited using single quotes (', apostrophe) and result in STRING_LITERAL values. Note that double quotes (") cannot be used as string delimiter character: instead, double quotes are used to delimit quoted identifiers.


### PR DESCRIPTION
It is invalid syntax to use backtick \` but since the LLM was instructed to use it verbatim, it did. So here, it replaces it with `'` instead.

Also fixes `read` queries like `read_csv('test.csv')` so it doesn't become `read_csv('test_csv')`

<img width="816" alt="image" src="https://github.com/user-attachments/assets/c49b715d-dd0a-4be4-a9dd-e6ef0c8ca5da">
