### PR TITLE
LLM decides metadata

### DIFF
--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -98,7 +98,7 @@ class RetrySpec(BaseModel):
 class RelevantFiles(BaseModel):
 
     files: list[str] = Field(
-        description="List of relevant files that are related to the user query."
+        description="List of relevant files that are related to the user query. Can be empty if no files are relevant."
     )
 
 

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -95,6 +95,13 @@ class RetrySpec(BaseModel):
     )
 
 
+class RelevantFiles(BaseModel):
+
+    files: list[str] = Field(
+        description="List of relevant files that are related to the user query."
+    )
+
+
 def make_plan_models(experts_or_tools: list[str], tables: list[str]):
     step = create_model(
         "Step",

--- a/lumen/ai/prompts/DocumentLookup/main.jinja2
+++ b/lumen/ai/prompts/DocumentLookup/main.jinja2
@@ -1,0 +1,11 @@
+{% extends 'Actor/main.jinja2' %}
+
+{%- block instructions %}
+Help select the most relevant files.
+{% endblock -%}
+
+{%- block context %}
+{% for filename in filenames %}
+- {{ filename }}
+{% endfor %}
+{% endblock %}

--- a/lumen/ai/prompts/DocumentLookup/main.jinja2
+++ b/lumen/ai/prompts/DocumentLookup/main.jinja2
@@ -5,7 +5,7 @@ Help select the most relevant files.
 {% endblock -%}
 
 {%- block context %}
-{% for filename in filenames %}
+{%- for filename in filenames %}
 - {{ filename }}
 {% endfor %}
 {% endblock %}

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -487,7 +487,7 @@ class DuckDBVectorStore(VectorStore):
         text: str,
         top_k: int = 5,
         filters: dict | None = None,
-        threshold: float = -0.1,
+        threshold: float = 0.0,
     ) -> list[dict]:
         """
         Query the DuckDB vector store for similar items.


### PR DESCRIPTION
Builds upon https://github.com/holoviz/lumen/pull/917 and maybe supersedes https://github.com/holoviz/lumen/pull/911

This implementation simply lets the LLM decide what files are the most relevant.

I also tried to do a hybrid content + metadata table ranking in https://github.com/holoviz/lumen/compare/main...meta_weight but it didn't work well and was complex...

![image](https://github.com/user-attachments/assets/0d21a011-0384-43ed-9ad4-021f1d34ca17)
<img width="633" alt="image" src="https://github.com/user-attachments/assets/79744187-04ed-4380-85c9-e56963288e72" />


![image](https://github.com/user-attachments/assets/1c09e040-b11b-47f2-a622-8bd1f97d050a)

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/2f10a6c3-fb49-46e3-8489-c3d63e29dbe2" />
