### PR TITLE
Make Join Analysis inaccessible by LLM

### DIFF
--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -29,6 +29,8 @@ class Analysis(param.ParameterizedFunction):
      # Whether to allow the analysis to be called multiple times in a row
     _consecutive_calls = False
 
+    _callable_by_llm = True
+
     _field_params = []
 
     @classmethod
@@ -59,6 +61,8 @@ class Join(Analysis):
     index_col = param.String(doc="The column to join on in the left table.")
 
     context = param.String(doc="Additional context to provide to the LLM.")
+
+    _callable_by_llm = False
 
     _previous_table = param.Parameter()
 

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -344,7 +344,7 @@ class Assistant(Viewer):
             if isinstance(agent, AnalysisAgent):
                 analyses = "\n".join(
                     f"- `{analysis.__name__}`: {(analysis.__doc__ or '').strip()}"
-                    for analysis in agent.analyses
+                    for analysis in agent.analyses if analysis._callable_by_llm
                 )
                 agent.__doc__ = f"Available analyses include:\n{analyses}\nSelect this agent to perform one of these analyses."
                 break


### PR DESCRIPTION
Sometimes I don't want to deal with the form; I just want the LLM to do a best guess SQL. Join is still accessible through suggestion buttons.

Before:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/ca6f0912-01aa-431d-8a1d-eb7fb88ca74c">

After:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/1dc632c3-c666-4e4a-9b26-a40657805b69">
