### PR TITLE
Prevent empty explorations from crashing

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -335,6 +335,9 @@ class ExplorerUI(UI):
 
     async def _update_conversation(self, event=None, tab=None):
         active = self._explorations.active
+        if len(self._conversations) <= active:
+            return
+
         if tab is None:
             # When user switches tabs and coordinator is running
             # wait to switch the conversation context


### PR DESCRIPTION
For a new user exploring the UI, randomly clicking on the tabs would crash the UI if they haven't input any message yet.