### PR TITLE
Improve sql agent

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -25,6 +25,7 @@ class Actor(param.Parameterized):
             prompt_overrides=self.prompt_overrides.get(prompt_name, {}),
             **context
         )
+        print(prompt)
         return prompt
 
     async def _render_main_prompt(self, messages: list[Message], **context) -> str:

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -25,7 +25,6 @@ class Actor(param.Parameterized):
             prompt_overrides=self.prompt_overrides.get(prompt_name, {}),
             **context
         )
-        print(prompt)
         return prompt
 
     async def _render_main_prompt(self, messages: list[Message], **context) -> str:

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -719,7 +719,7 @@ class SQLAgent(LumenBaseAgent):
                 table_name = source.tables[table_name]
 
             table_schemas[table_name] = {
-                "schema": yaml.dump(table_schema),
+                "schema": table_schema,
                 "sql": source.get_sql_expr(source_table)
             }
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -719,7 +719,7 @@ class SQLAgent(LumenBaseAgent):
                 table_name = source.tables[table_name]
 
             table_schemas[table_name] = {
-                "schema": table_schema,
+                "schema": yaml.dump(table_schema),
                 "sql": source.get_sql_expr(source_table)
             }
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -527,6 +527,7 @@ class SQLAgent(LumenBaseAgent):
                     )
                 }
             ]
+        print(errors)
 
         with self.interface.add_step(title=title or "SQL query", steps_layout=self._steps_layout) as step:
             response = self.llm.stream(messages, system=system, response_model=Sql)
@@ -695,7 +696,8 @@ class SQLAgent(LumenBaseAgent):
         if not hasattr(source, "get_sql_expr"):
             return None
 
-        schema = await get_schema(source, table, include_min_max=False)
+        # include min max for more context for data cleaning
+        schema = await get_schema(source, table, include_min_max=True)
         join_required = await self._check_requires_joins(messages, schema, table)
         if join_required:
             tables_to_source = await self.find_join_tables(messages)
@@ -707,7 +709,7 @@ class SQLAgent(LumenBaseAgent):
             if source_table == table:
                 table_schema = schema
             else:
-                table_schema = await get_schema(source, source_table, include_min_max=False)
+                table_schema = await get_schema(source, source_table, include_min_max=True)
 
             # Look up underlying table name
             table_name = source_table
@@ -719,8 +721,8 @@ class SQLAgent(LumenBaseAgent):
                 table_name = source.tables[table_name]
 
             table_schemas[table_name] = {
-                "schema": table_schema,
-                "sql": source.get_sql_expr(source_table)
+                "schema": yaml.dump(table_schema),
+                "sql": source.get_sql_expr(source_table),
             }
 
         dialect = source.dialect

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -559,7 +559,7 @@ class Planner(Coordinator):
         for table in requested:
             if table in provided or table in cache:
                 continue
-            cache[table] = await get_schema(tables[table], table, limit=3)
+            cache[table] = await get_schema(tables[table], table, limit=1000)
         schema_info = ''
         for table in requested:
             if table in provided:

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -55,7 +55,8 @@ class Sql(BaseModel):
 
     expr_slug: str = Field(
         description="""
-        Give the SQL expression a concise, but descriptive, slug that includes whatever transforms were applied to it.
+        Give the SQL expression a concise, but descriptive, slug that includes whatever transforms were applied to it,
+        e.g. top_5_athletes_gold_medals
         """
     )
 

--- a/lumen/ai/prompts/Actor/main.jinja2
+++ b/lumen/ai/prompts/Actor/main.jinja2
@@ -6,3 +6,6 @@
 
 {% block embeddings %}
 {% endblock %}
+
+{% block examples %}
+{% endblock %}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -7,8 +7,8 @@ You are an agent responsible for writing a SQL query that will perform the data 
 {% block context %}
 {% for table, details in tables_sql_schemas.items() %}
 
-The data for table '{{ table }}' follows the following YAML schema:
-```yaml
+The data for table '{{ table }}' follows the following JSON schema:
+```json
 {{ details.schema }}
 ```
 {% endfor %}
@@ -26,8 +26,12 @@ Checklist
 - Quote column names to ensure they do not clash with valid identifiers.
 - If it's a date column (excluding individual year/month/day integers) date, cast to date using appropriate syntax, e.g.
 CAST or TO_DATE
-- Use only `{{ dialect }}` syntax
+- Use only `{{ dialect }}` SQL syntax
 - Try to pretty print the SQL output with newlines and indentation.
+- Specify data types explicitly to avoid type mismatches.
+- Handle NULL values using functions like COALESCE or IS NULL.
+- Use parameterized queries to prevent SQL injection attacks.
+- Use Common Table Expressions (CTEs) and subqueries to break down complex queries into manageable parts.
 {% if dialect == 'duckdb' %}
 - If the table name originally did not have `read_*` prefix, use the original table name
 - Use table names verbatim; e.g. if table is read_csv('table.csv') then use read_csv('table.csv') and not 'table'
@@ -39,4 +43,48 @@ identifiers.
 {% if dialect == 'snowflake' %}
 - Do not under any circumstances add quotes around the database, schema or table name.
 {% endif %}
+{% endblock %}
+
+{%- block examples %}
+Examples:
+
+If the query is "Who won the most medals total?"...
+
+- GOOD:
+```sql
+SELECT
+    athlete_full_name,
+    COALESCE(TRY_CAST(regexp_extract(regexp_replace(athlete_medals, '[\n│]+', ' '), '(\d+)\s*G', 1) AS INTEGER), 0) AS gold_medals,
+    COALESCE(TRY_CAST(regexp_extract(regexp_replace(athlete_medals, '[\n│]+', ' '), '(\d+)\s*S', 1) AS INTEGER), 0) AS silver_medals,
+    COALESCE(TRY_CAST(regexp_extract(regexp_replace(athlete_medals, '[\n│]+', ' '), '(\d+)\s*B', 1) AS INTEGER), 0) AS bronze_medals,
+    (
+        COALESCE(TRY_CAST(regexp_extract(regexp_replace(athlete_medals, '[\n│]+', ' '), '(\d+)\s*G', 1) AS INTEGER), 0) +
+        COALESCE(TRY_CAST(regexp_extract(regexp_replace(athlete_medals, '[\n│]+', ' '), '(\d+)\s*S', 1) AS INTEGER), 0) +
+        COALESCE(TRY_CAST(regexp_extract(regexp_replace(athlete_medals, '[\n│]+', ' '), '(\d+)\s*B', 1) AS INTEGER), 0)
+    ) AS total_medals
+FROM read_csv('olympic_athletes.csv')
+ORDER BY total_medals DESC
+LIMI5 1;
+```
+
+- BAD:
+```sql
+SELECT
+    athlete_full_name,
+    COUNT(athlete_medals) AS total_medals
+FROM olympic_athletes
+```
+
+If the query is "Top 5 athletes with the most gold medals"...
+
+- GOOD:
+```sql
+SELECT
+    athlete_full_name,
+    COALESCE(TRY_CAST(regexp_extract(regexp_replace(athlete_medals, '[\n│]+', ' '), '(\d+)\s*G', 1) AS INTEGER), 0) AS gold_medals,
+FROM read_csv('olympic_athletes.csv')
+ORDER BY gold_medals DESC
+LIMIT 5;
+```
+
 {% endblock %}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -64,7 +64,7 @@ SELECT
     ) AS total_medals
 FROM read_csv('olympic_athletes.csv')
 ORDER BY total_medals DESC
-LIMI5 1;
+LIMIT 1;
 ```
 
 - BAD:

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -2,6 +2,7 @@
 
 {% block instructions %}
 You are an agent responsible for writing a SQL query that will perform the data transformations the user requested.
+Try not to take the query too literally, but instead focus on the user's intent and the data transformations required.
 {% endblock %}
 
 {% block context %}
@@ -32,6 +33,7 @@ CAST or TO_DATE
 - Handle NULL values using functions like COALESCE or IS NULL.
 - Use parameterized queries to prevent SQL injection attacks.
 - Use Common Table Expressions (CTEs) and subqueries to break down complex queries into manageable parts.
+- Be sure to remove suspiciously large or small values that may be invalid, like -9999.
 {% if dialect == 'duckdb' %}
 - If the table name originally did not have `read_*` prefix, use the original table name
 - Use table names verbatim; e.g. if table is read_csv('table.csv') then use read_csv('table.csv') and not 'table'

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -7,8 +7,8 @@ You are an agent responsible for writing a SQL query that will perform the data 
 {% block context %}
 {% for table, details in tables_sql_schemas.items() %}
 
-The data for table '{{ table }}' follows the following JSON schema:
-```json
+The data for table '{{ table }}' follows the following YAML schema:
+```yaml
 {{ details.schema }}
 ```
 {% endfor %}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -7,8 +7,8 @@ You are an agent responsible for writing a SQL query that will perform the data 
 {% block context %}
 {% for table, details in tables_sql_schemas.items() %}
 
-The data for table '{{ table }}' follows the following YAML schema:
-```yaml
+The data for table '{{ table }}' follows the following JSON schema:
+```json
 {{ details.schema }}
 ```
 {% endfor %}

--- a/lumen/ai/prompts/_Testing/topic.jinja2
+++ b/lumen/ai/prompts/_Testing/topic.jinja2
@@ -1,0 +1,5 @@
+{% extends 'Actor/main.jinja2' %}
+
+{% block instructions %}
+What is the topic of the table?
+{% endblock %}

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -163,7 +163,7 @@ class UI(Viewer):
             source = DuckDBSource(
                 tables=tables, mirrors=mirrors,
                 uri=':memory:', initializers=initializers,
-                name='Provided'
+                name='ProvidedSource00000'
             )
             sources.append(source)
         memory['available_sources'] = sources

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -126,6 +126,8 @@ def format_schema(schema):
                 spec["type"] = "str"
             elif spec["type"] == "integer":
                 spec["type"] = "int"
+            elif spec["type"] == "number":
+                spec["type"] = "num"
             elif spec["type"] == "boolean":
                 spec["type"] = "bool"
         formatted[field] = spec

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -178,7 +178,7 @@ async def get_schema(
             spec.pop("enum")
         elif limit and len(spec["enum"]) > limit:
             spec["enum"].append("...")
-        elif limit and spec["enum"][0] is None:
+        elif limit and len(spec["enum"]) == 1 and spec["enum"][0] is None:
             spec["enum"] = [f"(unknown; truncated to {get_kwargs['limit']} rows)"]
 
     schema = format_schema(schema)

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -245,7 +245,10 @@ class DuckDBSource(BaseSQLSource):
             table = self.tables[table]
         if '(' not in table and ')' not in table:
             table = f'"{table}"'
-        if 'select ' in table.lower():
+
+        # search if the so-called "table" already contains SELECT ... FROM
+        # if so, we don't need to wrap it in a SELECT * FROM
+        if re.search(r"(?i)\bselect\b[\s\S]+?\bfrom\b", table):
             sql_expr = table
         else:
             sql_expr = self.sql_expr.format(table=table)


### PR DESCRIPTION
This was driving me nuts and took me a while to debug:

<img width="683" alt="image" src="https://github.com/user-attachments/assets/d80b68f7-7952-4818-86d3-07355cc1eca1">

The shown SQL was valid, but internally, with `SQLLimit` transform, it was wrapping another layer of `SELECT *...` incorrectly, but the UI was not showing the final query...

1. Fixed with a regex to more robustly search for `SELECT ... FROM`; previously, it was doing `'select ' in`, but wasn't able to pick up `'select\n'`
2. added a jinja2 `examples` block so I can add example outputs, and users can also drop in examples, separately from instructions/context
3. changed the limit from 3 to 1000 because it was caching it, and it wasn't picking up enough enums to be useful for future cached queries
4. gave an example for expr_slug; sometimes it gave slugs with spaces "Top ..." which isn't a slug imo.
5. more checklist guidance for sqlagent