### PR TITLE
Support downloading pdf for YdataProfiler

### DIFF
--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -5,6 +5,7 @@ object.
 from __future__ import annotations
 
 import html
+import logging
 import sys
 
 from io import BytesIO, StringIO
@@ -1156,6 +1157,8 @@ class YdataProfilingView(View):
             except ImportError:
                 raise ImportError("weasyprint and PyPDF2 must be installed to save the report as PDF")
 
+            # stop all the long list of warnings from weasyprint
+            logging.getLogger("weasyprint").setLevel(logging.ERROR)
             pdf = weasyprint.HTML(string=report_html).write_pdf()
             with BytesIO(pdf) as buf:
                 reader = PdfReader(buf)


### PR DESCRIPTION
Requires weasyprint and PyPDF2 because weasyprint alone had empty pages in between and I couldnt figure out which CSS element was triggering that.

https://github.com/user-attachments/assets/8fe3e749-21b6-4262-b973-e3a96ce7e841

Requires (preferably under conda install section)
  - weasyprint
  - pypdf2

I think this method is preferable over selenium because this includes data/images from HTML tabs

example pdf
[profile_report (7).pdf](https://github.com/user-attachments/files/17285294/profile_report.7.pdf)

And it's also tested on deployment
