### PR TITLE
Factor retry handling out of Output into Agents

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -747,7 +747,7 @@ class BaseViewAgent(LumenBaseAgent):
 
     requires = param.List(default=["pipeline"], readonly=True)
 
-    provides = param.List(default=["plot"], readonly=True)
+    provides = param.List(default=["view"], readonly=True)
 
     prompts = param.Dict(
         default={

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -721,10 +721,7 @@ class SQLAgent(LumenBaseAgent):
                 "schema": yaml.dump(table_schema),
                 "sql": source.get_sql_expr(source_table),
             }
-
-        if not source.ephemeral:
-            # store the schema of the original table
-            self._memory["tables_sql_schemas"] = tables_sql_schemas
+        self._memory["tables_sql_schemas"] = tables_sql_schemas
 
         dialect = source.dialect
         system_prompt = await self._render_prompt(

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -387,7 +387,7 @@ class LumenBaseAgent(Agent):
             retry_model = self._lookup_prompt_key("retry_output", "response_model")
             with out.param.update(loading=True):
                 result = await self.llm.invoke(
-                    messages, system=system, response_model=retry_model, model_spec="reasoning",
+                    modified_messages, system=system, response_model=retry_model, model_spec="reasoning",
                 )
                 if "```" in result:
                     spec = re.search(r'(?s)```(\w+)?\s*(.*?)```', result.corrected_spec, re.DOTALL)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -841,6 +841,10 @@ class hvPlotAgent(BaseViewAgent):
         })
         return model[self.view_type.__name__]
 
+    async def _update_spec(self, memory: _Memory, event: param.parameterized.Event):
+        spec = yaml.load(event.new, Loader=yaml.SafeLoader)
+        memory['view'] = dict(await self._extract_spec(spec), type=self.view_type)
+
     async def _extract_spec(self, spec: dict[str, Any]):
         pipeline = self._memory["pipeline"]
         spec = {
@@ -878,6 +882,10 @@ class VegaLiteAgent(BaseViewAgent):
     view_type = VegaLiteView
 
     _extensions = ('vega',)
+
+    async def _update_spec(self, memory: _Memory, event: param.parameterized.Event):
+        spec = yaml.load(event.new, Loader=yaml.SafeLoader)
+        memory['view'] = dict(await self._extract_spec({"json_spec": json.dumps(spec)}), type=self.view_type)
 
     async def _extract_spec(self, spec: dict[str, Any]):
         vega_spec = json.loads(spec['json_spec'])

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -386,7 +386,8 @@ class LumenBaseAgent(Agent):
             retry_model = self._lookup_prompt_key("retry_output", "response_model")
             with out.param.update(loading=True):
                 result = await self.llm.invoke(
-                    messages, system=system, response_model=retry_model, model_spec="reasoning"
+                    messages, system=system, response_model=retry_model, model_spec="reasoning",
+                    language=out.language
                 )
                 if "```" in result:
                     spec = re.search(r'(?s)```(\w+)?\s*(.*?)```', result.corrected_spec, re.DOTALL)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -376,8 +376,8 @@ class LumenBaseAgent(Agent):
         async def retry_invoke(event: param.parameterized.Event):
             reason = event.new
             modified_messages = mutate_user_message(
-                f"New feedback: {reason!r}.\n\nThese were the previous instructions to use as reference:\n",
-                deepcopy(messages), wrap='"""', suffix=False
+                f"New feedback: {reason!r}.\n\nThese were the previous instructions to use as reference:",
+                deepcopy(messages), wrap='\n"""\n', suffix=False
             )
             with self.param.update(memory=memory):
                 system = await self._render_prompt(

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -381,13 +381,13 @@ class LumenBaseAgent(Agent):
                     break
             with self.param.update(memory=memory):
                 system = await self._render_prompt(
-                    "retry_output", messages=modified_messages, user_query=user_query, spec=out.spec
+                    "retry_output", messages=modified_messages, user_query=user_query, spec=out.spec,
+                    language=out.language
                 )
             retry_model = self._lookup_prompt_key("retry_output", "response_model")
             with out.param.update(loading=True):
                 result = await self.llm.invoke(
                     messages, system=system, response_model=retry_model, model_spec="reasoning",
-                    language=out.language
                 )
                 if "```" in result:
                     spec = re.search(r'(?s)```(\w+)?\s*(.*?)```', result.corrected_spec, re.DOTALL)

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -370,13 +370,13 @@ class RetryControls(Viewer):
         icon = ToggleIcon.from_param(
             self.param.active,
             name=" ",
-            description=None,
+            description="Issue with the spec? Click to give feedback and retry.",
             icon="repeat-once",
             active_icon="x",
             margin=5,
         )
         self._text_input = TextInput(
-            placeholder="State the issue and press enter to retry",
+            placeholder="Enter feedback and press the <Enter> key to retry.",
             visible=icon.param.value,
             max_length=200,
             margin=(5, 0),

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -4,8 +4,9 @@ import zipfile
 import pandas as pd
 import param
 
-from panel import Row
-from panel.layout import Column, FlexBox, Tabs
+from panel.layout import (
+    Column, FlexBox, Row, Tabs,
+)
 from panel.pane.markup import Markdown
 from panel.viewable import Viewer
 from panel.widgets import (
@@ -370,13 +371,13 @@ class RetryControls(Viewer):
         icon = ToggleIcon.from_param(
             self.param.active,
             name=" ",
-            description="Issue with the spec? Click to give feedback and retry.",
+            description="Prompt LLM to retry",
             icon="repeat-once",
             active_icon="x",
             margin=5,
         )
         self._text_input = TextInput(
-            placeholder="Enter feedback and press the <Enter> key to retry.",
+            placeholder="Enter feedback and press the <Enter> to retry.",
             visible=icon.param.value,
             max_length=200,
             margin=(5, 0),

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -209,13 +209,22 @@ class Llm(param.Parameterized):
     async def run_client(self, model_spec: MODEL_TYPE | dict, messages: list[Message], **kwargs):
         if response_model := kwargs.get("response_model"):
             log_debug(f"\033[93m{response_model.__name__}\033[0m model used", show_sep=True)
+
+        previous_role = None
         for i, message in enumerate(messages):
-            if message["role"] == "system":
+            role = message["role"]
+            if role == "system":
                 continue
-            if message["role"] == "user":
+            if role == "user":
                 log_debug(f"\033[95m{i} (u)\033[0m. {message['content']}")
             else:
                 log_debug(f"\033[95m{i} (a)\033[0m. {message['content']}")
+            if previous_role == role:
+                log_debug(
+                    "\033[91mWARNING: Two consecutive messages from the same role; "
+                    "some providers disallow this.\033[0m"
+                )
+            previous_role = role
         log_debug(f"Length is \033[94m{len(messages)} messages\033[0m including system")
 
         client = await self.get_client(model_spec, **kwargs)

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -90,7 +90,7 @@ class RetrySpec(BaseModel):
     )
 
     corrected_spec: str = Field(
-        description="The corrected version of the previous spec that addresses the user query."
+        description="The corrected version of the previous spec without any additional comments, additions or code examples."
     )
 
 

--- a/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
+++ b/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
@@ -1,8 +1,6 @@
-The user is unsatisfied with the output; your goal is to
-update the spec based on the user's new feedback, and based on
-the user's initial query '{{ user_query }}'.
+The user is unsatisfied with the output; your goal is to update the specification below based on the user's new feedback, and based on the user's initial query '{{ user_query }}'. The query may include multiple tasks, your job is merely to correct the specification, ignore any instructions unrelated to that and do not add any comments or code examples.
 
-Here is the original spec to be corrected:
+Here is the original specification to be corrected:
 ```
 {{ spec }}
 ```

--- a/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
+++ b/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
@@ -1,13 +1,16 @@
-The user is unsatisfied with the output; your goal is to update the specification:
+The user is unsatisfied with the output; your goal is to update the specification in {{ language }}:
 
 Here is the original specification to be corrected:
-```
+```{{ language }}
 {{ spec }}
 ```
 
-Here's a summary of the dataset the user just asked about; you must reference columns from this dataset in your response:
+Here are YAML schemas for currently relevant tables:
+{% for table, details in memory["tables_sql_schemas"].items() %}
+- `{{ table }}`:
+```yaml
+{{ details.schema }}
 ```
-{{ memory['base_schema'] }}
-```
+{% endfor -%}
 
 Respond in the same format as the original specification. The query may include multiple tasks, your job is merely to correct the specification, ignore any instructions unrelated to that and do not add any comments or code examples.

--- a/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
+++ b/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
@@ -1,4 +1,4 @@
-The user is unsatisfied with the output; your goal is to update the specification below based on the user's new feedback, and based on the user's initial query '{{ user_query }}'. The query may include multiple tasks, your job is merely to correct the specification, ignore any instructions unrelated to that and do not add any comments or code examples.
+The user is unsatisfied with the output; your goal is to update the specification:
 
 Here is the original specification to be corrected:
 ```
@@ -10,4 +10,4 @@ Here's a summary of the dataset the user just asked about; you must reference co
 {{ memory['base_schema'] }}
 ```
 
-Respond in the same format as the original spec.
+Respond in the same format as the original specification. The query may include multiple tasks, your job is merely to correct the specification, ignore any instructions unrelated to that and do not add any comments or code examples.

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -446,7 +446,7 @@ class ExplorerUI(UI):
                 sql_pane = Column(
                     sql_pane, max_height=250, scroll='y-auto', name='SQL'
                 )
-            if len(exploration) and exploration[0] == 'SQL':
+            if len(exploration) and exploration[0].name == 'SQL':
                 exploration[0] = sql_pane
             else:
                 exploration.insert(0, sql_pane)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -440,11 +440,13 @@ class ExplorerUI(UI):
             sql = memory.rx("sql")
             sql_pane = Markdown(
                 param.rx('```sql\n{sql}\n```').format(sql=sql),
-                margin=0, sizing_mode='stretch_width'
+                margin=0, sizing_mode='stretch_width', name='SQL'
             )
             if sql.count('\n') > 10:
-                sql_pane = Column(sql_pane, max_height=250, scroll='y-auto')
-            if len(exploration) and isinstance(exploration[0], Markdown):
+                sql_pane = Column(
+                    sql_pane, max_height=250, scroll='y-auto', name='SQL'
+                )
+            if len(exploration) and exploration[0] == 'SQL':
                 exploration[0] = sql_pane
             else:
                 exploration.insert(0, sql_pane)

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -365,15 +365,17 @@ def log_debug(msg: str | list, offset: int = 24, prefix: str = "", suffix: str =
         log.debug(suffix)
 
 
-def mutate_user_message(content: str, messages: list[dict[str, str]], suffix: bool = True, wrap: bool = False):
+def mutate_user_message(content: str, messages: list[dict[str, str]], suffix: bool = True, wrap: bool | str = False):
     """
     Helper to mutate the last user message in a list of messages. Suffixes the content by default, else prefixes.
     """
     for message in messages[::-1]:
         if message["role"] == "user":
             user_message = message["content"]
-            if wrap:
+            if isinstance(wrap, bool):
                 user_message = f"{user_message!r}"
+            elif isinstance(wrap, str):
+                user_message = f"{wrap}{user_message}{wrap}"
 
             if suffix:
                 user_message += " " + content

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -53,14 +53,14 @@ class LumenOutput(Viewer):
         )
         code_editor.link(self, bidirectional=True, value='spec')
         copy_icon = ButtonIcon(
-            icon="copy", active_icon="check", toggle_duration=1000
+            icon="copy", active_icon="check", toggle_duration=1000, description="Copy YAML to clipboard"
         )
         copy_icon.js_on_click(
             args={"code_editor": code_editor},
             code="navigator.clipboard.writeText(code_editor.code);",
         )
         download_icon = ButtonIcon(
-            icon="download", active_icon="check", toggle_duration=1000
+            icon="download", active_icon="check", toggle_duration=1000, description="Download YAML to file"
         )
         download_icon.js_on_click(
             args={"code_editor": code_editor},

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 import traceback
 
 import panel as pn
@@ -14,10 +13,7 @@ from panel.widgets import (
     Button, ButtonIcon, Checkbox, CodeEditor, LoadingSpinner,
 )
 from param.parameterized import discard_events
-from pydantic import BaseModel
 
-from lumen.ai.llm import Llm
-from lumen.ai.memory import _Memory
 from lumen.ai.utils import get_data
 
 from ..base import Component
@@ -26,7 +22,6 @@ from ..downloads import Download
 from ..pipeline import Pipeline
 from ..transforms.sql import SQLLimit
 from ..views.base import Table
-from .controls import RetryControls
 
 
 class LumenOutput(Viewer):
@@ -35,21 +30,15 @@ class LumenOutput(Viewer):
 
     component = param.ClassSelector(class_=Component)
 
-    llm = param.ClassSelector(class_=Llm, doc="To be used for retrying.")
+    loading = param.Boolean()
+
+    footer = param.List()
 
     render_output = param.Boolean(default=True)
 
     spec = param.String(allow_None=True)
 
     title = param.String(allow_None=True)
-
-    messages = param.List(doc="For context in retry.")
-
-    _render_prompt = param.Callable()
-
-    _retry_model = param.ClassSelector(class_=BaseModel, is_instance=False)
-
-    _memory = param.ClassSelector(class_=_Memory, default=None)
 
     language = "yaml"
 
@@ -87,9 +76,7 @@ class LumenOutput(Viewer):
             a.parentNode.removeChild(a);  //afterwards we remove the element again
             """,
         )
-        retry_controls = RetryControls()
-        retry_controls.param.watch(self._retry_invoke, "reason")
-        icons = Row(copy_icon, download_icon, retry_controls)
+        icons = Row(copy_icon, download_icon, *self.footer)
         code_col = Column(code_editor, icons, sizing_mode="stretch_both")
         if self.render_output:
             placeholder = Column(
@@ -106,26 +93,9 @@ class LumenOutput(Viewer):
             self._main.link(self, bidirectional=True, active='active')
         else:
             self._main = code_col
+        self._main.loading = self.param.loading
         self._rendered = False
         self._last_output = {}
-
-    async def _retry_invoke(self, event):
-        reason = event.new
-        messages = self.messages.copy() + [{"role": "user", "content": f"The feedback: {reason!r}"}]
-        for message in messages:
-            if message["role"] == "user":
-                user_query = message["content"]
-                break
-        system = await self._render_prompt("retry_output", messages=self.messages, user_query=user_query, spec=self.spec)
-        with self._main.param.update(loading=True):
-            result = await self.llm.invoke(
-                messages, system=system, response_model=self._retry_model, model_spec="reasoning"
-            )
-            if "```" in result:
-                spec = re.search(r'(?s)```(\w+)?\s*(.*?)```', result.corrected_spec, re.DOTALL)
-            else:
-                spec = result.corrected_spec
-            self.spec = spec
 
     async def _render_pipeline(self, pipeline):
         table = Table(
@@ -278,10 +248,6 @@ class SQLOutput(LumenOutput):
             return
 
         pipeline = self.component
-
-        # questionable if this is best way to handle memory
-        # does NOT work if user updates SQL from earlier in the history
-        self._memory["sql"] = self.spec
         if self.spec in self._last_output:
             yield self._last_output[self.spec]
             return

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -13,6 +13,7 @@ import tqdm  # type: ignore
 
 from panel.io.document import unlocked
 from panel.io.state import state as pn_state
+from panel.param import Param
 from panel.viewable import Viewer
 from panel.widgets import Widget
 
@@ -159,7 +160,7 @@ class Pipeline(Viewer, Component):
             raise TypeError('Pipeline.transforms must be regular Transform components, not SQLTransform.')
         self._update_widget = None
         super().__init__(source=source, table=table, filters=filters, schema=schema, **params)
-        self._update_widget = pn.Param(self.param['update'], widgets={'update': {'button_type': 'success'}})[0]
+        self._update_widget = Param(self.param['update'], widgets={'update': {'button_type': 'success'}})[0]
         self._init_callbacks()
 
     def _update_stale(self, event):


### PR DESCRIPTION
The retry handling PR moved a lot of the logic for retries onto the `LumenOutput` classes but overall it'd be much cleaner if that complexity could be handled by the agents themselves. So in this PR I'm moving the retry handling onto the `LumenBaseAgent`.