### PR TITLE
refactor joins

### DIFF
--- a/lumen/ai/prompts/SQLAgent/find_joins.jinja2
+++ b/lumen/ai/prompts/SQLAgent/find_joins.jinja2
@@ -1,12 +1,14 @@
 {% extends 'Actor/main.jinja2' %}
 
 {% block instructions %}
-Correctly assess and list the tables that need to be joined; be sure to include both `//`.
+Correctly assess and list the tables that need to be joined.
 
 Use table names verbatim:
-
 - if the table is read_csv('table.csv'), then use read_csv('table.csv') and not 'table' or 'table.csv'
 - if the table is table.csv, then use table.csv and not read_csv('table.csv')
+
+If there are delimiters `{{ separator }}`, be sure to include them:
+{{ separator }}source{{ separator }}table{{ separator }}
 {% endblock %}
 
 {% block context %}

--- a/lumen/ai/prompts/SQLAgent/find_joins.jinja2
+++ b/lumen/ai/prompts/SQLAgent/find_joins.jinja2
@@ -7,8 +7,8 @@ Use table names verbatim:
 - if the table is read_csv('table.csv'), then use read_csv('table.csv') and not 'table' or 'table.csv'
 - if the table is table.csv, then use table.csv and not read_csv('table.csv')
 
-If there are delimiters `{{ separator }}`, be sure to include them:
-{{ separator }}source{{ separator }}table{{ separator }}
+If there are delimiters, '{{ separator }}', be sure to include them:
+'{{ separator }}source{{ separator }}table{{ separator }}''
 {% endblock %}
 
 {% block context %}

--- a/lumen/ai/prompts/SQLAgent/require_joins.jinja2
+++ b/lumen/ai/prompts/SQLAgent/require_joins.jinja2
@@ -11,6 +11,12 @@ A join is unnecessary if the schema already includes all the required columns, u
 {% endblock %}
 
 {% block context %}
-Here are the tables (and schemas if available):
+
+The current table '{{ table }}' follows this YAML schema:
+```yaml
+{{ schema }}
+```
+
+Here are all the tables (and schemas if available):
 {{ tables_schema_str }}
 {%- endblock -%}

--- a/lumen/ai/prompts/SQLAgent/require_joins.jinja2
+++ b/lumen/ai/prompts/SQLAgent/require_joins.jinja2
@@ -5,14 +5,12 @@ Determine whether a table join is required to answer the user's query.
 
 Notes:
 - Carefully consider the columns described in the schema
-- If the schema references all the columns needed, no join is required
 - Consider if missing data can be calculated without a join
+
+A join is unnecessary if the schema already includes all the required columns, unless the schema values are untruncated and obviously missing necessary values in the min/max/enum.
 {% endblock %}
 
 {% block context %}
-The current table '{{ table }}' follows this YAML schema:
-
-```yaml
-{{ schema }}
-```
+Here are the tables (and schemas if available):
+{{ tables_schema_str }}
 {%- endblock -%}


### PR DESCRIPTION
The message:
```
2025-01-09 13:30:57,644 1 (u). 'In the months of JJA, which days of the week were most congested?' -- Here's the current instructions from the multi-step plan: 'Query the June, July, and August tables to aggregate data based on the day of the week, calculating congestion levels inferred from delays and cancellations.'
```

---
## PartialJoinRequired

Adds a listing of all the other tables in the PartialJoinRequired model so that it can reply like 
"""
To answer the user's query about congestion levels based on delays and cancellations for the months of June, July, and August, we need to aggregate data from all three tables (June.csv, July.csv, and August.csv). Each table contains relevant columns for delays and cancellations, but since the query spans multiple months, a join is necessary to combine the data from these tables for analysis.
""


"""
Determine whether a table join is required to answer the user's query.

Notes:
- Carefully consider the columns described in the schema
- Consider if missing data can be calculated without a join

A join is unnecessary if the schema already includes all the required columns, unless the schema values are untruncated and obviously missing necessary values in the min/max/enum.


The current table 'July.csv' follows this YAML schema:
```yaml
{'YEAR': {'type': 'int', 'min': 2024, 'max': 2024}, 'MONTH': {'type': 'int', 'min': 7, 'max': 7}, 'DAY_OF_WEEK': {'type': 'int', 'min': 1, 'max': 1}, 'FL_DATE': {'type': 'str', 'format': 'datetime', 'min': '2024-07-01T00:00:00', 'max': '2024-07-01T00:00:00'}, 'MKT_UNIQUE_CARRIER': {'type': 'str', 'enum': ['AA']}, 'MKT_CARRIER': {'type': 'str', 'enum': ['AA']}, 'ORIGIN_AIRPORT_SEQ_ID': {'type': 'int', 'min': 1013506, 'max': 1105703}, 'ORIGIN_CITY_NAME': {'type': 'str', 'enum': ['Allentown/Bethlehem/Easton, PA', 'Abilene, TX', 'Albuquerque, NM', 'Nantucket, MA', 'Waco, TX', '...']}, 'DEST_AIRPORT_SEQ_ID': {'type': 'int', 'min': 1013506, 'max': 1538005}, 'DEP_DELAY': {'type': 'num', 'min': -20.0, 'max': 1103.0}, 'DEP_DELAY_GROUP': {'type': 'num', 'min': -2.0, 'max': 12.0}, 'ARR_DELAY': {'type': 'num', 'min': -43.0, 'max': 1102.0}, 'ARR_DELAY_GROUP': {'type': 'num', 'min': -2.0, 'max': 12.0}, 'CANCELLED': {'type': 'num', 'min': 0.0, 'max': 1.0}, 'CANCELLATION_CODE': {'type': 'str', 'enum': [None, 'B', 'C', 'A']}, 'CARRIER_DELAY': {'type': 'num', 'min': 0.0, 'max': 1012.0}, 'WEATHER_DELAY': {'type': 'num', 'min': 0.0, 'max': 85.0}, 'NAS_DELAY': {'type': 'num', 'min': 0.0, 'max': 102.0}, 'SECURITY_DELAY': {'type': 'num', 'min': 0.0, 'max': 42.0}, 'LATE_AIRCRAFT_DELAY': {'type': 'num', 'min': 0.0, 'max': 907.0}}
```

Here are all the tables (and schemas if available):
- Aug.csv

- July.csv

- Jun.csv

- Sep.csv

## TableJoins model

TableJoins model also received a bug fix. It was using the old delimiter.
```
2025-01-09 13:30:57,644 1 (u). 'In the months of JJA, which days of the week were most congested?' -- Here's the current instructions from the multi-step plan: 'Query the June, July, and August tables to aggregate data based on the day of the week, calculating congestion levels inferred from delays and cancellations.'
2025-01-09 13:30:57,644 Length is 2 messages including system
2025-01-09 13:30:59,047 SQLAgent00213.prompts['find_joins']['template']:
Correctly assess and list the tables that need to be joined.

Use table names verbatim:
- if the table is read_csv('table.csv'), then use read_csv('table.csv') and not 'table' or 'table.csv'
- if the table is table.csv, then use table.csv and not read_csv('table.csv')

If there are delimiters, '<->', be sure to include them:
'<->source<->table<->''

Here are the available tables:

- Aug.csv

- July.csv

- Jun.csv

- Sep.csv
2025-01-09 13:30:59,047 Length is 494
"""


