### PR TITLE
Simplify source/table separator logic

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -638,10 +638,12 @@ class SQLAgent(LumenBaseAgent):
                 f"{a_source}{SOURCE_TABLE_SEPARATOR}{a_table}" for a_source in sources.values()
                 for a_table in a_source.get_tables()
             ]
+            sep = SOURCE_TABLE_SEPARATOR
         else:
             tables = self._memory["sources"][0].get_tables()
+            sep = None
         system = await self._render_prompt(
-            "find_tables", messages, separator=SOURCE_TABLE_SEPARATOR, tables_schema_str=tables_schema_str
+            "find_tables", messages, separator=sep, tables_schema_str=tables_schema_str
         )
         tables_model = self._get_model("find_tables", tables=tables)
         model_spec = self.prompts["find_tables"].get("llm_spec", "default")

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -633,7 +633,7 @@ class SQLAgent(LumenBaseAgent):
             log_debug("\033[91mRetry find_tables\033[0m")
 
         sources = {source.name: source for source in self._memory["sources"]}
-        if sources > 1:
+        if len(sources) > 1:
             tables = [
                 f"{a_source}{SOURCE_TABLE_SEPARATOR}{a_table}" for a_source in sources.values()
                 for a_table in a_source.get_tables()

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -580,7 +580,7 @@ class SQLAgent(LumenBaseAgent):
                     renamed_table = a_table
                 # Remove source prefixes from table names
                 if SOURCE_TABLE_SEPARATOR in renamed_table:
-                    renamed_table, _ = renamed_table.split(SOURCE_TABLE_SEPARATOR)
+                    _, renamed_table = renamed_table.split(SOURCE_TABLE_SEPARATOR)
                 sql_query = sql_query.replace(a_table, renamed_table)
                 mirrors[renamed_table] = (a_source, renamed_table)
             source = DuckDBSource(uri=":memory:", mirrors=mirrors)
@@ -668,7 +668,7 @@ class SQLAgent(LumenBaseAgent):
         tables_to_source = {}
         for source_table in selected_tables:
             if SOURCE_TABLE_SEPARATOR in source_table:
-                a_source_name, _ = source_table.split(SOURCE_TABLE_SEPARATOR)
+                _, a_source_name = source_table.split(SOURCE_TABLE_SEPARATOR)
                 a_source_obj = sources.get(a_source_name)
             else:
                 a_source_obj = next(iter(sources.values()))
@@ -689,7 +689,7 @@ class SQLAgent(LumenBaseAgent):
         tables_sql_schemas = {}
         for source_table, source in tables_to_source.items():
             # Look up underlying table name
-            source_table, _ = source_table.split(SOURCE_TABLE_SEPARATOR)
+            _, source_table = source_table.split(SOURCE_TABLE_SEPARATOR)
             table_schema = await get_schema(source, source_table, include_count=True)
             table_name = source.normalize_table(source_table)
             if (

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -580,7 +580,7 @@ class SQLAgent(LumenBaseAgent):
                     renamed_table = a_table
                 # Remove source prefixes from table names
                 if SOURCE_TABLE_SEPARATOR in renamed_table:
-                    _, renamed_table = renamed_table.split(SOURCE_TABLE_SEPARATOR)
+                    _, renamed_table = renamed_table.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)
                 sql_query = sql_query.replace(a_table, renamed_table)
                 mirrors[renamed_table] = (a_source, renamed_table)
             source = DuckDBSource(uri=":memory:", mirrors=mirrors)
@@ -668,7 +668,7 @@ class SQLAgent(LumenBaseAgent):
         tables_to_source = {}
         for source_table in selected_tables:
             if SOURCE_TABLE_SEPARATOR in source_table:
-                a_source_name, a_table = source_table.split(SOURCE_TABLE_SEPARATOR)
+                a_source_name, a_table = source_table.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)
                 a_source_obj = sources.get(a_source_name)
             else:
                 a_source_obj = next(iter(sources.values()))
@@ -690,7 +690,7 @@ class SQLAgent(LumenBaseAgent):
         for source_table, source in tables_to_source.items():
             # Look up underlying table name
             if SOURCE_TABLE_SEPARATOR in source_table:
-                _, source_table = source_table.split(SOURCE_TABLE_SEPARATOR)
+                _, source_table = source_table.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)
             table_schema = await get_schema(source, source_table, include_count=True)
             table_name = source.normalize_table(source_table)
             if (

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -578,9 +578,9 @@ class SQLAgent(LumenBaseAgent):
                     sql_query = sql_query.replace(a_table, renamed_table)
                 else:
                     renamed_table = a_table
+                # Remove source prefixes from table names
                 if SOURCE_TABLE_SEPARATOR in renamed_table:
-                    # Remove source prefixes from table names
-                    renamed_table = re.sub(rf".*?{SOURCE_TABLE_SEPARATOR}", "", renamed_table)
+                    renamed_table, _ = renamed_table.split(SOURCE_TABLE_SEPARATOR)
                 sql_query = sql_query.replace(a_table, renamed_table)
                 mirrors[renamed_table] = (a_source, renamed_table)
             source = DuckDBSource(uri=":memory:", mirrors=mirrors)
@@ -633,10 +633,13 @@ class SQLAgent(LumenBaseAgent):
             log_debug("\033[91mRetry find_tables\033[0m")
 
         sources = {source.name: source for source in self._memory["sources"]}
-        tables = [
-            f"{SOURCE_TABLE_SEPARATOR}{a_source}{SOURCE_TABLE_SEPARATOR}{a_table}" for a_source in sources.values()
-            for a_table in a_source.get_tables()
-        ]
+        if sources > 1:
+            tables = [
+                f"{a_source}{SOURCE_TABLE_SEPARATOR}{a_table}" for a_source in sources.values()
+                for a_table in a_source.get_tables()
+            ]
+        else:
+            tables = self._memory["sources"][0].get_tables()
         system = await self._render_prompt(
             "find_tables", messages, separator=SOURCE_TABLE_SEPARATOR, tables_schema_str=tables_schema_str
         )
@@ -663,21 +666,15 @@ class SQLAgent(LumenBaseAgent):
             step.success_title = f'Found {len(selected_tables)} relevant table(s)'
 
         tables_to_source = {}
-        pattern = rf"(?:^.*?{SOURCE_TABLE_SEPARATOR})?([^{SOURCE_TABLE_SEPARATOR}]+){SOURCE_TABLE_SEPARATOR}(.+)$"
         for source_table in selected_tables:
             if SOURCE_TABLE_SEPARATOR in source_table:
-                if match := re.match(pattern, source_table):
-                    a_source_name, a_table = match.groups()
-                    a_source_obj = sources.get(a_source_name)
-                    a_table = f"{SOURCE_TABLE_SEPARATOR}{a_source_name}{SOURCE_TABLE_SEPARATOR}{a_table}"
+                a_source_name, _ = source_table.split(SOURCE_TABLE_SEPARATOR)
+                a_source_obj = sources.get(a_source_name)
             else:
                 a_source_obj = next(iter(sources.values()))
                 a_table = source_table
             tables_to_source[a_table] = a_source_obj
         return tables_to_source, chain_of_thought
-
-    def _drop_source_table_separator(self, content: str) -> str:
-        return re.sub(rf".*?{SOURCE_TABLE_SEPARATOR}", "", content)
 
     async def respond(
         self,
@@ -692,7 +689,7 @@ class SQLAgent(LumenBaseAgent):
         tables_sql_schemas = {}
         for source_table, source in tables_to_source.items():
             # Look up underlying table name
-            source_table = self._drop_source_table_separator(source_table)
+            source_table, _ = source_table.split(SOURCE_TABLE_SEPARATOR)
             table_schema = await get_schema(source, source_table, include_count=True)
             table_name = source.normalize_table(source_table)
             if (

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -668,7 +668,7 @@ class SQLAgent(LumenBaseAgent):
         tables_to_source = {}
         for source_table in selected_tables:
             if SOURCE_TABLE_SEPARATOR in source_table:
-                _, a_source_name = source_table.split(SOURCE_TABLE_SEPARATOR)
+                a_source_name, a_table = source_table.split(SOURCE_TABLE_SEPARATOR)
                 a_source_obj = sources.get(a_source_name)
             else:
                 a_source_obj = next(iter(sources.values()))

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -689,7 +689,8 @@ class SQLAgent(LumenBaseAgent):
         tables_sql_schemas = {}
         for source_table, source in tables_to_source.items():
             # Look up underlying table name
-            _, source_table = source_table.split(SOURCE_TABLE_SEPARATOR)
+            if SOURCE_TABLE_SEPARATOR in source_table:
+                _, source_table = source_table.split(SOURCE_TABLE_SEPARATOR)
             table_schema = await get_schema(source, source_table, include_count=True)
             table_name = source.normalize_table(source_table)
             if (

--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -106,8 +106,8 @@ class Join(Analysis):
             agent = next(agent for agent in self.agents if type(agent).__name__ == "SQLAgent")
             content = (
                 "Join these tables: "
-                f"'{SOURCE_TABLE_SEPARATOR}{self._previous_source}{SOURCE_TABLE_SEPARATOR}{self._previous_table}' "
-                f"and '{SOURCE_TABLE_SEPARATOR}{memory['source']}{SOURCE_TABLE_SEPARATOR}{self.table_name}'"
+                f"'{self._previous_source}{SOURCE_TABLE_SEPARATOR}{self._previous_table}' "
+                f"and '{memory['source']}{SOURCE_TABLE_SEPARATOR}{self.table_name}'"
             )
             if self.index_col:
                 content += f" left join on {self.index_col}"

--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -47,7 +47,7 @@ UNRECOVERABLE_ERRORS = (
     asyncio.CancelledError
 )
 
-SOURCE_TABLE_SEPARATOR = ":::"
+SOURCE_TABLE_SEPARATOR = "__@__"
 PROVIDED_SOURCE_NAME = 'ProvidedSource00000'
 
 pn.chat.ChatStep.min_width = 375

--- a/lumen/ai/prompts/SQLAgent/find_tables.jinja2
+++ b/lumen/ai/prompts/SQLAgent/find_tables.jinja2
@@ -1,9 +1,10 @@
 {% extends 'Actor/main.jinja2' %}
 
 {% block instructions %}
-Correctly assess and consider which tables are necessary to answer the user query.
-
+Determine which tables are necessary to answer the user query, paying special attention to the available columns.
+{% if separator %}
 Use table names verbatim, and be sure to include the delimiters {{ separator }}, like '<source>{{ separator }}<table>'
+{% endif %}
 {% endblock %}
 
 {% block context %}

--- a/lumen/ai/prompts/SQLAgent/find_tables.jinja2
+++ b/lumen/ai/prompts/SQLAgent/find_tables.jinja2
@@ -3,7 +3,7 @@
 {% block instructions %}
 Correctly assess and consider which tables are necessary to answer the user query.
 
-Use table names verbatim, and be sure to include the delimiters {{ separator }}, like '{{ separator }}source{{ separator }}table{{ separator }}'
+Use table names verbatim, and be sure to include the delimiters {{ separator }}, like '<source>{{ separator }}<table>'
 {% endblock %}
 
 {% block context %}

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -540,7 +540,7 @@ class ExplorerUI(UI):
                 for t in source_tables:
                     if deduplicate:
                         t = f'{source.name}{SOURCE_TABLE_SEPARATOR}{t}'
-                    if t.rsplit(SOURCE_TABLE_SEPARATOR, 1)[-1] not in source_map and not init and not len(selected) > table_select.max_items and state.loaded:
+                    if t.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)[-1] not in source_map and not init and not len(selected) > table_select.max_items and state.loaded:
                         selected.append(t)
                     new[t] = source
             source_map.clear()
@@ -573,8 +573,8 @@ class ExplorerUI(UI):
                 explorers = []
                 for table in table_select.value:
                     source = source_map[table]
-                    if len(memory['sources']) > 1 and SOURCE_TABLE_SEPARATOR in table:
-                        _, table = table.rsplit(SOURCE_TABLE_SEPARATOR, 1)
+                    if SOURCE_TABLE_SEPARATOR in table:
+                        _, table = table.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)
                     pipeline = Pipeline(
                         source=source, table=table, sql_transforms=[SQLLimit(limit=100_000)]
                     )

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -368,7 +368,7 @@ async def gather_table_sources(sources: list[Source], include_provided: bool = T
             tables_to_source[table] = source
             if source.name == PROVIDED_SOURCE_NAME and not include_provided:
                 continue
-            label = f"{SOURCE_TABLE_SEPARATOR}{source}{SOURCE_TABLE_SEPARATOR}{table}" if include_sep else table
+            label = f"{source}{SOURCE_TABLE_SEPARATOR}{table}" if include_sep else table
             if isinstance(source, DuckDBSource) and source.ephemeral or "Provided" in source.name:
                 sql = source.get_sql_expr(table)
                 schema = await get_schema(source, table, include_enum=True, limit=3)


### PR DESCRIPTION
The logic for source table disambiguation was a little overcomplicated. This PR replaces the previous separator (`:::`) with `__@__` which isn't valid SQL syntax and even if it was has a tiny chance of collision.