### PR TITLE
Ability to break while loops

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -263,6 +263,9 @@ class SourceAgent(Agent):
         self.interface.send(source_controls, respond=False, user="SourceAgent")
         while not source_controls._add_button.clicks > 0:
             await asyncio.sleep(0.05)
+            if source_controls._cancel_button.clicks > 0:
+                self.interface.undo()
+                return None
         return source_controls
 
 

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -73,6 +73,8 @@ class SourceControls(Viewer):
 
     add = param.Event(doc="Use table(s)")
 
+    cancel = param.Event(doc="Cancel")
+
     memory = param.ClassSelector(class_=_Memory, default=None, doc="""
         Local memory which will be used to provide the agent context.
         If None the global memory will be used.""")
@@ -126,9 +128,18 @@ class SourceControls(Viewer):
             visible=False,
             button_type="success",
         )
+
+        self._cancel_button = Button.from_param(
+            self.param.cancel,
+            name="Cancel",
+            icon="circle-x",
+            visible=True,
+        )
+
         self.menu = Column(
             self._input_tabs if self.select_existing else self._input_tabs[0],
             self._add_button,
+            self._cancel_button,
             self.tables_tabs,
             sizing_mode="stretch_width",
         )

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -715,7 +715,7 @@ class Planner(Coordinator):
                 else:
                     planned = True
                 if attempts > 5:
-                    raise ValueError(f"Could not find a suitable plan for {messages[-1]["content"]!r}")
+                    raise ValueError(f"Could not find a suitable plan for {messages[-1]['content']!r}")
             self._memory['plan'] = plan
             istep.stream('\n\nHere are the steps:\n\n')
             for i, step in enumerate(plan.steps):

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -695,6 +695,7 @@ class Planner(Coordinator):
         unmet_dependencies = set()
         schemas = {}
         execution_graph = []
+        attempts = 0
         with self.interface.add_step(title="Planning how to solve user query...", user="Assistant") as istep:
             while not planned:
                 try:
@@ -710,8 +711,11 @@ class Planner(Coordinator):
                 execution_graph, unmet_dependencies = await self._resolve_plan(plan, agents, messages)
                 if unmet_dependencies:
                     istep.stream(f"The plan didn't account for {unmet_dependencies!r}", replace=True)
+                    attempts += 1
                 else:
                     planned = True
+                if attempts > 5:
+                    raise ValueError(f"Could not find a suitable plan for {messages[-1]["content"]!r}")
             self._memory['plan'] = plan
             istep.stream('\n\nHere are the steps:\n\n')
             for i, step in enumerate(plan.steps):


### PR DESCRIPTION
1. Before [the bug was fixed](https://github.com/holoviz/lumen/pull/811/files#diff-1051df66413da9671c9d8eab752bf7d4ee358831dd458fd3164878a98db21ac1L35-L37), Planner could go in an endless loop of trying to figure out how to meet the unmet_dependencies, so for future bugs that may arise, let the planner break after 5 attempts.
2. Due to the LLM's chaotic nature, SourceAgent may be called when it's unnecessary, but users have no choice besides uploading a dataset to continue--now, they can press cancel.