### PR TITLE
Fix doc lookup

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -283,7 +283,10 @@ class SourceControls(Viewer):
             file, file_extension=document_controls.extension
         ).text_content
 
-        metadata = f"Filename: {document_controls.filename} " + document_controls._metadata_input.value
+        metadata = {
+            "filename": document_controls.filename,
+            "comments": document_controls._metadata_input.value,
+        }
         document = {"text": text, "metadata": metadata}
         if "document_sources" in self._memory:
             self._memory["document_sources"].append(document)

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from typing import Any
 
 import param
@@ -68,10 +70,10 @@ class DocumentLookup(VectorLookupTool):
     def _update_vector_store(self, _, __, sources):
         for source in sources:
             if not self.vector_store.query(source["text"], threshold=1):
-                self.vector_store.add([{"text": source["text"], "metadata": source.get("metadata", "")}])
+                self.vector_store.add([{"text": source["text"], "metadata": source.get("metadata", {})}])
 
     async def respond(self, messages: list[Message], **kwargs: Any) -> str:
-        query = messages[-1]["content"]
+        query = re.findall(r"'(.*?)'", messages[-1]["content"])[0]
         results = self.vector_store.query(query, top_k=self.n, threshold=self.min_similarity)
         closest_doc_chunks = [
             f"{result['text']} (Relevance: {result['similarity']:.1f} - Metadata: {result['metadata']}"

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -243,7 +243,7 @@ class NumpyVectorStore(VectorStore):
             sorted_indices = np.argsort(similarities)[::-1]
             for idx in sorted_indices:
                 similarity = similarities[idx]
-                if similarity < threshold:
+                if similarity <= threshold:
                     continue
                 results.append(
                     {
@@ -346,7 +346,7 @@ class DuckDBVectorStore(VectorStore):
         """Set up the DuckDB database with necessary tables and indexes."""
         self.connection.execute("INSTALL 'vss';")
         self.connection.execute("LOAD 'vss';")
-
+        self.connection.execute("SET hnsw_enable_experimental_persistence = true;")
         self.connection.execute("CREATE SEQUENCE IF NOT EXISTS documents_id_seq;")
 
         self.connection.execute(
@@ -433,7 +433,7 @@ class DuckDBVectorStore(VectorStore):
 
         base_query = f"""
             SELECT id, text, metadata,
-                   1 - array_distance(embedding, ?::FLOAT[{self.vocab_size}], 'cosine') AS similarity
+                   1 - array_distance(embedding, ?::FLOAT[{self.vocab_size}]) AS similarity
             FROM documents
             WHERE 1=1
         """
@@ -445,7 +445,7 @@ class DuckDBVectorStore(VectorStore):
                 base_query += f" AND json_extract_string(metadata, '$.{key}') = ?"
                 params.append(str(value))
 
-        base_query += f" AND 1 - array_distance(embedding, ?::FLOAT[{self.vocab_size}], 'cosine') >= ?"
+        base_query += f" AND 1 - array_distance(embedding, ?::FLOAT[{self.vocab_size}]) >= ?"
         params.extend([query_embedding, threshold])
 
         base_query += """
@@ -525,6 +525,10 @@ class DuckDBVectorStore(VectorStore):
         self.connection.execute(query, ids)
 
     def clear(self) -> None:
-        """Clear all items from the DuckDB vector store."""
-        self.connection.execute("DELETE FROM documents;")
-        self.connection.execute("ALTER SEQUENCE documents_id_seq RESTART WITH 1;")
+        """
+        Clear all entries from both tables and reset sequence by dropping/recreating everything.
+        """
+        self.connection.execute("DROP TABLE IF EXISTS metadata_embeddings;")
+        self.connection.execute("DROP TABLE IF EXISTS documents;")
+        self.connection.execute("DROP SEQUENCE IF EXISTS documents_id_seq;")
+        self._setup_database()


### PR DESCRIPTION
1. Fixed type of metadata
2. Since user messages are mutated in planner (e.g. `'What's in the receipt'` becomes `"'What's in the receipt'. Be aware: ..."`, we need to extract back the original message to remove noise introduced from the LLM.
3. I realized DuckDBVectorStore was broken after adding the tests