### PR TITLE
Fix async race condition when setting context

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -452,7 +452,7 @@ class ExplorerUI(UI):
     async def _set_context(self, event):
         if len(self._conversations) == 0:
             return
-        active = event.new
+        active = self._explorations.active
         await self._idle.wait()
         if self._last_synced == active:
             self._conversations[active] = self.interface.objects


### PR DESCRIPTION
The async callback might be triggered after the exploration active state has already been changed again.