### PR TITLE
Remove semi colon on all transforms

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -628,16 +628,17 @@ class SQLAgent(LumenBaseAgent):
         else:
             source = next(iter(sources))
 
+        sql_transforms = [SQLLimit(limit=1_000_000)]
+        for transform in sql_transforms:
+            sql_query = transform.apply(sql_query)
+
         # check whether the SQL query is valid
         expr_slug = output.expr_slug
         try:
             sql_expr_source = source.create_sql_expr_source({expr_slug: sql_query})
             # Get validated query
             sql_query = sql_expr_source.tables[expr_slug]
-            sql_transforms = [SQLLimit(limit=1_000_000)]
-            pipeline = await get_pipeline(
-                source=sql_expr_source, table=expr_slug, sql_transforms=sql_transforms
-            )
+            pipeline = await get_pipeline(source=sql_expr_source, table=expr_slug)
         except Exception as e:
             report_error(e, step)
             raise e

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -58,7 +58,7 @@ class SQLTransform(Transform):
             sql_in = sql_in[1:-1]
         elif sql_in.startswith("'") and sql_in.endswith("'"):
             sql_in = sql_in[1:-1]
-        return sql_in
+        return sql_in.rstrip(';')
 
     @classmethod
     def _render_template(cls, template: str, **params: Any) -> str:
@@ -108,7 +108,7 @@ class SQLLimit(SQLTransform):
     def apply(self, sql_in):
         if self.limit is None:
             return sql_in
-        normalized = sql_in.rstrip(';').lower()
+        normalized = sql_in.lower()
         limited = 'limit' in normalized or 'fetch' in normalized
         sql_in = super().apply(sql_in)
         if limited:


### PR DESCRIPTION
I think at some point, I encountered some Lumen AI syntax error related to `;` or comments

```
WITH gold_medals AS (
    SELECT
        "athlete_full_name",
        COUNT(*) AS gold_count
    FROM read_csv('olympic_medals.csv')
    WHERE "medal_type" = 'GOLD'
      AND "slug_game" LIKE '%-2022'  -- Assuming Winter Olympics are identified by the year
    GROUP BY "athlete_full_name"
)
SELECT
    "athlete_full_name",
    gold_count
FROM gold_medals
ORDER BY gold_count DESC
LIMIT 1
```

Not sure if this will fix, but I think it should be applied to all transforms anyways.

Ideally, these transforms would be applied to the generated SQL for visibility, and not after under the hood in pipeline (okay applied)