### PR TITLE
Avoid repeatedly looking up and streaming context

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -662,20 +662,20 @@ class Planner(Coordinator):
                 if getattr(output, 'tables', None):
                     requested = [t for t in output.tables if t not in provided]
                     loaded = '\n'.join([f'- {table}' for table in requested])
-                    istep.stream(f'Looking up schemas for following tables:\n\n{loaded}')
-                    table_info += await self._lookup_schemas(tables, requested, provided, cache=schemas)
-                if getattr(output, 'tools', None):
-                    for tool in output.tools:
-                        tool_messages = list(messages)
-                        if tool.instruction:
-                            mutate_user_message(
-                                f"-- Here are instructions of the context you are to provide: {tool.instruction!r}",
-                                tool_messages, suffix=True, wrap=True, inplace=False
-                            )
-                        response = await tools[tool.name].respond(tool_messages)
-                        if response is not None:
-                            istep.stream(f'{response}\n')
-                            tool_context += f'\n- {response}'
+                    istep.stream(f'Looking up schemas for following tables:\n\n{loaded}', replace=True)
+            table_info += await self._lookup_schemas(tables, requested, provided, cache=schemas)
+            if getattr(output, 'tools', None):
+                for tool in output.tools:
+                    tool_messages = list(messages)
+                    if tool.instruction:
+                        mutate_user_message(
+                            f"-- Here are instructions of the context you are to provide: {tool.instruction!r}",
+                            tool_messages, suffix=True, wrap=True, inplace=False
+                        )
+                    response = await tools[tool.name].respond(tool_messages)
+                    if response is not None:
+                        istep.stream(f'{response}\n')
+                        tool_context += f'\n- {response}'
         return table_info, tool_context
 
     async def _make_plan(

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -659,9 +659,11 @@ class Planner(Coordinator):
                 max_retries=3,
             )
             async for output in response:
-                if getattr(output, 'tables', None):
-                    requested = [t for t in output.tables if t not in provided]
-                    loaded = '\n'.join([f'- {table}' for table in requested])
+                if not getattr(output, 'tables', None):
+                    continue
+                requested = [t for t in output.tables if t not in provided]
+                loaded = '\n'.join([f'- {table}' for table in requested])
+                if loaded:
                     istep.stream(f'Looking up schemas for following tables:\n\n{loaded}', replace=True)
             table_info += await self._lookup_schemas(tables, requested, provided, cache=schemas)
             if getattr(output, 'tools', None):


### PR DESCRIPTION
When refactoring the streaming of context requests some of the table schema lookups and tools context lookups were moved into the streaming loop resulting in repeatedly streaming the output (without replacing it), repeatedly loading the schemas, and repeatedly running the tools.