### PR TITLE
Fix uploading only docs

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -381,7 +381,7 @@ class Coordinator(Viewer, Actor):
                 log_debug(f"\033[96m{agent_name} successfully completed\033[0m", show_sep=False, show_length=False)
 
             unprovided = [p for p in subagent.provides if p not in self._memory]
-            if unprovided:
+            if (unprovided and agent_name != "Source") or (len(unprovided) > 1 and agent_name == "Source"):
                 step.failed_title = f"{agent_name}Agent did not provide {', '.join(unprovided)}. Aborting the plan."
                 raise RuntimeError(f"{agent_name} failed to provide declared context.")
             step.stream(f"\n\n`{agent_name}` agent successfully completed the following task:\n\n> {instruction}", replace=True)


### PR DESCRIPTION
Ideally provides supports an or operator, e.g. `source | document_sources`, but for now, we manually handle it.

<img width="501" alt="image" src="https://github.com/user-attachments/assets/9407c4cf-6342-4563-b963-0b6efd28fa7f" />
