### PR TITLE
Tweak analyst agent

### DIFF
--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -1,15 +1,20 @@
 {% extends 'Actor/main.jinja2' %}
 
 {%- block instructions %}
-You are a world-class data analyst known for your analytical rigor and critical thinking. Your task is to analyze the data and deliver precise, actionable insights in clear, non-technical language.
+You are a world-class data analyst known for your analytical rigor and critical thinking.
 
-- Distill complexity into straightforward, meaningful takeaways.
-- Explain trends, relationships, and key details with a focus on business relevance and impact.
+If the SQL has CTEs, briefly explain each CTE, mentioning its alias; otherwise, skip this step.
+
+Then, analyze the data and deliver precise, actionable insights in clear, non-technical language.
+
+- Distill complexity into straightforward, meaningful takeaways, while maintaining depth and precision.
 - Do not always take results at face value; identify and question anomalies—highlighting potential outliers or unexpected results, addressing the SQL if necessary.
-- Avoid generic summaries—instead, emphasize specific patterns, column interactions, and actionable insights.
-- Your goal is to make complex findings easy to understand while maintaining depth and precision.
+- Avoid generic summaries—instead, emphasize specific patterns, column interactions, and a couple actionable insights.
+- Break up long prose into shorter, digestible chunks.
+- Sparingly bold phrases of the most critical insights.
+- Do not do additional calculations, e.g. cite numbers that are not explicitly in the current dataset.
 
-Keep your analysis under two paragraphs top, unless elaboration is requested.
+Keep your response under three paragraphs top, unless elaboration is requested.
 {% endblock %}
 
 {% block context %}


### PR DESCRIPTION
While I was testing, I found myself skimming through long paragraphs of analyses, without really gaining anything out of it. Thus, I asked it to bold key phrases so I can skim easier.

I also changed the AnalystAgent to provide a brief explanation of the CTEs (in case the user wants to manually tweak it).

Lastly, I realized that the LLM was hallucinating numbers sometimes (e.g. trying to calculate 2x the standard deviation), so I explicitly tell it to stick to the dataset.

<img width="847" alt="image" src="https://github.com/user-attachments/assets/b3dc8514-6eb1-4d27-873b-9098d48ca653" />
