### PR TITLE
Tweak SQL prompt to better handle column name clashes and date casting

### DIFF
--- a/lumen/ai/prompts/sql_query.jinja2
+++ b/lumen/ai/prompts/sql_query.jinja2
@@ -15,13 +15,13 @@ closest match, or resample and aggregate the data to align the values.
 {% endif %}
 
 Checklist
-- If it's a date column (excluding individual year/month/day integers), cast as date
-- If no limit is specified, specify 10000 as the limit.
+- Quote column names to ensure they do not clash with valid identifiers.
+- If it's a date column (excluding individual year/month/day integers) date, cast to date using appropriate syntax, e.g. CAST or TO_DATE
+- If no LIMIT or FETCH FIRST/NEXT is specified, specify 10000 as the limit.
+- Use only `{{ dialect }}` syntax
+{% if dialect == 'duckdb' %}
+- If the table name originally did not have `read_*` prefix, use the original table name
 - Use table names verbatim; e.g. if table is read_csv('table.csv') then use read_csv('table.csv') and not 'table'
 - If `read_*` is used, use with alias, e.g. read_parquet('table.parq') as table_parq
-- If the table name originally did not have `read_*` prefix, use the original table name
-- Use only `{{ dialect }}` syntax
-
-{% if dialect == 'duckdb' %}
 - String literals are delimited using single quotes (', apostrophe) and result in STRING_LITERAL values. Note that double quotes (") cannot be used as string delimiter character: instead, double quotes are used to delimit quoted identifiers.
 {% endif %}


### PR DESCRIPTION
Three tweaks:

- Tell it to quote column names just in case
- Tell it to use the appropriate date casting syntax
- Do not give it instructions meant for DuckDB unless we're using DuckDB