### PR TITLE
search across all sources

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -343,7 +343,6 @@ class LumenBaseAgent(Agent):
         message_kwargs = dict(value=out, user=self.user)
         self.interface.stream(message=message, **message_kwargs, replace=True, max_width=self._max_width)
 
-
 class TableAgent(LumenBaseAgent):
     """
     Displays a single table / dataset. Does not discuss.
@@ -365,7 +364,19 @@ class TableAgent(LumenBaseAgent):
         return table_model
 
     async def answer(self, messages: list | str):
-        tables = tuple(memory["current_source"].get_tables())
+        available_sources = memory["available_sources"]
+
+        tables_to_source = {}
+        tables_schema_str = "\nHere are the table schemas\n"
+        for source in available_sources:
+            for table in source.get_tables():
+                tables_to_source[table] = source
+                schema = get_schema(source, table, include_min_max=False, include_enum=False, limit=1)
+                tables_schema_str += f"### {table}\n```yaml\n{yaml.safe_dump(schema)}```\n"
+
+        print(tables_schema_str)
+
+        tables = tuple(tables_to_source)
         if len(tables) == 1:
             table = tables[0]
         else:
@@ -375,7 +386,7 @@ class TableAgent(LumenBaseAgent):
                     tables = closest_tables
                 elif len(tables) > FUZZY_TABLE_LENGTH:
                     tables = await self._get_closest_tables(messages, tables)
-                system_prompt = await self._system_prompt_with_context(messages)
+                system_prompt = await self._system_prompt_with_context(messages) + tables_schema_str
                 if self.debug:
                     print(f"{self.name} is being instructed that it should {system_prompt}")
                 if len(tables) > 1:
@@ -390,6 +401,8 @@ class TableAgent(LumenBaseAgent):
                 else:
                     table = tables[0]
                 step.stream(f"Selected table: {table}")
+
+        memory["current_source"] = tables_to_source[table]
         memory["current_table"] = table
         memory["current_pipeline"] = pipeline = Pipeline(
             source=memory["current_source"], table=table

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -364,17 +364,20 @@ class TableAgent(LumenBaseAgent):
         return table_model
 
     async def answer(self, messages: list | str):
-        available_sources = memory["available_sources"]
 
-        tables_to_source = {}
-        tables_schema_str = "\nHere are the table schemas\n"
-        for source in available_sources:
-            for table in source.get_tables():
-                tables_to_source[table] = source
-                schema = get_schema(source, table, include_min_max=False, include_enum=False, limit=1)
-                tables_schema_str += f"### {table}\n```yaml\n{yaml.safe_dump(schema)}```\n"
-
-        print(tables_schema_str)
+        if len(memory["available_sources"]) >= 1:
+            available_sources = memory["available_sources"]
+            tables_to_source = {}
+            tables_schema_str = "\nHere are the table schemas\n"
+            for source in available_sources:
+                for table in source.get_tables():
+                    tables_to_source[table] = source
+                    schema = get_schema(source, table, include_min_max=False, include_enum=False, limit=1)
+                    tables_schema_str += f"### {table}\n```yaml\n{yaml.safe_dump(schema)}```\n"
+        else:
+            source = memory["current_source"]
+            tables_to_source = {table: source for table in source.get_tables()}
+            tables_schema_str = ""
 
         tables = tuple(tables_to_source)
         if len(tables) == 1:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -98,12 +98,18 @@ def format_schema(schema):
 
 
 def get_schema(
-    source: Source | Pipeline, table: str | None = None, include_min_max: bool = True
+    source: Source | Pipeline,
+    table: str | None = None,
+    include_min_max: bool = True,
+    include_enum: bool = True,
+    **get_kwargs
 ):
     if isinstance(source, Pipeline):
         schema = source.get_schema()
     else:
-        schema = source.get_schema(table, limit=100)
+        if "limit" not in get_kwargs:
+            get_kwargs["limit"] = 100
+        schema = source.get_schema(table, **get_kwargs)
     schema = dict(schema)
 
     if include_min_max:
@@ -118,6 +124,16 @@ def get_schema(
                 spec.pop("inclusiveMinimum")
             if "inclusiveMaximum" in spec:
                 spec.pop("inclusiveMaximum")
+            if "min" in spec:
+                spec.pop("min")
+            if "max" in spec:
+                spec.pop("max")
+
+    if not include_enum:
+        for field, spec in schema.items():
+            if "enum" in spec:
+                spec.pop("enum")
+
     schema = format_schema(schema)
     return schema
 


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/657

With this, the LLM is able to back out from very specific ephemeral sources with limited number of columns.

Not sure if it's helpful to keep the types, or just column names.

```python
Here are the table schemas
### read_csv('olympic_medals.csv')
```yaml
athlete_full_name:
  type: str
athlete_url:
  type: str
country_3_letter_code:
  type: str
country_code:
  type: str
country_name:
  type: str
discipline_title:
  type: str
event_gender:
  type: str
event_title:
  type: str
medal_type:
  type: str
participant_title:
  type: str
participant_type:
  type: str
slug_game:
  type: str
```
### read_csv('olympic_results.csv')
```yaml
athlete_full_name:
  type: str
athlete_url:
  type: str
athletes:
  type: str
country_3_letter_code:
  type: str
country_code:
  type: str
country_name:
  type: str
discipline_title:
  type: str
event_title:
  type: str
medal_type:
  type: str
participant_type:
  type: str
rank_equal:
  type: bool
rank_position:
  type: str
slug_game:
  type: str
value_type:
  type: str
value_unit:
  type: str
```
### read_csv('olympic_hosts.csv')
```yaml
game_end_date:
  format: datetime
  type: str
game_location:
  type: str
game_name:
  type: str
game_season:
  type: str
game_slug:
  type: str
game_start_date:
  format: datetime
  type: str
game_year:
  type: int
```
### read_csv('olympic_athletes.csv')
```yaml
athlete_full_name:
  type: str
athlete_medals:
  type: str
athlete_url:
  type: str
athlete_year_birth:
  type: int
bio:
  type: str
first_game:
  type: str
games_participations:
  type: int
```
### most_medals_by_country
```yaml
country_name:
  type: str
total_medals:
  type: int
```
```