### PR TITLE
Improve handling when cancelling execution

### DIFF
--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import asyncio
+
 from pathlib import Path
 
 import panel as pn
@@ -34,6 +38,7 @@ UNRECOVERABLE_ERRORS = (
     ImportError,
     LlmSetupError,
     RecursionError,
+    asyncio.CancelledError
 )
 
 pn.chat.ChatStep.min_width = 450

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -69,7 +69,7 @@ class UI(Viewer):
     llm = param.ClassSelector(class_=Llm, default=OpenAI(), doc="""
         The LLM provider to be used by default""")
 
-    log_level = param.ObjectSelector(default='INFO', objects=['DEBUG', 'INFO', 'WARNING', 'ERROR'], doc="""
+    log_level = param.ObjectSelector(default='DEBUG', objects=['DEBUG', 'INFO', 'WARNING', 'ERROR'], doc="""
         The log level to use.""")
 
     logs_db_path = param.String(default=None, doc="""
@@ -117,6 +117,8 @@ class UI(Viewer):
             tools=self.tools,
             logs_db_path=self.logs_db_path
         )
+        if self.log_level == "DEBUG":
+            self._coordinator.interface.callback_exception = "verbose"
         self._notebook_export = FileDownload(
             icon="notebook",
             icon_size="1.5em",
@@ -435,9 +437,9 @@ class ExplorerUI(UI):
     def _add_outputs(self, exploration: Column, outputs: list[LumenOutput], memory: _Memory):
         from panel_gwalker import GraphicWalker
         if "sql" in memory:
-            sql = memory["sql"]
+            sql = memory.rx("sql")
             sql_pane = Markdown(
-                f'```sql\n{sql}\n```',
+                param.rx('```sql\n{sql}\n```').format(sql=sql),
                 margin=0, sizing_mode='stretch_width'
             )
             if sql.count('\n') > 10:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -100,7 +100,6 @@ def retry_llm_output(retries=3, sleep=1):
                 for i in range(retries):
                     if errors:
                         kwargs["errors"] = errors
-
                     try:
                         output = await func(*args, **kwargs)
                         if not output:
@@ -108,7 +107,7 @@ def retry_llm_output(retries=3, sleep=1):
                         return output
                     except Exception as e:
                         if isinstance(e, UNRECOVERABLE_ERRORS) or i == retries - 1:
-                            raise
+                            raise e
                         errors.append(str(e))
                         if sleep:
                             await asyncio.sleep(sleep)


### PR DESCRIPTION
We should generally avoid surfacing errors to the user, especially when the user explicitly requested cancelling execution.