### PR TITLE
Fix stubborn planner

### DIFF
--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -50,6 +50,16 @@ Here's a list of tools:
 {%- endif %}
 
 {% if unmet_dependencies %}
-Note that a previous plan was unsuccessful because it was missing {{ unmet_dependencies }} so you should ensure that is provided in the next plan!
+Here were your failed previous plans:
+{%- for previous_plan in previous_plans %}
+- {{ previous_plan }}
+{%- endfor %}
+These previous plans failed because it did not satisfy all requirements; the last plan failed to provide for: `{{ unmet_dependencies }}`
+
+Please include some of these these experts to provide for the missing requirements:
+{%- for candidate in candidates %}
+- `{{ candidate.name[:-5] }}`
+{%- endfor %}
+
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Prior to this PR the planner was stuck trying to solve for `SourceAgent` (can reproduce by doing `lumen-ai serve`:

https://github.com/user-attachments/assets/e52d85dc-7831-45d0-9fd5-3e9acf562cb6

No matter how I worded `unmet_dependencies`, it wouldn't use it. So I decided to add some context about the previous plans and also guide which agents can provide those unmet requirements.

After:
![image](https://github.com/user-attachments/assets/7b45a0a3-cf32-44e6-a642-3fd50fdf8ab7)
<img width="743" alt="image" src="https://github.com/user-attachments/assets/f436c721-b9bb-4a7a-8f7d-9b783781aabf">
