### PR TITLE
Properly handle joins and propagate invalidation assessment

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -653,20 +653,22 @@ class SQLAgent(LumenBaseAgent):
 
         tables_to_source = {}
         for source_table in join_tables:
+            available_sources = memory["available_sources"]
             if multi_source:
                 try:
                     _, a_source_name, a_table = source_table.split("//", maxsplit=2)
                 except ValueError:
                     a_source_name, a_table = source_table.split("//", maxsplit=1)
-                for source in memory["available_sources"]:
+                for source in available_sources:
                     if source.name == a_source_name:
                         a_source = source
                         break
                 if a_table in tables_to_source:
                     a_table = f"//{a_source_name}//{a_table}"
             else:
-                a_source = next(iter(memory["available_sources"]))
+                a_source = next(iter(available_sources))
                 a_table = source_table
+
             tables_to_source[a_table] = a_source
         return tables_to_source
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -662,7 +662,7 @@ class SQLAgent(LumenBaseAgent):
                     a_source = source
                     break
             if a_table in tables_to_source:
-                a_table = f"{a_source_name}//{a_table}"
+                a_table = f"//{a_source_name}//{a_table}"
             tables_to_source[a_table] = a_source
         return tables_to_source
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -653,16 +653,20 @@ class SQLAgent(LumenBaseAgent):
 
         tables_to_source = {}
         for source_table in join_tables:
-            try:
-                _, a_source_name, a_table = source_table.split("//", maxsplit=2)
-            except ValueError:
-                a_source_name, a_table = source_table.split("//", maxsplit=1)
-            for source in memory["available_sources"]:
-                if source.name == a_source_name:
-                    a_source = source
-                    break
-            if a_table in tables_to_source:
-                a_table = f"//{a_source_name}//{a_table}"
+            if multi_source:
+                try:
+                    _, a_source_name, a_table = source_table.split("//", maxsplit=2)
+                except ValueError:
+                    a_source_name, a_table = source_table.split("//", maxsplit=1)
+                for source in memory["available_sources"]:
+                    if source.name == a_source_name:
+                        a_source = source
+                        break
+                if a_table in tables_to_source:
+                    a_table = f"//{a_source_name}//{a_table}"
+            else:
+                a_source = next(iter(memory["available_sources"]))
+                a_table = source_table
             tables_to_source[a_table] = a_source
         return tables_to_source
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -45,7 +45,7 @@ class Llm(param.Parameterized):
         **input_kwargs,
     ) -> BaseModel:
         system = system.strip().replace("\n\n", "\n")
-        print("\033[33m" + system + "\033[0m")  # useful for debugging
+        print("\n\n---\n\033[33m" + system + "\033[0m")  # useful for debugging
         if isinstance(messages, str):
             messages = [{"role": "user", "content": messages}]
         if system:

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -45,7 +45,6 @@ class Llm(param.Parameterized):
         **input_kwargs,
     ) -> BaseModel:
         system = system.strip().replace("\n\n", "\n")
-        print("\n\n---\n\033[33m" + system + "\033[0m")  # useful for debugging
         if isinstance(messages, str):
             messages = [{"role": "user", "content": messages}]
         if system:

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -39,6 +39,12 @@ class JoinRequired(BaseModel):
 
 class TableJoins(BaseModel):
 
+    chain_of_thought: str = Field(
+        description="""
+        Consider the tables that need to be joined to answer the user's query.
+        """
+    )
+
     tables: list[str] = Field(
         description=(
             "List of tables that need to be joined to answer the user's query. "

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -78,9 +78,10 @@ class Validity(BaseModel):
 
     correct_assessment: str = Field(
         description="""
-        Thoughts on whether the current table meets the requirement
-        to answer the user's query, i.e. table contains all necessary columns,
-        unless user explicitly asks for a refresh.
+        Restate the current table and think thru whether the current table meets the requirement
+        to answer the user's query, i.e. table contains all necessary raw columns that are not
+        derivable from SQL expressions. If the user user explicitly asks for a refresh,
+        then the table is invalid.
         """
     )
 

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -78,7 +78,7 @@ class Validity(BaseModel):
 
     correct_assessment: str = Field(
         description="""
-        Restate the current table and think thru whether the current table meets the requirement
+        Restate the current table and think through whether the current table meets the requirement
         to answer the user's query, i.e. table contains all necessary raw columns that are not
         derivable from SQL expressions. If the user user explicitly asks for a refresh,
         then the table is invalid.

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -41,7 +41,7 @@ class TableJoins(BaseModel):
 
     chain_of_thought: str = Field(
         description="""
-        Consider the tables that need to be joined to answer the user's query.
+        Concisely consider the tables that need to be joined to answer the user's query.
         """
     )
 

--- a/lumen/ai/prompts/check_validity.jinja2
+++ b/lumen/ai/prompts/check_validity.jinja2
@@ -1,8 +1,4 @@
-Based on the latest user's query, decide whether the current table and data contains the the required data. If the user
-is referencing "this data" or "that" they probably are referring to the current data. Pay particular attention to
-whether the data actually contains the columns required to answer the query, e.g. if they are asking for a location but
-there are no location related column the data is invalid. However, if the query can be solved through SQL,
-the data is assumed to be valid.
+Based on the latest user's query, decide whether the current table and data contains the the required data. If the user is referencing "this data" or "that" they probably are referring to the current data. Pay particular attention to whether the data actually contains the columns required to answer the query, e.g. if they are asking for a location but there are no location related column the data is invalid. However, if the query can be solved through SQL, the data is assumed to be valid.
 
 ### Current Table:
 ```

--- a/lumen/ai/prompts/check_validity.jinja2
+++ b/lumen/ai/prompts/check_validity.jinja2
@@ -1,4 +1,8 @@
-Based on the latest user's query, decide whether the current table and data contains the the required data. If the user is referencing "this data" or "that" they probably are referring to the current data. Pay particular attention to whether the data actually contains the columns required to answer the query, e.g. if they are asking for a location but there are no location related column the data is invalid.
+Based on the latest user's query, decide whether the current table and data contains the the required data. If the user
+is referencing "this data" or "that" they probably are referring to the current data. Pay particular attention to
+whether the data actually contains the columns required to answer the query, e.g. if they are asking for a location but
+there are no location related column the data is invalid. However, if the query can be solved through SQL,
+the data is assumed to be valid.
 
 ### Current Table:
 ```

--- a/lumen/ai/prompts/find_joins.jinja2
+++ b/lumen/ai/prompts/find_joins.jinja2
@@ -1,0 +1,6 @@
+Correctly assess and list the tables that need to be joined; be sure to include both `//`.
+
+Here are the available tables:
+{% for table in available_tables %}
+- {{ table }}
+{% endfor %}

--- a/lumen/ai/prompts/sql_query.jinja2
+++ b/lumen/ai/prompts/sql_query.jinja2
@@ -7,12 +7,10 @@ The data for table '{{ table }}' follows the following YAML schema:
 {% endfor %}
 
 {% if not join_required %}
-It was already determined that no join is required, so only use the existing
-table '{{ table }}' to calculate the result.
+It was already determined that no join is required, so only use the existing table '{{ table }}' to calculate the result.
 {% else %}
 Please perform a join between the necessary tables.
-If the join's values do not align based on the min/max lowest common denominator, then perform a join based on the
-closest match, or resample and aggregate the data to align the values.
+If the join's values do not align based on the min/max lowest common denominator, then perform a join based on the closest match, or resample and aggregate the data to align the values.
 {% endif %}
 
 Checklist

--- a/lumen/ai/prompts/sql_query.jinja2
+++ b/lumen/ai/prompts/sql_query.jinja2
@@ -10,6 +10,7 @@ The data for table '{{ table }}' follows the following YAML schema:
 It was already determined that no join is required, so only use the existing
 table '{{ table }}' to calculate the result.
 {% else %}
+Please perform a join between the necessary tables.
 If the join's values do not align based on the min/max lowest common denominator, then perform a join based on the
 closest match, or resample and aggregate the data to align the values.
 {% endif %}

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -237,6 +237,7 @@ class DuckDBSource(BaseSQLSource):
         return [t[0] for t in self._connection.execute('SHOW TABLES').fetchall()]
 
     def get_sql_expr(self, table: str):
+        print(self.tables, "TABLES...")
         if isinstance(self.tables, dict):
             table = self.tables[table]
         if '(' not in table and ')' not in table:

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -237,7 +237,6 @@ class DuckDBSource(BaseSQLSource):
         return [t[0] for t in self._connection.execute('SHOW TABLES').fetchall()]
 
     def get_sql_expr(self, table: str):
-        print(self.tables, "TABLES...")
         if isinstance(self.tables, dict):
             table = self.tables[table]
         if '(' not in table and ')' not in table:


### PR DESCRIPTION
I am now properly able to back out of the ephemeral table and consistently get the desired result.

<img width="465" alt="image" src="https://github.com/user-attachments/assets/69652744-b4fe-4e7a-b6a8-0813ac0dbbf1">

<img width="818" alt="image" src="https://github.com/user-attachments/assets/e59fac64-67e9-4213-8096-dc3493ff818e">

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/252f4ac8-8b2c-4868-bcbb-199f94f3b44a">

The root issue was that if there were multiple tables within a single source that needed to be joined, the key `a_source_name` was overridden, so no joins really happened.
`sources[a_source_name] = (a_source, a_table)`

I refactored it so the table name is the key; and if there are duplicate it prefixes with the source name and then re-extracts it out when fetching the table.