### PR TITLE
Tweak message logs

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -67,7 +67,7 @@ class Coordinator(Viewer, Actor):
     interface = param.ClassSelector(class_=ChatInterface, doc="""
         The ChatInterface for the Coordinator to interact with.""")
 
-    messages_db_path = param.String(default=None, doc="""
+    logs_db_path = param.String(default=None, doc="""
         The path to the log file that will store the messages exchanged with the LLM.""")
 
     render_output = param.Boolean(default=True, doc="""
@@ -94,7 +94,7 @@ class Coordinator(Viewer, Actor):
         llm: Llm | None = None,
         interface: ChatInterface | None = None,
         agents: list[Agent | type[Agent]] | None = None,
-        messages_db_path: str = "",
+        logs_db_path: str = "",
         **params,
     ):
         def on_message(message, instance):
@@ -138,9 +138,9 @@ class Coordinator(Viewer, Actor):
 
         self._session_id = id(self)
 
-        if messages_db_path:
+        if logs_db_path:
             interface.message_params["reaction_icons"] = {"like": "thumb-up", "dislike": "thumb-down"}
-            self._logs = ChatLogs(filename=messages_db_path)
+            self._logs = ChatLogs(filename=logs_db_path)
             interface.post_hook = on_message
         else:
             interface.message_params["show_reaction_icons"] = False
@@ -166,7 +166,7 @@ class Coordinator(Viewer, Actor):
             agent.interface = interface
             instantiated.append(agent)
 
-        super().__init__(llm=llm, agents=instantiated, interface=interface, messages_db_path=messages_db_path, **params)
+        super().__init__(llm=llm, agents=instantiated, interface=interface, logs_db_path=logs_db_path, **params)
 
         self._tools["__main__"] = [
             tool if isinstance(tool, Actor) else (FunctionTool(tool, llm=llm) if isinstance(tool, FunctionType) else tool(llm=llm))

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -72,7 +72,7 @@ class UI(Viewer):
     log_level = param.ObjectSelector(default='INFO', objects=['DEBUG', 'INFO', 'WARNING', 'ERROR'], doc="""
         The log level to use.""")
 
-    messages_db_path = param.String(default=None, doc="""
+    logs_db_path = param.String(default=None, doc="""
         The path to the log file that will store the messages exchanged with the LLM.""")
 
     notebook_preamble = param.String(default='', doc="""
@@ -115,7 +115,7 @@ class UI(Viewer):
             agents=agents,
             llm=self.llm,
             tools=self.tools,
-            messages_db_path=self.messages_db_path
+            logs_db_path=self.logs_db_path
         )
         self._notebook_export = FileDownload(
             icon="notebook",

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -72,6 +72,9 @@ class UI(Viewer):
     log_level = param.ObjectSelector(default='INFO', objects=['DEBUG', 'INFO', 'WARNING', 'ERROR'], doc="""
         The log level to use.""")
 
+    messages_db_path = param.String(default=None, doc="""
+        The path to the log file that will store the messages exchanged with the LLM.""")
+
     notebook_preamble = param.String(default='', doc="""
         Preamble to add to exported notebook(s).""")
 
@@ -112,6 +115,7 @@ class UI(Viewer):
             agents=agents,
             llm=self.llm,
             tools=self.tools,
+            messages_db_path=self.messages_db_path
         )
         self._notebook_export = FileDownload(
             icon="notebook",


### PR DESCRIPTION
Hides chat reaction icons + copy icon on the help message.

Also properly serializes the messages into strings, so it's not showing objects reprs.

![image](https://github.com/user-attachments/assets/b846bd6e-d938-4d76-849b-73f19e047ec5)

However, I'm not sure how to differentiate across Exploration tabs since it's on coordinator and not explorer ui.

Also, not sure if we need to redesign the database schema, to include a separate steps table.  