### PR TITLE
Rename methods and tweak API

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -701,13 +701,12 @@ class SQLAgent(LumenBaseAgent):
             # Remove source prefixes message, e.g. //<source>//<table>
             messages[-1]["content"] = re.sub(r"//[^/]+//", "", messages[-1]["content"])
         sql_query = await self._create_valid_sql(messages, system, tables_to_source)
-        pipeline = memory['current_pipeline']
-        output = SQLOutput(component=pipeline, spec=sql_query.rstrip(';'))
-        return output
+        return sql_query
 
     async def respond(self, messages: list):
         output = await self.step_through(messages)
-        self._render_lumen(output)
+        pipeline = memory['current_pipeline']
+        self._render_lumen(pipeline, spec=output)
 
 
 class BaseViewAgent(LumenBaseAgent):

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -871,7 +871,7 @@ class AnalysisAgent(LumenBaseAgent):
             system_prompt += f"\n### CONTEXT: {context}".strip()
         return system_prompt
 
-    async def respond(self, messages: list, title: str = "", render_output: bool = True, agents: list[Agent] | None = None):
+    async def respond(self, messages: list, title: str = "", render_output: bool = True, agents: list[Agent] | None = None) -> None:
         pipeline = memory['current_pipeline']
         analyses = {a.name: a for a in self.analyses if await a.applies(pipeline)}
         if not analyses:

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -88,7 +88,7 @@ class Agent(Viewer):
             )
 
         if "interface" not in params:
-            params["interface"] = ChatInterface(callback=self._chat_invoke)
+            params["interface"] = ChatInterface(callback=self._interface_callback)
         super().__init__(**params)
         if not self.debug:
             pn.config.exception_handler = _exception_handler
@@ -105,7 +105,7 @@ class Agent(Viewer):
         """
         return True
 
-    async def _chat_respond(self, contents: list | str, user: str, instance: ChatInterface):
+    async def _interface_callback(self, contents: list | str, user: str, instance: ChatInterface):
         await self.respond(contents)
         self._retries_left = 1
 

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import param
 import yaml
 
-from panel import bind
+from panel import Card, bind
 from panel.chat import ChatInterface, ChatStep
 from panel.layout import Column, FlexBox, Tabs
 from panel.pane import HTML, Markdown
@@ -447,8 +447,9 @@ class Assistant(Viewer):
                     custom_messages.append({"role": "user", "content": instruction})
 
                 respond_kwargs = {}
+                # attach the new steps to the existing steps--used when there is intermediate Lumen output
                 last_steps_message = self.interface.objects[-2]
-                if last_steps_message.user == "Assistant":
+                if last_steps_message.user == "Assistant" and isinstance(last_steps_message.object, Card):
                     respond_kwargs["steps_layout"] = last_steps_message.object
 
                 await subagent.respond(custom_messages, title=title, render_output=render_output, **respond_kwargs)
@@ -513,7 +514,8 @@ class Assistant(Viewer):
 
         last_steps_message = self.interface.objects[-2]
         respond_kwargs = {"title": title, "render_output": True}
-        if last_steps_message.user == "Assistant":
+        # attach the new steps to the existing steps--used when there is intermediate Lumen output
+        if last_steps_message.user == "Assistant" and isinstance(last_steps_message.object, Card):
             respond_kwargs["steps_layout"] = last_steps_message.object
         if isinstance(agent, AnalysisAgent):
             respond_kwargs["agents"] = self.agents

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -199,7 +199,7 @@ class Assistant(Viewer):
                     else:
                         print("No analysis agent found.")
                         return
-                    await agent.invoke([{'role': 'user', 'content': contents}], agents=self.agents)
+                    await agent.respond([{'role': 'user', 'content': contents}], agents=self.agents)
                     await self._add_analysis_suggestions()
                 else:
                     self.interface.send(contents)
@@ -419,7 +419,7 @@ class Assistant(Viewer):
                         custom_messages.append({"role": "user", "content": custom_message})
                 if instruction:
                     custom_messages.append({"role": "user", "content": instruction})
-                await subagent.answer(custom_messages)
+                await subagent.step_through(custom_messages)
                 step.stream(f"`{agent_name}` agent successfully completed the following task:\n\n- {instruction}", replace=True)
                 step.success_title = f"{agent_name} agent successfully responded"
         return selected
@@ -475,7 +475,7 @@ class Assistant(Viewer):
         kwargs = {}
         if isinstance(agent, AnalysisAgent):
             kwargs["agents"] = self.agents
-        await agent.invoke(messages[-context_length:], **kwargs)
+        await agent.respond(messages[-context_length:], **kwargs)
         self._current_agent.object = "## No agent active"
         if "current_pipeline" in agent.provides:
             await self._add_analysis_suggestions()

--- a/lumen/ai/assistant.py
+++ b/lumen/ai/assistant.py
@@ -436,7 +436,7 @@ class Assistant(Viewer):
                         custom_messages.append({"role": "user", "content": custom_message})
                 if instruction:
                     custom_messages.append({"role": "user", "content": instruction})
-                await subagent.step_through(custom_messages, title=title)
+                await subagent.respond(custom_messages, title=title, render_output=False)
                 step.stream(f"`{agent_name}` agent successfully completed the following task:\n\n- {instruction}", replace=True)
                 step.success_title = f"{agent_name} agent successfully responded"
 

--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -37,4 +37,4 @@ UNRECOVERABLE_ERRORS = (
     RecursionError,
 )
 
-pn.chat.ChatStep.min_width = 350
+pn.chat.ChatStep.min_width = 450

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 
 from functools import partial
-from types import SimpleNamespace, TypedDict
+from types import SimpleNamespace
+from typing import Literal, TypedDict
 
 import instructor
 import panel as pn

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 
 from .interceptor import Interceptor
 
+
 class Message(TypedDict):
     role: Literal["system", "user", "assistant"]
     content: str

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from functools import partial
-from types import SimpleNamespace
+from types import SimpleNamespace, TypedDict
 
 import instructor
 import panel as pn
@@ -14,6 +14,11 @@ from instructor.patch import Mode, patch
 from pydantic import BaseModel
 
 from .interceptor import Interceptor
+
+class Message(TypedDict):
+    role: Literal["system", "user", "assistant"]
+    content: str
+    name: str | None
 
 
 class Llm(param.Parameterized):
@@ -58,7 +63,7 @@ class Llm(param.Parameterized):
 
     async def invoke(
         self,
-        messages: list | str,
+        messages: list[Message],
         system: str = "",
         response_model: BaseModel | None = None,
         allow_partial: bool = False,
@@ -91,7 +96,7 @@ class Llm(param.Parameterized):
 
     async def stream(
         self,
-        messages: list | str,
+        messages: list[Message],
         system: str = "",
         response_model: BaseModel | None = None,
         field: str | None = None,
@@ -357,7 +362,7 @@ class MistralAI(Llm):
 
     async def invoke(
         self,
-        messages: list | str,
+        messages: list[Message],
         system: str = "",
         response_model: BaseModel | None = None,
         allow_partial: bool = False,
@@ -470,7 +475,7 @@ class AnthropicAI(Llm):
 
     async def invoke(
         self,
-        messages: list | str,
+        messages: list[Message],
         system: str = "",
         response_model: BaseModel | None = None,
         allow_partial: bool = False,

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -107,8 +107,9 @@ def make_plan_models(agent_names: list[str], tables: list[str]):
     step = create_model(
         "Step",
         expert=(Literal[agent_names], FieldInfo(description="The name of the expert to assign a task to.")),
-        instruction=(str, FieldInfo(description="Instructions to the expert to assist in the task.")),
+        instruction=(str, FieldInfo(description="Instructions to the expert to assist in the task, and whether rendering is required.")),
         title=(str, FieldInfo(description="Short title of the task to be performed; up to six words.")),
+        render_output=(bool, FieldInfo(description="Whether the output of the expert should be rendered. If the user wants to see the table, and the expert is SQL, then this should be `True`.")),
     )
     extras = {}
     if tables:

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -102,11 +102,13 @@ class VegaLiteSpec(BaseModel):
     json_spec: str = Field(description="A vega-lite JSON specification WITHOUT the data field, which will be added automatically.")
 
 
+
 def make_plan_models(agent_names: list[str], tables: list[str]):
     step = create_model(
         "Step",
         expert=(Literal[agent_names], FieldInfo(description="The name of the expert to assign a task to.")),
-        instruction=(str, FieldInfo(description="Instructions to the expert to assist in the task."))
+        instruction=(str, FieldInfo(description="Instructions to the expert to assist in the task.")),
+        title=(str, FieldInfo(description="Short title of the task to be performed; up to six words.")),
     )
     extras = {}
     if tables:


### PR DESCRIPTION
1. Renames `answer` -> `step_through`
2. Renames `Agent().invoke` -> `respond`
3. Improve typing (messages: list)
4. Use only `step.stream` in `step_through`, and `interface.stream` in `respond`
5. Wrap output from `step_through` in `AgentStepResults` parameterized
6. Migrate agent chain tuples into `AgentChainLink` parameterized
7. Make LLM generate a short title for steps (I was confused why the LLM was doing consecutive SQLAgent calls) and widen the default min_width
8. Prevent plan step from flashing (due to empty string replace=True)

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/abb9d812-7235-42d4-9cdd-46c9a1c9b668">
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/263f30fb-a739-4998-8ea6-fa1dc1f522bf">

