### PR TITLE
Improve VegaLite and fix issue with removing count column

### DIFF
--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -63,6 +63,10 @@ class Sql(BaseModel):
 
 class VegaLiteSpec(BaseModel):
 
+    chain_of_thought: str = Field(
+        description="Explain how you will use the data to create a vegalite plot."
+    )
+
     json_spec: str = Field(description="A vega-lite JSON specification. Do not under any circumstances generate the data field.")
 
 

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -162,7 +162,7 @@ async def get_schema(
 
     # first pop regardless to prevent
     # argument of type 'numpy.int64' is not iterable
-    count = schema.pop("count", None)
+    count = schema.pop("__count__", None)
 
     if include_min_max:
         for field, spec in schema.items():
@@ -220,7 +220,7 @@ async def get_schema(
         ]
 
     if count and include_count:
-        schema["count"] = count
+        schema["__count__"] = count
     return schema
 
 

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -162,7 +162,7 @@ async def get_schema(
 
     # first pop regardless to prevent
     # argument of type 'numpy.int64' is not iterable
-    count = schema.pop("__count__", None)
+    count = schema.pop("__len__", None)
 
     if include_min_max:
         for field, spec in schema.items():
@@ -220,7 +220,7 @@ async def get_schema(
         ]
 
     if count and include_count:
-        schema["__count__"] = count
+        schema["__len__"] = count
     return schema
 
 

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -815,7 +815,7 @@ class BaseSQLSource(Source):
             count_expr = SQLCount().apply(sql_expr)
             count_expr = ' '.join(count_expr.splitlines())
             count_data = self.execute(count_expr)
-            schema['count'] = cast(count_data['count'].iloc[0])
+            schema['__count__'] = cast(count_data['count'].iloc[0])
 
         return schemas if table is None else schemas[table]
 

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -815,7 +815,7 @@ class BaseSQLSource(Source):
             count_expr = SQLCount().apply(sql_expr)
             count_expr = ' '.join(count_expr.splitlines())
             count_data = self.execute(count_expr)
-            schema['__count__'] = cast(count_data['count'].iloc[0])
+            schema['__len__'] = cast(count_data['count'].iloc[0])
 
         return schemas if table is None else schemas[table]
 

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -202,19 +202,19 @@ class TestGetSchema:
         mock_source = MagicMock()
         mock_source.get_schema.return_value = {
             "field1": {"type": "integer"},
-            "__count__": 1000,
+            "__len__": 1000,
         }
         schema = await get_schema(mock_source, include_count=True)
-        assert schema["__count___"] == 1000
+        assert schema["__len___"] == 1000
 
     async def test_no_count(self):
         mock_source = MagicMock()
         mock_source.get_schema.return_value = {
             "field1": {"type": "integer"},
-            "__count__": 1000,
+            "__len__": 1000,
         }
         schema = await get_schema(mock_source, include_count=False)
-        assert "__count__" not in schema
+        assert "__len__" not in schema
 
     async def test_table(self):
         mock_source = MagicMock()

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -202,19 +202,19 @@ class TestGetSchema:
         mock_source = MagicMock()
         mock_source.get_schema.return_value = {
             "field1": {"type": "integer"},
-            "count": 1000,
+            "__count__": 1000,
         }
         schema = await get_schema(mock_source, include_count=True)
-        assert schema["count"] == 1000
+        assert schema["__count___"] == 1000
 
     async def test_no_count(self):
         mock_source = MagicMock()
         mock_source.get_schema.return_value = {
             "field1": {"type": "integer"},
-            "count": 1000,
+            "__count__": 1000,
         }
         schema = await get_schema(mock_source, include_count=False)
-        assert "count" not in schema
+        assert "__count__" not in schema
 
     async def test_table(self):
         mock_source = MagicMock()

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -66,7 +66,7 @@ def test_duckdb_get_schema(duckdb_source):
             'inclusiveMinimum': '2009-01-01 00:00:00',
             'type': 'string'
         },
-        'count': '5'
+        '__count__': '5'
     }
     source = duckdb_source.get_schema('test_sql')
     source["C"]["enum"].sort()
@@ -86,7 +86,7 @@ def test_duckdb_get_schema_with_none(duckdb_source):
             'inclusiveMinimum': '2009-01-01 00:00:00',
             'type': 'string'
         },
-        'count': '5'
+        '__count__': '5'
     }
     source = duckdb_source.get_schema('test_sql_with_none')
     source["C"]["enum"].sort(key=enum.index)

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -66,7 +66,7 @@ def test_duckdb_get_schema(duckdb_source):
             'inclusiveMinimum': '2009-01-01 00:00:00',
             'type': 'string'
         },
-        '__count__': '5'
+        '__len__': '5'
     }
     source = duckdb_source.get_schema('test_sql')
     source["C"]["enum"].sort()
@@ -86,7 +86,7 @@ def test_duckdb_get_schema_with_none(duckdb_source):
             'inclusiveMinimum': '2009-01-01 00:00:00',
             'type': 'string'
         },
-        '__count__': '5'
+        '__len__': '5'
     }
     source = duckdb_source.get_schema('test_sql_with_none')
     source["C"]["enum"].sort(key=enum.index)


### PR DESCRIPTION
Before, I noticed the "count" column wasn't included in the spec, which resulted in poor Vega lite plots because the LLM did not know about it.
```
The data to be plotted originates from a table called 'athlete_ages_at_gold_medals' and follows the following YAML schema:
```yaml
age_at_gold:
  type: num
```
Found:
```
# first pop regardless to prevent
    # argument of type 'numpy.int64' is not iterable
    count = schema.pop("count", None)
```

After:


<img width="1470" alt="image" src="https://github.com/user-attachments/assets/944133b4-06b4-4259-ad11-9eea7e57f897" />

