### PR TITLE
Catch SQL errors and report on step title

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -518,8 +518,8 @@ class SQLAgent(LumenBaseAgent):
 
         # check whether the SQL query is valid
         expr_slug = output.expr_slug
-        sql_expr_source = source.create_sql_expr_source({expr_slug: sql_query})
         try:
+            sql_expr_source = source.create_sql_expr_source({expr_slug: sql_query})
             pipeline = Pipeline(source=sql_expr_source, table=expr_slug)
         except Exception as e:
             step.status = "failed"


### PR DESCRIPTION
Previously, `create_sql_expr_source` would fail somewhere and would trigger the decorator, but not before the step was able to report error. This makes sure the error bubbles up to the step beforehand so it's easier to debug and that there's no false hope in the resulting SQL expression :P

Before:
<img width="506" alt="image" src="https://github.com/user-attachments/assets/305b62eb-c941-43a7-9cbf-a1daa2b8561c">

After:
<img width="525" alt="image" src="https://github.com/user-attachments/assets/5167d790-bd40-4222-82a3-aa5131ff8f86">
