### PR TITLE
Clarify invalidation only valid for specific table

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -519,7 +519,7 @@ class Coordinator(Viewer, Actor):
             invalidation = await self._invalidate_memory(messages)
             if invalidation:
                 messages = mutate_user_message(
-                    f"Please be aware, {invalidation['table']!r} was invalidated because {invalidation['assessment']!r}",
+                    f"Please be aware the prior, current table, {invalidation['table']!r}, was invalidated because {invalidation['assessment']!r}",
                     messages[-3:]
                 )
 

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -358,7 +358,7 @@ class Coordinator(Viewer, Actor):
                 self._memory.pop("data", None)
                 self._memory.pop("pipeline", None)
                 log_debug("\033[91mInvalidated SQL from memory.\033[0m")
-            return output.correct_assessment
+            return {"table": table, "assessment": output.correct_assessment}
 
     async def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
         log_debug("\033[94mNEW\033[0m", show_sep=True)
@@ -516,9 +516,12 @@ class Coordinator(Viewer, Actor):
                 max_user_messages=3
             )
 
-            invalidation_assessment = await self._invalidate_memory(messages)
-            if invalidation_assessment:
-                messages = mutate_user_message(f"Please be aware: {invalidation_assessment!r}", messages[-3:])
+            invalidation = await self._invalidate_memory(messages)
+            if invalidation:
+                messages = mutate_user_message(
+                    f"Please be aware, {invalidation['table']!r} was invalidated because {invalidation['assessment']!r}",
+                    messages[-3:]
+                )
 
             agents = {agent.name[:-5]: agent for agent in self.agents}
             execution_graph = await self._compute_execution_graph(messages, agents)


### PR DESCRIPTION
I was stuck having the LLM believe that it couldn't do another year in the dataset because invalidation assessment was providing instructions that there's no data in the current table (so it has to invalidate the table), but this was propagated downstream to the planner.

Before:
"""
 3 (u). "'What about 2002?' Please be aware: '**The current table and data do not contain any information regarding total passengers for the year 2002**. The SQL query provided is specifically filtering for the year 2022, and there is no indication that data for 2002 is available in the current dataset.'" -- Here's the current instructions from the multi-step plan: 'Inform the user that the current dataset does not contain information for the year 2002 and that the SQL query provided is specifically for 2022.'
"""
<img width="722" alt="image" src="https://github.com/user-attachments/assets/12c509cf-f352-400a-8a07-5f7c0113f970" />

<img width="716" alt="image" src="https://github.com/user-attachments/assets/2b26c7dc-dd76-421e-8ec9-fbbcefc2fa8e" />


After, I clarified that it's only for that table:
"""
3 (u). "'What about 2002?' **Please be aware, 'total_passengers_2022' was invalidated because 'The current table only contains data for the year 2022 and does not include any data for the year 2002**. Therefore, it cannot provide the total passengers for 2002.'" -- Here's the current instructions from the multi-step plan: "Execute a SQL query to sum the total passengers for the year 2002 from the 'passengers.csv' table."
"""

<img width="674" alt="image" src="https://github.com/user-attachments/assets/98372844-5520-4d36-93df-f1e6f33f274b" />

And it successfully answered