### PR TITLE
Fix overlap

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -79,8 +79,7 @@ class SourceControls(pn.viewable.Viewer):
         self._upload_tabs = pn.Tabs(sizing_mode="stretch_width")
 
         self._input_tabs = pn.Tabs(
-            ("Upload", pn.Column(self._file_input, self._upload_tabs)),
-            sizing_mode="stretch_both",
+            ("Upload", pn.Column(self._file_input, self._upload_tabs))
         )
 
         if self.select_existing:
@@ -171,7 +170,7 @@ class SourceControls(pn.viewable.Viewer):
                         (
                             t,
                             pn.widgets.Tabulator(
-                                src.get(t), sizing_mode="stretch_width"
+                                src.get(t), sizing_mode="stretch_both"
                             ),
                         )
                         for t in src.get_tables()

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -71,6 +71,7 @@ class SourceControls(pn.viewable.Viewer):
         self.tables_tabs = pn.Tabs(sizing_mode="stretch_width")
         self._file_input = pn.widgets.FileDropper(
             multiple=self.param.multiple,
+            margin=0,
             sizing_mode="stretch_both",
             # accepted_filetypes=[".csv", ".parquet", ".parq", ".json", ".xlsx"],
         )

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -71,15 +71,14 @@ class SourceControls(pn.viewable.Viewer):
         self.tables_tabs = pn.Tabs(sizing_mode="stretch_width")
         self._file_input = pn.widgets.FileDropper(
             multiple=self.param.multiple,
-            sizing_mode="stretch_width",
-            max_width=500,
-            height=200,
+            sizing_mode="stretch_both",
             # accepted_filetypes=[".csv", ".parquet", ".parq", ".json", ".xlsx"],
         )
         self._upload_tabs = pn.Tabs(sizing_mode="stretch_width")
 
         self._input_tabs = pn.Tabs(
-            ("Upload", pn.Column(self._file_input, self._upload_tabs))
+            ("Upload", pn.Column(self._file_input, self._upload_tabs)),
+            sizing_mode="stretch_both",
         )
 
         if self.select_existing:


### PR DESCRIPTION
I think sizing_mode="stretch_both" fixes https://github.com/holoviz/panel/issues/7169

Before
![image](https://github.com/user-attachments/assets/916fb55a-033f-4b72-bb26-d3a66f0426d6)

After
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/b557d33c-e80d-4926-82eb-22a78b1b077a">
