### PR TITLE
Rename to ChatLogs to ChatTelemetry

### DIFF
--- a/lumen/ai/telemetry.py
+++ b/lumen/ai/telemetry.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from lumen.ai.coordinator import Coordinator
 
 
-class ChatLogs(param.Parameterized):
+class ChatTelemetry(param.Parameterized):
     """A class for managing and storing chat message logs in SQLite.
 
     The class handles storage, retrieval, and versioning of chat messages,
@@ -27,7 +27,7 @@ class ChatLogs(param.Parameterized):
     LLM configurations, agents, coordinators, and sessions.
     """
 
-    filename: str = param.String(default="lumen_chat_logs.db")
+    filename: str = param.String(default="lumen_telemetry.db")
 
     def __init__(self, **params) -> None:
         super().__init__(**params)

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -196,7 +196,7 @@ class LumenOutput(Viewer):
             self._last_output[self.spec] = output
             yield output
 
-            self.interface._logs.update_retry(
+            self.interface._telemetry.update_retry(
                 message_id=str(id(self.parent_message)),
                 message=self.parent_message
             )
@@ -355,7 +355,7 @@ class SQLOutput(LumenOutput):
             self._last_output[self.spec] = output
             yield output
 
-            self.interface._logs.update_retry(
+            self.interface._telemetry.update_retry(
                 message_id=str(id(self.parent_message)),
                 message=self.parent_message
             )


### PR DESCRIPTION
I think ChatLogs is a bit ambiguous, easily confused with logging. It might be more appropriate to rename it to ChatTelemetry, but it's a breaking change.