### PR TITLE
Allow specifying specific LLMs for different prompts

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -65,7 +65,7 @@ class Actor(param.Parameterized):
                     f"Prompt {prompt_name!r} is not a valid prompt name. "
                     f"Valid prompt names are {self.param.prompts.default.keys()}."
                 )
-            extra_keys = set(self.prompts[prompt_name].keys()) - {"template", "model", "tools"}
+            extra_keys = set(self.prompts[prompt_name].keys()) - {"template", "response_model", "tools"}
             if extra_keys:
                 raise ValueError(
                     f"Prompt {prompt_name!r} has unexpected keys {extra_keys}. "
@@ -88,7 +88,7 @@ class Actor(param.Parameterized):
         return prompt_spec[key]
 
     def _get_model(self, prompt_name: str, **context) -> type[BaseModel]:
-        model_spec = self._lookup_prompt_key(prompt_name, "model")
+        model_spec = self._lookup_prompt_key(prompt_name, "response_model")
         if isinstance(model_spec, FunctionType):
             model = model_spec(**context)
         else:

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -65,11 +65,11 @@ class Actor(param.Parameterized):
                     f"Prompt {prompt_name!r} is not a valid prompt name. "
                     f"Valid prompt names are {self.param.prompts.default.keys()}."
                 )
-            extra_keys = set(self.prompts[prompt_name].keys()) - {"template", "response_model", "tools", "llm_key"}
+            extra_keys = set(self.prompts[prompt_name].keys()) - {"template", "response_model", "tools", "llm_model"}
             if extra_keys:
                 raise ValueError(
                     f"Prompt {prompt_name!r} has unexpected keys {extra_keys}. "
-                    "Valid keys are 'template', 'response_model', 'tools', and 'llm_key'."
+                    "Valid keys are 'template', 'response_model', 'tools', and 'llm_model'."
                 )
 
     @property

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -65,11 +65,11 @@ class Actor(param.Parameterized):
                     f"Prompt {prompt_name!r} is not a valid prompt name. "
                     f"Valid prompt names are {self.param.prompts.default.keys()}."
                 )
-            extra_keys = set(self.prompts[prompt_name].keys()) - {"template", "response_model", "tools", "llm_model"}
+            extra_keys = set(self.prompts[prompt_name].keys()) - {"template", "response_model", "tools", "llm_spec"}
             if extra_keys:
                 raise ValueError(
                     f"Prompt {prompt_name!r} has unexpected keys {extra_keys}. "
-                    "Valid keys are 'template', 'response_model', 'tools', and 'llm_model'."
+                    "Valid keys are 'template', 'response_model', 'tools', and 'llm_spec'."
                 )
 
     @property

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -65,11 +65,11 @@ class Actor(param.Parameterized):
                     f"Prompt {prompt_name!r} is not a valid prompt name. "
                     f"Valid prompt names are {self.param.prompts.default.keys()}."
                 )
-            extra_keys = set(self.prompts[prompt_name].keys()) - {"template", "response_model", "tools"}
+            extra_keys = set(self.prompts[prompt_name].keys()) - {"template", "response_model", "tools", "llm_key"}
             if extra_keys:
                 raise ValueError(
                     f"Prompt {prompt_name!r} has unexpected keys {extra_keys}. "
-                    "Valid keys are 'template', 'model' and 'tools'."
+                    "Valid keys are 'template', 'response_model', 'tools', and 'llm_key'."
                 )
 
     @property

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -121,9 +121,9 @@ class Agent(Viewer, Actor, ContextProvider):
 
     async def _stream(self, messages: list[Message], system_prompt: str) -> Any:
         message = None
-        model_key = self.prompts["main"].get("llm_model", "default")
+        model_spec = self.prompts["main"].get("llm_model", "default")
         async for output_chunk in self.llm.stream(
-            messages, system=system_prompt, model_key=model_key, field="output"
+            messages, system=system_prompt, model_spec=model_spec, field="output"
         ):
             message = self.interface.stream(
                 output_chunk, replace=True, message=message, user=self.user, max_width=self._max_width
@@ -423,12 +423,12 @@ class SQLAgent(LumenBaseAgent):
                     )
                     if "closest_tables" in self._memory:
                         tables = self._memory["closest_tables"]
-                    model_key = self.prompts["select_table"].get("llm_model", "default")
+                    model_spec = self.prompts["select_table"].get("llm_model", "default")
                     table_model = self._get_model("select_table", tables=tables)
                     result = await self.llm.invoke(
                         messages,
                         system=system_prompt,
-                        model_key=model_key,
+                        model_spec=model_spec,
                         response_model=table_model,
                         allow_partial=False,
                         max_retries=3,
@@ -473,8 +473,8 @@ class SQLAgent(LumenBaseAgent):
         log_debug(f"Below are the errors in `_create_valid_sql` retry:\n{errors}")
 
         with self.interface.add_step(title=title or "SQL query", steps_layout=self._steps_layout) as step:
-            model_key = self.prompts["main"].get("llm_model", "default")
-            response = self.llm.stream(messages, system=system, model_Key=model_key, response_model=self._get_model("main"))
+            model_spec = self.prompts["main"].get("llm_model", "default")
+            response = self.llm.stream(messages, system=system, model_spec=model_spec, response_model=self._get_model("main"))
             sql_query = None
             async for output in response:
                 step_message = output.chain_of_thought
@@ -559,11 +559,11 @@ class SQLAgent(LumenBaseAgent):
                 schema=yaml.dump(schema),
                 table=table
             )
-            model_key = self.prompts["require_joins"].get("llm_model", "default")
+            model_spec = self.prompts["require_joins"].get("llm_model", "default")
             response = self.llm.stream(
                 messages[-1:],
                 system=join_prompt,
-                model_key=model_key,
+                model_spec=model_spec,
                 response_model=self._get_model("require_joins"),
             )
             async for output in response:
@@ -583,12 +583,12 @@ class SQLAgent(LumenBaseAgent):
             tables = self._memory['source'].get_tables()
 
         find_joins_prompt = await self._render_prompt("find_joins", messages, tables=tables)
-        model_key = self.prompts["find_joins"].get("llm_model", "default")
+        model_spec = self.prompts["find_joins"].get("llm_model", "default")
         with self.interface.add_step(title="Determining tables required for join", steps_layout=self._steps_layout) as step:
             output = await self.llm.invoke(
                 messages,
                 system=find_joins_prompt,
-                model_key=model_key,
+                model_spec=model_spec,
                 response_model=self._get_model("find_joins"),
             )
             tables_to_join = output.tables_to_join
@@ -729,11 +729,11 @@ class BaseViewAgent(LumenBaseAgent):
             view=self._memory.get('view'),
             doc=doc,
         )
-        model_key = self.prompts["main"].get("llm_model", "default")
+        model_spec = self.prompts["main"].get("llm_model", "default")
         output = await self.llm.invoke(
             messages,
             system=system_prompt,
-            model_key=model_key,
+            model_spec=model_spec,
             response_model=self._get_model("main", schema=schema),
         )
         spec = await self._extract_spec(output)
@@ -881,11 +881,11 @@ class AnalysisAgent(LumenBaseAgent):
                     analyses=analyses,
                     data=self._memory.get("data"),
                 )
-                model_key = self.prompts["main"].get("llm_model", "default")
+                model_spec = self.prompts["main"].get("llm_model", "default")
                 analysis_name = (await self.llm.invoke(
                     messages,
                     system=system_prompt,
-                    model_key=model_key,
+                    model_spec=model_spec,
                     response_model=analysis_model,
                     allow_partial=False,
                 )).correct_name

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -121,8 +121,9 @@ class Agent(Viewer, Actor, ContextProvider):
 
     async def _stream(self, messages: list[Message], system_prompt: str) -> Any:
         message = None
+        model_key = self.prompts["main"].get("llm_key", "default")
         async for output_chunk in self.llm.stream(
-            messages, system=system_prompt, field="output"
+            messages, system=system_prompt, model_key=model_key, field="output"
         ):
             message = self.interface.stream(
                 output_chunk, replace=True, message=message, user=self.user, max_width=self._max_width
@@ -377,7 +378,8 @@ class SQLAgent(LumenBaseAgent):
         default={
             "main": {
                 "response_model": Sql,
-                "template": PROMPTS_DIR / "SQLAgent" / "main.jinja2"
+                "template": PROMPTS_DIR / "SQLAgent" / "main.jinja2",
+                "llm_key": "reasoning",
             },
             "select_table": {
                 "response_model": make_table_model,
@@ -421,10 +423,12 @@ class SQLAgent(LumenBaseAgent):
                     )
                     if "closest_tables" in self._memory:
                         tables = self._memory["closest_tables"]
+                    model_key = self.prompts["select_table"].get("llm_key", "default")
                     table_model = self._get_model("select_table", tables=tables)
                     result = await self.llm.invoke(
                         messages,
                         system=system_prompt,
+                        model_key=model_key,
                         response_model=table_model,
                         allow_partial=False,
                         max_retries=3,
@@ -469,7 +473,8 @@ class SQLAgent(LumenBaseAgent):
         log_debug(f"Below are the errors in `_create_valid_sql` retry:\n{errors}")
 
         with self.interface.add_step(title=title or "SQL query", steps_layout=self._steps_layout) as step:
-            response = self.llm.stream(messages, system=system, response_model=self._get_model("main"))
+            model_key = self.prompts["main"].get("llm_key", "default")
+            response = self.llm.stream(messages, system=system, model_Key=model_key, response_model=self._get_model("main"))
             sql_query = None
             async for output in response:
                 step_message = output.chain_of_thought
@@ -554,9 +559,11 @@ class SQLAgent(LumenBaseAgent):
                 schema=yaml.dump(schema),
                 table=table
             )
+            model_key = self.prompts["require_joins"].get("llm_key", "default")
             response = self.llm.stream(
                 messages[-1:],
                 system=join_prompt,
+                model_key=model_key,
                 response_model=self._get_model("require_joins"),
             )
             async for output in response:
@@ -576,10 +583,12 @@ class SQLAgent(LumenBaseAgent):
             tables = self._memory['source'].get_tables()
 
         find_joins_prompt = await self._render_prompt("find_joins", messages, tables=tables)
+        model_key = self.prompts["find_joins"].get("llm_key", "default")
         with self.interface.add_step(title="Determining tables required for join", steps_layout=self._steps_layout) as step:
             output = await self.llm.invoke(
                 messages,
                 system=find_joins_prompt,
+                model_key=model_key,
                 response_model=self._get_model("find_joins"),
             )
             tables_to_join = output.tables_to_join
@@ -720,9 +729,11 @@ class BaseViewAgent(LumenBaseAgent):
             view=self._memory.get('view'),
             doc=doc,
         )
+        model_key = self.prompts["main"].get("llm_key", "default")
         output = await self.llm.invoke(
             messages,
             system=system_prompt,
+            model_key=model_key,
             response_model=self._get_model("main", schema=schema),
         )
         spec = await self._extract_spec(output)
@@ -870,9 +881,11 @@ class AnalysisAgent(LumenBaseAgent):
                     analyses=analyses,
                     data=self._memory.get("data"),
                 )
+                model_key = self.prompts["main"].get("llm_key", "default")
                 analysis_name = (await self.llm.invoke(
                     messages,
                     system=system_prompt,
+                    model_key=model_key,
                     response_model=analysis_model,
                     allow_partial=False,
                 )).correct_name

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -121,7 +121,7 @@ class Agent(Viewer, Actor, ContextProvider):
 
     async def _stream(self, messages: list[Message], system_prompt: str) -> Any:
         message = None
-        model_key = self.prompts["main"].get("llm_key", "default")
+        model_key = self.prompts["main"].get("llm_model", "default")
         async for output_chunk in self.llm.stream(
             messages, system=system_prompt, model_key=model_key, field="output"
         ):
@@ -379,7 +379,7 @@ class SQLAgent(LumenBaseAgent):
             "main": {
                 "response_model": Sql,
                 "template": PROMPTS_DIR / "SQLAgent" / "main.jinja2",
-                "llm_key": "reasoning",
+                "llm_model": "reasoning",
             },
             "select_table": {
                 "response_model": make_table_model,
@@ -423,7 +423,7 @@ class SQLAgent(LumenBaseAgent):
                     )
                     if "closest_tables" in self._memory:
                         tables = self._memory["closest_tables"]
-                    model_key = self.prompts["select_table"].get("llm_key", "default")
+                    model_key = self.prompts["select_table"].get("llm_model", "default")
                     table_model = self._get_model("select_table", tables=tables)
                     result = await self.llm.invoke(
                         messages,
@@ -473,7 +473,7 @@ class SQLAgent(LumenBaseAgent):
         log_debug(f"Below are the errors in `_create_valid_sql` retry:\n{errors}")
 
         with self.interface.add_step(title=title or "SQL query", steps_layout=self._steps_layout) as step:
-            model_key = self.prompts["main"].get("llm_key", "default")
+            model_key = self.prompts["main"].get("llm_model", "default")
             response = self.llm.stream(messages, system=system, model_Key=model_key, response_model=self._get_model("main"))
             sql_query = None
             async for output in response:
@@ -559,7 +559,7 @@ class SQLAgent(LumenBaseAgent):
                 schema=yaml.dump(schema),
                 table=table
             )
-            model_key = self.prompts["require_joins"].get("llm_key", "default")
+            model_key = self.prompts["require_joins"].get("llm_model", "default")
             response = self.llm.stream(
                 messages[-1:],
                 system=join_prompt,
@@ -583,7 +583,7 @@ class SQLAgent(LumenBaseAgent):
             tables = self._memory['source'].get_tables()
 
         find_joins_prompt = await self._render_prompt("find_joins", messages, tables=tables)
-        model_key = self.prompts["find_joins"].get("llm_key", "default")
+        model_key = self.prompts["find_joins"].get("llm_model", "default")
         with self.interface.add_step(title="Determining tables required for join", steps_layout=self._steps_layout) as step:
             output = await self.llm.invoke(
                 messages,
@@ -729,7 +729,7 @@ class BaseViewAgent(LumenBaseAgent):
             view=self._memory.get('view'),
             doc=doc,
         )
-        model_key = self.prompts["main"].get("llm_key", "default")
+        model_key = self.prompts["main"].get("llm_model", "default")
         output = await self.llm.invoke(
             messages,
             system=system_prompt,
@@ -881,7 +881,7 @@ class AnalysisAgent(LumenBaseAgent):
                     analyses=analyses,
                     data=self._memory.get("data"),
                 )
-                model_key = self.prompts["main"].get("llm_key", "default")
+                model_key = self.prompts["main"].get("llm_model", "default")
                 analysis_name = (await self.llm.invoke(
                     messages,
                     system=system_prompt,

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -376,20 +376,20 @@ class SQLAgent(LumenBaseAgent):
     prompts = param.Dict(
         default={
             "main": {
-                "model": Sql,
+                "response_model": Sql,
                 "template": PROMPTS_DIR / "SQLAgent" / "main.jinja2"
             },
             "select_table": {
-                "model": make_table_model,
+                "response_model": make_table_model,
                 "template": PROMPTS_DIR / "SQLAgent" / "select_table.jinja2",
                 "tools": [TableLookup]
             },
             "require_joins": {
-                "model": JoinRequired,
+                "response_model": JoinRequired,
                 "template": PROMPTS_DIR / "SQLAgent" / "require_joins.jinja2"
             },
             "find_joins": {
-                "model": TableJoins,
+                "response_model": TableJoins,
                 "template": PROMPTS_DIR / "SQLAgent" / "find_joins.jinja2"
             },
         }
@@ -799,7 +799,7 @@ class VegaLiteAgent(BaseViewAgent):
     prompts = param.Dict(
         default={
             "main": {
-                "model": VegaLiteSpec,
+                "response_model": VegaLiteSpec,
                 "template": PROMPTS_DIR / "VegaLiteAgent" / "main.jinja2"},
         }
     )

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -121,7 +121,7 @@ class Agent(Viewer, Actor, ContextProvider):
 
     async def _stream(self, messages: list[Message], system_prompt: str) -> Any:
         message = None
-        model_spec = self.prompts["main"].get("llm_model", "default")
+        model_spec = self.prompts["main"].get("llm_spec", "default")
         async for output_chunk in self.llm.stream(
             messages, system=system_prompt, model_spec=model_spec, field="output"
         ):
@@ -379,7 +379,7 @@ class SQLAgent(LumenBaseAgent):
             "main": {
                 "response_model": Sql,
                 "template": PROMPTS_DIR / "SQLAgent" / "main.jinja2",
-                "llm_model": "reasoning",
+                "llm_spec": "reasoning",
             },
             "select_table": {
                 "response_model": make_table_model,
@@ -423,7 +423,7 @@ class SQLAgent(LumenBaseAgent):
                     )
                     if "closest_tables" in self._memory:
                         tables = self._memory["closest_tables"]
-                    model_spec = self.prompts["select_table"].get("llm_model", "default")
+                    model_spec = self.prompts["select_table"].get("llm_spec", "default")
                     table_model = self._get_model("select_table", tables=tables)
                     result = await self.llm.invoke(
                         messages,
@@ -473,7 +473,7 @@ class SQLAgent(LumenBaseAgent):
         log_debug(f"Below are the errors in `_create_valid_sql` retry:\n{errors}")
 
         with self.interface.add_step(title=title or "SQL query", steps_layout=self._steps_layout) as step:
-            model_spec = self.prompts["main"].get("llm_model", "default")
+            model_spec = self.prompts["main"].get("llm_spec", "default")
             response = self.llm.stream(messages, system=system, model_spec=model_spec, response_model=self._get_model("main"))
             sql_query = None
             async for output in response:
@@ -559,7 +559,7 @@ class SQLAgent(LumenBaseAgent):
                 schema=yaml.dump(schema),
                 table=table
             )
-            model_spec = self.prompts["require_joins"].get("llm_model", "default")
+            model_spec = self.prompts["require_joins"].get("llm_spec", "default")
             response = self.llm.stream(
                 messages[-1:],
                 system=join_prompt,
@@ -583,7 +583,7 @@ class SQLAgent(LumenBaseAgent):
             tables = self._memory['source'].get_tables()
 
         find_joins_prompt = await self._render_prompt("find_joins", messages, tables=tables)
-        model_spec = self.prompts["find_joins"].get("llm_model", "default")
+        model_spec = self.prompts["find_joins"].get("llm_spec", "default")
         with self.interface.add_step(title="Determining tables required for join", steps_layout=self._steps_layout) as step:
             output = await self.llm.invoke(
                 messages,
@@ -729,7 +729,7 @@ class BaseViewAgent(LumenBaseAgent):
             view=self._memory.get('view'),
             doc=doc,
         )
-        model_spec = self.prompts["main"].get("llm_model", "default")
+        model_spec = self.prompts["main"].get("llm_spec", "default")
         output = await self.llm.invoke(
             messages,
             system=system_prompt,
@@ -881,7 +881,7 @@ class AnalysisAgent(LumenBaseAgent):
                     analyses=analyses,
                     data=self._memory.get("data"),
                 )
-                model_spec = self.prompts["main"].get("llm_model", "default")
+                model_spec = self.prompts["main"].get("llm_spec", "default")
                 analysis_name = (await self.llm.invoke(
                     messages,
                     system=system_prompt,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -82,7 +82,7 @@ class Coordinator(Viewer, Actor):
         default={
             "check_validity": {
                 "template": PROMPTS_DIR / "Coordinator" / "check_validity.jinja2",
-                "model": Validity,
+                "response_model": Validity,
             },
         }
     )
@@ -479,11 +479,11 @@ class DependencyResolver(Coordinator):
         default={
             "main": {
                 "template": PROMPTS_DIR / "DependencyResolver" / "main.jinja2",
-                "model": make_agent_model,
+                "response_model": make_agent_model,
             },
             "check_validity": {
                 "template": PROMPTS_DIR / "Coordinator" / "check_validity.jinja2",
-                "model": Validity,
+                "response_model": Validity,
             },
         },
     )
@@ -578,11 +578,11 @@ class Planner(Coordinator):
         default={
             "main": {
                 "template": PROMPTS_DIR / "Planner" / "main.jinja2",
-                "model": make_plan_models,
+                "response_model": make_plan_models,
             },
             "check_validity": {
                 "template": PROMPTS_DIR / "Coordinator" / "check_validity.jinja2",
-                "model": Validity,
+                "response_model": Validity,
             },
         }
     )

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -313,7 +313,7 @@ class Coordinator(Viewer, Actor):
             "check_validity", messages, table=table, spec=yaml.dump(spec), sql=sql, analyses=analyses_names
         )
         with self.interface.add_step(title="Checking memory...", user="Assistant") as step:
-            model_spec = self.prompts["check_validity"].get("llm_model", "default")
+            model_spec = self.prompts["check_validity"].get("llm_spec", "default")
             output = await self.llm.invoke(
                 messages=messages,
                 system=system,
@@ -348,7 +348,7 @@ class Coordinator(Viewer, Actor):
             errors = '\n'.join(errors)
             messages += [{"role": "user", "content": f"\nExpertly resolve these issues:\n{errors}"}]
 
-        model_spec = self.prompts["main"].get("llm_model", "default")
+        model_spec = self.prompts["main"].get("llm_spec", "default")
         out = await self.llm.invoke(
             messages=messages,
             system=system,
@@ -629,7 +629,7 @@ class Planner(Coordinator):
                 table_info=info,
                 tables=available
             )
-            model_spec = self.prompts["main"].get("llm_model", "default")
+            model_spec = self.prompts["main"].get("llm_spec", "default")
             reasoning = await self.llm.invoke(
                 messages=messages,
                 system=system,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -313,7 +313,7 @@ class Coordinator(Viewer, Actor):
             "check_validity", messages, table=table, spec=yaml.dump(spec), sql=sql, analyses=analyses_names
         )
         with self.interface.add_step(title="Checking memory...", user="Assistant") as step:
-            model_key = self.prompts["check_validity"].get("llm_key", "default")
+            model_key = self.prompts["check_validity"].get("llm_model", "default")
             output = await self.llm.invoke(
                 messages=messages,
                 system=system,
@@ -348,7 +348,7 @@ class Coordinator(Viewer, Actor):
             errors = '\n'.join(errors)
             messages += [{"role": "user", "content": f"\nExpertly resolve these issues:\n{errors}"}]
 
-        model_key = self.prompts["main"].get("llm_key", "default")
+        model_key = self.prompts["main"].get("llm_model", "default")
         out = await self.llm.invoke(
             messages=messages,
             system=system,
@@ -629,7 +629,7 @@ class Planner(Coordinator):
                 table_info=info,
                 tables=available
             )
-            model_key = self.prompts["main"].get("llm_key", "default")
+            model_key = self.prompts["main"].get("llm_model", "default")
             reasoning = await self.llm.invoke(
                 messages=messages,
                 system=system,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -313,11 +313,11 @@ class Coordinator(Viewer, Actor):
             "check_validity", messages, table=table, spec=yaml.dump(spec), sql=sql, analyses=analyses_names
         )
         with self.interface.add_step(title="Checking memory...", user="Assistant") as step:
-            model_key = self.prompts["check_validity"].get("llm_model", "default")
+            model_spec = self.prompts["check_validity"].get("llm_model", "default")
             output = await self.llm.invoke(
                 messages=messages,
                 system=system,
-                model_key=model_key,
+                model_spec=model_spec,
                 response_model=self._get_model("check_validity"),
             )
             step.stream(output.correct_assessment, replace=True)
@@ -348,11 +348,11 @@ class Coordinator(Viewer, Actor):
             errors = '\n'.join(errors)
             messages += [{"role": "user", "content": f"\nExpertly resolve these issues:\n{errors}"}]
 
-        model_key = self.prompts["main"].get("llm_model", "default")
+        model_spec = self.prompts["main"].get("llm_model", "default")
         out = await self.llm.invoke(
             messages=messages,
             system=system,
-            model_key=model_key,
+            model_spec=model_spec,
             response_model=agent_model
         )
         return out
@@ -629,11 +629,11 @@ class Planner(Coordinator):
                 table_info=info,
                 tables=available
             )
-            model_key = self.prompts["main"].get("llm_model", "default")
+            model_spec = self.prompts["main"].get("llm_model", "default")
             reasoning = await self.llm.invoke(
                 messages=messages,
                 system=system,
-                model_key=model_key,
+                model_spec=model_spec,
                 response_model=reason_model,
                 max_retries=3,
             )

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -66,6 +66,7 @@ class Llm(param.Parameterized):
             model_kwargs = self.model_kwargs.get(model_key)
         else:
             model_kwargs = self.model_kwargs["default"]
+            model_kwargs["model"] = model_key  # override the default model with user provided model
         return dict(model_kwargs)
 
     @property
@@ -229,6 +230,21 @@ class Llama(Llm):
             "n_ctx": 131072,
         },
     })
+
+    def _get_model_kwargs(self, model_key: MODEL_TYPE) -> dict[str, Any]:
+        if model_key in self.model_kwargs:
+            model_kwargs = self.model_kwargs.get(model_key)
+        else:
+            model_kwargs = self.model_kwargs["default"]
+            repo, model_spec = model_key.rsplit("/", 1)
+            if ":" in model_spec:
+                model_file, chat_format = model_spec.split(":")
+                model_kwargs["chat_format"] = chat_format
+            else:
+                model_file = model_spec
+            model_kwargs["repo"] = repo
+            model_kwargs["model_file"] = model_file
+        return dict(model_kwargs)
 
     @property
     def _client_kwargs(self) -> dict[str, Any]:

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -61,12 +61,12 @@ class Llm(param.Parameterized):
 
     __abstract = True
 
-    def _get_model_kwargs(self, model_key: MODEL_TYPE) -> dict[str, Any]:
-        if model_key in self.model_kwargs:
-            model_kwargs = self.model_kwargs.get(model_key)
+    def _get_model_kwargs(self, model_spec: MODEL_TYPE | dict) -> dict[str, Any]:
+        if model_spec in self.model_kwargs:
+            model_kwargs = self.model_kwargs.get(model_spec)
         else:
             model_kwargs = self.model_kwargs["default"]
-            model_kwargs["model"] = model_key  # override the default model with user provided model
+            model_kwargs["model"] = model_spec  # override the default model with user provided model
         return dict(model_kwargs)
 
     @property
@@ -89,7 +89,7 @@ class Llm(param.Parameterized):
         system: str = "",
         response_model: BaseModel | None = None,
         allow_partial: bool = False,
-        model_key: MODEL_TYPE = "default",
+        model_spec: MODEL_TYPE | dict = "default",
         **input_kwargs,
     ) -> BaseModel:
         """
@@ -128,7 +128,7 @@ class Llm(param.Parameterized):
                 response_model = Partial[response_model]
             kwargs["response_model"] = response_model
 
-        output = await self.run_client(model_key, messages, **kwargs)
+        output = await self.run_client(model_spec, messages, **kwargs)
         if output is None or output == "":
             raise ValueError("LLM failed to return valid output.")
         return output
@@ -145,7 +145,7 @@ class Llm(param.Parameterized):
         system: str = "",
         response_model: BaseModel | None = None,
         field: str | None = None,
-        model_key: str = "default",
+        model_spec: str | dict = "default",
         **kwargs,
     ):
         """
@@ -175,7 +175,7 @@ class Llm(param.Parameterized):
                 messages,
                 system=system,
                 response_model=response_model,
-                model_key=model_key,
+                model_spec=model_spec,
                 **kwargs,
             )
             return
@@ -187,7 +187,7 @@ class Llm(param.Parameterized):
             response_model=response_model,
             stream=True,
             allow_partial=True,
-            model_key=model_key,
+            model_spec=model_spec,
             **kwargs,
         )
         try:
@@ -207,8 +207,8 @@ class Llm(param.Parameterized):
                 else:
                     yield getattr(chunk, field) if field is not None else chunk
 
-    async def run_client(self, model_key: MODEL_TYPE, messages: list[Message], **kwargs):
-        client = await self.get_client(model_key, **kwargs)
+    async def run_client(self, model_spec: MODEL_TYPE | dict, messages: list[Message], **kwargs):
+        client = await self.get_client(model_spec, **kwargs)
         return await client(messages=messages, **kwargs)
 
 
@@ -231,12 +231,15 @@ class Llama(Llm):
         },
     })
 
-    def _get_model_kwargs(self, model_key: MODEL_TYPE) -> dict[str, Any]:
-        if model_key in self.model_kwargs:
-            model_kwargs = self.model_kwargs.get(model_key)
+    def _get_model_kwargs(self, model_spec: MODEL_TYPE | dict) -> dict[str, Any]:
+        if isinstance(model_spec, dict):
+            return model_spec
+
+        if model_spec in self.model_kwargs:
+            model_kwargs = self.model_kwargs.get(model_spec)
         else:
             model_kwargs = self.model_kwargs["default"]
-            repo, model_spec = model_key.rsplit("/", 1)
+            repo, model_spec = model_spec.rsplit("/", 1)
             if ":" in model_spec:
                 model_file, chat_format = model_spec.split(":")
                 model_kwargs["chat_format"] = chat_format
@@ -250,7 +253,7 @@ class Llama(Llm):
     def _client_kwargs(self) -> dict[str, Any]:
         return {"temperature": self.temperature}
 
-    def _cache_model(self, model_key: MODEL_TYPE, **kwargs):
+    def _cache_model(self, model_spec: MODEL_TYPE | dict, **kwargs):
         from llama_cpp import Llama as LlamaCpp
         llm = LlamaCpp(**kwargs)
 
@@ -260,15 +263,15 @@ class Llama(Llm):
             create=raw_client,
             mode=Mode.JSON_SCHEMA,
         )
-        pn.state.cache[model_key] = client_callable
+        pn.state.cache[model_spec] = client_callable
         return client_callable
 
-    async def get_client(self, model_key: MODEL_TYPE, response_model: BaseModel | None = None, **kwargs):
-        if client_callable := pn.state.cache.get(model_key):
+    async def get_client(self, model_spec: MODEL_TYPE | dict, response_model: BaseModel | None = None, **kwargs):
+        if client_callable := pn.state.cache.get(model_spec):
             return client_callable
         from huggingface_hub import hf_hub_download
 
-        model_kwargs = self._get_model_kwargs(model_key)
+        model_kwargs = self._get_model_kwargs(model_spec)
         repo = model_kwargs["repo"]
         model_file = model_kwargs["model_file"]
         chat_format = model_kwargs["chat_format"]
@@ -284,11 +287,11 @@ class Llama(Llm):
             use_mlock=True,
             verbose=False
         )
-        client_callable = await asyncio.to_thread(self._cache_model, model_key, **llm_kwargs)
+        client_callable = await asyncio.to_thread(self._cache_model, model_spec, **llm_kwargs)
         return client_callable
 
-    async def run_client(self, model_key: MODEL_TYPE, messages: list[Message], **kwargs):
-        client = await self.get_client(model_key, **kwargs)
+    async def run_client(self, model_spec: MODEL_TYPE | dict, messages: list[Message], **kwargs):
+        client = await self.get_client(model_spec, **kwargs)
         return client(messages=messages, **kwargs)
 
 
@@ -319,10 +322,10 @@ class OpenAI(Llm):
     def _client_kwargs(self):
         return {"temperature": self.temperature}
 
-    async def get_client(self, model_key: MODEL_TYPE, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: MODEL_TYPE | dict, response_model: BaseModel | None = None, **kwargs):
         import openai
 
-        model_kwargs = self._get_model_kwargs(model_key)
+        model_kwargs = self._get_model_kwargs(model_spec)
         model = model_kwargs.pop("model")
         if self.endpoint:
             model_kwargs["base_url"] = self.endpoint
@@ -370,10 +373,10 @@ class AzureOpenAI(Llm):
     def _client_kwargs(self):
         return {"temperature": self.temperature}
 
-    async def get_client(self, model_key: MODEL_TYPE, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: MODEL_TYPE | dict, response_model: BaseModel | None = None, **kwargs):
         import openai
 
-        model_kwargs = self._get_model_kwargs(model_key)
+        model_kwargs = self._get_model_kwargs(model_spec)
         model = model_kwargs.pop("model")
         if self.api_version:
             model_kwargs["api_version"] = self.api_version
@@ -419,10 +422,10 @@ class MistralAI(Llm):
     def _client_kwargs(self):
         return {"temperature": self.temperature}
 
-    async def get_client(self, model_key: str, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: str | dict, response_model: BaseModel | None = None, **kwargs):
         from mistralai import Mistral
 
-        model_kwargs = self._get_model_kwargs(model_key)
+        model_kwargs = self._get_model_kwargs(model_spec)
         model_kwargs["api_key"] = self.api_key
         model = model_kwargs.pop("model")
         llm = Mistral(**model_kwargs)
@@ -455,7 +458,7 @@ class MistralAI(Llm):
         system: str = "",
         response_model: BaseModel | None = None,
         allow_partial: bool = False,
-        model_key: str = "default",
+        model_spec: str | dict = "default",
         **input_kwargs,
     ) -> BaseModel:
         if isinstance(messages, str):
@@ -470,7 +473,7 @@ class MistralAI(Llm):
             system,
             response_model,
             allow_partial,
-            model_key,
+            model_spec,
             **input_kwargs,
         )
 
@@ -488,14 +491,14 @@ class AzureMistralAI(MistralAI):
         "default": {"model": "azureai"},
     })
 
-    async def get_client(self, model_key: str, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: str | dict, response_model: BaseModel | None = None, **kwargs):
         from mistralai_azure import MistralAzure
 
         async def llm_chat_non_stream_async(*args, **kwargs):
             response = await llm.chat.complete_async(*args, **kwargs)
             return response.choices[0].message.content
 
-        model_kwargs = self._get_model_kwargs(model_key)
+        model_kwargs = self._get_model_kwargs(model_spec)
         model_kwargs["api_key"] = self.api_key
         model_kwargs["azure_endpoint"] = self.endpoint
         model = model_kwargs.pop("model")
@@ -540,13 +543,13 @@ class AnthropicAI(Llm):
     def _client_kwargs(self):
         return {"temperature": self.temperature, "max_tokens": 1024}
 
-    async def get_client(self, model_key: MODEL_TYPE, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: MODEL_TYPE | dict, response_model: BaseModel | None = None, **kwargs):
         if self.interceptor:
             raise NotImplementedError("Interceptors are not supported for AnthropicAI.")
 
         from anthropic import AsyncAnthropic
 
-        model_kwargs = self._get_model_kwargs(model_key)
+        model_kwargs = self._get_model_kwargs(model_spec)
         model = model_kwargs.pop("model")
 
         llm = AsyncAnthropic(api_key=self.api_key, **model_kwargs)
@@ -574,7 +577,7 @@ class AnthropicAI(Llm):
         system: str = "",
         response_model: BaseModel | None = None,
         allow_partial: bool = False,
-        model_key: MODEL_TYPE = "default",
+        model_spec: MODEL_TYPE | dict = "default",
         **input_kwargs,
     ) -> BaseModel:
         if isinstance(messages, str):
@@ -597,4 +600,4 @@ class AnthropicAI(Llm):
             if not messages[i]["content"]:
                 messages[i]["content"] = "--"
 
-        return await super().invoke(messages, system, response_model, allow_partial, model_key, **input_kwargs)
+        return await super().invoke(messages, system, response_model, allow_partial, model_spec, **input_kwargs)

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -121,11 +121,11 @@ class FunctionTool(Tool):
         prompt = await self._render_prompt("main", messages)
         kwargs = {}
         if any(field not in self.requires for field in self._model.model_fields):
-            model_key = self.prompts["main"].get("llm_model", "default")
+            model_spec = self.prompts["main"].get("llm_model", "default")
             kwargs = await self.llm.invoke(
                 messages,
                 system=prompt,
-                model_key=model_key,
+                model_spec=model_spec,
                 response_model=self._model,
                 allow_partial=False,
                 max_retries=3,

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -121,9 +121,11 @@ class FunctionTool(Tool):
         prompt = await self._render_prompt("main", messages)
         kwargs = {}
         if any(field not in self.requires for field in self._model.model_fields):
+            model_key = self.prompts["main"].get("llm_key", "default")
             kwargs = await self.llm.invoke(
                 messages,
                 system=prompt,
+                model_key=model_key,
                 response_model=self._model,
                 allow_partial=False,
                 max_retries=3,

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -121,7 +121,7 @@ class FunctionTool(Tool):
         prompt = await self._render_prompt("main", messages)
         kwargs = {}
         if any(field not in self.requires for field in self._model.model_fields):
-            model_key = self.prompts["main"].get("llm_key", "default")
+            model_key = self.prompts["main"].get("llm_model", "default")
             kwargs = await self.llm.invoke(
                 messages,
                 system=prompt,

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -121,7 +121,7 @@ class FunctionTool(Tool):
         prompt = await self._render_prompt("main", messages)
         kwargs = {}
         if any(field not in self.requires for field in self._model.model_fields):
-            model_spec = self.prompts["main"].get("llm_model", "default")
+            model_spec = self.prompts["main"].get("llm_spec", "default")
             kwargs = await self.llm.invoke(
                 messages,
                 system=prompt,


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/pull/829

1. Rename to `response_model` to give some room to `llm_spec` or `llm_model` or `llm_key`
2. Adds `llm_spec` which accepts keys like `default` and `reasoning`, but also real models like `o1-mini` or `Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/qwen2.5-coder-7b-instruct-q5_k_m.gguf:qwen` (repo/model_file:chat_format) or simply just a dict