### PR TITLE
Fix enum checks

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -194,9 +194,9 @@ async def get_schema(
         if not include_enum:
             spec.pop("enum")
             continue
-        elif limit and len(spec["enum"]) > truncate_limit:
+        elif len(spec["enum"]) > truncate_limit:
             spec["enum"] = spec["enum"][:truncate_limit] + ["..."]
-        elif limit and len(spec["enum"]) == 1 and spec["enum"][0] is None:
+        elif len(spec["enum"]) == 1 and spec["enum"][0] is None:
             spec["enum"] = [f"(unknown; truncated to {get_kwargs['limit']} rows)"]
         # truncate each enum to 100 characters
         spec["enum"] = [enum if enum is None or len(enum) < 100 else f"{enum[:100]} ..." for enum in spec["enum"]]

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -197,7 +197,16 @@ async def get_schema(
         elif len(spec["enum"]) > truncate_limit:
             spec["enum"] = spec["enum"][:truncate_limit] + ["..."]
         elif limit and len(spec["enum"]) == 1 and spec["enum"][0] is None:
-            spec["enum"] = [f"(unknown; truncated to {get_kwargs['limit']} rows)"]
+            spec["enum"] = [
+                enum
+                if (
+                    enum is None
+                    or not isinstance(enum, str)
+                    or len(enum) < 100
+                )
+                else f"{enum[:100]} ..."
+                for enum in spec["enum"]
+            ]
         # truncate each enum to 100 characters
         spec["enum"] = [enum if enum is None or len(enum) < 100 else f"{enum[:100]} ..." for enum in spec["enum"]]
 

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -196,7 +196,7 @@ async def get_schema(
             continue
         elif len(spec["enum"]) > truncate_limit:
             spec["enum"] = spec["enum"][:truncate_limit] + ["..."]
-        elif len(spec["enum"]) == 1 and spec["enum"][0] is None:
+        elif limit and len(spec["enum"]) == 1 and spec["enum"][0] is None:
             spec["enum"] = [f"(unknown; truncated to {get_kwargs['limit']} rows)"]
         # truncate each enum to 100 characters
         spec["enum"] = [enum if enum is None or len(enum) < 100 else f"{enum[:100]} ..." for enum in spec["enum"]]


### PR DESCRIPTION
I noticed significant amount of enums listed in the Vega schema input 

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/d1269cfb-d360-4ee5-be14-5520df387d98" />

Also sometimes there are numeric values in enum columns

```
Traceback (most recent call last):
  File "/Users/ahuang/repos/lumen/lumen/ai/coordinator.py", line 837, in _compute_execution_graph
    plan = await self._make_plan(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/coordinator.py", line 703, in _make_plan
    info += await self._lookup_schemas(tables, requested, provided, cache=schemas)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/coordinator.py", line 672, in _lookup_schemas
    cache[table] = await get_schema(tables[table], table, limit=1000)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 202, in get_schema
    spec["enum"] = [enum if enum is None or len(enum) < 100 else f"{enum[:100]} ..." for enum in spec["enum"]]
                                            ^^^^^^^^^
TypeError: object of type 'float' has no len()
```