### PR TITLE
fix closest tables source

### DIFF
--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -240,7 +240,10 @@ class DuckDBSource(BaseSQLSource):
 
     def get_sql_expr(self, table: str):
         if isinstance(self.tables, dict):
-            table = self.tables[table]
+            try:
+                table = self.tables[table]
+            except KeyError:
+                raise KeyError(f"Table {table} not found in {self.tables.keys()}")
         if '(' not in table and ')' not in table:
             table = f'"{table}"'
 


### PR DESCRIPTION

<img width="613" alt="image" src="https://github.com/user-attachments/assets/bf3e502e-a23e-4770-9ce8-0604d7585655" />

To reproduce:
1. Show the table: 'windturbines.parquet'
2. Which county has the highest power prod
3. Can you search up what Torrance county is known for?

This uses the tool, but the tool doesn't provide a table, so that crashes because the closest table isn't in the source
```python
Traceback (most recent call last):

  File "/Users/ahuang/repos/lumen/lumen/ai/coordinator.py", line 414, in _execute_graph_node
    result = await subagent.respond(
             ^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/ahuang/repos/lumen/lumen/ai/agents.py", line 256, in respond
    await get_schema(self._memory["source"], table, include_count=True, limit=1000)

  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 154, in get_schema
    schema = await asyncio.to_thread(source.get_schema, table, **get_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/ahuang/repos/lumen/lumen/sources/base.py", line 128, in wrapped
    schema[missing] = method(self, missing, limit)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/ahuang/repos/lumen/lumen/sources/base.py", line 769, in get_schema
    sql_expr = self.get_sql_expr(entry)
               ^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/ahuang/repos/lumen/lumen/sources/duckdb.py", line 253, in get_sql_expr
    raise KeyError(f"Table {table} not found in {self.tables.keys()}")
```
