### PR TITLE
Start duckdb implementation of dremio

### DIFF
--- a/lumen/sources/dremio.py
+++ b/lumen/sources/dremio.py
@@ -1,0 +1,69 @@
+from functools import reduce
+
+from pyarrow import flight
+
+
+class DremioClientAuthMiddleware(flight.ClientMiddleware):
+    """
+    A ClientMiddleware that extracts the bearer token from
+    the authorization header returned by the Dremio
+    Flight Server Endpoint.
+
+    Parameters
+    ----------
+    factory : ClientHeaderAuthMiddlewareFactory
+        The factory to set call credentials if an
+        authorization header with bearer token is
+        returned by the Dremio server.
+    """
+
+    def __init__(self, factory):
+        self.factory = factory
+
+    def received_headers(self, headers):
+        if self.factory.call_credential:
+            return
+
+        auth_header_key = "authorization"
+
+        authorization_header = reduce(
+            lambda result, header: (
+                header[1] if header[0] == auth_header_key else result
+            ),
+            headers.items(),
+        )
+        if not authorization_header:
+            raise Exception("Did not receive authorization header back from server.")
+        bearer_token = authorization_header[1][0]
+        self.factory.set_call_credential(
+            [b"authorization", bearer_token.encode("utf-8")]
+        )
+
+
+class DremioClientAuthMiddlewareFactory(flight.ClientMiddlewareFactory):
+    """A factory that creates DremioClientAuthMiddleware(s)."""
+
+    def __init__(self):
+        self.call_credential = []
+
+    def start_call(self, info):
+        return DremioClientAuthMiddleware(self)
+
+    def set_call_credential(self, call_credential):
+        self.call_credential = call_credential
+
+
+class HttpDremioClientAuthHandler(flight.ClientAuthHandler):
+
+    def __init__(self, username, password):
+        super(flight.ClientAuthHandler, self).__init__()
+        self.basic_auth = flight.BasicAuth(username, password)
+        self.token = None
+
+    def authenticate(self, outgoing, incoming):
+        auth = self.basic_auth.serialize()
+        outgoing.write(auth)
+        self.token = incoming.read()
+
+    def get_token(self):
+        return self.token


### PR DESCRIPTION
Started migrating stuff over to DuckDB source and will start testing.

Based off https://www.dremio.com/blog/using-duckdb-with-your-dremio-data-lakehouse/ 

> With a well-curated semantic layer, Dremio makes access and discovery of data much easier for analysts to pull the data they need and have permission to access using Apache Arrow Flight. They can then proceed locally for ad hoc queries on the subset of the data they pulled from Dremio

So essentially, we still have to read the entire dataset and migrate it into a duckdb source. Previously with intake-dremio, I think we were doing dremio -> intake -> duckdb. now it's dremio -> duckdb

While doing that, would like your feedback on implementation or anything.

I think there are things we can tinker with for optimizing the reads like `read_chunk` and partitioning, etc


```
def dataset(source, schema=None, format=None, filesystem=None,
            partitioning=None, partition_base_dir=None,
            exclude_invalid_files=None, ignore_prefixes=None):
```
