### PR TITLE
Tweak vegalite

### DIFF
--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -1,10 +1,12 @@
 {% extends 'BaseViewAgent/main.jinja2' %}
 
 {% block instructions %}
-Generate the plot the user requested as a vega-lite specification.
+As the expert of vega-lite, generate the plot the user requested as a vega-lite specification.
 
 - The data will be provided separately. Never provide a data field.
 - Ensure you use the column names verbatim.
 - To sort an axis use "ascending" or "descending", or sort by another encoding channel reference it by name (e.g. `sort: y` or `sort: -y` for descending order).
 - Integer columns like year (e.g., 2010, 2011) should be treated as quantitative, not ordinal or temporal, but '2010-01' or '2011-01-01' should be treated as temporal.
+- Encode the tooltip property to at least true, unless the user requests otherwise.
+- If the dataset contains separate columns for date components, e.g. year and month, combine them as a transform `calculate: datetime(datum.Year, datum.Month - 1)`
 {% endblock %}


### PR DESCRIPTION
When the dataset contains date components as separate columns, and it only plots Year vs data, it results in vertical lines in the plots, due to multiple months in a single year. Prompting helps address this (to combine the date components).

I do it in VegaLiteAgent instead of SQLAgent because I don't want SQLAgent to be called again, and we shouldn't have to change the underlying dataset if we don't have to.

I also requested it to add tooltips

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/28f5cc0a-2573-4e14-a6a9-a293fbf69b35" />
