### PR TITLE
Ensure root conversation is synced if no exploration is created

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -712,7 +712,10 @@ class ExplorerUI(UI):
                 with self._coordinator.param.update(memory=local_memory):
                     await callback(contents, user, instance)
             finally:
-                self._conversations[index] = self.interface.objects
+                if self._conversations:
+                    self._conversations[index] = self.interface.objects
+                else:
+                    self._root_conversation = self.interface.objects
                 self._idle.set()
                 local_memory.remove_on_change('plan', render_plan)
                 local_memory.remove_on_change('__error__', remove_output)


### PR DESCRIPTION
Oversight in previous PRs, if no new exploration is created we have to sync the root conversation.