### PR TITLE
Add sql context

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -676,7 +676,8 @@ class Planner(Coordinator):
             if table in provided:
                 continue
             provided.append(table)
-            schema_info += f'- {table}: {cache[table]}\n\n'
+            schema = cache[table]
+            schema_info += f'- {table}\nSchema:\n```yaml\n{yaml.dump(schema)}```\n'
         return schema_info
 
     async def _make_plan(
@@ -726,7 +727,7 @@ class Planner(Coordinator):
                 step.stream(reasoning.chain_of_thought, replace=True)
                 previous_plans.append(reasoning.chain_of_thought)
             requested = [
-                t for t in getattr(reasoning, 'tables', [])
+                t for t in getattr(reasoning, 'requested_tables', [])
                 if t and t not in provided
             ]
 

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -44,7 +44,8 @@ class Sql(BaseModel):
         If it's simple, just provide one step. However, if applicable, be sure to carefully
         study the schema, discuss the values in the columns, and whether you need to
         wrangle the data before you can use it, before finally writing a correct and valid
-        SQL query that fully answers the user's query.
+        SQL query that fully answers the user's query. If using CTEs, comment on the purpose of each.
+        Everything should be made as simple as possible, but no simpler.
         """
     )
 
@@ -104,10 +105,10 @@ def make_plan_models(experts_or_tools: list[str], tables: list[str]):
     )
     extras = {}
     if tables:
-        extras['tables'] = (
+        extras['requested_tables'] = (
             list[Literal[tuple(tables)]],
             FieldInfo(
-                description="A list of tables to load into memory before coming up with a plan. NOTE: Simple queries asking to list the tables/datasets do not require loading the tables. Table names MUST match verbatim including the quotations, apostrophes, periods, or lack thereof."
+                description="A list of the most relevant tables to explore and load into memory before coming up with a plan, based on the chain of thought. NOTE: Simple queries asking to list the tables/datasets do not require loading the tables. Table names MUST match verbatim including the quotations, apostrophes, periods, or lack thereof."
             )
         )
     reasoning = create_model(
@@ -115,7 +116,7 @@ def make_plan_models(experts_or_tools: list[str], tables: list[str]):
         chain_of_thought=(
             str,
             FieldInfo(
-                description="Describe at a high-level how the actions of each expert will solve the user query."
+                description="Describe at a high-level how the actions of each expert will solve the user query. If the user asks a question about data that is seemingly unavailable, please request to see tables' schemas."
             ),
         ),
         **extras

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -22,14 +22,11 @@ Agent Rules:
 {%- if 'table' in memory %}- The result of the previous step was the `{{ memory['table'] }}` table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif -%}
 
 {%- if table_info %}
-Here are schemas for tables that were recently used (note that these schemas are computed on a subset of data):
+Here are schemas for tables that were recently requested (note that these schemas are computed on a subset of data):
 {{ table_info }}
 {%- endif %}
-{%- if tables %}
-Additionally the following datasets/tables are available and you may request to look at them before revising your plan:
-{% for table in tables %}
-- {{ table }}
-{% endfor %}
+{%- if tables_schema_str %}
+{{ tables_schema_str }}
 {%- endif -%}
 {% if memory.get('document_sources') %}
 Here are the documents you have access to:

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -22,7 +22,7 @@ Agent Rules:
 {%- if 'table' in memory %}- The result of the previous step was the `{{ memory['table'] }}` table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif -%}
 
 {%- if table_info %}
-Here are schemas for tables that were recently requested (note that these schemas are computed on a subset of data):
+Here are tables and schemas that are available to you:
 {{ table_info }}
 {%- endif %}
 {%- if tables_schema_str %}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -36,7 +36,7 @@ CAST or TO_DATE
 - Try to pretty print the SQL output with newlines and indentation.
 - Specify data types explicitly to avoid type mismatches.
 - Handle NULL values using functions like COALESCE or IS NULL.
-- Capture only the required numeric values while removing all whitespace, like `(\d+)`, or remove characters like `$`, `%`, `,`, etc, if necessary.
+- Capture only the required numeric values while removing all whitespace, like `(\d+)`, or remove characters like `$`, `%`, `,`, etc, only if needed.
 - Use parameterized queries to prevent SQL injection attacks.
 - Use Common Table Expressions (CTEs) and subqueries to break down complex queries into manageable parts.
 - Be sure to remove suspiciously large or small values that may be invalid, like -9999.

--- a/lumen/ai/prompts/SQLAgent/select_table.jinja2
+++ b/lumen/ai/prompts/SQLAgent/select_table.jinja2
@@ -7,5 +7,6 @@ accurate information if it's available.
 {% endblock %}
 
 {% block context %}
+Here are the tables (and schemas if available):
 {{ tables_schema_str }}
 {% endblock %}

--- a/lumen/ai/prompts/SQLAgent/select_table.jinja2
+++ b/lumen/ai/prompts/SQLAgent/select_table.jinja2
@@ -2,10 +2,10 @@
 
 {% block instructions %}
 Select the most appropriate table to use in the SQL query to answer the user's question.
+Note the table names may be outdated or incorrect, so check the schemas for the most
+accurate information if it's available.
 {% endblock %}
 
 {% block context %}
-Here are the table schemas:
-
 {{ tables_schema_str }}
 {% endblock %}

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -330,7 +330,7 @@ async def gather_table_sources(sources: list[Source]) -> tuple[dict[str, Source]
     and a markdown string of the tables and their schemas.
     """
     tables_to_source = {}
-    tables_schema_str = "\nHere are the tables and schemas if available\n"
+    tables_schema_str = ""
     for source in sources:
         for table in source.get_tables():
             tables_to_source[table] = source

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -330,16 +330,17 @@ async def gather_table_sources(sources: list[Source]) -> tuple[dict[str, Source]
     and a markdown string of the tables and their schemas.
     """
     tables_to_source = {}
-    tables_schema_str = "\nHere are the tables\n"
+    tables_schema_str = "\nHere are the tables and schemas if available\n"
     for source in sources:
         for table in source.get_tables():
             tables_to_source[table] = source
             if isinstance(source, DuckDBSource) and source.ephemeral:
-                schema = await get_schema(source, table, include_min_max=False, include_enum=True, limit=1)
-                tables_schema_str += f"### {table}\nSchema:\n```yaml\n{yaml.dump(schema)}```\n"
+                sql = source.get_sql_expr(table)
+                schema = await get_schema(source, table, include_min_max=False, include_enum=True, limit=3)
+                tables_schema_str += f"- {table}\nSchema:\n```yaml\n{yaml.dump(schema)}```\nSQL:\n```sql\n{sql}\n```\n\n"
             else:
-                tables_schema_str += f"### {table}\n"
-    return tables_to_source, tables_schema_str
+                tables_schema_str += f"- {table}\n\n"
+    return tables_to_source, tables_schema_str.strip()
 
 
 def log_debug(msg: str | list, offset: int = 24, prefix: str = "", suffix: str = "", show_sep: bool = False, show_length: bool = False):

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -203,6 +203,7 @@ class DuckDBSource(BaseSQLSource):
         if 'uri' not in kwargs and 'initializers' not in kwargs:
             params['_connection'] = self._connection
         params.pop('name', None)
+        params["ephemeral"] = True
         source = type(self)(**params)
         if not materialize:
             return source


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/889

Motivated by if user changes the spec a lot, (or even a little, change max to min) the table name may not be relevant, so the LLM should be able to look at the SQL for the source of truth.

Fixes a bug where `create_sql_expr_source` doesn't set ephemeral=True.

Also, provides additional SQL context for ephemeral tables in Planner. The planner can additionally look at the non-eph tables' schemas if requested

Lastly, it uses consistent formatting across templates