### PR TITLE
Do not show error traceback on lumen-ai serve

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import traceback
 
 from io import StringIO
@@ -149,7 +150,8 @@ class UI(Viewer):
             self.interface = ChatInterface(
                 load_buffer=5,
             )
-        if self.log_level == "DEBUG":
+        levels = logging.getLevelNamesMapping()
+        if levels.get(self.log_level) < 20:
             self.interface.callback_exception = "verbose"
         self._coordinator = self.coordinator(
             agents=agents,

--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import inspect
 import json
+import logging
 import os
 import sys
 import traceback
@@ -243,7 +244,8 @@ def main(args=None):
     try:
         ret = args.invoke(args)
     except Exception as e:
-        if args.log_level.upper() == 'DEBUG':
+        levels = logging.getLevelNamesMapping()
+        if levels.get(args.log_level.upper(), 30) < 20:
             traceback.print_exc()
         die("ERROR: " + str(e))
 

--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import os
 import sys
+import traceback
 
 from textwrap import dedent
 
@@ -242,9 +243,8 @@ def main(args=None):
     try:
         ret = args.invoke(args)
     except Exception as e:
-        import traceback
-
-        traceback.print_exc()
+        if args.log_level.upper() == 'DEBUG':
+            traceback.print_exc()
         die("ERROR: " + str(e))
 
     if ret is False:


### PR DESCRIPTION
Do not show full traceback on `lumen-ai serve` unless log level is set.