### PR TITLE
Ensure invalid tables are cleaned up by SQLAgent

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -4,6 +4,7 @@ import time
 
 from functools import wraps
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import jinja2
 import pandas as pd
@@ -12,6 +13,9 @@ from lumen.pipeline import Pipeline
 from lumen.sources.base import Source
 
 from .config import THIS_DIR, UNRECOVERABLE_ERRORS
+
+if TYPE_CHECKING:
+    from panel.chat.step import ChatStep
 
 
 def render_template(template, **context):
@@ -251,3 +255,12 @@ def clean_sql(sql_expr):
     backticks, fencing and extraneous space and semi-colons.
     """
     return sql_expr.replace("```sql", "").replace("```", "").replace('`', '"').strip().rstrip(";")
+
+
+def report_error(exc: Exception, step: ChatStep):
+    error_msg = str(exc)
+    step.stream(f'\n```python\n{error_msg}\n```')
+    if len(error_msg) > 50:
+        error_msg = error_msg[:50] + "..."
+    step.failed_title = error_msg
+    step.status = "failed"


### PR DESCRIPTION
Does two things:

1. Delete the table definition if the SQL query generated by the SQLAgent cannot be executed (ensuring that it can overwrite the table on retry)
2. Declares the `answer` method on the Agent baseclass