### PR TITLE
improve user flow in overview

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -215,7 +215,6 @@ class SourceControls(Viewer):
             self._memory.trigger("available_sources")
         else:
             self._memory["available_sources"] = [duckdb_source]
-        print(self._memory["available_sources"])
         self._last_table = table
 
     @param.depends("add", watch=True)

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -215,6 +215,7 @@ class SourceControls(Viewer):
             self._memory.trigger("available_sources")
         else:
             self._memory["available_sources"] = [duckdb_source]
+        print(self._memory["available_sources"])
         self._last_table = table
 
     @param.depends("add", watch=True)

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -17,7 +17,7 @@ from .memory import _Memory, memory
 class TableControls(Viewer):
 
     filename = param.String(default="", doc="Filename")
-    table = param.String(default="", doc="Table name")
+    table = param.String(default="", doc="What to name the uploaded file when querying it as a table")
     extension = param.String(default="", doc="File extension")
     sheet = param.Selector(default=None, objects=[], doc="Sheet")
 
@@ -35,7 +35,7 @@ class TableControls(Viewer):
         super().__init__(**params)
         self.file = file
         self._name_input = TextInput.from_param(
-            self.param.table, name="Table name"
+            self.param.table, name="Table alias",
         )
         self._sheet_select = Select.from_param(
             self.param.sheet, name="Sheet", visible=False
@@ -71,7 +71,7 @@ class TableControls(Viewer):
 
 class SourceControls(Viewer):
 
-    add = param.Event(doc="Add tables")
+    add = param.Event(doc="Use table(s)")
 
     memory = param.ClassSelector(class_=_Memory, default=None, doc="""
         Local memory which will be used to provide the agent context.
@@ -121,7 +121,7 @@ class SourceControls(Viewer):
 
         self._add_button = Button.from_param(
             self.param.add,
-            name="Use tables",
+            name="Use table(s)",
             icon="table-plus",
             visible=False,
             button_type="success",

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -331,6 +331,7 @@ class ExplorerUI(UI):
             name='Load table(s)', icon='table-plus', button_type='primary', align='center',
             disabled=table_select.param.value.rx().rx.not_()
         )
+        input_row = Row(table_select, load_button)
 
         source_map = {}
         def update_source_map(_, __, sources, init=False):
@@ -348,6 +349,11 @@ class ExplorerUI(UI):
             source_map.clear()
             source_map.update(new)
             table_select.param.update(options=list(source_map), value=selected)
+            input_row.visible = bool(source_map)
+            if len(table_select.options) == 1:
+                # if only one table is available, help the user load it without having them click twice
+                load_button.param.trigger("value")
+                table_select.value = []
         memory.on_change('available_sources', update_source_map)
         update_source_map(None, None, memory['available_sources'], init=True)
 
@@ -356,6 +362,7 @@ class ExplorerUI(UI):
 
         @param.depends(table_select, load_button, watch=True)
         def get_explorers(tables, load):
+            print(load)
             if not load:
                 return
             with load_button.param.update(loading=True):
@@ -377,8 +384,8 @@ class ExplorerUI(UI):
 
         return Column(
             Markdown('### Start chatting or select an existing dataset or upload a .csv, .parquet, .xlsx file.', margin=(5, 0)),
-            Row(table_select, load_button),
             tabs,
+            input_row,
             sizing_mode='stretch_both',
         )
 

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -327,11 +327,11 @@ class ExplorerUI(UI):
         table_select = MultiChoice(
             sizing_mode='stretch_width', max_height=200, margin=(5, 0), max_items=5
         )
-        load_button = Button(
-            name='Load table(s)', icon='table-plus', button_type='primary', align='center',
+        explore_button = Button(
+            name='Explore table(s)', icon='table-plus', button_type='primary', align='center',
             disabled=table_select.param.value.rx().rx.not_()
         )
-        input_row = Row(table_select, load_button)
+        input_row = Row(table_select, explore_button)
 
         source_map = {}
         def update_source_map(_, __, sources, init=False):
@@ -353,7 +353,7 @@ class ExplorerUI(UI):
         memory.on_change('available_sources', update_source_map)
         update_source_map(None, None, memory['available_sources'], init=True)
 
-        def load_table_if_single(event):
+        def explore_table_if_single(event):
             """
             If only one table is uploaded, help the user load it
             without requiring them to click twice. This step
@@ -361,19 +361,17 @@ class ExplorerUI(UI):
             i.e. does not trigger with uploads through the SourceAgent
             """
             if len(table_select.options) == 1:
-                load_button.param.trigger("value")
+                explore_button.param.trigger("value")
 
         controls = SourceControls(select_existing=False, name='Upload')
-        controls.param.watch(load_table_if_single, "add")
+        controls.param.watch(explore_table_if_single, "add")
         tabs = Tabs(controls, sizing_mode='stretch_both', design=Material)
 
-        @param.depends(table_select, load_button, watch=True)
-        def get_explorers(tables, load):
-            if not load:
-                return
-            with load_button.param.update(loading=True):
+        @param.depends(explore_button, watch=True)
+        def get_explorers(load):
+            with explore_button.param.update(loading=True):
                 explorers = []
-                for table in tables:
+                for table in table_select.value:
                     source = source_map[table]
                     if len(memory['available_sources']) > 1:
                         _, table = table.rsplit(' : ', 1)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -328,7 +328,7 @@ class ExplorerUI(UI):
             sizing_mode='stretch_width', max_height=200, margin=(5, 0), max_items=5
         )
         explore_button = Button(
-            name='Explore table(s)', icon='table-plus', button_type='primary', align='center',
+            name='Explore table(s)', icon='chart-bar', button_type='primary', align='center',
             disabled=table_select.param.value.rx().rx.not_()
         )
         input_row = Row(table_select, explore_button)
@@ -380,7 +380,7 @@ class ExplorerUI(UI):
                     )
                     walker = GraphicWalker(
                         pipeline.param.data, sizing_mode='stretch_both', min_height=800,
-                        kernel_computation=True, name=table, tab='data'
+                        kernel_computation=True, name=f"View {table}", tab='data'
                     )
                     explorers.append(walker)
 

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -362,7 +362,6 @@ class ExplorerUI(UI):
             """
             if len(table_select.options) == 1:
                 load_button.param.trigger("value")
-                table_select.value = []
 
         controls = SourceControls(select_existing=False, name='Upload')
         controls.param.watch(load_table_if_single, "add")
@@ -388,6 +387,7 @@ class ExplorerUI(UI):
                     explorers.append(walker)
 
                 tabs.objects = explorers + [controls]
+                table_select.value = []
 
         return Column(
             Markdown('### Start chatting or select an existing dataset or upload a .csv, .parquet, .xlsx file.', margin=(5, 0)),

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -362,7 +362,6 @@ class ExplorerUI(UI):
 
         @param.depends(table_select, load_button, watch=True)
         def get_explorers(tables, load):
-            print(load)
             if not load:
                 return
             with load_button.param.update(loading=True):

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -350,14 +350,22 @@ class ExplorerUI(UI):
             source_map.update(new)
             table_select.param.update(options=list(source_map), value=selected)
             input_row.visible = bool(source_map)
-            if len(table_select.options) == 1:
-                # if only one table is available, help the user load it without having them click twice
-                load_button.param.trigger("value")
-                table_select.value = []
         memory.on_change('available_sources', update_source_map)
         update_source_map(None, None, memory['available_sources'], init=True)
 
+        def load_table_if_single(event):
+            """
+            If only one table is uploaded, help the user load it
+            without requiring them to click twice. This step
+            only triggers when the Upload in the Overview tab is used,
+            i.e. does not trigger with uploads through the SourceAgent
+            """
+            if len(table_select.options) == 1:
+                load_button.param.trigger("value")
+                table_select.value = []
+
         controls = SourceControls(select_existing=False, name='Upload')
+        controls.param.watch(load_table_if_single, "add")
         tabs = Tabs(controls, sizing_mode='stretch_both', design=Material)
 
         @param.depends(table_select, load_button, watch=True)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -369,6 +369,8 @@ class ExplorerUI(UI):
 
         @param.depends(explore_button, watch=True)
         def get_explorers(load):
+            if not load:
+                return
             with explore_button.param.update(loading=True):
                 explorers = []
                 for table in table_select.value:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -453,7 +453,19 @@ class ExplorerUI(UI):
                 if any(step.expert == 'SQLAgent' for step in plan.steps):
                     self._add_exploration(plan.title, local_memory)
                     index += 1
+
+            def sync_available_sources_memory(_, __, sources):
+                """
+                For cases when the user uploads a dataset through SourceAgent
+                this will update the available_sources in the global memory
+                so that the overview explorer can access it
+                """
+                memory["available_sources"] += [
+                    source for source in sources if source not in memory["available_sources"]
+                ]
+
             local_memory.on_change('plan', render_plan)
+            local_memory.on_change('available_sources', sync_available_sources_memory)
 
             def render_output(_, old, new):
                 added = [out for out in new if out not in old]


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/771 and https://github.com/holoviz/lumen/issues/772

Builds on top of usability_tweaks branch

Before, required two clicks to really "load" the table, and the order of the buttons was confusing:

https://github.com/user-attachments/assets/91ff4a0e-9255-4de8-b17e-6b2208fbd2ce

After, set the input row to invisible, until a table/source is available to load, and if user uploads a single table, immediately load that.

https://github.com/user-attachments/assets/baefbfc6-f853-4000-97ca-2bf73d7cba49

