### PR TITLE
Improve loading Llama UX

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -436,7 +436,7 @@ class Coordinator(Viewer, Actor):
                 with self.interface.add_step(title="Loading Llama model...", success_title="Using the cached Llama model", user="Assistant") as step:
                     default_kwargs = self.llm.model_kwargs["default"]
                     step.stream(f"Model: `{default_kwargs['repo']}/{default_kwargs['model_file']}`")
-                    self.llm.get_client("default")  # caches the model for future use
+                    await self.llm.get_client("default")  # caches the model for future use
 
             messages = self.interface.serialize(custom_serializer=self._serialize)[-4:]
             invalidation_assessment = await self._invalidate_memory(messages[-2:])


### PR DESCRIPTION
Prior to these changes, there was no indication that there was any activity while it was loading the weights into memory because the event loop was blocked before the chat `steps` was sent to the interface.

This makes it show everything as expected.
<img width="743" alt="image" src="https://github.com/user-attachments/assets/dbcdb2a4-4e4d-43c3-bff2-34f4de7b7763">
