### PR TITLE
Drop current_ and available_ prefixes from memory keys

### DIFF
--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -78,8 +78,8 @@ class Join(Analysis):
         self._run_button = self._source_controls._add_button
         self._source_controls.param.watch(self._update_table_name, "_last_table")
 
-        source = memory.get("current_source")
-        table = memory.get("current_table")
+        source = memory.get("source")
+        table = memory.get("table")
         self._previous_source = source
         self._previous_table = table
         columns = list(source.get_schema(table).keys())
@@ -99,7 +99,7 @@ class Join(Analysis):
     async def __call__(self, pipeline) -> Component:
         if self.table_name:
             agent = next(agent for agent in self.agents if type(agent).__name__ == "SQLAgent")
-            content = f"Join these tables: '//{self._previous_source}//{self._previous_table}' and '//{memory['current_source']}//{self.table_name}'"
+            content = f"Join these tables: '//{self._previous_source}//{self._previous_table}' and '//{memory['source']}//{self.table_name}'"
             if self.index_col:
                 content += f" left join on {self.index_col}"
             else:
@@ -107,5 +107,5 @@ class Join(Analysis):
             if self.context:
                 content += f"\nadditional context:\n{self.context!r}"
             await agent.answer(messages=[{"role": "user", "content": content}])
-            pipeline = memory["current_pipeline"]
+            pipeline = memory["pipeline"]
         return pipeline

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -106,7 +106,7 @@ class SourceControls(Viewer):
 
         if self.select_existing:
             nested_sources_tables = {
-                source.name: source.get_tables() for source in self._memory["available_sources"]
+                source.name: source.get_tables() for source in self._memory["sources"]
             }
             first_table = {k: nested_sources_tables[k][0] for k in list(nested_sources_tables)[:1]}
             self._select_table = NestedSelect(
@@ -208,13 +208,13 @@ class SourceControls(Viewer):
         else:
             df_rel.to_view(table)
         duckdb_source.tables[table] = sql_expr
-        self._memory["current_source"] = duckdb_source
-        self._memory["current_table"] = table
-        if "available_sources" in self._memory:
-            self._memory["available_sources"].append(duckdb_source)
-            self._memory.trigger("available_sources")
+        self._memory["source"] = duckdb_source
+        self._memory["table"] = table
+        if "sources" in self._memory:
+            self._memory["sources"].append(duckdb_source)
+            self._memory.trigger("sources")
         else:
-            self._memory["available_sources"] = [duckdb_source]
+            self._memory["sources"] = [duckdb_source]
         self._last_table = table
 
     @param.depends("add", watch=True)
@@ -229,7 +229,7 @@ class SourceControls(Viewer):
                     self._add_table(duckdb_source, table_controls.file, table_controls)
 
                 if self.replace_controls:
-                    src = self._memory["current_source"]
+                    src = self._memory["source"]
                     self.tables_tabs[:] = [
                         (t, Tabulator(src.get(t), sizing_mode="stretch_both"))
                         for t in src.get_tables()
@@ -239,9 +239,9 @@ class SourceControls(Viewer):
             elif self.select_existing and self._input_tabs.active == 1:
                 table = self._select_table.value["table"]
                 duckdb_source.tables[table] = f"SELECT * FROM {table}"
-                self._memory["current_source"] = duckdb_source
-                self._memory["current_table"] = table
-                self._memory["available_sources"].append(duckdb_source)
+                self._memory["source"] = duckdb_source
+                self._memory["table"] = table
+                self._memory["sources"].append(duckdb_source)
                 self._last_table = table
 
     def __panel__(self):

--- a/lumen/ai/prompts/AnalysisAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalysisAgent/main.jinja2
@@ -11,9 +11,9 @@ Available analyses include:
 
 {% block context %}
 Here are the columns of the current data:
-{% if current_data is mapping %}
-{{ current_data.stats.keys() | join(', ') }}
+{% if data is mapping %}
+{{ data.stats.keys() | join(', ') }}
 {% else %}
-{{ current_data.columns | join(', ') }}
+{{ data.columns | join(', ') }}
 {% endif %}
 {% endblock %}

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -11,7 +11,7 @@ suggest analysis code unless explicitly requested.
 {% endblock %}
 
 {% block context %}
-Here is the current SQL query: {{ memory.current_sql }}
+Here is the current SQL query: {{ memory.sql }}
 
-Here is the current dataset: {{ memory.current_data }}
+Here is the current dataset: {{ memory.data }}
 {% endblock %}

--- a/lumen/ai/prompts/BaseViewAgent/main.jinja2
+++ b/lumen/ai/prompts/BaseViewAgent/main.jinja2
@@ -9,10 +9,10 @@ The data to be plotted originates from a table called '{{ table }}' and follows 
 {{ schema }}
 ```
 
-{% if current_view %}
+{% if view %}
 The previous view specification was:
 ```
-{{ current_view }}
+{{ view }}
 ```
 {% endif %}
 {% endblock %}

--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -13,10 +13,10 @@ Available tables:
 {% elif schema %}
 {{ table }} with schema: {{ schema }}
 {% endif %}
-{% if 'current_data' in memory %}
+{% if 'data' in memory %}
 Here's a summary of the dataset the user just asked about:
 ```
-{{ memory['current_data'] }}
+{{ memory['data'] }}
 ```
 {% endif %}
 {% endblock %}

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -12,7 +12,7 @@ You are team lead and have to make a plan to solve how to address the user query
 {% endblock %}
 
 {% block context %}
-- {% if 'current_table' in memory %}The result of the previous step was the `{{ memory['current_table'] }}` table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif %}
+- {% if 'table' in memory %}The result of the previous step was the `{{ memory['table'] }}` table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif %}
 
 {% if table_info %}
 Here are schemas for tables that were recently used (note that these schemas are computed on a subset of data):

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -311,14 +311,14 @@ def report_error(exc: Exception, step: ChatStep):
     step.status = "failed"
 
 
-async def gather_table_sources(available_sources: list[Source]) -> tuple[dict[str, Source], str]:
+async def gather_table_sources(sources: list[Source]) -> tuple[dict[str, Source], str]:
     """
     Get a dictionary of tables to their respective sources
     and a markdown string of the tables and their schemas.
     """
     tables_to_source = {}
     tables_schema_str = "\nHere are the tables\n"
-    for source in available_sources:
+    for source in sources:
         for table in source.get_tables():
             tables_to_source[table] = source
             if isinstance(source, DuckDBSource) and source.ephemeral:


### PR DESCRIPTION
The `current_` and `available_` prefixes for the memory keys did not convey any real meaning and just made things more verbose. This PR drops these prefixes across the codebase.