### PR TITLE
Bump instructor version

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -68,7 +68,7 @@ sqlalchemy = "*"
 # [feature.ai.dependencies]
 # datashader = "*"
 # python-duckdb = "*"
-# instructor = ">=1"
+# instructor = ">=1.4.3"
 # nbformat = "*"
 # openai = "*"
 # pyarrow = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ HoloViz = "https://holoviz.org/"
 [project.optional-dependencies]
 tests = ['pytest', 'pytest-rerunfailures']
 sql = ['duckdb', 'intake-sql', 'sqlalchemy']
-ai = ['nbformat', 'duckdb', 'pyarrow', 'openai', 'instructor >=1', 'pydantic >=2.8.0', 'datashader']
+ai = ['nbformat', 'duckdb', 'pyarrow', 'openai', 'instructor >=1.4.3', 'pydantic >=2.8.0', 'datashader']
 ai-local = ['lumen[ai]', 'huggingface_hub']
 ai-llama = ['lumen[ai-local]', 'llama-cpp-python']
 


### PR DESCRIPTION
Was encountering issues with plotting with instructor==1.3.7, but I kind of remember an issue with newer versions too?
<img width="428" alt="image" src="https://github.com/user-attachments/assets/4f58d699-440b-48f2-8353-d5613bbbfd1f">

Maybe it was https://github.com/holoviz/lumen/pull/623