### PR TITLE
Minor UI fixes

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import traceback
 
 from copy import deepcopy
 from functools import partial
@@ -981,11 +982,18 @@ class VegaLiteAgent(BaseViewAgent):
     _extensions = ('vega',)
 
     async def _update_spec(self, memory: _Memory, event: param.parameterized.Event):
-        spec = yaml.load(event.new, Loader=yaml.SafeLoader)
-        memory['view'] = dict(await self._extract_spec({"json_spec": json.dumps(spec)}), type=self.view_type)
+        try:
+            spec = await self._extract_spec({"yaml_spec": event.new})
+        except Exception as e:
+            traceback.print_exception(e)
+            return
+        memory['view'] = dict(spec, type=self.view_type)
 
     async def _extract_spec(self, spec: dict[str, Any]):
-        vega_spec = json.loads(spec['json_spec'])
+        if yaml_spec:= spec.get('yaml_spec'):
+            vega_spec = yaml.load(yaml_spec, Loader=yaml.SafeLoader)
+        elif json_spec:= spec.get('json_spec'):
+            vega_spec = json.loads(json_spec)
         if "$schema" not in vega_spec:
             vega_spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
         if "width" not in vega_spec:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -469,6 +469,7 @@ class ExplorerUI(UI):
             self._conversations[event.old if old is None else old] = self._snapshot_messages()
         conversation = self._conversations[active]
         self.interface.objects = conversation
+        self.interface._chat_log.scroll_to_latest()
         self._notebook_export.param.update(
             filename = f"{self._titles[active].replace(' ', '_')}.ipynb"
         )

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -703,6 +703,7 @@ class ExplorerUI(UI):
                 with self._coordinator.param.update(memory=local_memory):
                     await callback(contents, user, instance)
             finally:
+                self._conversations[index] = self.interface.objects
                 self._idle.set()
                 local_memory.remove_on_change('plan', render_plan)
                 local_memory.remove_on_change('__error__', remove_output)


### PR DESCRIPTION
Addresses two problems:

- Ensure that conversation is synced after exchange completes
- Ensure that when switching exploration tab the internal state of the internal `Feed` is reset to ensure that objects are not "out-of-range" resulting in a blank screen.