### PR TITLE
Fix loading indicator on explorations and file uploads

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -567,6 +567,7 @@ class ExplorerUI(UI):
 
             async def render_output(_, old, new):
                 added = [out for out in new if out not in old]
+                index = self._explorations.active if len(self._explorations) else -1
                 exploration = self._explorations[index]
                 self._add_outputs(exploration, added, local_memory)
                 exploration.loading = False

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -550,7 +550,7 @@ class ExplorerUI(UI):
                 plan = local_memory["plan"]
                 if any(step.expert_or_tool == 'SQLAgent' for step in plan.steps):
                     await self._add_exploration(plan.title, local_memory)
-                    index += 1
+                    index = len(self._explorations)-1
 
             def sync_available_sources_memory(_, __, sources):
                 """
@@ -567,7 +567,6 @@ class ExplorerUI(UI):
 
             async def render_output(_, old, new):
                 added = [out for out in new if out not in old]
-                index = self._explorations.active if len(self._explorations) else -1
                 exploration = self._explorations[index]
                 self._add_outputs(exploration, added, local_memory)
                 exploration.loading = False


### PR DESCRIPTION
`exploration=Column(loading=True)` would go on forever because render_output would update the wrong tab because the pre-computed index was outdated. Since it's such a negligible computation, I decided to just re-compute it right before rendering output.

Also, previously, unsupported file uploads would crash the UI, but now it catches the exception gracefully.