### PR TITLE
Catch when no keys

### DIFF
--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -168,6 +168,13 @@ class AIHandler(CodeHandler):
 
     def _build_source_code(self, tables: list[str], **config) -> str:
         """Build source code with configuration"""
+        if config.get("provider") is None:
+            raise RuntimeError(
+                "No provider detected. Please specify a provider with --provider "
+                "and an API key with --api-key, set an environment variable with "
+                "the API key, or specify a custom endpoint with --provider-endpoint."
+            )
+
         context = {
             "llm_provider": LLM_PROVIDERS[config['provider']],
             "tables": [repr(t) for t in tables],


### PR DESCRIPTION
When user has no keys in their environment, provider is None, and it'll error.