### PR TITLE
Query by filename

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -282,7 +282,10 @@ class SourceControls(Viewer):
             file, file_extension=document_controls.extension
         ).text_content
 
-        metadata = f"Filename: {document_controls.filename} " + document_controls._metadata_input.value
+        metadata = {
+            "filename": document_controls.filename,
+            "provided": document_controls._metadata_input.value
+        }
         document = {"text": text, "metadata": metadata}
         if "document_sources" in self._memory:
             self._memory["document_sources"].append(document)

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -94,10 +94,11 @@ class DocumentLookup(VectorLookupTool):
         # drop duplicates and sort by similarity, and take the top n
         unique_results = {}
         for result in results:
-            if result["similarity"] > self.min_similarity:
-                content = result["text"]
-                if content not in unique_results or unique_results[content]["similarity"] < result["similarity"]:
-                    unique_results[content] = result
+            if result["similarity"] <= self.min_similarity:
+                continue
+            content = result["text"]
+            if content not in unique_results:
+                unique_results[content] = result
         results = sorted(unique_results.values(), key=lambda x: x["similarity"], reverse=True)[:self.n]
 
         closest_doc_chunks = [
@@ -105,7 +106,7 @@ class DocumentLookup(VectorLookupTool):
             for result in results
         ]
         if not closest_doc_chunks:
-            return ""
+            return "No relevant documents found."
         message = "Please augment your response with the following context if relevant:\n"
         message += "\n".join(f"- {doc}" for doc in closest_doc_chunks)
         return message

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -33,7 +33,7 @@ class VectorLookupTool(Tool):
         The minimum similarity to include a document.""")
 
     n = param.Integer(default=5, bounds=(0, None), doc="""
-        The number of document results to return, per document.""")
+        The number of document chunks to return""")
 
     vector_store = param.ClassSelector(class_=VectorStore, constant=True, doc="""
         Vector store object which is queried to provide additional context


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/873

For context, I uploaded two completely separate documents:

1. a receipt
2. an org chart

When I asked `what's in the receipt`, it referenced contents from the org chart instead of the receipt because the receipt doesn't mention it's a receipt in its contents.

This PR adds some weights to the relevancy based on filename