### PR TITLE
Add debugging logging

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -4,7 +4,7 @@ from typing import Any
 import param
 
 from .llm import Message
-from .utils import render_template
+from .utils import log_debug, render_template
 
 
 class Actor(param.Parameterized):
@@ -25,7 +25,7 @@ class Actor(param.Parameterized):
             prompt_overrides=self.prompt_overrides.get(prompt_name, {}),
             **context
         )
-        print(prompt)
+        log_debug(f"\033[92mRendered prompt\033[0m '{prompt_name}':\n{prompt}")
         return prompt
 
     async def _render_main_prompt(self, messages: list[Message], **context) -> str:

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -113,6 +113,7 @@ class Llm(param.Parameterized):
         The completed response_model.
         """
         system = system.strip().replace("\n\n", "\n")
+
         if isinstance(messages, str):
             messages = [{"role": "user", "content": messages}]
         messages, input_kwargs = self._add_system_message(messages, system, input_kwargs)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -23,6 +23,7 @@ from ..pipeline import Pipeline
 from ..sources import Source
 from ..sources.duckdb import DuckDBSource
 from ..transforms.sql import SQLLimit
+from ..util import log
 from .agents import (
     AnalysisAgent, ChatAgent, ChatDetailsAgent, SourceAgent, SQLAgent,
     TableListAgent, VegaLiteAgent,
@@ -79,6 +80,9 @@ class UI(Viewer):
 
     title = param.String(default='Lumen UI', doc="Title of the app.")
 
+    log_level = param.ObjectSelector(default='INFO', objects=['DEBUG', 'INFO', 'WARNING', 'ERROR'], doc="""
+        The log level to use.""")
+
     __abstract = True
 
     def __init__(
@@ -87,6 +91,8 @@ class UI(Viewer):
         **params
     ):
         super().__init__(**params)
+        log.setLevel(self.log_level)
+
         agents = self.default_agents + self.agents
         if self.analyses:
             agents.append(AnalysisAgent(analyses=self.analyses))

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -7,6 +7,7 @@ import time
 
 from functools import wraps
 from pathlib import Path
+from shutil import get_terminal_size
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
@@ -22,6 +23,7 @@ from lumen.pipeline import Pipeline
 from lumen.sources.base import Source
 from lumen.sources.duckdb import DuckDBSource
 
+from ..util import log
 from .config import PROMPTS_DIR, UNRECOVERABLE_ERRORS
 
 if TYPE_CHECKING:
@@ -325,3 +327,17 @@ async def gather_table_sources(available_sources: list[Source]) -> tuple[dict[st
             else:
                 tables_schema_str += f"### {table}\n"
     return tables_to_source, tables_schema_str
+
+
+def log_debug(msg: str, sep: bool = True, offset: int = 24):
+    """
+    Log a debug message with a separator line above and below.
+    """
+    terminal_cols, _ = get_terminal_size()
+    terminal_cols -= offset  # Account for the timestamp and log level
+    delimiter = "*" * terminal_cols
+    if sep:
+        log.debug(f"\033[95m{delimiter}\033[0m")
+    log.debug(msg)
+    if sep:
+        log.debug(f"\033[90m{delimiter}\033[0m")


### PR DESCRIPTION
A lot of times, debugging Lumen is looking at the system prompt and making sure it rendered correctly. Every time I debug, I have to print, then when I make a PR, remove that print. This PR makes it easy to toggle it on/off and also makes it prettier than just a simple print.

(I wonder if all those new lines are wasting tokens)

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/71b87222-70a8-4745-be8c-5e176c9a7d88">
