### PR TITLE
Add support for serializing Panel objects with refs

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -14,7 +14,7 @@ import yaml
 from instructor.retry import InstructorRetryException
 from panel.chat import ChatInterface
 from panel.layout import Column
-from panel.viewable import Viewer
+from panel.viewable import Viewable, Viewer
 from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
 
@@ -25,7 +25,9 @@ from ..sources.base import BaseSQLSource
 from ..sources.duckdb import DuckDBSource
 from ..state import state
 from ..transforms.sql import SQLLimit
-from ..views import VegaLiteView, View, hvPlotUIView
+from ..views import (
+    Panel, VegaLiteView, View, hvPlotUIView,
+)
 from .actor import Actor, ContextProvider
 from .config import PROMPTS_DIR
 from .controls import SourceControls
@@ -912,6 +914,8 @@ class AnalysisAgent(LumenBaseAgent):
                     view = await analysis_callable(pipeline)
                 else:
                     view = await asyncio.to_thread(analysis_callable, pipeline)
+                if isinstance(view, Viewable):
+                    view = Panel(object=view, pipeline=self._memory.get('pipeline'))
                 spec = view.to_spec()
                 if isinstance(view, View):
                     view_type = view.view_type

--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import panel as pn
 import param
 
-from lumen.ai.utils import get_data
+from panel.viewable import Viewable
 
 from ..base import Component
 from .controls import SourceControls
 from .memory import memory
+from .utils import get_data
 
 
 class Analysis(param.ParameterizedFunction):
@@ -50,7 +53,7 @@ class Analysis(param.ParameterizedFunction):
         if config_options:
             return pn.Param(self.param, parameters=config_options)
 
-    def __call__(self, pipeline) -> Component:
+    def __call__(self, pipeline) -> Component | Viewable:
         return pipeline
 
 
@@ -96,7 +99,7 @@ class Join(Analysis):
         )
         return controls
 
-    async def __call__(self, pipeline) -> Component:
+    async def __call__(self, pipeline):
         if self.table_name:
             agent = next(agent for agent in self.agents if type(agent).__name__ == "SQLAgent")
             content = f"Join these tables: '//{self._previous_source}//{self._previous_table}' and '//{memory['source']}//{self.table_name}'"

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -4,6 +4,9 @@ from typing import Any
 
 import param
 
+from panel.viewable import Viewable
+
+from ..views.base import View
 from .actor import Actor, ContextProvider
 from .config import PROMPTS_DIR
 from .embeddings import NumpyEmbeddings
@@ -185,6 +188,8 @@ class FunctionTool(Tool):
             result = await self.function(**arguments)
         else:
             result = self.function(**arguments)
+        if isinstance(result, (View, Viewable)):
+            return result
         if self.provides:
             if len(self.provides) == 1 and not isinstance(result, dict):
                 self._memory[self.provides[0]] = result

--- a/lumen/base.py
+++ b/lumen/base.py
@@ -164,6 +164,7 @@ class Component(param.Parameterized):
             op = dict(obj._operation)
             if not isinstance(op['fn'], str):
                 op['fn'] = f"{op['fn'].__module__}.{op['fn'].__name__}"
+            op['args'] = list(op['args'])
         else:
             op = None
         return {

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -4,11 +4,17 @@ import pandas as pd
 import panel as pn
 import pytest
 
+from panel.layout import Column
+from panel.pane import Markdown
+from panel.widgets import Checkbox
+
 from lumen.panel import DownloadButton
 from lumen.sources.base import FileSource
 from lumen.state import state
 from lumen.variables.base import Variables
-from lumen.views.base import View, hvOverlayView, hvPlotView
+from lumen.views.base import (
+    Panel, View, hvOverlayView, hvPlotView,
+)
 
 
 def test_resolve_module_type():
@@ -318,3 +324,121 @@ def test_view_list_param_function_roundtrip(set_root):
     view = View.from_spec(original_spec)
     assert isinstance(view, hvOverlayView)
     assert view.to_spec() == original_spec
+
+
+def test_panel_view_roundtrip():
+    md = Markdown("TEST", width=420)
+
+    spec = Panel(object=md).to_spec()
+    assert spec == {
+        'type': 'panel',
+        'object': {
+            'name': f'"{md.name}"',
+            'object': '"TEST"',
+            'type': 'panel.pane.markup.Markdown',
+            'width': '420',
+        }
+    }
+
+    panel_view = Panel.from_spec(spec)
+    obj = panel_view.object
+    assert isinstance(obj, Markdown)
+    assert obj.name == md.name
+    assert obj.object == md.object
+    assert obj.width == 420
+
+
+def test_panel_layout_roundtrip():
+    a, b = Markdown("A"), Markdown("B")
+    column = Column(a, b)
+
+    spec = Panel(object=column).to_spec()
+    assert spec == {
+        'type': 'panel',
+        'object': {
+            'name': f'"{column.name}"',
+            'objects': [
+                {'type': 'panel.pane.markup.Markdown', 'object': '"A"', 'name': f'"{a.name}"'},
+                {'type': 'panel.pane.markup.Markdown', 'object': '"B"', 'name': f'"{b.name}"'}
+            ],
+            'type': 'panel.layout.base.Column'
+        }
+    }
+
+def test_panel_cross_reference_param():
+    a = Checkbox(name="A")
+    b = Markdown("B", visible=a)
+    column = Column(a, b)
+
+    spec = Panel(object=column).to_spec()
+    assert spec == {
+        'type': 'panel',
+        'object': {
+            'name': f'"{column.name}"',
+            'objects': [
+                {
+                    'type': 'panel.widgets.input.Checkbox',
+                    'name': f'"{a.name}"'
+                },
+                {
+                    'type': 'panel.pane.markup.Markdown',
+                    'object': '"B"',
+                    'name': f'"{b.name}"',
+                    'visible': {
+                        'name': 'value',
+                        'owner': 'A',
+                        'type': 'param'
+                    }
+                }
+            ],
+            'type': 'panel.layout.base.Column'
+        }
+    }
+
+def test_panel_cross_reference_rx():
+    a = Checkbox(name="A")
+    b = Markdown("B", visible=a.rx().rx.not_())
+    column = Column(a, b)
+    spec = Panel(object=column).to_spec()
+    assert spec == {
+        'type': 'panel',
+        'object': {
+            'name': f'"{column.name}"',
+            'objects': [
+                {
+                    'type': 'panel.widgets.input.Checkbox',
+                    'name': f'"{a.name}"'
+                },
+                {
+                    'type': 'panel.pane.markup.Markdown',
+                    'object': '"B"',
+                    'name': f'"{b.name}"',
+                    'visible': {
+                        'input_obj': None,
+                        'kwargs': {},
+                        'method': None,
+                        'operation': {
+                            'args': [],
+                            'fn': '_operator.not_',
+                            'kwargs': {},
+                            'reverse': False,
+                        },
+                        'prev': {
+                            'type': 'rx',
+                            'input_obj': None,
+                            'kwargs': {},
+                            'method': None,
+                            'operation': None,
+                            'prev': {
+                                'name': 'value',
+                                'owner': 'A',
+                                'type': 'param'
+                            }
+                        },
+                        'type': 'rx',
+                    }
+                }
+            ],
+            'type': 'panel.layout.base.Column'
+        }
+    }

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -685,6 +685,8 @@ class Panel(View):
                 )
                 refs.append(ref)
                 continue
+            elif p in ('design',):
+                continue
 
             if value is obj_type.param[p].default:
                 continue

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -25,7 +25,9 @@ from panel.pane.perspective import (
 )
 from panel.param import Param
 from panel.util import classproperty
-from panel.viewable import Viewable, Viewer
+from panel.viewable import (
+    Child, Children, Viewable, Viewer,
+)
 
 from ..base import MultiTypeComponent
 from ..config import _INDICATORS
@@ -287,7 +289,10 @@ class View(MultiTypeComponent, Viewer):
                 "full specification for the View."
             )
         spec = spec.copy()
-        view_type = View._get_type(spec.pop('type', None))
+        type_spec = spec.pop('type', None)
+        view_type = View._get_type(type_spec)
+        if view_type is not cls:
+            return view_type.from_spec(dict(spec, type=type_spec), source=source, filters=filters, pipeline=pipeline)
         resolved_spec, refs = {}, {}
 
         # Resolve pipeline
@@ -333,6 +338,7 @@ class View(MultiTypeComponent, Viewer):
                     _chain_update=True
                 )
             resolved_spec['pipeline'] = pipeline
+        pipeline = resolved_spec['pipeline']
 
         # Resolve View parameters
         for p, value in spec.items():
@@ -342,7 +348,10 @@ class View(MultiTypeComponent, Viewer):
                 resolved_spec[p] = value
                 continue
             parameter = view_type.param[p]
-            if is_ref(value):
+            resolver = f'_resolve_{p}'
+            if hasattr(view_type, resolver):
+                value = getattr(view_type, resolver)(value, pipeline)
+            elif is_ref(value):
                 refs[p] = value
                 value = state.resolve_reference(value)
             if view_type._is_param_function(p):
@@ -589,33 +598,86 @@ class Panel(View):
     ```
     """
 
-    spec = param.Dict()
+    object = Child()
 
     view_type: ClassVar[str] = 'panel'
 
+    _allows_refs: ClassVar[bool] = False
     _requires_source: ClassVar[bool] = False
 
-    def _resolve_spec(self, spec):
+    @classmethod
+    def from_spec(
+        cls, spec: dict[str, Any] | str, source=None, filters=None, pipeline=None
+    ) -> View:
+        if isinstance(spec, dict) and 'spec' in spec:
+            spec['object'] = spec.pop('spec')
+        return super().from_spec(spec, source=source, filters=filters, pipeline=pipeline)
+
+    @classmethod
+    def _resolve_object(cls, spec, pipeline: Pipeline | None = None):
         if not isinstance(spec, dict) or 'type' not in spec:
             return spec
-        spec = self.spec.copy()
-        ptype = resolve_module_reference(spec.pop('type'), Viewable)
-        params = dict(self.kwargs)
+        if spec['type'] in ('rx', 'param'):
+            return cls._materialize_param_ref(spec, objects={'pipeline': pipeline})
+        spec_type = spec.pop('type')
+        ptype = resolve_module_reference(spec_type, Viewable)
+        params = {}
         for p, v in spec.items():
             if isinstance(v, dict) and 'type' in v:
-                v = self._resolve_spec(v)
+                v = cls._resolve_object(v, pipeline=pipeline)
             elif isinstance(v, list):
-                v = [self._resolve_spec(sv) for sv in v]
+                v = [cls._resolve_object(sv, pipeline=pipeline) for sv in v]
             elif is_ref(v):
                 if v == '$data':
-                    v = self.get_data()
+                    v = pipeline.param.data
                 else:
                     v = state.resolve_reference(v)
+            else:
+                try:
+                    v = ptype.param.deserialize_value(p, v)
+                except Exception:
+                    pass
             params[p] = v
         return ptype(**params)
 
+    def _serialize_object(self, obj):
+        obj_type = type(obj)
+        type_spec = f'{obj_type.__module__}.{obj_type.__name__}'
+        prefs = obj._param__private.refs
+        params = {}
+        for p, pobj in obj.param.objects().items():
+            value = getattr(obj, p)
+            if p in prefs:
+                pref = prefs[p]
+                params[p] = self._serialize_param_ref(
+                    pref, objects={'pipeline': self.pipeline}
+                )
+                continue
+
+            if value is obj_type.param[p].default:
+                continue
+            try:
+                equal = value == obj_type.param[p].default
+            except Exception:
+                equal = False
+            if equal:
+                continue
+            elif isinstance(pobj, Child):
+                value = self._serialize_object(value)
+            elif isinstance(pobj, Children):
+                value = [self._serialize_object(child) for child in value]
+            else:
+                value = obj.param.serialize_value(p)
+            params[p] = value
+        return {'type': type_spec, **params}
+
+    def to_spec(self, context: dict[str, Any] | None = None) -> dict[str, Any]:
+        spec = super().to_spec(context)
+        spec['object'] = self._serialize_object(self.object)
+        return spec
+
     def get_panel(self):
-        return self._resolve_spec(self.spec)
+        return self.object
 
 
 class StringView(View):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -350,7 +350,7 @@ class View(MultiTypeComponent, Viewer):
             parameter = view_type.param[p]
             resolver = f'_resolve_{p}'
             if hasattr(view_type, resolver):
-                value = getattr(view_type, resolver)(value, pipeline)
+                value = getattr(view_type, resolver)(value, {'pipeline': pipeline})
             elif is_ref(value):
                 refs[p] = value
                 value = state.resolve_reference(value)
@@ -614,22 +614,36 @@ class Panel(View):
         return super().from_spec(spec, source=source, filters=filters, pipeline=pipeline)
 
     @classmethod
-    def _resolve_object(cls, spec, pipeline: Pipeline | None = None):
+    def _resolve_object(cls, spec, objects=None, unresolved=None, depth=0):
         if not isinstance(spec, dict) or 'type' not in spec:
             return spec
-        if spec['type'] in ('rx', 'param'):
-            return cls._materialize_param_ref(spec, objects={'pipeline': pipeline})
+        elif spec['type'] in ('rx', 'param'):
+            try:
+                return cls._materialize_param_ref(spec, objects=objects)
+            except KeyError:
+                return None
+
+        if unresolved is None:
+            unresolved = []
         spec_type = spec.pop('type')
         ptype = resolve_module_reference(spec_type, Viewable)
-        params = {}
+        params, refs = {}, {}
         for p, v in spec.items():
             if isinstance(v, dict) and 'type' in v:
-                v = cls._resolve_object(v, pipeline=pipeline)
-            elif isinstance(v, list):
-                v = [cls._resolve_object(sv, pipeline=pipeline) for sv in v]
+                vtype = v['type']
+                v = cls._resolve_object(v, objects=objects, unresolved=unresolved, depth=depth+1)
+                if vtype in ('param', 'rx') and v is None:
+                    refs[p] = spec[p]
+                    continue
+            elif isinstance(v, list) and all(isinstance(o, dict) and 'type' in o for o in v):
+                resolved = []
+                for sv in v:
+                    robj = cls._resolve_object(sv, objects=objects, unresolved=unresolved, depth=depth+1)
+                    resolved.append(robj)
+                v = resolved
             elif is_ref(v):
                 if v == '$data':
-                    v = pipeline.param.data
+                    v = objects['pipeline'].param.data
                 else:
                     v = state.resolve_reference(v)
             else:
@@ -638,10 +652,27 @@ class Panel(View):
                 except Exception:
                     pass
             params[p] = v
-        return ptype(**params)
+        obj = ptype(**params)
+        objects[obj.name] = obj
+        if refs:
+            unresolved.append((obj, refs))
+        if depth == 0:
+            for obj, refs in unresolved:
+                param_refs = {}
+                for p, ref in refs.items():
+                     param_refs[p] = cls._resolve_object(ref, objects=objects, depth=depth+1)
+                obj.param.update(param_refs)
+        return obj
 
-    def _serialize_object(self, obj):
+    def _serialize_object(self, obj, objects=None, refs=None, depth=0):
         obj_type = type(obj)
+        if objects is None:
+            objects = {'pipeline': self.pipeline, obj.name: obj}
+        else:
+            objects[obj.name] = obj
+
+        if refs is None:
+            refs = []
         type_spec = f'{obj_type.__module__}.{obj_type.__name__}'
         prefs = obj._param__private.refs
         params = {}
@@ -649,9 +680,10 @@ class Panel(View):
             value = getattr(obj, p)
             if p in prefs:
                 pref = prefs[p]
-                params[p] = self._serialize_param_ref(
-                    pref, objects={'pipeline': self.pipeline}
+                params[p] = ref = self._serialize_param_ref(
+                    pref, objects=objects
                 )
+                refs.append(ref)
                 continue
 
             if value is obj_type.param[p].default:
@@ -663,12 +695,21 @@ class Panel(View):
             if equal:
                 continue
             elif isinstance(pobj, Child):
-                value = self._serialize_object(value)
+                value = self._serialize_object(value, objects=objects, refs=refs, depth=depth+1)
             elif isinstance(pobj, Children):
-                value = [self._serialize_object(child) for child in value]
+                value = [
+                    self._serialize_object(child, objects=objects, refs=refs, depth=depth+1)
+                    for child in value
+                ]
             else:
                 value = obj.param.serialize_value(p)
             params[p] = value
+
+        if depth != 0:
+            return {'type': type_spec, **params}
+
+        for ref in refs:
+            self._finalize_param_ref(ref, objects)
         return {'type': type_spec, **params}
 
     def to_spec(self, context: dict[str, Any] | None = None) -> dict[str, Any]:


### PR DESCRIPTION
Add the ability to serialize Panel objects including parameter references. This should make it possible to write Agents and Tools that render Panel objects as outputs without having to write a custom Lumen `View` to wrap them. For now we can only serialize references pointing to the `Pipeline` and I'm also working towards making cross-references between the serialized Panel objects work.

- [x] Add tests
- [x] Allow cross-references