### PR TITLE
Ensure conversation is saved on context switches

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -297,14 +297,16 @@ class ExplorerUI(UI):
             c.cleanup()
 
     def _update_conversation(self, event):
+        active = self._explorations.active
         if event.new:
-            active = self._explorations.active
             if active < len(self._conversations):
                 conversation = self._conversations[active]
             else:
                 conversation = list(self._coordinator.interface.objects)
             self._exports.visible = True
         else:
+            if len(self._explorations):
+                self._conversations[active] = list(self._coordinator.interface.objects)
             self._exports.visible = False
             conversation = self._root_conversation
         self._coordinator.interface.objects = conversation
@@ -316,9 +318,11 @@ class ExplorerUI(UI):
             if old is not new:
                 self._contexts.pop(i)
                 self._conversations.pop(i)
+                self._titles.pop(i)
                 break
 
     def _set_context(self, event):
+        self._conversations[event.old] = list(self._coordinator.interface.objects)
         if event.new == len(self._conversations):
             return
         self._coordinator.interface.objects = self._conversations[event.new]


### PR DESCRIPTION
When switching between the overview and different explorations in the `ExplorerUI` it seemed that parts of the conversation would be lost, presumably due to the `ChatInterface.objects` being copied somewhere. Here we now back up the current conversation state whenever we switch between different explorations.