### PR TITLE
Move tabs to the right

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -361,7 +361,7 @@ class ExplorerUI(UI):
         self._coordinator.render_output = False
         self.interface.callback = self._wrap_callback(cb)
         self._explorations = Tabs(
-            sizing_mode='stretch_both', closable=True, tabs_location="left",
+            sizing_mode='stretch_both', closable=True, tabs_location="left" if self.chat_ui_position == "right" else "right",
             stylesheets=[':host(.bk-left) .bk-header .bk-tab { padding-left: 5px; padding-right: 2px; text-align: left; }']
         )
         self._explorations.param.watch(self._cleanup_explorations, ['objects'])


### PR DESCRIPTION
<img width="1314" alt="image" src="https://github.com/user-attachments/assets/b18ff9e6-4b5e-4a48-8cbc-b6b88a9fde71" />

Without this PR, the tabs labels' is awkwardly placed in the center of the screen