### PR TITLE
Disable past specs and minor tweaks

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -404,6 +404,7 @@ class LumenBaseAgent(Agent):
             title=title,
             **kwargs
         )
+        retry_controls.disabled = out.param.disabled
         out.param.watch(partial(self._update_spec, self._memory), 'spec')
         if 'outputs' in self._memory:
             # We have to create a new list to trigger an event

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -366,6 +366,8 @@ class RetryControls(Viewer):
 
     reason = param.String(doc="Reason for retry")
 
+    disabled = param.Boolean(False, doc="Disable retry", allow_refs=True)
+
     def __init__(self, **params):
         super().__init__(**params)
         icon = ToggleIcon.from_param(
@@ -375,6 +377,7 @@ class RetryControls(Viewer):
             icon="repeat-once",
             active_icon="x",
             margin=5,
+            visible=self.param.disabled.rx().rx.not_(),
         )
         self._text_input = TextInput(
             placeholder="Enter feedback and press the <Enter> to retry.",

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -199,7 +199,11 @@ async def get_schema(
         elif limit and len(spec["enum"]) == 1 and spec["enum"][0] is None:
             spec["enum"] = [f"(unknown; truncated to {get_kwargs['limit']} rows)"]
         # truncate each enum to 100 characters
-        spec["enum"] = [enum if enum is None or len(enum) < 100 else f"{enum[:100]} ..." for enum in spec["enum"]]
+        spec["enum"] = [
+            enum
+            if enum is None or not isinstance(enum, str) or len(enum) < 100
+            else f"{enum[:100]} ..." for enum in spec["enum"]
+        ]
 
     if count and include_count:
         schema["count"] = count

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -40,6 +40,8 @@ class LumenOutput(Viewer):
 
     title = param.String(allow_None=True)
 
+    disabled = param.Boolean(default=False)
+
     language = "yaml"
 
     def __init__(self, **params):
@@ -51,6 +53,7 @@ class LumenOutput(Viewer):
             value=self.param.spec, language=self.language, theme='tomorrow_night_bright', sizing_mode="stretch_both",
             on_keyup=False
         )
+        code_editor.link(self, bidirectional=True, disabled='disabled')
         code_editor.link(self, bidirectional=True, value='spec')
         copy_icon = ButtonIcon(
             icon="copy", active_icon="check", toggle_duration=1000, description="Copy YAML to clipboard"
@@ -76,7 +79,7 @@ class LumenOutput(Viewer):
             a.parentNode.removeChild(a);  //afterwards we remove the element again
             """,
         )
-        icons = Row(copy_icon, download_icon, *self.footer)
+        icons = Row(copy_icon, download_icon, pn.Spacer(width=5), *self.footer)
         code_col = Column(code_editor, icons, sizing_mode="stretch_both")
         if self.render_output:
             placeholder = Column(


### PR DESCRIPTION
1. Hides the retry icon + disable codeeditor
<img width="704" alt="image" src="https://github.com/user-attachments/assets/516b1a3e-d7d7-4366-91d1-ce19beb39c76" />

2. enum had a bug where if it was numeric, it would crash
3. there was uneven spacing between each icon so I added a spacer.