### PR TITLE
Fix repeat follow up queries, with no errors at all

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -582,7 +582,7 @@ class SQLAgent(LumenBaseAgent):
                     # Remove source prefixes from table names
                     renamed_table = re.sub(rf".*?{SOURCE_TABLE_SEPARATOR}", "", renamed_table)
                 sql_query = sql_query.replace(a_table, renamed_table)
-                mirrors[renamed_table] = (a_source, a_table)
+                mirrors[renamed_table] = (a_source, renamed_table)
             source = DuckDBSource(uri=":memory:", mirrors=mirrors)
         else:
             source = next(iter(sources))


### PR DESCRIPTION
I need a little more testing later. I'm not 100% sure about the implications of this yet across multiple sources

```python

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 111, in async_wrapper
    output = await func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/agents.py", line 586, in _create_valid_sql
    source = DuckDBSource(uri=":memory:", mirrors=mirrors)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/sources/duckdb.py", line 85, in __init__
    df = source.get(src_table)
         ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/sources/base.py", line 87, in wrapped
    df = method(self, table, **cache_query)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/sources/duckdb.py", line 317, in get
    sql_expr = self.get_sql_expr(table)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/sources/duckdb.py", line 302, in get_sql_expr
    raise KeyError(f"Table {table} not found in {self.tables.keys()}")
KeyError: "Table :::ProvidedSource00000:::
```