### PR TITLE
Add mistral support

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -278,7 +278,7 @@ class MistralAI(Llm):
 
     api_key = param.String(default=os.getenv("MISTRAL_API_KEY"))
 
-    mode = param.Selector(default=Mode.JSON_SCHEMA, objects=[Mode.JSON_SCHEMA, Mode.MISTRAL_TOOLS])
+    mode = param.Selector(default=Mode.MISTRAL_TOOLS, objects=[Mode.JSON_SCHEMA, Mode.MISTRAL_TOOLS])
 
     temperature = param.Number(default=0.7, bounds=(0, 1), constant=True)
 
@@ -305,6 +305,8 @@ class MistralAI(Llm):
 
         llm = Mistral(api_key=self.api_key)
         if response_model:
+            # can't use from_mistral due to new mistral API
+            # https://github.com/jxnl/instructor/issues/969
             return patch(
                 create=partial(llm.chat.complete_async, model=model),
                 mode=self.mode,


### PR DESCRIPTION
Seems to work, even with mistral-small; haven't tested the Azure one though.

Maybe can use codestral for the SQL
https://docs.mistral.ai/getting-started/models/#overview

```python

import lumen.ai as lmai
import panel as pn

from lumen.sources.duckdb import DuckDBSource
from lumen.ai.analysis import Join

pn.extension(
    "tabulator",
    "codeeditor",
    "vega",
    inline=False,
    template="fast",
    notifications=True,
)

llm = lmai.llm.MistralAI()

cs = lmai.memory["current_source"] = DuckDBSource(
    tables=["windturbines.parquet"],
    uri=":memory:",
    initializers=["INSTALL httpfs;", "LOAD httpfs;"],
)

custom_agent = lmai.agents.AnalysisAgent(analyses=[Join])

assistant = lmai.Assistant(
    llm=llm,
    agents=[
        lmai.agents.SourceAgent,
        lmai.agents.TableAgent,
        lmai.agents.TableListAgent,
        lmai.agents.SQLAgent,
        lmai.agents.PipelineAgent,
        lmai.agents.hvPlotAgent,
        lmai.agents.ChatAgent,
        custom_agent,
    ],
)
assistant.servable("Lumen.ai")
assistant.controls().servable(area="sidebar")

```
<img width="614" alt="image" src="https://github.com/user-attachments/assets/1457eca3-28a1-47e5-acb5-fb547a01300d">
<img width="887" alt="image" src="https://github.com/user-attachments/assets/f22da26c-2ab2-4d86-9e97-fd4febc14b09">
