### PR TITLE
Share SQL in BaseViewAgent

### DIFF
--- a/lumen/ai/prompts/BaseViewAgent/main.jinja2
+++ b/lumen/ai/prompts/BaseViewAgent/main.jinja2
@@ -4,6 +4,11 @@
 Available visualization types:
 {{ doc }}
 
+The current SQL
+```sql
+{{ memory['sql'] }}
+```
+
 The data to be plotted originates from a table called '{{ table }}' and follows the following YAML schema:
 ```yaml
 {{ schema }}


### PR DESCRIPTION
Vegalite agent seems to be doubling down on what the SQL is already doing:
here:
```
  transform:
  - filter:
      field: magnitude
      gt: 5
```
```
max_width: 1200
min_height: 300
pipeline:
  source:
    tables:
      earthquakes_lon_lat_high_mag: "SELECT\n    \"longitude\",\n    \"latitude\"\n\
        FROM read_csv('/Users/ahuang/repos/lumen/earthquakes.csv')\nWHERE\n    TRY_CAST(\"\
        mag\" AS DECIMAL) > 5\n    AND \"mag\" IS NOT NULL\n    AND \"mag\" > 0"
    type: duckdb
    uri: ':memory:'
  sql_transforms:
  - limit: 1000000
    type: sql_limit
  table: earthquakes_lon_lat_high_mag
sizing_mode: stretch_both
spec:
  $schema: https://vega.github.io/schema/vega-lite/v5.json
  data:
    format:
      type: csv
    url: data/earthquakes_lon_lat_high_mag.csv
  description: A scatter plot of earthquakes with magnitude greater than 5.
  encoding:
    x:
      field: longitude
      type: quantitative
    y:
      field: latitude
      type: quantitative
  height: container
  mark: point
  transform:
  - filter:
      field: magnitude
      gt: 5
  width: container
type: vegalite
```