### PR TITLE
Stop SQLAgent from backtracking when streaming CoT and SQL

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -539,9 +539,10 @@ class SQLAgent(LumenBaseAgent):
             sql_query = None
             try:
                 async for output in response:
-                    step_message = output.chain_of_thought
+                    step_message = output.chain_of_thought or ""
                     if output.query:
                         sql_query = clean_sql(output.query)
+                    if sql_query is not None:
                         step_message += f"\n```sql\n{sql_query}\n```"
                     step.stream(step_message, replace=True)
             except asyncio.CancelledError as e:


### PR DESCRIPTION
When streaming the CoT and SQL query as it's being generated it's possible for the LLM to start streaming the SQL query but then drop the streamed SQL query again in a subsequent iteration of the streaming call. This PR simply retains the previous SQL until the returned model updates the SQL again. This avoids apparent flicker where the streaming SQL query appears and then disappears in rapid succession.