### PR TITLE
Refactor handling of outputs

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -364,7 +364,10 @@ class LumenBaseAgent(Agent):
             component=component, render_output=render_output, **kwargs
         )
         if 'outputs' in self._memory:
-            self._memory['outputs'].append(out)
+            # We have to create a new list to trigger an event
+            # since inplace updates will not trigger updates
+            # and won't allow diffing between old and new values
+            self._memory['outputs'] = self._memory['outputs']+[out]
         message_kwargs = dict(value=out, user=self.user)
         self.interface.stream(message=message, **message_kwargs, replace=True, max_width=self._max_width)
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -358,10 +358,11 @@ class LumenBaseAgent(Agent):
         component: Component,
         message: pn.chat.ChatMessage = None,
         render_output: bool = False,
+        title: str | None = None,
         **kwargs
     ):
         out = self._output_type(
-            component=component, render_output=render_output, **kwargs
+            component=component, render_output=render_output, title=title, **kwargs
         )
         if 'outputs' in self._memory:
             # We have to create a new list to trigger an event
@@ -727,7 +728,7 @@ class SQLAgent(LumenBaseAgent):
             messages[-1]["content"] = re.sub(r"//[^/]+//", "", messages[-1]["content"])
         sql_query = await self._create_valid_sql(messages, system_prompt, tables_to_source, step_title)
         pipeline = self._memory['current_pipeline']
-        self._render_lumen(pipeline, spec=sql_query, render_output=render_output)
+        self._render_lumen(pipeline, spec=sql_query, render_output=render_output, title=step_title)
         return pipeline
 
 
@@ -791,7 +792,7 @@ class BaseViewAgent(LumenBaseAgent):
         print(f"{self.name} settled on spec: {spec!r}.")
         self._memory["current_view"] = dict(spec, type=self.view_type)
         view = self.view_type(pipeline=pipeline, **spec)
-        self._render_lumen(view, render_output=render_output)
+        self._render_lumen(view, render_output=render_output, title=step_title)
         return view
 
 
@@ -982,6 +983,7 @@ class AnalysisAgent(LumenBaseAgent):
                 view,
                 analysis=analysis,
                 pipeline=pipeline,
-                render_output=render_output
+                render_output=render_output,
+                title=step_title
             )
         return view

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -675,7 +675,7 @@ class Planner(Coordinator):
                     istep.stream(f"The plan didn't account for {unmet_dependencies!r}", replace=True)
                 else:
                     planned = True
-            self._memory['current_plan'] = plan.title
+            self._memory['plan'] = plan
             istep.stream('\n\nHere are the steps:\n\n')
             for i, step in enumerate(plan.steps):
                 istep.stream(f"{i+1}. {step.expert}: {step.instruction}\n")

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -14,12 +14,19 @@ class _Memory(SessionCache):
         self._callbacks = defaultdict(list)
         self._rx = {}
 
-    def __setitem__(self, key, value):
-        super().__setitem__(key, value)
-        self._trigger_update(key, value)
+    def __setitem__(self, key, new):
+        if key in self:
+            old = self[key]
+        else:
+            old = None
+        super().__setitem__(key, new)
+        self._trigger_update(key, old, new)
 
     def on_change(self, key, callback):
         self._callbacks[key].append(callback)
+
+    def remove_on_change(self, key, callback):
+        self._callbacks[key].remove(callback)
 
     def rx(self, key):
         if key in self._rx:
@@ -28,13 +35,13 @@ class _Memory(SessionCache):
         return rxp
 
     def trigger(self, key):
-        self._trigger_update(key, self[key])
+        self._trigger_update(key, self[key], self[key])
 
-    def _trigger_update(self, key, value):
+    def _trigger_update(self, key, old, new):
         for cb in self._callbacks[key]:
-            cb(value)
+            cb(key, old, new)
         if key in self._rx:
-            self._rx[key].rx.value = value
+            self._rx[key].rx.value = new
 
 
 memory = _Memory()

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -94,7 +94,7 @@ def make_plan_models(agent_names: list[str], tables: list[str]):
         "Step",
         expert=(Literal[agent_names], FieldInfo(description="The name of the expert to assign a task to.")),
         instruction=(str, FieldInfo(description="Instructions to the expert to assist in the task, and whether rendering is required.")),
-        title=(str, FieldInfo(description="Short title of the task to be performed; up to six words.")),
+        title=(str, FieldInfo(description="Short title of the task to be performed; up to three words.")),
         render_output=(bool, FieldInfo(description="Whether the output of the expert should be rendered. If the user wants to see the table, and the expert is SQL, then this should be `True`.")),
     )
     extras = {}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -27,6 +27,7 @@ Checklist
 - If it's a date column (excluding individual year/month/day integers) date, cast to date using appropriate syntax, e.g.
 CAST or TO_DATE
 - Use only `{{ dialect }}` syntax
+- Try to pretty print the SQL output with newlines and indentation.
 {% if dialect == 'duckdb' %}
 - If the table name originally did not have `read_*` prefix, use the original table name
 - Use table names verbatim; e.g. if table is read_csv('table.csv') then use read_csv('table.csv') and not 'table'

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -34,6 +34,8 @@ class LumenOutput(Viewer):
 
     spec = param.String(allow_None=True)
 
+    title = param.String(allow_None=True)
+
     language = "yaml"
 
     def __init__(self, **params):

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -1,11 +1,17 @@
 import asyncio
+import traceback
 
 import panel as pn
 import param
 import yaml
 
+from panel.layout import Column, Row, Tabs
+from panel.pane import Alert
 from panel.param import ParamMethod
 from panel.viewable import Viewer
+from panel.widgets import (
+    Button, ButtonIcon, Checkbox, CodeEditor, LoadingSpinner,
+)
 from param.parameterized import discard_events
 
 from lumen.ai.utils import get_data
@@ -35,19 +41,19 @@ class LumenOutput(Viewer):
             component_spec = params['component'].to_spec()
             params['spec'] = yaml.dump(component_spec)
         super().__init__(**params)
-        code_editor = pn.widgets.CodeEditor(
+        code_editor = CodeEditor(
             value=self.param.spec, language=self.language, theme='tomorrow_night_bright', sizing_mode="stretch_both",
             on_keyup=False
         )
         code_editor.link(self, bidirectional=True, value='spec')
-        copy_icon = pn.widgets.ButtonIcon(
+        copy_icon = ButtonIcon(
             icon="copy", active_icon="check", toggle_duration=1000
         )
         copy_icon.js_on_click(
             args={"code_editor": code_editor},
             code="navigator.clipboard.writeText(code_editor.code);",
         )
-        download_icon = pn.widgets.ButtonIcon(
+        download_icon = ButtonIcon(
             icon="download", active_icon="check", toggle_duration=1000
         )
         download_icon.js_on_click(
@@ -64,14 +70,14 @@ class LumenOutput(Viewer):
             a.parentNode.removeChild(a);  //afterwards we remove the element again
             """,
         )
-        icons = pn.Row(copy_icon, download_icon)
-        code_col = pn.Column(code_editor, icons, sizing_mode="stretch_both")
+        icons = Row(copy_icon, download_icon)
+        code_col = Column(code_editor, icons, sizing_mode="stretch_both")
         if self.render_output:
-            placeholder = pn.Column(
+            placeholder = Column(
                 ParamMethod(self.render, inplace=True),
                 sizing_mode="stretch_width"
             )
-            self._main = pn.Tabs(
+            self._main = Tabs(
                 ("Code", code_col),
                 ("Output", placeholder),
                 styles={'min-width': '100%', 'height': 'fit-content', 'min-height': '300px'},
@@ -103,7 +109,7 @@ class LumenOutput(Viewer):
         )
         download_pane = download.__panel__()
         download_pane.sizing_mode = 'fixed'
-        controls = pn.Row(
+        controls = Row(
             download_pane,
             styles={'position': 'absolute', 'right': '40px', 'top': '-35px'}
         )
@@ -118,16 +124,16 @@ class LumenOutput(Viewer):
             if limited:
                 def unlimit(e):
                     sql_limit.limit = None if e.new else 1_000_000
-                full_data = pn.widgets.Checkbox(
+                full_data = Checkbox(
                     name='Full data', width=100, visible=limited
                 )
                 full_data.param.watch(unlimit, 'value')
                 controls.insert(0, full_data)
-        return pn.Column(controls, table)
+        return Column(controls, table)
 
     @param.depends('spec', 'active')
     async def render(self):
-        yield pn.indicators.LoadingSpinner(
+        yield LoadingSpinner(
             value=True, name="Rendering component...", height=50, width=50
         )
 
@@ -138,7 +144,7 @@ class LumenOutput(Viewer):
             yield self._last_output[self.spec]
             return
         elif self.component is None:
-            yield pn.pane.Alert(
+            yield Alert(
                 "No component to render. Please complete the Config tab.",
                 alert_type="warning",
             )
@@ -157,9 +163,8 @@ class LumenOutput(Viewer):
             self._last_output[self.spec] = output
             yield output
         except Exception as e:
-            import traceback
             traceback.print_exc()
-            yield pn.pane.Alert(
+            yield Alert(
                 f"```\n{e}\n```\nPlease press undo, edit the YAML, or continue chatting.",
                 alert_type="danger",
             )
@@ -191,7 +196,7 @@ class AnalysisOutput(LumenOutput):
                 run_button.param.watch(self._rerun, 'clicks')
                 self._main.insert(1, ('Config', controls))
             else:
-                run_button = pn.widgets.Button(
+                run_button = Button(
                     icon='player-play', name='Run', on_click=self._rerun,
                     button_type='success', margin=(10, 0, 0 , 10)
                 )
@@ -221,7 +226,7 @@ class SQLOutput(LumenOutput):
 
     @param.depends('spec', 'active')
     async def render(self):
-        yield pn.indicators.LoadingSpinner(
+        yield LoadingSpinner(
             value=True, name="Executing SQL query...", height=50, width=50
         )
         if self.active != 1:
@@ -234,7 +239,9 @@ class SQLOutput(LumenOutput):
 
         try:
             if self._rendered:
-                pipeline.source = pipeline.source.create_sql_expr_source(tables={pipeline.table: self.spec})
+                pipeline.source = pipeline.source.create_sql_expr_source(
+                    tables={pipeline.table: self.spec}
+                )
             output = await self._render_pipeline(pipeline)
             self._rendered = True
             self._last_output.clear()
@@ -243,7 +250,7 @@ class SQLOutput(LumenOutput):
         except Exception as e:
             import traceback
             traceback.print_exc()
-            yield pn.pane.Alert(
+            yield Alert(
                 f"```\n{e}\n```\nPlease press undo, edit the YAML, or continue chatting.",
                 alert_type="danger",
             )


### PR DESCRIPTION
Previously the `ExplorerUI` had to wait until all outputs were generated to render any of them. We now add progressive rendering, showing the outputs as they are added.