### PR TITLE
Implement generic mechanism to normalize table name

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -780,7 +780,7 @@ class SQLAgent(LumenBaseAgent):
                 table_schema = await get_schema(source, source_table, include_min_max=True)
 
             # Look up underlying table name
-            table_name = source_table
+            table_name = source.normalize_table(source_table)
             if (
                 'tables' in source.param and
                 isinstance(source.tables, dict) and

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -722,6 +722,13 @@ class BaseSQLSource(Source):
     # Declare this source supports SQL transforms
     _supports_sql = True
 
+    def normalize_table(self, table: str) -> str:
+        """
+        Allows implementing table name normalization to allow fuzze matching
+        of the table name for minor variations such as quoting differences.
+        """
+        return table
+
     def get_sql_expr(self, table: str):
         """
         Returns the SQL expression corresponding to a particular table.

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -239,12 +239,16 @@ class DuckDBSource(BaseSQLSource):
             return list(self.tables)
         return [t[0] for t in self._connection.execute('SHOW TABLES').fetchall()]
 
+    def normalize_table(self, table: str):
+        tables = self.get_tables()
+        if table not in tables and 'read_' in table:
+            table = re.search(r"read_(\w+)\('(.+?)'", table).group(2)
+        return table
+
     def get_sql_expr(self, table: str):
         if isinstance(self.tables, dict):
             try:
-                if table not in self.tables and 'read_' in table:
-                    table = re.search(r"read_(\w+)\('(.+?)'", table).group(2)
-                table = self.tables[table]
+                table = self.tables[self.normalize_table(table)]
             except KeyError:
                 raise KeyError(f"Table {table} not found in {self.tables.keys()}")
         if '(' not in table and ')' not in table:

--- a/lumen/sources/intake_dremio.py
+++ b/lumen/sources/intake_dremio.py
@@ -25,13 +25,17 @@ class IntakeBaseDremioSource(IntakeBaseSQLSource):
 
     dialect = 'dremio'
 
-    def _get_source(self, table):
+    def normalize_table(self, table: str):
         # Fuzzy matching to ignore quoting issues
-        normalized_table = table.replace('"', '').lower()
         tables = self.get_tables()
+        normalized_table = table.replace('"', '').lower()
         normalized_tables = [t.replace('"', '').lower() for t in tables]
         if table not in tables and normalized_table in normalized_tables:
             table = tables[normalized_tables.index(normalized_table)]
+        return table
+
+    def _get_source(self, table):
+        table = self.normalize_table(table)
         return super()._get_source(table)
 
     def __contains__(self, table):


### PR DESCRIPTION
LLMs (and humans) can get confused about table names, particularly when quotes or prefixes/suffixes are involved. This implements a `normalize_table` method that allows the table names to be normalized, ensuring that exactly matching the existing table naming isn't necessarily required.