### PR TITLE
Fix globbing tables cli

### DIFF
--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -165,7 +165,7 @@ class AIHandler(CodeHandler):
         """Build source code with configuration"""
         context = {
             "llm_provider": LLM_PROVIDERS[config['provider']],
-            "tables": ([repr(t) for t in tables]),
+            "tables": [repr(t) for t in tables],
             "api_key": config.get("api_key"),
             "endpoint": config.get("endpoint"),
             "agents": config.get("agents"),

--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -165,7 +165,7 @@ class AIHandler(CodeHandler):
         """Build source code with configuration"""
         context = {
             "llm_provider": LLM_PROVIDERS[config['provider']],
-            "tables": [repr(t) for t in tables],
+            "tables": ([repr(t) for t in tables]),
             "api_key": config.get("api_key"),
             "endpoint": config.get("endpoint"),
             "agents": config.get("agents"),

--- a/lumen/command/app.py.jinja2
+++ b/lumen/command/app.py.jinja2
@@ -24,8 +24,8 @@ from lumen.ai.agents import {{ agent }}
 llm = lmai.llm.{{ llm_provider }}{{ "()" if args == [] else "(\n    "+', '.join(args)+"\n)" }}
 {% endif %}
 
-{# Initialize an empty list to collect assistant arguments #}
-{%- set assistant_args = tables -%}
+data = [{{ tables | join(', ') }}]
+{% set assistant_args = ['data=data'] -%}
 {%- if llm_provider is defined -%}
   {%- set assistant_args = assistant_args + ['llm=llm'] -%}
 {%- endif -%}


### PR DESCRIPTION
`lumen-ai serve *.csv` was broken with the new jinja2 template.

It was doing:

```
ExplorerUI(table1.csv, table2.csv, table3.csv)
```
instead of

ExplorerUI(data=[table1.csv, table2.csv, table3.csv])