### PR TITLE
Verify that LLM is working on load

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import traceback
 
 from copy import deepcopy
 from types import FunctionType
@@ -842,9 +843,11 @@ class Planner(Coordinator):
                     )
                 except asyncio.CancelledError as e:
                     istep.failed_title = 'Planning was cancelled, please try again.'
+                    traceback.print_exception(e)
                     raise e
                 except Exception as e:
                     istep.failed_title = 'Failed to make plan. Ensure LLM is configured correctly and/or try again.'
+                    traceback.print_exception(e)
                     raise e
                 execution_graph, unmet_dependencies = await self._resolve_plan(plan, agents, messages)
                 if unmet_dependencies:
@@ -854,7 +857,9 @@ class Planner(Coordinator):
                     planned = True
                 if attempts > 5:
                     istep.failed_title = "Planning failed to come up with viable plan, please restate the problem and try again."
-                    raise RuntimeError("Planner failed to come up with viable plan after 5 attempts.")
+                    e = RuntimeError("Planner failed to come up with viable plan after 5 attempts.")
+                    traceback.print_exception(e)
+                    raise e
             self._memory["plan"] = plan
             istep.stream('\n\nHere are the steps:\n\n')
             for i, step in enumerate(plan.steps):

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import html
 import inspect
 import math
 import re
 import time
+import traceback
 
 from functools import wraps
 from pathlib import Path
@@ -394,3 +396,25 @@ def mutate_user_message(content: str, messages: list[dict[str, str]], suffix: bo
             message["content"] = user_message
             break
     return messages
+
+
+def format_exception(exc: Exception, limit: int = 0) -> str:
+    """
+    Format and return a string representation of an exception.
+
+    Parameters
+    ----------
+    exc : Exception
+        The exception to be formatted.
+    limit : int
+        The maximum number of layers of traceback to include in the output.
+        Default is 0.
+
+    Returns
+    -------
+    str
+        A formatted string describing the exception and its traceback.
+    """
+    e_msg = str(exc).replace('\033[1m', '<b>').replace('\033[0m', '</b>')
+    tb = html.escape('\n'.join(traceback.format_exception(exc, limit=limit))).replace('\033[1m', '<b>').replace('\033[0m', '</b>')
+    return f'<b>{type(exc).__name__}</b>: {e_msg}\n<pre style="overflow-y: auto">{tb}</pre>'

--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -176,9 +176,11 @@ class AIHandler(CodeHandler):
         """Build source code with configuration"""
         if config.get("provider") is None:
             raise RuntimeError(
-                "No provider detected. Please specify a provider with --provider "
-                "and an API key with --api-key, set an environment variable with "
-                "the API key, or specify a custom endpoint with --provider-endpoint."
+                "No LLM provider was detected. To resolve this specify a provider "
+                "using the --provider CLI argument along with an API key (using --api-key) "
+                "or configure environment variable(s) for your favorite LLM cloud provider "
+                "(e.g. OPENAI_API_KEY or ANTHROPIC_API_KEY). If you are running an OpenAI "
+                "compatible API specify a custom endpoint with --provider-endpoint."
             )
 
         context = {
@@ -194,7 +196,6 @@ class AIHandler(CodeHandler):
         }
         context = {k: v for k, v in context.items() if v is not None}
 
-        print(context)
         source = render_template(
             CMD_DIR / "app.py.jinja2", relative_to=CMD_DIR, **context
         ).replace("\n\n", "\n").strip()


### PR DESCRIPTION
One of the first things people might encounter is that they haven't configured the LLM correctly. This is the one case where it's potentially useful to surface tracebacks to the user, so we make a call to the LLM on load and then either tell the user loading the LLM was successful or show them the error.

<img width="330" alt="Screenshot 2025-01-25 at 21 04 38" src="https://github.com/user-attachments/assets/69cefad8-f12e-49ec-be38-32425408c324" />

<img width="850" alt="Screenshot 2025-01-25 at 21 05 22" src="https://github.com/user-attachments/assets/a2d48cf6-4d67-45f2-b7a2-2d59cdf0364a" />

