### PR TITLE
Add llama_url in cli

### DIFF
--- a/doc/lumen_ai/how_to/llm/llama_cpp.md
+++ b/doc/lumen_ai/how_to/llm/llama_cpp.md
@@ -74,12 +74,12 @@ lumen-ai serve --provider llama --model-kwargs '{
 }'
 ```
 
-Providing these arguments via the CLI can be cumbersome. Instead, paste the quantized model file's `llama-url` and pass `model_kwargs` as query parameters. If `llama-url` is set, `provider` automatically defaults to `llama`, and will error if another `provider` is set.
+Providing these arguments via the CLI can be cumbersome. Instead, paste the quantized model file's `llm-model-url` and pass `model_kwargs` as query parameters. If `llm-model-url` is set, `provider` automatically defaults to `llama`, and will error if another `provider` is set.
 
 ```bash
-lumen-ai serve --llama-url https://huggingface.co/unsloth/Mistral-Small-24B-Instruct-2501-GGUF/blob/main/Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf?chat_format=mistral-instruct
+lumen-ai serve --llm-model-url https://huggingface.co/unsloth/Mistral-Small-24B-Instruct-2501-GGUF/blob/main/Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf?chat_format=mistral-instruct
 ```
 
 ```bash
-lumen-ai serve --llama-url https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF/blob/main/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf?chat_format=qwen&n_ctx=131072
+lumen-ai serve --llm-model-url https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF/blob/main/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf?chat_format=qwen&n_ctx=131072
 ```

--- a/doc/lumen_ai/how_to/llm/llama_cpp.md
+++ b/doc/lumen_ai/how_to/llm/llama_cpp.md
@@ -39,7 +39,7 @@ If you do not want to use the default model (`Qwen/Qwen2.5-Coder-7B-Instruct-GGU
 
 As an example you can override the model configuration by providing the `repo` and `model_file` to look up on [Huggingface](https://huggingface.co/) or a `model_path` pointing to a model on disk. Any other configuration are passed through to the `llama.cpp` [`Llama`](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#high-level-api) object.
 
-As an example, let's replace Qwen 2.5 Coder with a quantized DeepSeek model we found by searching for it on [Huggingface] and then providing the repo name, model file, chat format and other configuration options:
+As an example, let's replace Qwen 2.5 Coder with a quantized DeepSeek model we found by searching for it on [Huggingface] and then providing the repo name, model file, chat format and other configuration options in Python:
 
 ```python
 import lumen.ai as lmai
@@ -61,3 +61,25 @@ lmai.ui.ExplorerUI('<your-data-file-or-url>', llm=llm).servable()
 :::{note}
 Find all valid configuration options in the [Llama.cpp API reference](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#high-level-api).
 :::
+
+Using another model can be done in the CLI as well:
+
+```bash
+lumen-ai serve --provider llama --model-kwargs '{
+  "default": {
+    "repo": "unsloth/Mistral-Small-24B-Instruct-2501-GGUF",
+    "model_file": "Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf",
+    "chat_format": "mistral-instruct"
+  }
+}'
+```
+
+Providing these arguments via the CLI can be cumbersome. Instead, paste the quantized model file's `llama-url` and pass `model_kwargs` as query parameters. If `llama-url` is set, `provider` automatically defaults to `llama`, and will error if another `provider` is set.
+
+```bash
+lumen-ai serve --llama-url https://huggingface.co/unsloth/Mistral-Small-24B-Instruct-2501-GGUF/blob/main/Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf?chat_format=mistral-instruct
+```
+
+```bash
+lumen-ai serve --llama-url https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF/blob/main/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf?chat_format=qwen&n_ctx=131072
+```

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import html
 import inspect
+import json
 import math
 import re
 import time
@@ -13,6 +14,7 @@ from pathlib import Path
 from shutil import get_terminal_size
 from textwrap import dedent
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qs
 
 import pandas as pd
 import yaml
@@ -446,3 +448,43 @@ def format_exception(exc: Exception, limit: int = 0) -> str:
     e_msg = str(exc).replace('\033[1m', '<b>').replace('\033[0m', '</b>')
     tb = html.escape('\n'.join(traceback.format_exception(exc, limit=limit))).replace('\033[1m', '<b>').replace('\033[0m', '</b>')
     return f'<b>{type(exc).__name__}</b>: {e_msg}\n<pre style="overflow-y: auto">{tb}</pre>'
+
+
+def cast_value(value):
+    if len(value) == 1:
+        value = value[0]
+        if ',' in value and value.replace(',', '').isdigit():
+            return [cast_value(v) for v in value.split(",")]
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return [cast_value(v) for v in value]
+
+
+def parse_huggingface_url(url: str) -> tuple[str, str, dict]:
+    """Parse a HuggingFace URL to extract repo, model file, and model_kwargs.
+
+    Args:
+        url: HuggingFace URL in format https://huggingface.co/org/repo/blob/main/file.gguf?param1=value1&param2=value2
+
+    Returns:
+        tuple: (repo, model_file, model_kwargs)
+
+    Raises:
+        ValueError: If URL format is invalid
+    """
+    parts = url.split('/')
+    hf_index = parts.index('huggingface.co')
+    if len(parts) < hf_index + 4:  # Need at least org/repo after huggingface.co
+        raise ValueError
+    repo = f"{parts[hf_index+1]}/{parts[hf_index+2]}"
+    model_file = parts[-1]  # Last component is the filename
+
+    # Parse query parameters
+    model_kwargs = {}
+    if "?" in model_file:
+        model_file, query_params = model_file.split('?')
+        for key, value in parse_qs(query_params).items():
+            model_kwargs[key] = cast_value(value)
+    return repo, model_file, model_kwargs

--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -85,7 +85,7 @@ class LumenAIServe(Serve):
             help="JSON string of model keyword arguments for the LLM. Example: --model-kwargs '{\"default\": {\"repo\": \"abcdef\"}}'",
         )
         group.add_argument(
-            "--llama-url",
+            "--llm-model-url",
             type=str,
             help="""
             Huggingface URL to the GGUF file and model kwargs as query params.

--- a/lumen/command/ai.py
+++ b/lumen/command/ai.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 from ..ai import agents as lumen_agents, llm as lumen_llms  # Aliased here
-from ..ai.utils import render_template
+from ..ai.utils import parse_huggingface_url, render_template
 
 CMD_DIR = THIS_DIR / ".." / "command"
 
@@ -82,7 +82,15 @@ class LumenAIServe(Serve):
         group.add_argument(
             "--model-kwargs",
             type=str,
-            help="JSON string of model keyword arguments for the LLM. Example: --model-kwargs '{\"repo\": \"abcdef\"}'",
+            help="JSON string of model keyword arguments for the LLM. Example: --model-kwargs '{\"default\": {\"repo\": \"abcdef\"}}'",
+        )
+        group.add_argument(
+            "--llama-url",
+            type=str,
+            help="""
+            Huggingface URL to the GGUF file and model kwargs as query params.
+            Example --huggingface-url 'https://huggingface.co/RE/PO/blob/main/FILE.gguf?chat_format=chat_format'
+            """,
         )
 
     def invoke(self, args: argparse.Namespace) -> bool:
@@ -95,7 +103,15 @@ class LumenAIServe(Serve):
         agents = args.agents
         log_level = args.log_level
 
-        if not provider:
+        llama_url = args.llama_url
+        if llama_url and provider and provider != "llama":
+            raise ValueError(
+                f"Cannot specify both --huggingface-url and --provider {provider!r}. "
+                f"Use --huggingface-url to load a model from HuggingFace."
+            )
+        elif llama_url:
+            provider = "llama"
+        elif not provider:
             provider = LLMConfig.detect_provider()
 
         try:
@@ -116,13 +132,29 @@ class LumenAIServe(Serve):
             )
 
         model_kwargs = None
-        if args.model_kwargs:
-            try:
-                model_kwargs = json.loads(args.model_kwargs)
-            except json.JSONDecodeError as e:
-                die(f"Invalid JSON format for --model-kwargs: {e}\n"
-                    f"Ensure the argument is properly escaped. Example: --model-kwargs '{{\"key\": \"value\"}}'")
+        if args.model_kwargs or llama_url:
+            model_kwargs = {}
+            if args.model_kwargs:
+                try:
+                    model_kwargs = json.loads(args.model_kwargs)
+                except json.JSONDecodeError as e:
+                    die(f"Invalid JSON format for --model-kwargs: {e}\n"
+                        f"Ensure the argument is properly escaped. Example: --model-kwargs '{{\"key\": \"value\"}}'")
 
+            # Handle huggingface URL if provided
+            if llama_url:
+                try:
+                    repo, model_file, query_kwargs = parse_huggingface_url(llama_url)
+                    # Initialize default dict if not exists
+                    if 'default' not in model_kwargs:
+                        model_kwargs['default'] = {}
+                    model_kwargs['default'].update({
+                        'repo': repo,
+                        'model_file': model_file,
+                        **query_kwargs
+                    })
+                except ValueError as e:
+                    die(str(e))
         provider_cls.warmup(model_kwargs)
 
         agent_classes = [

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -7,13 +7,12 @@ import pytest
 
 from panel.chat import ChatStep
 
-from lumen.ai.utils import parse_huggingface_url
-
 try:
     from lumen.ai.config import PROMPTS_DIR
     from lumen.ai.utils import (
         UNRECOVERABLE_ERRORS, clean_sql, describe_data, format_schema,
-        get_schema, render_template, report_error, retry_llm_output,
+        get_schema, parse_huggingface_url, render_template, report_error,
+        retry_llm_output,
     )
 except ImportError:
     pytest.skip("Skipping tests that require lumen.ai", allow_module_level=True)

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -7,6 +7,8 @@ import pytest
 
 from panel.chat import ChatStep
 
+from lumen.ai.utils import parse_huggingface_url
+
 try:
     from lumen.ai.config import PROMPTS_DIR
     from lumen.ai.utils import (
@@ -302,3 +304,22 @@ def test_report_error():
     assert step.failed_title == "Test error"
     assert step.status == "failed"
     assert step.objects[0].object == "\n```python\nTest error\n```"
+
+
+class TestParseHuggingFaceUrl:
+
+    def test_no_query_params(self):
+        repo, file, model_kwargs = parse_huggingface_url("https://huggingface.co/unsloth/Mistral-Small-24B-Instruct-2501-GGUF/blob/main/Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf")
+        assert repo == "unsloth/Mistral-Small-24B-Instruct-2501-GGUF"
+        assert file == "Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf"
+        assert model_kwargs == {}
+
+    def test_query_params(self):
+        repo, file, model_kwargs = parse_huggingface_url("https://huggingface.co/unsloth/Mistral-Small-24B-Instruct-2501-GGUF/blob/main/Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf?chat_format=mistral-instruct&n_ctx=1028")
+        assert repo == "unsloth/Mistral-Small-24B-Instruct-2501-GGUF"
+        assert file == "Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf"
+        assert model_kwargs == {"chat_format": "mistral-instruct", "n_ctx": 1028}
+
+    def test_bad_error(self):
+        with pytest.raises(ValueError):
+            parse_huggingface_url("https://huggingface.co/Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf?chat_format=mistral-instruct&n_ctx=1028")


### PR DESCRIPTION
Was playing around with local models and experienced how tedious it was to change the local model, so I added support for:

```
lumen-ai serve --llama-url https://huggingface.co/unsloth/Mistral-Small-24B-Instruct-2501-GGUF/blob/main/Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf?chat_format=mistral-instruct&n_ctx=1028
```
 
URL's query_params are used as model_kwargs