### PR TITLE
Fix VegaLite retry by moving the log outside

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -771,6 +771,7 @@ class BaseViewAgent(LumenBaseAgent):
             model_spec=model_spec,
             response_model=self._get_model("main", schema=schema),
         )
+        spec = ""
         with self.interface.add_step(
             title=step_title or "Generating view...",
             steps_layout=self._steps_layout
@@ -780,6 +781,8 @@ class BaseViewAgent(LumenBaseAgent):
                 step.stream(chain_of_thought, replace=True)
             self._last_output = dict(output)
             spec = await self._extract_spec(self._last_output)
+        if not spec:
+            raise ValueError(f"{self._last_output} is invalid.")
         return spec
 
     async def _extract_spec(self, spec: dict[str, Any]):

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -771,7 +771,6 @@ class BaseViewAgent(LumenBaseAgent):
             model_spec=model_spec,
             response_model=self._get_model("main", schema=schema),
         )
-        spec = ""
         error = ""
         with self.interface.add_step(
             title=step_title or "Generating view...",
@@ -788,6 +787,7 @@ class BaseViewAgent(LumenBaseAgent):
                 report_error(e, step)
         if error:
             raise ValueError(error)
+        log_debug(f"{self.name} settled on spec: {spec!r}.")
         return spec
 
     async def _extract_spec(self, spec: dict[str, Any]):
@@ -823,7 +823,6 @@ class BaseViewAgent(LumenBaseAgent):
             doc=doc,
         )
         spec = await self._create_valid_spec(messages, system_prompt, schema, step_title)
-        log_debug(f"{self.name} settled on spec: {spec!r}.")
         self._memory["view"] = dict(spec, type=self.view_type)
         view = self.view_type(pipeline=pipeline, **spec)
         self._render_lumen(view, messages=messages, render_output=render_output, title=step_title)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -898,11 +898,7 @@ class VegaLiteAgent(BaseViewAgent):
     _output_type = VegaLiteOutput
 
     async def _update_spec(self, memory: _Memory, event: param.parameterized.Event):
-        try:
-            spec = await self._extract_spec({"yaml_spec": event.new})
-        except Exception as e:
-            traceback.print_exception(e)
-            return
+        spec = await self._extract_spec({"yaml_spec": event.new})
         memory['view'] = dict(spec, type=self.view_type)
 
     async def _extract_spec(self, spec: dict[str, Any]):


### PR DESCRIPTION
Because of https://github.com/holoviz/lumen/pull/1063/files

The retry was getting wrong exception summaries:
"""
Your task is to expertly revise these errors:
```
cannot access local variable 'spec' where it is not associated with a value
cannot access local variable 'spec' where it is not associated with a value
```
"""

Rather than this:
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/b5542aab-85e8-4737-b5aa-af854ddacbd7" />

I think the reason was because the ChatStep context manager suppressed the error from being raised, so it was able to continue to the next line.

<img width="939" alt="image" src="https://github.com/user-attachments/assets/1f6ba53a-bdf3-4d1e-b9d6-3a66f5d02cd6" />

So we need to do something like SQLAgent:
```

        try:
            df = await get_data(pipeline)
        except Exception as e:
            source._connection.execute(f'DROP TABLE IF EXISTS "{expr_slug}"')
            report_error(e, step)
            raise e
```