### PR TITLE
ci: Add checkout to setup so it doesn't fail

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,8 @@ jobs:
       img_change: ${{ steps.filter.outputs.img }}
       matrix: ${{ env.MATRIX }}
     steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
       - name: Check for code changes
         uses: dorny/paths-filter@v3
         id: filter


### PR DESCRIPTION
Currently, CI on the main branch fails with this:
![image](https://github.com/user-attachments/assets/b5de1200-3a1c-4005-b619-3365d46888e4)

I _think_ this will fix it.