### PR TITLE
Ensure Analyses are performed in context of the exploration

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -203,6 +203,7 @@ class Coordinator(Viewer, Actor):
             if len(self.interface.objects) > num_objects:
                 suggestion_buttons.visible = False
 
+        memory = self._memory
         async def use_suggestion(event):
             button = event.obj
             with button.param.update(loading=True), self.interface.active_widget.param.update(loading=True):
@@ -219,10 +220,11 @@ class Coordinator(Viewer, Actor):
                         print("No analysis agent found.")
                         return
                     messages = [{'role': 'user', 'content': contents}]
-                    await agent.respond(
-                        messages, render_output=self.render_output, agents=self.agents
-                    )
-                    await self._add_analysis_suggestions()
+                    with agent.param.update(memory=memory):
+                        await agent.respond(
+                            messages, render_output=self.render_output, agents=self.agents
+                        )
+                        await self._add_analysis_suggestions()
                 else:
                     self.interface.send(contents)
 

--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -22,6 +22,10 @@ class _Memory(SessionCache):
         super().__setitem__(key, new)
         self._trigger_update(key, old, new)
 
+    def cleanup(self):
+        self._callbacks.clear()
+        self._rx.clear()
+
     def on_change(self, key, callback):
         self._callbacks[key].append(callback)
 


### PR DESCRIPTION
Previously the analysis buttons were added and would then run in the current context when clicked. However, analyses are deeply coupled to the data of the exploration so they should inherit that context.