### PR TITLE
Prevent duplicate analyses from appearing

### DIFF
--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -24,6 +24,8 @@ class Analysis(param.ParameterizedFunction):
 
     _run_button = param.Parameter(default=None)
 
+    _consecutive_calls = False
+
     @classmethod
     def applies(cls, pipeline) -> bool:
         return all(col in pipeline.data.columns for col in cls.columns)

--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -24,7 +24,7 @@ class Analysis(param.ParameterizedFunction):
 
     _run_button = param.Parameter(default=None)
 
-    _consecutive_calls = False
+    _consecutive_calls = False  # whether to allow the analysis to be called multiple times in a row
 
     @classmethod
     def applies(cls, pipeline) -> bool:

--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -24,7 +24,8 @@ class Analysis(param.ParameterizedFunction):
 
     _run_button = param.Parameter(default=None)
 
-    _consecutive_calls = False  # whether to allow the analysis to be called multiple times in a row
+     # Whether to allow the analysis to be called multiple times in a row
+    _consecutive_calls = False
 
     @classmethod
     def applies(cls, pipeline) -> bool:

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -230,8 +230,9 @@ class Assistant(Viewer):
         applicable_analyses = []
         for analysis in self._analyses:
             if analysis.applies(pipeline):
-                if current_analysis and analysis.__name__ == current_analysis.__name__:
-                    continue
+                if current_analysis and not current_analysis._consecutive_calls:
+                    if analysis.__name__ == current_analysis.__name__:
+                        continue
                 applicable_analyses.append(analysis)
         self._add_suggestions_to_footer(
             [f"Apply {analysis.__name__}" for analysis in applicable_analyses],

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -226,9 +226,13 @@ class Assistant(Viewer):
 
     def _add_analysis_suggestions(self):
         pipeline = memory['current_pipeline']
-        applicable_analyses = [
-            analysis for analysis in self._analyses if analysis.applies(pipeline)
-        ]
+        current_analysis = memory.get("current_analysis")
+        applicable_analyses = []
+        for analysis in self._analyses:
+            if analysis.applies(pipeline):
+                if current_analysis and analysis.__name__ == current_analysis.__name__:
+                    continue
+                applicable_analyses.append(analysis)
         self._add_suggestions_to_footer(
             [f"Apply {analysis.__name__}" for analysis in applicable_analyses],
             append_demo=False,

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -227,12 +227,10 @@ class Assistant(Viewer):
     def _add_analysis_suggestions(self):
         pipeline = memory['current_pipeline']
         current_analysis = memory.get("current_analysis")
+        allow_consecutive = getattr(current_analysis, '_consecutive_calls', True)
         applicable_analyses = []
         for analysis in self._analyses:
-            if analysis.applies(pipeline):
-                if current_analysis and not current_analysis._consecutive_calls:
-                    if analysis.__name__ == current_analysis.__name__:
-                        continue
+            if analysis.applies(pipeline) and (allow_consecutive or analysis is not current_analysis):
                 applicable_analyses.append(analysis)
         self._add_suggestions_to_footer(
             [f"Apply {analysis.__name__}" for analysis in applicable_analyses],

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -230,7 +230,7 @@ class Assistant(Viewer):
         allow_consecutive = getattr(current_analysis, '_consecutive_calls', True)
         applicable_analyses = []
         for analysis in self._analyses:
-            if analysis.applies(pipeline) and (allow_consecutive or analysis is not current_analysis):
+            if analysis.applies(pipeline) and (allow_consecutive or analysis is not type(current_analysis)):
                 applicable_analyses.append(analysis)
         self._add_suggestions_to_footer(
             [f"Apply {analysis.__name__}" for analysis in applicable_analyses],


### PR DESCRIPTION
A lot of times, I hit `Apply Join` instead of `Use tables`

<img width="710" alt="image" src="https://github.com/user-attachments/assets/48781818-72db-459b-b7fd-71cfece29f73">

This prevents previous analysis to be the same as current analysis if `_consecutive_calls` is set to False