### PR TITLE
Speculatively cast columns to determine if they are wrongly typed

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -716,6 +716,22 @@ class BaseSQLSource(Source):
     # Declare this source supports SQL transforms
     _supports_sql = True
 
+    def _compute_subset_schema(self, data):
+        casts = {}
+        for col in data.columns:
+            if not hasattr(data[col], 'str'):
+                continue
+            if data[col].str.isdigit().all():
+                data[col] = data[col].astype(int)
+                casts[col] = 'INT'
+                continue
+            try:
+                data[col] = data[col].astype(float)
+                casts[col] = 'FLOAT'
+            except ValueError:
+                continue
+        return get_dataframe_schema(data)['items']['properties'], casts
+
     def get_sql_expr(self, table: str):
         """
         Returns the SQL expression corresponding to a particular table.

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -11,9 +11,8 @@ from ..config import config
 from ..serializers import Serializer
 from ..transforms import Filter
 from ..transforms.sql import (
-    SQLDistinct, SQLFilter, SQLLimit, SQLMinMax,
+    SQLCast, SQLDistinct, SQLFilter, SQLLimit, SQLMinMax,
 )
-from ..util import get_dataframe_schema
 from .base import (
     BaseSQLSource, Source, cached, cached_schema,
 )
@@ -272,23 +271,24 @@ class DuckDBSource(BaseSQLSource):
             tables = [table]
 
         schemas = {}
-        sql_limit = SQLLimit(limit=limit or 1)
+        sql_limit = SQLLimit(limit=limit or 3)
         for entry in tables:
             if not self.load_schema:
                 schemas[entry] = {}
                 continue
             sql_expr = self.get_sql_expr(entry)
             data = self._connection.execute(sql_limit.apply(sql_expr)).fetch_df()
-            schemas[entry] = schema = get_dataframe_schema(data)['items']['properties']
+            schema, casts = self._compute_subset_schema(data)
+            schemas[entry] = schema
             if limit:
                 continue
 
             enums, min_maxes = [], []
             for name, col_schema in schema.items():
-                if 'enum' in col_schema:
-                    enums.append(name)
-                elif 'inclusiveMinimum' in col_schema:
+                if 'inclusiveMinimum' in col_schema or name in casts:
                     min_maxes.append(name)
+                elif 'enum' in col_schema:
+                    enums.append(name)
             for col in enums:
                 distinct_expr = SQLDistinct(columns=[col]).apply(sql_expr)
                 distinct_expr = ' '.join(distinct_expr.splitlines())
@@ -298,6 +298,8 @@ class DuckDBSource(BaseSQLSource):
             if not min_maxes:
                 continue
 
+            if casts:
+                sql_expr = SQLCast(columns=casts, force=True).apply(sql_expr)
             minmax_expr = SQLMinMax(columns=min_maxes).apply(sql_expr)
             minmax_expr = ' '.join(minmax_expr.splitlines())
             minmax_data = self._connection.execute(minmax_expr).fetch_df()


### PR DESCRIPTION
Sometimes SQL data will be incorrectly typed as strings rather than the actual type. Since computing enums for float or integer values is extremely expensive and silly we have the `get_schema` methods speculatively try to cast each column in the subset of columns. If we can successfully cast the subset we will TRY_CAST before computing the min/max values for the schema.