### PR TITLE
Change quotes to apostrophes in prompt

### DIFF
--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -10,7 +10,7 @@ You are team lead and have to make a plan to solve how to address the user query
 {% endblock %}
 
 {% block context %}
-- {% if 'current_table' in memory %}The result of the previous step was the '{{ memory['current_table'] }}' table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif %}
+- {% if 'current_table' in memory %}The result of the previous step was the `{{ memory['current_table'] }}` table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif %}
 
 {% if table_info %}
 Here are schemas for tables that were recently used (note that these schemas are computed on a subset of data):

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -10,7 +10,7 @@ You are team lead and have to make a plan to solve how to address the user query
 {% endblock %}
 
 {% block context %}
-- {% if 'current_table' in memory %}The result of the previous step was the "{{ memory['current_table'] }}" table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif %}
+- {% if 'current_table' in memory %}The result of the previous step was the '{{ memory['current_table'] }}' table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif %}
 
 {% if table_info %}
 Here are schemas for tables that were recently used (note that these schemas are computed on a subset of data):


### PR DESCRIPTION
An alternative to: https://github.com/holoviz/lumen/pull/777

Since it's mentioned that: "Table names MUST match verbatim including the quotations, apostrophes, periods, or lack thereof.", given that the prompt has quote, and the table name also has quote, e.g. `"some"."table"`, it becomes `""some".table""` which confuses the LLM to drop the inner layer, `"some.table"`. However, with apostrophes it becomes `'"some"."table"'` which may fix the literal issue.