### PR TITLE
Propagate tool context

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -272,7 +272,6 @@ class ChatAgent(Agent):
                 for table in self._memory["closest_tables"] if table in source_tables
             ]
             context["tables_schemas"] = list(zip(self._memory["closest_tables"], schemas))
-        print(messages, "MESSAGES...")
         system_prompt = await self._render_prompt("main", messages, **context)
         return await self._stream(messages, system_prompt)
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -272,6 +272,7 @@ class ChatAgent(Agent):
                 for table in self._memory["closest_tables"] if table in source_tables
             ]
             context["tables_schemas"] = list(zip(self._memory["closest_tables"], schemas))
+        print(messages, "MESSAGES...")
         system_prompt = await self._render_prompt("main", messages, **context)
         return await self._stream(messages, system_prompt)
 


### PR DESCRIPTION
While testing tools, I noticed that the Planner saw the tool output:  

> *The user requested information about Kern County from Wikipedia. Since this data was already retrieved, I can summarize key details without another lookup.*  

However, the subsequent agent did not:  

> *I cannot look up external sources like Wikipedia directly...*  

To address this, I included the tool output in the user message.

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/0cf447f5-e766-4748-bd28-089193380405" />

The downside is that if a tool is meant only for planning, it wastes tokens downstream. Should tools have a `coordinator_only` flag? Open to feedback.

---

## Examples:

Before:
<img width="604" alt="image" src="https://github.com/user-attachments/assets/ab5b5294-9e71-4a2d-aa9f-2778d8958381" />

After:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/0311a077-9a76-4ca4-9516-a31228a78107" />
