### PR TITLE
Touch ups

### DIFF
--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -52,7 +52,7 @@ class Sql(BaseModel):
     expr_slug: str = Field(
         description="""
         Give the SQL expression a concise, but descriptive, slug that includes whatever transforms were applied to it,
-        e.g. top_5_athletes_gold_medals. The slug must be unique, i.e. should not match other existing table names or slugs.
+        e.g. top_5_athletes. The slug must be unique, i.e. should not match other existing table names or slugs.
         """
     )
 
@@ -124,7 +124,7 @@ def make_plan_models(experts_or_tools: list[str], tables: list[str]):
     plan = create_model(
         "Plan",
         title=(
-            str, FieldInfo(description="A title that describes this plan in a few words")
+            str, FieldInfo(description="A title that describes this plan, up to three words.")
         ),
         steps=(
             list[step],

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -505,7 +505,7 @@ class ExplorerUI(UI):
 
         controls = SourceControls(select_existing=False, cancellable=False, clear_uploads=True, multiple=True, name='Upload')
         controls.param.watch(explore_table_if_single, "add")
-        tabs = Tabs(controls, sizing_mode='stretch_both', design=Material)
+        tabs = Tabs(controls, dynamic=True, sizing_mode='stretch_both', design=Material)
 
         @param.depends(explore_button, watch=True)
         def get_explorers(load):
@@ -515,14 +515,16 @@ class ExplorerUI(UI):
                 explorers = []
                 for table in table_select.value:
                     source = source_map[table]
-                    if len(memory['sources']) > 1:
+                    print(table)
+                    if len(memory['sources']) > 1 and SOURCE_TABLE_SEPARATOR in table:
                         _, table = table.rsplit(SOURCE_TABLE_SEPARATOR, 1)
                     pipeline = Pipeline(
                         source=source, table=table, sql_transforms=[SQLLimit(limit=100_000)]
                     )
+                    table_label = f"{table[:15]}..." if len(table) > 15 else table
                     walker = GraphicWalker(
                         pipeline.param.data, sizing_mode='stretch_both', min_height=800,
-                        kernel_computation=True, name=f"View {table}", tab='data'
+                        kernel_computation=True, name=table_label, tab='data'
                     )
                     explorers.append(walker)
 
@@ -549,7 +551,8 @@ class ExplorerUI(UI):
         self._contexts.append(memory)
         self._coordinator.interface.objects = conversation = list(self._coordinator.interface.objects)
         self._conversations.append(conversation)
-        self._explorations.append((title, Column(name=title, sizing_mode='stretch_both', loading=True)))
+        tab_title = f"{title[:15]}..." if len(title) > 15 else title
+        self._explorations.append((tab_title, Column(name=title, sizing_mode='stretch_both', loading=True)))
         self._notebook_export.filename = f"{title.replace(' ', '_')}.ipynb"
         if n:
             self._conversations[active] = self._snapshot_messages(new=True)
@@ -588,14 +591,13 @@ class ExplorerUI(UI):
                     sizing_mode='stretch_both'
                 ))
             )
-        content.extend([
-            (out.title or type(out).__name__.replace('Output', ''), ParamMethod(
-                out.render, inplace=True,
-                sizing_mode='stretch_both'
-            )) for out in outputs
-        ])
+        for out in outputs:
+            title = out.title or type(out).__name__.replace('Output', '')
+            if len(title) > 15:
+                title = f"{title[:15]}..."
+            content.append((title, ParamMethod(out.render, inplace=True, sizing_mode='stretch_both')))
         if exploration.loading:
-            tabs = Tabs(*content, active=len(outputs), dynamic=True)
+            tabs = Tabs(*content, dynamic=True, active=len(outputs))
             exploration.append(tabs)
         else:
             tabs = exploration[-1]

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -515,7 +515,6 @@ class ExplorerUI(UI):
                 explorers = []
                 for table in table_select.value:
                     source = source_map[table]
-                    print(table)
                     if len(memory['sources']) > 1 and SOURCE_TABLE_SEPARATOR in table:
                         _, table = table.rsplit(SOURCE_TABLE_SEPARATOR, 1)
                     pipeline = Pipeline(


### PR DESCRIPTION
1. Fixes a bug with opening explorations
2. Shorten titles
3. Set `dynamic=True` because the explore tables button was all the way pushed down when there were tables and hidden from view.
<img width="630" alt="image" src="https://github.com/user-attachments/assets/92b915f2-3ea7-4664-81d8-9178d02e9d5b" />
