### PR TITLE
Limit the amount of data that TableAgent pulls

### DIFF
--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -20,7 +20,7 @@ def test_sql_group_by_multi_columns():
 def test_sql_limit():
     assert (
         SQLLimit.apply_to('SELECT * FROM TABLE', limit=10) ==
-        """SELECT\n    *\nFROM ( SELECT * FROM TABLE )\nLIMIT 10"""
+        """SELECT * FROM TABLE LIMIT 10"""
     )
 
 def test_sql_columns():

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -101,18 +101,15 @@ class SQLLimit(SQLTransform):
     Performs a LIMIT SQL operation on the query
     """
 
-    limit = param.Integer(default=1000, doc="Limit on the number of rows to return")
+    limit = param.Integer(default=1000, allow_None=True, doc="Limit on the number of rows to return")
 
     transform_type: ClassVar[str] = 'sql_limit'
 
     def apply(self, sql_in):
+        if self.limit is None:
+            return sql_in
         sql_in = super().apply(sql_in)
-        template = """
-            SELECT
-                *
-            FROM ( {{sql_in}} )
-            LIMIT {{limit}}
-        """
+        template = "{{sql_in}} LIMIT {{limit}}"
         return self._render_template(template, sql_in=sql_in, limit=self.limit)
 
 


### PR DESCRIPTION
Accidentally pulling 10s or 100s of millions of rows from a database is not a good experience. So by default we add a `SQLLimit`, which the user can un-toggle.