### PR TITLE
Add markitdown and tweak

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -222,11 +222,12 @@ class ChatAgent(Agent):
         and continuing the conversation.
 
         Is capable of providing suggestions to get started or comment on interesting tidbits.
-        It can talk about the data, if available.
+        It can talk about the data, if available. Or, it can also solely talk about documents.
 
         Usually not used concurrently with SQLAgent, unlike AnalystAgent.
         Can be used concurrently with TableListAgent to describe available tables
-        and potential ideas for analysis.""")
+        and potential ideas for analysis, but if only documents are available,
+        then it can be used alone.""")
 
     prompts = param.Dict(
         default={

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -31,6 +31,13 @@ Additionally the following datasets/tables are available and you may request to 
 - {{ table }}
 {% endfor %}
 {%- endif -%}
+{% if memory.get('document_sources') %}
+Here are the documents you have access to:
+{%- for document_source in memory['document_sources'] %}
+- '''{{ document_source['text'][:80].replace('\n', ' ') | default('<No text available></No>') }}...''' ({{ document_source['metadata'] | default('Unknown Filename') }})
+
+{%- endfor %}
+{% endif %}
 Here's the choice of experts and their uses:
 {%- for agent in agents %}
 - `{{ agent.name[:-5] }}`

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -79,7 +79,7 @@ class DocumentLookup(VectorLookupTool):
         ]
         if not closest_doc_chunks:
             return ""
-        message = "Please augment your response with the following context:\n"
+        message = "Please augment your response with the following context if relevant:\n"
         message += "\n".join(f"- {doc}" for doc in closest_doc_chunks)
         return message
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ HoloViz = "https://holoviz.org/"
 [project.optional-dependencies]
 tests = ['pytest', 'pytest-rerunfailures', 'pytest-asyncio']
 sql = ['duckdb', 'intake-sql', 'sqlalchemy']
-ai = ['griffe', 'nbformat', 'duckdb', 'pyarrow', 'instructor >=1.4.3', 'pydantic >=2.8.0', 'pydantic-extra-types', 'panel-graphic-walker[kernel]']
+ai = ['griffe', 'nbformat', 'duckdb', 'pyarrow', 'instructor >=1.4.3', 'pydantic >=2.8.0', 'pydantic-extra-types', 'panel-graphic-walker[kernel]', 'markitdown']
 ai-local = ['lumen[ai]', 'huggingface_hub']
 ai-openai = ['lumen[ai]', 'openai']
 ai-mistralai = ['lumen[ai]', 'mistralai']


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/871

1. uses markitdown
2. fixes file uploads were persisting after "add"
3. allows upload tabs to be closable, in case a doc was accidentally uploaded
4. tweaks system prompts so Planner/ChatAgent knows about the docs and not have source agent trigger

<img width="882" alt="image" src="https://github.com/user-attachments/assets/ddbae8df-7ebd-48a5-8287-497d41d71fed" />
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/704d4764-a4cc-4bd6-9068-f9ed0776c2ff" />
