### PR TITLE
Fix schema enums

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -309,7 +309,7 @@ class ChatAgent(Agent):
             self._memory["current_table"] = table = self._memory.get(
                 "current_table", tables[0]
             )
-            schema = await get_schema(self._memory["current_source"], table)
+            schema = await get_schema(self._memory["current_source"], table, include_count=True, limit=1000)
             context["table"] = table
             context["schema"] = schema
         system_prompt = self._render_prompt("main", **context)

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -172,15 +172,20 @@ async def get_schema(
     for field, spec in schema.items():
         if "enum" not in spec:
             continue
-        elif not include_enum:
-            spec.pop("enum")
-        elif "limit" in get_kwargs and len(spec["enum"]) > get_kwargs["limit"]:
-            spec["enum"].append("...")
 
-    if count and include_count:
-        spec["count"] = count
+        limit = get_kwargs.get("limit")
+        if not include_enum:
+            spec.pop("enum")
+        elif limit and len(spec["enum"]) > limit:
+            spec["enum"].append("...")
+        elif limit and spec["enum"][0] is None:
+            spec["enum"] = [f"(unknown; truncated to {get_kwargs['limit']} rows)"]
 
     schema = format_schema(schema)
+
+    if count and include_count:
+        schema["count"] = count
+
     return schema
 
 

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -205,8 +205,7 @@ class TestGetSchema:
             "count": 1000,
         }
         schema = await get_schema(mock_source, include_count=True)
-        assert "count" in schema["field1"]
-        assert schema["field1"]["count"] == 1000
+        assert schema["count"] == 1000
 
     async def test_no_count(self):
         mock_source = MagicMock()


### PR DESCRIPTION
1. when limited to the first 100 rows, and the column had missing data in the first 100, the LLM was stating that columns "were placeholders" or it had no available data, which was misleading
<img width="1106" alt="image" src="https://github.com/user-attachments/assets/13a5f56d-82da-4df3-8603-0b3ee3f5ff65">

Instead, it should mention the data was truncated:
<img width="724" alt="image" src="https://github.com/user-attachments/assets/a8294157-e928-4b19-8da2-9d015af15f8d">

2. I changed the limit from 100 to 1000; shouldn't seriously affect performance on modern processors(?)
3. The count was placed in the nested dict vs outer dict.
