### PR TITLE
Fix for single table

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -632,17 +632,12 @@ class SQLAgent(LumenBaseAgent):
             messages = mutate_user_message(content, messages)
             log_debug("\033[91mRetry find_tables\033[0m")
 
+        sep = SOURCE_TABLE_SEPARATOR
         sources = {source.name: source for source in self._memory["sources"]}
-        if len(sources) > 1:
-            tables = [
-                f"{a_source}{SOURCE_TABLE_SEPARATOR}{a_table}" for a_source in sources.values()
-                for a_table in a_source.get_tables()
-            ]
-            sep = SOURCE_TABLE_SEPARATOR
-        else:
-            tables = self._memory["sources"][0].get_tables()
-            sep = None
-
+        tables = [
+            f"{a_source}{sep}{a_table}" for a_source in sources.values()
+            for a_table in a_source.get_tables()
+        ]
         if len(tables) == 1:
             # if only one source and one table, return it directly
             return {tables[0]: next(iter(sources.values()))}, ""

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -710,8 +710,7 @@ class SQLAgent(LumenBaseAgent):
 
         dialect = source.dialect
         try:
-            sql_query = await self._create_valid_sql(
-                messages, dialect, comments, step_title, tables_to_source)
+            sql_query = await self._create_valid_sql(messages, dialect, comments, step_title, tables_to_source)
             pipeline = self._memory['pipeline']
         except RetriesExceededError as e:
             traceback.print_exception(e)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -642,6 +642,11 @@ class SQLAgent(LumenBaseAgent):
         else:
             tables = self._memory["sources"][0].get_tables()
             sep = None
+
+        if len(tables) == 1:
+            # if only one source and one table, return it directly
+            return {tables[0]: next(iter(sources.values()))}, ""
+
         system = await self._render_prompt(
             "find_tables", messages, separator=sep, tables_schema_str=tables_schema_str
         )
@@ -710,7 +715,8 @@ class SQLAgent(LumenBaseAgent):
 
         dialect = source.dialect
         try:
-            sql_query = await self._create_valid_sql(messages, dialect, comments, step_title, tables_to_source)
+            sql_query = await self._create_valid_sql(
+                messages, dialect, comments, step_title, tables_to_source)
             pipeline = self._memory['pipeline']
         except RetriesExceededError as e:
             traceback.print_exception(e)


### PR DESCRIPTION
I was testing with single table but I encountered this issue:
![image](https://github.com/user-attachments/assets/757a7356-7593-4b3e-a04c-03dd16180394)

Stemming from
```
        else:
            tables = self._memory["sources"][0].get_tables()
            sep = None
```

So to fix:
1. Made it consistent; always include source & table (for one source, multi tables)
2. Don't have to call find_tables model if there's only a single table.