### PR TITLE
compat: Python 3.13

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ PYTHONIOENCODING = "utf-8"
 test-310 = ["py310", "test-core", "test", "ai", "sql"]
 test-311 = ["py311", "test-core", "test", "ai", "sql"]
 test-312 = ["py312", "test-core", "test", "ai", "sql"]
-test-core = ["py312", "test-core"]
+test-core = ["py313", "test-core"]
 docs = ["py311", "doc", "ai", "sql"]
 build = ["py311", "build"]
 lint = ["py311", "lint"]
@@ -39,6 +39,15 @@ python = "3.11.*"
 
 [feature.py312.dependencies]
 python = "3.12.*"
+
+[feature.py312.activation.env]
+COVERAGE_CORE = "sysmon"
+
+[feature.py313.dependencies]
+python = "3.13.*"
+
+[feature.py313.activation.env]
+COVERAGE_CORE = "sysmon"
 
 [feature.ai.dependencies]
 duckdb = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Enables Python 3.13 testing for core tests. 

It also adds sysmon, see https://github.com/holoviz/holoviews/pull/6465