### PR TITLE
Separate context lookups in Planner

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -711,28 +711,35 @@ class Planner(Coordinator):
             table_info=table_info,
             tools=list(tools.values()),
         )
-        context = await self.llm.invoke(
-            messages=messages,
-            system=system,
-            model_spec=model_spec,
-            response_model=context_model,
-            max_retries=3,
-        )
-        if getattr(context, 'tables', None):
-            requested = [t for t in context.tables if t not in provided]
-            table_info += await self._lookup_schemas(tables, requested, provided, cache=schemas)
-        tool_context = ''
-        if getattr(context, 'tools', None):
-            for tool in context.tools:
-                tool_messages = list(messages)
-                if tool.instruction:
-                    mutate_user_message(
-                        f"-- Here are instructions of the context you are to provide: {tool.instruction!r}",
-                        tool_messages, suffix=True, wrap=True, inplace=False
-                    )
-                response = await tools[tool.name].respond(tool_messages)
-                if response is not None:
-                    tool_context += f'\n- {response}'
+        with self.interface.add_step(
+            success_title="Obtained necessary context",
+            title="Obtaining additional context...",
+            user="Assistant"
+        ) as istep:
+            context = await self.llm.invoke(
+                messages=messages,
+                system=system,
+                model_spec=model_spec,
+                response_model=context_model,
+                max_retries=3,
+            )
+            if getattr(context, 'tables', None):
+                requested = [t for t in context.tables if t not in provided]
+                istep.stream(f'Looking up schemas for following tables: {requested}')
+                table_info += await self._lookup_schemas(tables, requested, provided, cache=schemas)
+            tool_context = ''
+            if getattr(context, 'tools', None):
+                for tool in context.tools:
+                    tool_messages = list(messages)
+                    if tool.instruction:
+                        mutate_user_message(
+                            f"-- Here are instructions of the context you are to provide: {tool.instruction!r}",
+                            tool_messages, suffix=True, wrap=True, inplace=False
+                        )
+                    response = await tools[tool.name].respond(tool_messages)
+                    if response is not None:
+                        istep.stream(f'{response}\n')
+                        tool_context += f'\n- {response}'
         return table_info, tool_context
 
     async def _make_plan(

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -29,7 +29,9 @@ from .agents import (
 from .config import DEMO_MESSAGES, GETTING_STARTED_SUGGESTIONS, PROMPTS_DIR
 from .llm import Llama, Llm, Message
 from .logs import ChatLogs
-from .models import Validity, make_agent_model, make_plan_models
+from .models import (
+    Validity, make_agent_model, make_context_model, make_plan_models,
+)
 from .tools import FunctionTool, Tool
 from .utils import (
     gather_table_sources, get_schema, log_debug, mutate_user_message,
@@ -338,13 +340,13 @@ class Coordinator(Viewer, Actor):
         )
         with self.interface.add_step(title="Checking memory...", user="Assistant") as step:
             model_spec = self.prompts["check_validity"].get("llm_spec", "default")
-            output = await self.llm.invoke(
+            async for output in self.llm.stream(
                 messages=messages,
                 system=system,
                 model_spec=model_spec,
                 response_model=self._get_model("check_validity"),
-            )
-            step.stream(output.correct_assessment, replace=True)
+            ):
+                step.stream(output.correct_assessment, replace=True)
             step.success_title = f"{output.is_invalid.title()} needs refresh" if output.is_invalid else "Memory still valid"
 
         if output and output.is_invalid:
@@ -651,14 +653,18 @@ class Planner(Coordinator):
 
     prompts = param.Dict(
         default={
-            "main": {
-                "template": PROMPTS_DIR / "Planner" / "main.jinja2",
-                "response_model": make_plan_models,
-            },
             "check_validity": {
                 "template": PROMPTS_DIR / "Coordinator" / "check_validity.jinja2",
                 "response_model": Validity,
             },
+            "context": {
+                "template":  PROMPTS_DIR / "Planner" / "context.jinja2",
+                "response_model": make_context_model
+            },
+            "main": {
+                "template": PROMPTS_DIR / "Planner" / "main.jinja2",
+                "response_model": make_plan_models,
+            }
         }
     )
 
@@ -684,6 +690,43 @@ class Planner(Coordinator):
             schema_info += f'- {table}\nSchema:\n```yaml\n{yaml.dump(schema)}```\n'
         return schema_info
 
+    async def _lookup_context(
+        self, messages: list[Message], tables: dict[str, Source], schemas: dict[str, dict] | None
+    ) -> tuple[str, str]:
+        requested, provided = [], []
+        if "table" in self._memory:
+            requested.append(self._memory["table"])
+        elif len(tables) == 1:
+            requested.append(next(iter(tables)))
+        table_info = await self._lookup_schemas(tables, requested, provided, cache=schemas)
+        available = [table for table in tables if table not in requested]
+        tools = {tool.name: tool for tool in self._tools["__main__"]}
+        if not tools and not available:
+            return table_info, ''
+        context_model = make_context_model(tools=list(tools), tables=available)
+        model_spec = self.prompts["context"].get("llm_spec", "default")
+        system = await self._render_prompt(
+            "context",
+            messages,
+            table_info=table_info,
+            tools=list(tools.values()),
+        )
+        context = await self.llm.invoke(
+            messages=messages,
+            system=system,
+            model_spec=model_spec,
+            response_model=context_model,
+            max_retries=3,
+        )
+        if getattr(context, 'tables', None):
+            requested = [t for t in context.tables if t not in provided]
+            table_info += await self._lookup_schemas(tables, requested, provided, cache=schemas)
+        tool_context = ''
+        if getattr(context, 'tools', None):
+            for tool in context.tools:
+                tool_context += f'\n- {await tools[tool].respond(messages)}'
+        return table_info, tool_context
+
     async def _make_plan(
         self,
         messages: list[Message],
@@ -697,17 +740,10 @@ class Planner(Coordinator):
         schemas: dict[str, dict] | None = None,
         tables_schema_str: str = ""
     ) -> BaseModel:
-        info = ''
+        table_info, tool_context = await self._lookup_context(messages, tables, schemas)
         reasoning = None
         tools = self._tools["__main__"]
-        requested, provided = [], []
-        if "table" in self._memory:
-            requested.append(self._memory["table"])
-        elif len(tables) == 1:
-            requested.append(next(iter(tables)))
-        while reasoning is None or requested:
-            log_debug(f"Creating plan for \033[91m{requested}\033[0m")
-            info += await self._lookup_schemas(tables, requested, provided, cache=schemas)
+        while reasoning is None:
             system = await self._render_prompt(
                 "main",
                 messages,
@@ -716,26 +752,22 @@ class Planner(Coordinator):
                 unmet_dependencies=unmet_dependencies,
                 candidates=[agent for agent in agents.values() if not unmet_dependencies or set(agent.provides) & unmet_dependencies],
                 previous_plans=previous_plans,
-                table_info=info,
+                table_info=table_info,
                 tables_schema_str=tables_schema_str,
+                tool_context=tool_context
             )
             model_spec = self.prompts["main"].get("llm_spec", "default")
-            reasoning = await self.llm.invoke(
+            async for reasoning in self.llm.stream(
                 messages=messages,
                 system=system,
                 model_spec=model_spec,
                 response_model=reason_model,
                 max_retries=3,
-            )
-            if reasoning.chain_of_thought:  # do not replace with empty string
-                self._memory["reasoning"] = reasoning.chain_of_thought
-                step.stream(reasoning.chain_of_thought, replace=True)
-                previous_plans.append(reasoning.chain_of_thought)
-            requested = [
-                t for t in getattr(reasoning, 'requested_tables', [])
-                if t and t not in provided
-            ]
-
+            ):
+                if reasoning.chain_of_thought:  # do not replace with empty string
+                    self._memory["reasoning"] = reasoning.chain_of_thought
+                    step.stream(reasoning.chain_of_thought, replace=True)
+            previous_plans.append(reasoning.chain_of_thought)
         mutated_messages = mutate_user_message(
             f"Follow this latest plan: {reasoning.chain_of_thought!r} to finish answering: ",
             deepcopy(messages),
@@ -823,8 +855,8 @@ class Planner(Coordinator):
 
         reason_model, plan_model = self._get_model(
             "main",
-            experts_or_tools=agent_names+tool_names,
-            tables=list(tables)
+            agents=agent_names,
+            tools=tool_names,
         )
         planned = False
         unmet_dependencies = set()

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -724,7 +724,15 @@ class Planner(Coordinator):
         tool_context = ''
         if getattr(context, 'tools', None):
             for tool in context.tools:
-                tool_context += f'\n- {await tools[tool].respond(messages)}'
+                tool_messages = list(messages)
+                if tool.instruction:
+                    mutate_user_message(
+                        f"-- Here are instructions of the context you are to provide: {tool.instruction!r}",
+                        tool_messages, suffix=True, wrap=True, inplace=False
+                    )
+                response = await tools[tool.name].respond(tool_messages)
+                if response is not None:
+                    tool_context += f'\n- {response}'
         return table_info, tool_context
 
     async def _make_plan(

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -105,10 +105,15 @@ def make_context_model(tools: list[str], tables: list[str]):
             )
         )
     if tools:
+        tool = create_model(
+            "Tool",
+            name=(Literal[tuple(tools)], FieldInfo(description="The name of the tool.")),
+            instruction=(str, FieldInfo(description="Instructions for the tool.")),
+        )
         fields['tools'] = tools=(
-            list[Literal[tuple(tools)]],
+            list[tool],
             FieldInfo(
-                description="A list of tools to call to provide context before launching into the planning stage."
+                description="A list of tools to call to provide context before launching into the planning stage. Use tools to gather additional context or clarification, tools should NEVER be used to obtain the actual data you will be working with."
             )
         )
     return create_model("Context", **fields)

--- a/lumen/ai/prompts/Planner/context.jinja2
+++ b/lumen/ai/prompts/Planner/context.jinja2
@@ -1,0 +1,26 @@
+{% extends 'Actor/main.jinja2' %}
+
+{%- block instructions %}
+You are team lead and have to make a plan to solve the user's query but before you start you can look up some context to make informed decisions.
+{% endblock -%}
+
+{% block context -%}
+{%- if 'table' in memory %}- The result of the previous step was the `{{ memory['table'] }}` table. Consider carefully if it contains all the information you need and only request more tables if absolutely necessary.{% endif -%}
+
+{%- if table_info %}
+Here are tables and schemas that are already available to you:
+{{ table_info }}
+{%- endif %}
+
+Here's the choice of tools and their uses:
+{% if tools %}
+Here's a list of tools:
+{%- for tool in tools %}
+- `{{ tool.name }}`
+  Requires: {{ tool.requires }}
+  Provides: {{ tool.provides }}
+  Description: {{ tool.purpose.strip().split() | join(' ') }}
+{%- endfor -%}
+{%- endif %}
+
+{%- endblock -%}

--- a/lumen/ai/prompts/Planner/context.jinja2
+++ b/lumen/ai/prompts/Planner/context.jinja2
@@ -2,6 +2,9 @@
 
 {%- block instructions %}
 You are team lead and have to make a plan to solve the user's query but before you start you can look up some context to make informed decisions.
+
+- Only use tables to request info about tables that might contain relevant data.
+- You have access to the tables so never invoke a tool with the goal of getting data.
 {% endblock -%}
 
 {% block context -%}

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -19,6 +19,10 @@ Agent Rules:
 {% endblock -%}
 
 {% block context -%}
+{%- if tool_context %}
+Note that you previously decided that you required additional context and got the following responses DO NOT invoke the same tools again: {{ tool_context }}
+{% endif %}
+
 {%- if 'table' in memory %}- The result of the previous step was the `{{ memory['table'] }}` table. Consider carefully if it contains all the information you need and only invoke the SQL agent if some other calculation needs to be performed.{% endif -%}
 
 {%- if table_info %}


### PR DESCRIPTION
Due to limitations in the way `instructor` works we cannot currently stream the planning stage. This reduces the interactive feel of running an exploration and makes the user wait on output. To avoid this we now separate the context lookup stage of the planning stage and the actual planning. In other words we first have the `Planner` request tables that it will need and any tools it wants to call to provide context and only when those steps have been resolved do we start the planning.