### PR TITLE
Simplify requires/provides

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -447,7 +447,7 @@ class SQLAgent(LumenBaseAgent):
         }
     )
 
-    provides = param.List(default=["pipeline"], readonly=True)
+    provides = param.List(default=["table", "sql", "pipeline", "data"], readonly=True)
 
     requires = param.List(default=["source"], readonly=True)
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -324,7 +324,7 @@ class AnalystAgent(ChatAgent):
         relationships within the data, while avoiding general overviews or
         superficial descriptions.""")
 
-    requires = param.List(default=["source", "table", "pipeline", "sql"], readonly=True)
+    requires = param.List(default=["source", "pipeline"], readonly=True)
 
     prompts = param.Dict(
         default={
@@ -447,7 +447,7 @@ class SQLAgent(LumenBaseAgent):
         }
     )
 
-    provides = param.List(default=["table", "sql", "pipeline", "data"], readonly=True)
+    provides = param.List(default=["pipeline"], readonly=True)
 
     requires = param.List(default=["source"], readonly=True)
 


### PR DESCRIPTION
At this moment, if I'm not mistaken, pipeline contains all of sql, data table, so I simplified the requires and provides, so that the LLM has less to juggle.

We can re-introduce the other requirements if TransformAgent is ever introduced back.

With this, the Planner has a higher success rate to satisfy all requirements on first try (from my limited testing)

Closes https://github.com/holoviz/lumen/issues/810