### PR TITLE
Ensure invalid table can be invalidated

### DIFF
--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -257,7 +257,11 @@ class Assistant(Viewer):
             else:
                 raise KeyError(f'Table {table} could not be found in available sources.')
 
-        spec = get_schema(source, table=table)
+        try:
+            spec = get_schema(source, table=table)
+        except Exception:
+            # If the selected table cannot be fetched we should invalidate it
+            spec = None
         sql = memory.get("current_sql")
         system = render_template("check_validity.jinja2", table=table, spec=spec, sql=sql, analyses=self._analyses)
         with self.interface.add_step(title="Checking memory...", user="Assistant") as step:

--- a/lumen/ai/prompts/check_validity.jinja2
+++ b/lumen/ai/prompts/check_validity.jinja2
@@ -10,10 +10,14 @@ Based on the latest user's query, decide whether the current table and data cont
 {{ sql }}
 ```
 
+{% if spec %}
 ### Current Data `{column: stat}`:
 ```
 {{ spec }}
 ```
+{% else %}
+Schema for current table could not be determined.
+{% endif %}
 
 {% if analyses %}
 If the user requests one of the current analyses, the data is assumed to be valid.


### PR DESCRIPTION
Previously, if you happened to load a table that would error you could not invalidate it again because the invalidation call would try to access the table, which would in turn error out again.