### PR TITLE
Add Serializer component type to (de)serialize ephemeral tables

### DIFF
--- a/lumen/ai/export.py
+++ b/lumen/ai/export.py
@@ -9,6 +9,7 @@ from panel import Column
 from panel.chat import ChatStep
 
 from lumen.ai.views import LumenOutput
+from lumen.config import config
 from lumen.pipeline import Pipeline
 from lumen.views import View
 
@@ -40,7 +41,8 @@ def format_markdown(msg):
 def format_output(msg):
     output = msg.object
     code = []
-    spec = json.dumps(output.component.to_spec(), indent=2).replace('true', 'True').replace('false', 'False')
+    with config.param.update(serializer='csv'):
+        spec = json.dumps(output.component.to_spec(), indent=2).replace('true', 'True').replace('false', 'False')
     if isinstance(output.component, Pipeline):
         code.extend([
             f'pipeline = lm.Pipeline.from_spec({spec})',

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -9,47 +9,10 @@ from panel import state
 from panel.viewable import Viewer
 
 from ..base import Component
+from ..config import SessionCache
 
 if TYPE_CHECKING:
     from bokeh.document import Document
-
-class SessionCache:
-
-    _session_contexts: ClassVar[WeakKeyDictionary[Document, Any]] = WeakKeyDictionary()
-
-    _global_context = {}
-
-    @property
-    def _curcontext(self):
-        if state.curdoc:
-            if state.curdoc in self._session_contexts:
-                context = self._session_contexts[state.curdoc]
-            else:
-                self._session_contexts[state.curdoc] = context = {}
-            return context
-        else:
-            return self._global_context
-
-    def __contains__(self, key):
-        return key in self._curcontext or key in self._global_context
-
-    def __getitem__(self, key):
-        return self._curcontext[key]
-
-    def __setitem__(self, key, value):
-        self._curcontext[key] = value
-
-    def get(self, key, default=None):
-        obj = dict(self._global_context, **self._curcontext).get(key, default)
-        if hasattr(obj, "copy"):
-            obj = obj.copy()
-        return obj
-
-    def keys(self):
-        return dict(self._global_context, **self._curcontext).keys()
-
-    def pop(self, key, default=None):
-        return self._curcontext.pop(key, default)
 
 
 class _Memory(SessionCache, Viewer):

--- a/lumen/serializers.py
+++ b/lumen/serializers.py
@@ -65,7 +65,7 @@ class SessionSerializer(Serializer):
         data_id = uuid.uuid4().hex
         self._session_cache[data_id] = data
         return {
-            'type': 'session',
+            'type': self.serializer_type,
             'id': data_id,
             'serializer': self.to_spec()
         }

--- a/lumen/serializers.py
+++ b/lumen/serializers.py
@@ -1,0 +1,86 @@
+import uuid
+
+from io import StringIO
+
+import numpy as np
+import pandas as pd
+
+from .base import MultiTypeComponent
+from .config import SessionCache
+
+
+class Serializer(MultiTypeComponent):
+
+    serializer_type = None
+
+    @classmethod
+    def serialize(self, data) -> dict[str, any]:
+        raise NotImplementedError
+
+    @classmethod
+    def deserialize(cls, data) -> dict[str, any]:
+        serialize_spec = dict(data.pop('serializer', {}))
+        serializer = cls.from_spec(serialize_spec)
+        return serializer.deserialize(data)
+
+
+class CSVSerializer(Serializer):
+
+    serializer_type = 'csv'
+
+    def serialize(self, data) -> dict[str, any]:
+        csv = StringIO()
+        index = list(data.index.names)
+        if len(index) == 1 and index[0] is None:
+            index = False
+        data.to_csv(csv, index=bool(index))
+        csv.seek(0)
+        return {
+            'data': csv.read(),
+            'type': self.serializer_type,
+            'index': index,
+            'date_cols': list(data.select_dtypes(np.datetime64).columns),
+            'dtypes': {col: str(data[col].dtype) for col in data.columns},
+            'serializer': self.to_spec()
+        }
+
+    def deserialize(self, data) -> dict[str, any]:
+        data = StringIO(data['data'])
+        df = pd.read_csv(
+            data, parse_dates=data['date_cols']
+        ).astype(data['dtypes'])
+        index_cols = data['index']
+        if index_cols:
+            df = df.set_index(index_cols)
+        else:
+            raise ValueError(
+                "Table data type {table_json['type']!r} unknown. "
+                "Cannot be deserialized."
+            )
+        return df
+
+
+class SessionSerializer(Serializer):
+
+    serializer_type = 'session'
+
+    _session_cache = SessionCache()
+
+    def serialize(self, data) -> dict[str, any]:
+        data_id = uuid.uuid4().hex
+        self._session_cache[data_id] = data
+        return {
+            'type': 'session',
+            'id': data_id,
+            'serializer': self.to_spec()
+        }
+
+    def deserialize(self, data) -> dict[str, any]:
+        if data['id'] in self._session_cache:
+            return self._session_cache[data['id']]
+        else:
+            raise KeyError(
+                'Data was not found in session cache. Ensure you are'
+                'loading a dataset that was created in the same session '
+                'you are attempting to load it from.'
+            )

--- a/lumen/serializers.py
+++ b/lumen/serializers.py
@@ -52,11 +52,6 @@ class CSVSerializer(Serializer):
         index_cols = data['index']
         if index_cols:
             df = df.set_index(index_cols)
-        else:
-            raise ValueError(
-                "Table data type {table_json['type']!r} unknown. "
-                "Cannot be deserialized."
-            )
         return df
 
 


### PR DESCRIPTION
Currently implements two different serialization approaches:

- `SessionSerializer`: Literally just writes the dataset to the local session cache
- `CSVSerializer`: Serializes the data to a CSV string along with some metadata