### PR TITLE
Keep all steps open, and close steps card on complete

### DIFF
--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -51,3 +51,4 @@ SOURCE_TABLE_SEPARATOR = ":::"
 PROVIDED_SOURCE_NAME = 'ProvidedSource00000'
 
 pn.chat.ChatStep.min_width = 375
+pn.chat.ChatStep.collapsed_on_success = False

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -481,6 +481,11 @@ class Coordinator(Viewer, Actor):
                 await self._add_analysis_suggestions()
             log_debug("\033[92mDONE\033[0m\n\n", show_sep=True)
 
+        for message_obj in self.interface.objects[::-1]:
+            if isinstance(message_obj.object, Card):
+                message_obj.object.collapsed = True
+                break
+
 
 class DependencyResolver(Coordinator):
     """


### PR DESCRIPTION
There were mentions that the streaming was nausea inducing. Was wondering whether keeping all the cards open so it doesn't keep popping back and forth would help, until the final step, then collapsing it all.

https://github.com/user-attachments/assets/4526b08f-357c-419b-abbc-01eb0ad6020d

