### PR TITLE
Shorten analyst agent

### DIFF
--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -57,7 +57,7 @@ class Sql(BaseModel):
 
     query: str = Field(description="""
         Correct, valid SQL query that answers the user's query and is based on
-        the chain of thought; do NOT add extraneous comments.""")
+        the chain of thought. If the query is complex, please leave inlined comments.""")
 
 
 class Validity(BaseModel):

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -57,7 +57,7 @@ class Sql(BaseModel):
 
     query: str = Field(description="""
         Correct, valid SQL query that answers the user's query and is based on
-        the chain of thought. If the query is complex, please leave inlined comments.""")
+        the chain of thought; do NOT add extraneous comments.""")
 
 
 class Validity(BaseModel):

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -1,15 +1,10 @@
 {% extends 'Actor/main.jinja2' %}
 
 {%- block instructions %}
-You are a world-class data analyst and subject expert. Your role is to analyze the data and present precise, actionable
-insights in a way that is clear and understandable to someone without significant technical knowledge, such as a CEO.
-Focus on distilling complex findings into straightforward, meaningful takeaways while avoiding technical jargon. Explain
-trends, relationships, and/or key details in the data with clarity, emphasizing their business relevance and impact, but
-make sure to leverage your broader perspective to call out any results that appear odd. Avoid general overviews; instead,
-highlight specific patterns, relationships between columns, and/or actionable insights.
-Brevity is a must key: focus on the most important insights and avoid overwhelming the audience,
-limited to a paragraph, ideally to two/three short bullet points, unless elaboration is requested.
-Do not write or suggest analysis code unless explicitly requested.
+You are a world-class data analyst and subject expert. Your role is to analyze the data and present precise, actionable insights in a way that is clear and understandable to someone without significant technical knowledge, such as a CEO. Focus on distilling complex findings into straightforward, meaningful takeaways while avoiding technical jargon. Explain trends, relationships, and/or key details in the data with clarity, emphasizing their business relevance and impact, but make sure to leverage your broader perspective to call out any results that appear odd. Avoid general overviews; instead, highlight specific patterns, relationships between columns, and/or actionable insights.
+
+- Brevity is a must: focus on the most important insights and avoid overwhelming the audience, limited to a paragraph, ideally to two/three short bullet points, unless elaboration is requested.
+- Do not write or suggest analysis code unless explicitly requested.
 {% endblock %}
 
 {% block context %}

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -4,11 +4,12 @@
 You are a world-class data analyst and subject expert. Your role is to analyze the data and present precise, actionable
 insights in a way that is clear and understandable to someone without significant technical knowledge, such as a CEO.
 Focus on distilling complex findings into straightforward, meaningful takeaways while avoiding technical jargon. Explain
-trends, relationships, and key details in the data with clarity, emphasizing their business relevance and impact, but
-make sure to leverage your broader perspective to call out any results that appear odd or run counter to your own understanding.
-Avoid general overviews; instead, highlight specific patterns, relationships between columns, and actionable insights. Present
-your analysis in a professional and approachable tone that inspires confidence and understanding. Do not write or
-suggest analysis code unless explicitly requested.
+trends, relationships, and/or key details in the data with clarity, emphasizing their business relevance and impact, but
+make sure to leverage your broader perspective to call out any results that appear odd. Avoid general overviews; instead,
+highlight specific patterns, relationships between columns, and/or actionable insights.
+Brevity is a must key: focus on the most important insights and avoid overwhelming the audience,
+limited to a paragraph, ideally to two/three short bullet points, unless elaboration is requested.
+Do not write or suggest analysis code unless explicitly requested.
 {% endblock %}
 
 {% block context %}


### PR DESCRIPTION
Before, it would send paragraphs per turn. Now it's more manageable.

Before:
<img width="708" alt="image" src="https://github.com/user-attachments/assets/316b5467-5abc-4eb8-b5c0-7b2b537b2e58" />

AFter:
<img width="688" alt="image" src="https://github.com/user-attachments/assets/f3f2548f-44a1-479e-acf1-ec83c6d0e63a" />

Also, can ask for more.
<img width="742" alt="image" src="https://github.com/user-attachments/assets/5d43c426-366b-4f9e-9a64-ee5ff4cef0be" />
