### PR TITLE
fix temporal year in vega

### DIFF
--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -6,4 +6,5 @@ Generate the plot the user requested as a vega-lite specification.
 - The data will be provided separately. Never provide a data field.
 - Ensure you use the column names verbatim.
 - To sort the x axis, use `sort: x` or `sort: -x` for descending.
+- Integer columns like year (e.g., 2010, 2011) should be treated as quantitative, not temporal.
 {% endblock %}

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -6,5 +6,5 @@ Generate the plot the user requested as a vega-lite specification.
 - The data will be provided separately. Never provide a data field.
 - Ensure you use the column names verbatim.
 - To sort the x axis, use `sort: x` or `sort: -x` for descending.
-- Integer columns like year (e.g., 2010, 2011) should be treated as quantitative, not temporal.
+- Integer columns like year (e.g., 2010, 2011) should be treated as quantitative, not temporal, but '2010-01' or '2011-01-01' should be treated as temporal.
 {% endblock %}


### PR DESCRIPTION
<img width="733" alt="image" src="https://github.com/user-attachments/assets/6b72e857-52a7-4062-8f2a-dacf25955075" />
When using temporal, the xaxis values were like 0.24 instead of 2024

