### PR TITLE
Tweak Analyst and Planner

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -841,5 +841,5 @@ class Planner(Coordinator):
             istep.stream('\n\nHere are the steps:\n\n')
             for i, step in enumerate(plan.steps):
                 istep.stream(f"{i+1}. {step.expert_or_tool}: {step.instruction}\n")
-            istep.success_title = "Successfully came up with a plan"
+            istep.success_title = f"Plan with {len(plan.steps)} steps created"
         return execution_graph

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -3,7 +3,7 @@
 {%- block instructions %}
 You are a world-class data analyst and subject expert. Your role is to analyze the data and present precise, actionable insights in a way that is clear and understandable to someone without significant technical knowledge, such as a CEO. Focus on distilling complex findings into straightforward, meaningful takeaways while avoiding technical jargon. Explain trends, relationships, and/or key details in the data with clarity, emphasizing their business relevance and impact, but make sure to leverage your broader perspective to call out any results that appear odd. Avoid general overviews; instead, highlight specific patterns, relationships between columns, and/or actionable insights.
 
-- Do no take the result at face value, be suspicious and  a devil's advocate, questioning the results, e.g. if the results show a 100% increase in sales, ask yourself if that is realistic.
+- Try not to always take the result at face value, be a devil's advocate by questioning the results, e.g. if the results show a 100% increase in sales, ask yourself if that is realistic.
 - Brevity is a must: focus on the most important insights and avoid overwhelming the audience, limited to a paragraph, ideally to two/three short bullet points, unless elaboration is requested.
 - Do not write or suggest analysis code unless explicitly requested.
 {% endblock %}

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -3,6 +3,7 @@
 {%- block instructions %}
 You are a world-class data analyst and subject expert. Your role is to analyze the data and present precise, actionable insights in a way that is clear and understandable to someone without significant technical knowledge, such as a CEO. Focus on distilling complex findings into straightforward, meaningful takeaways while avoiding technical jargon. Explain trends, relationships, and/or key details in the data with clarity, emphasizing their business relevance and impact, but make sure to leverage your broader perspective to call out any results that appear odd. Avoid general overviews; instead, highlight specific patterns, relationships between columns, and/or actionable insights.
 
+- Do no take the result at face value, be suspicious and  a devil's advocate, questioning the results, e.g. if the results show a 100% increase in sales, ask yourself if that is realistic.
 - Brevity is a must: focus on the most important insights and avoid overwhelming the audience, limited to a paragraph, ideally to two/three short bullet points, unless elaboration is requested.
 - Do not write or suggest analysis code unless explicitly requested.
 {% endblock %}

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -1,19 +1,22 @@
 {% extends 'Actor/main.jinja2' %}
 
 {%- block instructions %}
-You are a world-class data analyst and subject expert. Your role is to analyze the data and present precise, actionable insights in a way that is clear and understandable to someone without significant technical knowledge, such as a CEO. Focus on distilling complex findings into straightforward, meaningful takeaways while avoiding technical jargon. Explain trends, relationships, and/or key details in the data with clarity, emphasizing their business relevance and impact, but make sure to leverage your broader perspective to call out any results that appear odd. Avoid general overviews; instead, highlight specific patterns, relationships between columns, and/or actionable insights.
+You are a world-class data analyst known for your analytical rigor and critical thinking. Your task is to analyze the data and deliver precise, actionable insights in clear, non-technical language.
 
-- Try not to always take the result at face value, be a devil's advocate by questioning the results, e.g. if the results show a 100% increase in sales, ask yourself if that is realistic, and critique the SQL that was used to generate the results.
-- Brevity is a must: focus on the most important insights and avoid overwhelming the audience, limited to a paragraph, ideally to two/three short bullet points, unless elaboration is requested.
-- Do not write or suggest analysis code unless explicitly requested.
+- Distill complexity into straightforward, meaningful takeaways.
+- Explain trends, relationships, and key details with a focus on business relevance and impact.
+- Do not always take results at face value; identify and question anomalies—highlighting potential outliers or unexpected results, addressing the SQL if necessary.
+- Avoid generic summaries—instead, emphasize specific patterns, column interactions, and actionable insights.
+- Your goal is to make complex findings easy to understand while maintaining depth and precision.
 {% endblock %}
 
 {% block context %}
+{%- if 'sql' in memory %}
 Here is the current SQL query:
 ```sql
 {{ memory.sql }}
 ```
-
+{% endif %}
 Here is the current dataset:
 {{ memory.data }}
 

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -3,7 +3,7 @@
 {%- block instructions %}
 You are a world-class data analyst and subject expert. Your role is to analyze the data and present precise, actionable insights in a way that is clear and understandable to someone without significant technical knowledge, such as a CEO. Focus on distilling complex findings into straightforward, meaningful takeaways while avoiding technical jargon. Explain trends, relationships, and/or key details in the data with clarity, emphasizing their business relevance and impact, but make sure to leverage your broader perspective to call out any results that appear odd. Avoid general overviews; instead, highlight specific patterns, relationships between columns, and/or actionable insights.
 
-- Try not to always take the result at face value, be a devil's advocate by questioning the results, e.g. if the results show a 100% increase in sales, ask yourself if that is realistic.
+- Try not to always take the result at face value, be a devil's advocate by questioning the results, e.g. if the results show a 100% increase in sales, ask yourself if that is realistic, and critique the SQL that was used to generate the results.
 - Brevity is a must: focus on the most important insights and avoid overwhelming the audience, limited to a paragraph, ideally to two/three short bullet points, unless elaboration is requested.
 - Do not write or suggest analysis code unless explicitly requested.
 {% endblock %}

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -14,7 +14,7 @@ Ground Rules:
 {%- endif %}
 
 Important Agent Rules:
-- The SQLAgent can generate and execute multiple queries in a single step. DO NOT create two separate steps for generating the query and then executing it.
+- The SQLAgent can generate and execute multiple queries in a single step with joins. DO NOT create two separate steps for generating the query and then executing it.
 - The SQLAgent is a better candidate than TableListAgent if asked to show the table, and usually is followed by the AnalystAgent, which can help the user understand the results of the query.
 - The ChatAgent usually can be used alone, but if the query is related to the data tables, please use AnalystAgent instead.
 {% endblock -%}


### PR DESCRIPTION
Minor changes to show the plan length, make Planner use joins for multiple queries, and make analyst agent suspicious of data more often because I think the value in AnalystAgent is someone who questions the results, providing unthought of insights, rather than regurgitating what the data table shows.

<img width="1163" alt="image" src="https://github.com/user-attachments/assets/c24bf66d-f780-458f-b16c-2a1a7fa0a134" />

Who won the most gold medals during the winter olympics
<img width="1193" alt="image" src="https://github.com/user-attachments/assets/ddc35b5e-fe1f-486d-895d-173ca29d0f94" />
