### PR TITLE
Add docs list agent

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -369,7 +369,7 @@ class DocumentListAgent(Agent):
         step_title: str | None = None,
     ) -> Any:
         # extract the filename, following this pattern `Filename: 'filename'``
-        sources = [re.search(r"'(.*?)'", src["metadata"]).group(1) for src in self._memory["document_sources"]]
+        sources = [doc["metadata"].get("filename", "untitled") for doc in self._memory["document_sources"]]
         self._df = pd.DataFrame({"Documents": sources})
         document_list = pn.widgets.Tabulator(
             self._df,

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -338,6 +338,9 @@ class TableListAgent(Agent):
 
 
 class DocumentListAgent(Agent):
+    """
+    The DocumentListAgent lists all available documents provided by the user.
+    """
 
     purpose = param.String(default="""
         Renders a list of all availables documents to the user and lets the user

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -186,7 +186,7 @@ class SourceAgent(Agent):
 
     requires = param.List(default=[], readonly=True)
 
-    provides = param.List(default=["source"], readonly=True)
+    provides = param.List(default=["source", "document_sources"], readonly=True)
 
     on_init = param.Boolean(default=True)
 
@@ -293,12 +293,6 @@ class TableListAgent(Agent):
         Not useful for gathering information about the tables.
         """)
 
-    prompts = param.Dict(
-        default={
-            "main": {"template": PROMPTS_DIR / "TableListAgent" / "main.jinja2"},
-        }
-    )
-
     requires = param.List(default=["source"], readonly=True)
 
     _extensions = ('tabulator',)
@@ -341,6 +335,56 @@ class TableListAgent(Agent):
         self.interface.stream(table_list, user="Lumen")
         self._memory["closest_tables"] = tables[:5]
         return table_list
+
+
+class DocumentListAgent(Agent):
+
+    purpose = param.String(default="""
+        Renders a list of all availables documents to the user and lets the user
+        pick one. Not useful for gathering details about the documents;
+        use ChatAgent for that instead.
+        """)
+
+    requires = param.List(default=["document_sources"], readonly=True)
+
+    _extensions = ('tabulator',)
+
+    @classmethod
+    async def applies(cls, memory: _Memory) -> bool:
+        sources = memory.get("document_sources")
+        if not sources:
+            return False  # source not loaded yet; always apply
+        return len(sources) > 1
+
+    def _use_document(self, event):
+        if event.column != "show":
+            return
+        document = self._df.iloc[event.row, 0]
+        self.interface.send(f"Tell me about: {document!r}")
+
+    async def respond(
+        self,
+        messages: list[Message],
+        render_output: bool = False,
+        step_title: str | None = None,
+    ) -> Any:
+        # extract the filename, following this pattern `Filename: 'filename'``
+        sources = [re.search(r"'(.*?)'", src["metadata"]).group(1) for src in self._memory["document_sources"]]
+        self._df = pd.DataFrame({"Documents": sources})
+        document_list = pn.widgets.Tabulator(
+            self._df,
+            buttons={'show': '<i class="fa fa-eye"></i>'},
+            show_index=False,
+            min_height=150,
+            min_width=350,
+            widths={'Table': '90%'},
+            disabled=True,
+            page_size=10,
+            header_filters=True
+        )
+        document_list.on_click(self._use_document)
+        self.interface.stream(document_list, user="Lumen")
+        return document_list
 
 
 class LumenBaseAgent(Agent):

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -312,8 +312,7 @@ class SourceControls(Viewer):
             else:
                 self._memory["document_sources"].append(document)
         else:
-            with param.discard_events(self._memory):
-                self._memory["document_sources"] = [document]
+            self._memory["document_sources"] = [document]
         return 1
 
     @param.depends("add", watch=True)

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -300,7 +300,7 @@ class SourceControls(Viewer):
             return 0
 
         metadata = {
-            "filename": document_controls.filename,
+            "filename": f"{document_controls.filename}.{document_controls.extension}",
             "comments": document_controls._metadata_input.value,
         }
         document = {"text": text, "metadata": metadata}

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -431,7 +431,7 @@ class Coordinator(Viewer, Actor):
                 log_debug(f"\033[96m{agent_name} successfully completed\033[0m", show_sep=False, show_length=False)
 
             unprovided = [p for p in subagent.provides if p not in self._memory]
-            if unprovided:
+            if unprovided and not any(unprovided):
                 step.failed_title = f"{agent_name} did not provide {', '.join(unprovided)}. Aborting the plan."
                 raise RuntimeError(f"{agent_name} failed to provide declared context.")
             step.stream(f"\n\n`{agent_name}` agent successfully completed the following task:\n\n> {instruction}", replace=True)

--- a/lumen/ai/prompts/DocumentListAgent/main.jinja2
+++ b/lumen/ai/prompts/DocumentListAgent/main.jinja2
@@ -1,0 +1,5 @@
+{% extends 'Actor/main.jinja2' %}
+
+{% block instructions %}
+You are an agent responsible for listing the available document sources.
+{% endblock %}

--- a/lumen/ai/prompts/DocumentListAgent/main.jinja2
+++ b/lumen/ai/prompts/DocumentListAgent/main.jinja2
@@ -1,5 +1,0 @@
-{% extends 'Actor/main.jinja2' %}
-
-{% block instructions %}
-You are an agent responsible for listing the available document sources.
-{% endblock %}

--- a/lumen/ai/prompts/TableListAgent/main.jinja2
+++ b/lumen/ai/prompts/TableListAgent/main.jinja2
@@ -1,5 +1,0 @@
-{% extends 'Actor/main.jinja2' %}
-
-{% block instructions %}
-You are an agent responsible for listing the available tables in the current source.
-{% endblock %}

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -31,8 +31,8 @@ from ..sources.duckdb import DuckDBSource
 from ..transforms.sql import SQLLimit
 from ..util import log
 from .agents import (
-    AnalysisAgent, AnalystAgent, ChatAgent, SourceAgent, SQLAgent,
-    TableListAgent, VegaLiteAgent,
+    AnalysisAgent, AnalystAgent, ChatAgent, DocumentListAgent, SourceAgent,
+    SQLAgent, TableListAgent, VegaLiteAgent,
 )
 from .components import SplitJS
 from .controls import SourceControls
@@ -87,7 +87,7 @@ class UI(Viewer):
     )
 
     default_agents = param.List(default=[
-        TableListAgent, ChatAgent, AnalystAgent, SourceAgent, SQLAgent, VegaLiteAgent
+        TableListAgent, ChatAgent, DocumentListAgent, AnalystAgent, SourceAgent, SQLAgent, VegaLiteAgent
     ], doc="""List of default agents which will always be added.""")
 
     export_functions = param.Dict(default={}, doc="""


### PR DESCRIPTION
Shows users a list of documents they uploaded.

I think `provides` should accept `sources|document_sources`. Right now, I work around that by doing:

```
if p not in self._memory]
            if unprovided and not any(unprovided):
                step.failed_title = f"{agent_name} did not provide {', '.join(unprovided)}. Aborting the plan."
```

Since there's an RC out, maybe merge this after release.

<img width="632" alt="image" src="https://github.com/user-attachments/assets/01e1726e-d77d-4ccf-8243-630533778067" />
