### PR TITLE
Add print method

### DIFF
--- a/doc/lumen_ai/getting_started/configuring_lumen_ai.md
+++ b/doc/lumen_ai/getting_started/configuring_lumen_ai.md
@@ -7,6 +7,8 @@ Lumen AI is designed to be highly customizable and composable. Users can easily 
 In a script, users can initialize Lumen AI with specific datasets by injecting `current_source` into `lmai.memory`:
 
 ```python
+from lumen.sources.duckdb import DuckDBSource
+
 lmai.memory["current_source"] = DuckDBSource(
     tables=["path/to/table.csv", "dir/data.parquet"]
 )

--- a/doc/lumen_ai/how_to/template_prompts.md
+++ b/doc/lumen_ai/how_to/template_prompts.md
@@ -117,6 +117,8 @@ Some `Agent`s may have multiple prompts, besides the `main` prompt. For example,
 - `find_joins`: Prompt to find the necessary joins
 
 Not all prompts will be used in every interaction, e.g. `find_joins` may not be used if `require_joins` decides that joins are not necessary.
+
+To see all the prompts available for an `Agent`, you can check the `prompts` parameter of the `Agent` class.
 :::
 
 If you simply want to prefix or suffix the original `instructions`, you can specify `{{ super() }}`:
@@ -127,6 +129,13 @@ template_overrides = {
         "instructions": "{{ super() }}. Spice it up by speaking like a pirate."
     },
 }
+```
+
+If you aren't sure what the original prompt is, you can print it out:
+
+```python
+Agent.print_prompt_template()  # defaults to key='main'
+```
 
 :::{admonition} Tip
 :class: success

--- a/doc/lumen_ai/how_to/template_prompts.md
+++ b/doc/lumen_ai/how_to/template_prompts.md
@@ -134,7 +134,7 @@ template_overrides = {
 If you aren't sure what the original prompt is, you can print it out:
 
 ```python
-Agent.print_prompt_template()  # defaults to key='main'
+print(Agent.get_prompt_template())  # defaults to key='main'
 ```
 
 :::{admonition} Tip

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -156,6 +156,14 @@ class Actor(param.Parameterized):
         Responds to the provided messages.
         """
 
+    @classmethod
+    def get_prompt_template(cls, key: str = "main") -> str:
+        return cls._lookup_prompt_key(cls, key, "template").read_text()
+
+    @classmethod
+    def print_prompt_template(cls, key: str = "main"):
+        print(cls.get_prompt_template(key))
+
 
 class ContextProvider(param.Parameterized):
     """

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -161,8 +161,14 @@ class Actor(param.Parameterized):
         """
         Returns the template for the given prompt key.
 
-        Parameters:
-            key (str): The key of the prompt to return the template for.
+        Parameters
+        ----------
+        key : str, optional
+            The key of the prompt to return the template for. Default is "main".
+
+        Returns
+        -------
+        The template associated with the given prompt key.
         """
         return cls._lookup_prompt_key(cls, key, "template").read_text()
 

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -158,11 +158,13 @@ class Actor(param.Parameterized):
 
     @classmethod
     def get_prompt_template(cls, key: str = "main") -> str:
-        return cls._lookup_prompt_key(cls, key, "template").read_text()
+        """
+        Returns the template for the given prompt key.
 
-    @classmethod
-    def print_prompt_template(cls, key: str = "main"):
-        print(cls.get_prompt_template(key))
+        Parameters:
+            key (str): The key of the prompt to return the template for.
+        """
+        return cls._lookup_prompt_key(cls, key, "template").read_text()
 
 
 class ContextProvider(param.Parameterized):


### PR DESCRIPTION
As I was tailoring the AnalystAgent, I wanted to know what was the base prompt to build off from there.

I remember we discussed this before, and I still feel strongly about having a way to examine the prompts without having to open a browser and navigate to the code base, or having to type all of `print(lmai.agents.AnalystAgent.prompts["main"]["template"].read_text())` every time I want to read the default prompt (nested dict too which can be confusing to a new user who simply wants to modify the prompt).

Now, it's simplified down to `lmai.agents.AnalystAgent.print_prompt_template()`, but not sure if need both methods (e.g. `get_prompt_template`).

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/ffa2187f-592e-43eb-80fe-22ccc0e50bd2" />

