### PR TITLE
Fix `read_` regex on export

### DIFF
--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -130,8 +130,8 @@ class DuckDBSource(BaseSQLSource):
         if isinstance(sql_expr, dict):
             return {self._process_sql_paths(k): v for k, v in sql_expr.items()}
 
-        # Look for read_* patterns like read_parquet, read_csv etc.
-        matches = re.finditer(r"read_\w+\('([^']+)'\)", sql_expr)
+        # Look for read_* patterns (case insensitive) like read_parquet, READ_CSV etc.
+        matches = re.finditer(r"(?i)read_\w+\('([^']+)'\)", sql_expr)
         processed_sql = sql_expr
 
         for match in matches:


### PR DESCRIPTION
With the new sqlglot changes, it converted read_csv to READ_CSV

Which caused downloading the file and running the cells to output:
`IOException: IO Error: No files found that match the pattern "passengers.csv"`