### PR TITLE
Add template_overrides and prompts validation

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -42,12 +42,6 @@ class Actor(param.Parameterized):
                     f"Prompt {prompt_name!r} is not a valid prompt name. "
                     f"Valid prompt names are {valid_prompt_names}."
                 )
-            for block_name in template_override:
-                if block_name not in ["instructions", "context", "embeddings", "examples"]:
-                    raise ValueError(
-                        f"Block {block_name!r} is not a valid block name. "
-                        f"Valid block names are ['instructions', 'context', 'embeddings', 'examples']."
-                    )
 
     def _validate_prompts(self):
         for prompt_name in self.prompts:

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -109,7 +109,6 @@ class Actor(param.Parameterized):
                     f"please ensure overrides contains the {e} key"
                 ) from e
         else:
-            print(overrides, "OVERRIDES")
             prompt = render_template(
                 prompt_template,
                 overrides=overrides,

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -93,9 +93,16 @@ class UI(Viewer):
         super().__init__(**params)
         log.setLevel(self.log_level)
 
-        agents = self.default_agents + self.agents
+        agents = self.agents
+        agent_types = {type(agent) for agent in agents}
+        for default_agent in self.default_agents:
+            if default_agent not in agent_types:
+                # only add default agents if they are not already set by the user
+                agents.append(default_agent)
+
         if self.analyses:
             agents.append(AnalysisAgent(analyses=self.analyses))
+
         self._coordinator = self.coordinator(
             agents=agents,
             llm=self.llm


### PR DESCRIPTION

I initially thought it was a bug with the Planner using default agent instead of the user provided agent instance so I added some logic to prevent adding the same type of default agents.

However, I realized, I formatted it improperly:
```python
agents = [lmai.agents.ChatAgent(template_overrides={"instructions": "Act like the user's meteorologist, and explain jargon in the format of a weather report."})]
```
But there wasn't an error...

Should be nested like:
```python
{"main": {"instructions": "Act like the user's meteorologist, and explain jargon in the format of a weather report."}}
```

So I added some validation functions.