### PR TITLE
Fix duplicate tables already existing

### DIFF
--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -52,7 +52,7 @@ class Sql(BaseModel):
     expr_slug: str = Field(
         description="""
         Give the SQL expression a concise, but descriptive, slug that includes whatever transforms were applied to it,
-        e.g. top_5_athletes_gold_medals
+        e.g. top_5_athletes_gold_medals. The slug must be unique, i.e. should not match other existing table names or slugs.
         """
     )
 

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -207,13 +207,11 @@ class DuckDBSource(BaseSQLSource):
         source = type(self)(**params)
         if not materialize:
             return source
-        existing = self.get_tables()
+
         for table, sql_expr in tables.copy().items():
             if sql_expr == self.sql_expr.format(table=f'"{table}"'):
                 continue
-            if table in existing:
-                self._connection.execute(f'DROP TABLE IF EXISTS "{table}"')
-            table_expr = f'CREATE TEMP TABLE "{table}" AS ({sql_expr})'
+            table_expr = f'CREATE OR REPLACE TEMP TABLE "{table}" AS ({sql_expr})'
             try:
                 self._connection.execute(table_expr)
             except duckdb.CatalogException as e:


### PR DESCRIPTION
Previously, if the LLM decides to use an existing table slug/name:
1. it first drops the existing table
2. if the query doesn't depend on the existing table, it works...
3. however, it the new query depends on the existing table, i.e. "SELECT * FROM existing_table WHERE something = 1", then the table no longer exists and it crashes and is unrecoverable

Here, I request the LLM to use unique table names because the system message enumerates the tables I think in tables_sql_schemas
```python
        system_prompt = await self._render_prompt(
            "main",
            messages,
            tables_sql_schemas=tables_sql_schemas,
            dialect=dialect,
            join_required=join_required,
            table=table,
        )
```

and as a fallback, `CREATE OR REPLACE`.
```python
import duckdb

# Connect to an in-memory DuckDB instance
con = duckdb.connect()

# Create a persistent table
con.execute("""
    CREATE TABLE example (
        id INTEGER,
        value TEXT
    )
""")

# Insert some data
con.execute("""
    INSERT INTO example VALUES
    (1, 'DuckDB'),
    (2, 'Python')
""")

# Query the table
print(con.execute("SELECT * FROM example").fetchall(), "ORIGINAL")

# Drop and recreate a TEMP table of the same name
con.execute("""
    CREATE OR REPLACE TEMP TABLE example AS
    SELECT id, value || ' Temp' AS value
    FROM example
""")

# Query the new temp table
print(con.execute("SELECT * FROM example").fetchall(), "NEW")
```

Closes https://github.com/holoviz/lumen/issues/717