### PR TITLE
Allow DuckDBSource to determine correct table

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -521,6 +521,8 @@ class SQLAgent(LumenBaseAgent):
         expr_slug = output.expr_slug
         try:
             sql_expr_source = source.create_sql_expr_source({expr_slug: sql_query})
+            # Get validated query
+            sql_query = sql_expr_source.tables[expr_slug]
             pipeline = Pipeline(source=sql_expr_source, table=expr_slug)
         except Exception as e:
             step.status = "failed"


### PR DESCRIPTION
`DuckDBSource.create_sql_expr_source` will now attempt to fix provided SQL expressions should they reference a table by its Lumen name rather than by the underlying table name.