### PR TITLE
literal workaround

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -461,7 +461,6 @@ class SQLAgent(LumenBaseAgent):
         tables_to_source, tables_schema_str = await gather_table_sources(available_sources)
         tables = tuple(tables_to_source)
 
-        table = None
         if messages and messages[-1]["content"].startswith("Show the table: '"):
             # Handle the case where explicitly requested a table
             table = messages[-1]["content"].replace("Show the table: '", "")[:-1]
@@ -479,8 +478,7 @@ class SQLAgent(LumenBaseAgent):
                     tables_aliases = {
                         re.sub(r'[^a-zA-Z0-9_]', '_', table): table for table in tables
                     }
-                    print(tables_aliases, list(tables_aliases), "TABLES...")
-                    table_model = make_table_model(list(tables_aliases))
+                    table_model = make_table_model(tuple(tables_aliases))
                     result = await self.llm.invoke(
                         messages,
                         system=system_prompt,

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -39,8 +39,8 @@ from .models import (
 )
 from .translate import param_to_pydantic
 from .utils import (
-    clean_sql, describe_data, gather_table_sources, get_data, get_pipeline,
-    get_schema, report_error, retry_llm_output,
+    clean_sql, create_aliases, describe_data, gather_table_sources, get_data,
+    get_pipeline, get_schema, report_error, retry_llm_output,
 )
 from .views import AnalysisOutput, LumenOutput, SQLOutput
 
@@ -475,9 +475,7 @@ class SQLAgent(LumenBaseAgent):
                     elif len(tables) > FUZZY_TABLE_LENGTH:
                         tables = await self._get_closest_tables(messages, tables)
                     system_prompt = self._render_prompt("select_table", tables_schema_str=tables_schema_str)
-                    tables_aliases = {
-                        re.sub(r'[^a-zA-Z0-9_]', '_', table): table for table in tables
-                    }
+                    tables_aliases = create_aliases(tables)
                     table_model = make_table_model(tuple(tables_aliases))
                     result = await self.llm.invoke(
                         messages,

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -460,6 +460,8 @@ class SQLAgent(LumenBaseAgent):
         available_sources = self._memory["available_sources"]
         tables_to_source, tables_schema_str = await gather_table_sources(available_sources)
         tables = tuple(tables_to_source)
+
+        table = None
         if messages and messages[-1]["content"].startswith("Show the table: '"):
             # Handle the case where explicitly requested a table
             table = messages[-1]["content"].replace("Show the table: '", "")[:-1]
@@ -477,6 +479,7 @@ class SQLAgent(LumenBaseAgent):
                     tables_aliases = {
                         re.sub(r'[^a-zA-Z0-9_]', '_', table): table for table in tables
                     }
+                    print(tables_aliases, list(tables_aliases), "TABLES...")
                     table_model = make_table_model(list(tables_aliases))
                     result = await self.llm.invoke(
                         messages,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -606,7 +606,7 @@ class Planner(Coordinator):
             role=user_msg['role'],
             content=(
                 f"<user query>{user_msg['content']}</user query>"
-                "{reasoning.chain_of_thought}"
+                f"{reasoning.chain_of_thought}"
             )
         )
         messages = messages[:-1] + [new_msg]

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -660,7 +660,7 @@ class Planner(Coordinator):
         tables_aliases = {
             re.sub(r'[^a-zA-Z0-9_]', '_', table): table for table in tables
         }
-        reason_model, plan_model = make_plan_models(agent_names, list(tables_aliases))
+        reason_model, plan_model = make_plan_models(agent_names, tuple(tables_aliases))
         planned = False
         unmet_dependencies = set()
         schemas = {}

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -25,7 +25,7 @@ from .llm import Llama, Llm, Message
 from .logs import ChatLogs
 from .memory import _Memory, memory
 from .models import Validity, make_agent_model, make_plan_models
-from .utils import get_schema, retry_llm_output
+from .utils import create_aliases, get_schema, retry_llm_output
 
 if TYPE_CHECKING:
     from panel.chat.step import ChatStep
@@ -657,9 +657,7 @@ class Planner(Coordinator):
             for table in src.get_tables():
                 tables[table] = src
 
-        tables_aliases = {
-            re.sub(r'[^a-zA-Z0-9_]', '_', table): table for table in tables
-        }
+        tables_aliases = create_aliases(tables)
         reason_model, plan_model = make_plan_models(agent_names, tuple(tables_aliases))
         planned = False
         unmet_dependencies = set()

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -102,7 +102,7 @@ def make_plan_models(agent_names: list[str], tables: list[str]):
         extras['tables'] = (
             list[Literal[tuple(tables)]],
             FieldInfo(
-                description="A list of tables to load into memory before coming up with a plan. NOTE: Simple queries asking to list the tables/datasets do not require loading the tables. Table names MUST match verbatim including the quotations, apostrophes, periods, or lack thereof."
+                description="A list of tables to load into memory before coming up with a plan. NOTE: Simple queries asking to list the tables/datasets do not require loading the tables. Table names MUST match verbatim."
             )
         )
     reasoning = create_model(
@@ -157,7 +157,7 @@ def make_table_model(tables):
             description="A concise, one sentence decision-tree-style analysis on choosing a table."
         )),
         relevant_table=(Literal[tuple(tables)], FieldInfo(
-            description="The most relevant table based on the user query; if none are relevant, select the first. Table names MUST match verbatim including the quotations, apostrophes, periods, or lack thereof."
+            description="The most relevant table based on the user query; if none are relevant, select the first. Table names MUST match verbatim."
         ))
     )
     return table_model

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -156,7 +156,7 @@ def make_table_model(tables):
         chain_of_thought=(str, FieldInfo(
             description="A concise, one sentence decision-tree-style analysis on choosing a table."
         )),
-        relevant_table=(Literal[tables], FieldInfo(
+        relevant_table=(Literal[tuple(tables)], FieldInfo(
             description="The most relevant table based on the user query; if none are relevant, select the first. Table names MUST match verbatim including the quotations, apostrophes, periods, or lack thereof."
         ))
     )

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -10,7 +10,7 @@ You are team lead and have to make a plan to solve how to address the user query
 {% endblock %}
 
 {% block context %}
-- {% if 'current_table' in memory %}The result of the previous step was the "{{ memory['current_table'] }}" table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif %}
+- {% if 'current_table' in memory %}The result of the previous step was the '{{ memory['current_table'] }}' table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif %}
 
 {% if table_info %}
 Here are schemas for tables that were recently used (note that these schemas are computed on a subset of data):

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import math
+import re
 import time
 
 from functools import wraps
@@ -318,3 +319,12 @@ async def gather_table_sources(available_sources: list[Source]) -> tuple[dict[st
             else:
                 tables_schema_str += f"### {table}\n"
     return tables_to_source, tables_schema_str
+
+
+def create_aliases(names: list[str]) -> dict[str, str]:
+    """
+    Replaces non-alphanumeric characters with underscore `_`.
+    """
+    return {
+        re.sub(r'[^a-zA-Z0-9_]', '_', name): name for name in names
+    }


### PR DESCRIPTION
Since quotations `'"table"."name"'` is unconventional, the LLMs would hallucinate table names, i.e. drop quotations, and it would crash the Pydantic model, raising an invalid error. So, to workaround that, replaces everything except alphanumeric with `_` which the LLM understands/copies well, then remaps it back to the original table name with all the special characters after the LLM chooses the table.