### PR TITLE
Add Source.get_metadata

### DIFF
--- a/doc/lumen_ai/how_to/template_prompts.md
+++ b/doc/lumen_ai/how_to/template_prompts.md
@@ -37,7 +37,7 @@ The base system prompt template follows this format:
 For example, the `ChatAgent`'s prompt template uses `instructions` and `context`:
 
 ```jinja2
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {% block instructions %}
 Act as a helpful assistant for high-level data exploration, focusing on available datasets and, only if data is
@@ -84,7 +84,7 @@ ui = lmai.ExplorerUI(agents=agents)
 This will result in the following prompt template:
 
 ```jinja2
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {% block instructions %}
 Act like the user's meteorologist, and explain jargon in the format of a weather report.
@@ -168,7 +168,7 @@ ui = lmai.ExplorerUI(agents=agents)
 Which produces the following prompt template:
 
 ```jinja2
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {% block instructions %}
 Speak like a pirate.

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -114,7 +114,7 @@ class Actor(param.Parameterized):
                 with tool.param.update(memory=self.memory):
                     tool_context = await tool.respond(messages)
                     if tool_context:
-                        tools_context += f"\n\n{tool_context}"
+                        tools_context += f"\n{tool_context}"
         return tools_context
 
     async def _render_prompt(self, prompt_name: str, messages: list[Message], **context) -> str:

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -652,11 +652,7 @@ class SQLAgent(LumenBaseAgent):
             log_debug("\033[91mRetry find_tables\033[0m")
 
         sources = {source.name: source for source in self._memory["sources"]}
-        tables = [
-            f"{a_source}{SOURCE_TABLE_SEPARATOR}{a_table}" if SOURCE_TABLE_SEPARATOR not in a_table else a_table
-            for a_source in sources.values()
-            for a_table in self._memory.get("closest_tables", a_source.get_tables()[:5])
-        ]
+        tables = self._memory.get("closest_tables", next(iter(sources)).get_tables()[:5])
         if len(tables) > 1:
             system = await self._render_prompt(
                 "find_tables", messages, separator=SOURCE_TABLE_SEPARATOR

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -370,6 +370,8 @@ class TableListAgent(ListAgent):
         return len(source.get_tables()) > 1
 
     def _get_items(self) -> list[str]:
+        if "closest_tables" in self._memory:
+            return self._memory["closest_tables"]
         tables = []
         for source in self._memory["sources"]:
             tables += source.get_tables()

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -37,12 +37,11 @@ from .memory import _Memory
 from .models import (
     PartialBaseModel, RetrySpec, Sql, VegaLiteSpec, make_tables_model,
 )
-from .tools import DocumentLookup, TableLookup
+from .tools import DocumentLookup
 from .translate import param_to_pydantic
 from .utils import (
-    clean_sql, describe_data, gather_table_sources, get_data, get_pipeline,
-    get_schema, load_json, log_debug, mutate_user_message, report_error,
-    retry_llm_output,
+    clean_sql, describe_data, get_data, get_pipeline, get_schema, load_json,
+    log_debug, mutate_user_message, report_error, retry_llm_output,
 )
 from .views import (
     AnalysisOutput, LumenOutput, SQLOutput, VegaLiteOutput,
@@ -243,7 +242,7 @@ class ChatAgent(Agent):
         default={
             "main": {
                 "template": PROMPTS_DIR / "ChatAgent" / "main.jinja2",
-                "tools": [TableLookup, DocumentLookup]
+                "tools": [DocumentLookup]
             },
         }
     )
@@ -257,21 +256,6 @@ class ChatAgent(Agent):
         step_title: str | None = None,
     ) -> Any:
         context = {"tool_context": await self._use_tools("main", messages)}
-        table = self._memory.get("table")
-        source = self._memory.get("source")
-        source_tables = source.get_tables() if source else []
-        if table:
-            schema = await get_schema(source, table, include_count=True, limit=1000)
-            context["table"] = table
-            context["schema"] = schema
-        elif "closest_tables" in self._memory and any(
-            table for table in self._memory["closest_tables"] if table in source_tables
-        ):
-            schemas = [
-                await get_schema(source, table, include_count=True, limit=1000)
-                for table in self._memory["closest_tables"] if table in source_tables
-            ]
-            context["tables_schemas"] = list(zip(self._memory["closest_tables"], schemas))
         system_prompt = await self._render_prompt("main", messages, **context)
         return await self._stream(messages, system_prompt)
 
@@ -522,7 +506,7 @@ class SQLAgent(LumenBaseAgent):
 
     provides = param.List(default=["table", "sql", "pipeline", "data", "tables_sql_schemas"], readonly=True)
 
-    requires = param.List(default=["source"], readonly=True)
+    requires = param.List(default=["source", "closest_tables"], readonly=True)
 
     _extensions = ('codeeditor', 'tabulator',)
 
@@ -655,7 +639,7 @@ class SQLAgent(LumenBaseAgent):
         memory['sql'] = event.new
 
     @retry_llm_output()
-    async def _find_tables(self, messages: list[Message], tables_schema_str: str, errors: list | None = None) -> tuple[dict[str, BaseSQLSource], str]:
+    async def _find_tables(self, messages: list[Message], errors: list | None = None) -> tuple[dict[str, BaseSQLSource], str]:
         if errors:
             last_content = self.interface.objects[-1].object[-1][-1].object
             chain_of_thought = last_content.split("```")[0]
@@ -666,18 +650,17 @@ class SQLAgent(LumenBaseAgent):
             messages = mutate_user_message(content, messages)
             log_debug("\033[91mRetry find_tables\033[0m")
 
-        sep = SOURCE_TABLE_SEPARATOR
         sources = {source.name: source for source in self._memory["sources"]}
         tables = [
-            f"{a_source}{sep}{a_table}" for a_source in sources.values()
-            for a_table in a_source.get_tables()
+            f"{a_source}{SOURCE_TABLE_SEPARATOR}{a_table}" for a_source in sources.values()
+            for a_table in self._memory["closest_tables"]
         ]
         if len(tables) == 1:
             # if only one source and one table, return it directly
             return {tables[0]: next(iter(sources.values()))}, ""
 
         system = await self._render_prompt(
-            "find_tables", messages, separator=sep, tables_schema_str=tables_schema_str
+            "find_tables", messages, separator=SOURCE_TABLE_SEPARATOR
         )
         tables_model = self._get_model("find_tables", tables=tables)
         model_spec = self.prompts["find_tables"].get("llm_spec", self.llm_spec_key)
@@ -718,10 +701,7 @@ class SQLAgent(LumenBaseAgent):
         render_output: bool = False,
         step_title: str | None = None,
     ) -> Any:
-        sources = self._memory["sources"]
-        tables_to_source, tables_schema_str = await gather_table_sources(sources, include_sep=True)
-        tables_to_source, comments = await self._find_tables(messages, tables_schema_str)
-
+        tables_to_source, comments = await self._find_tables(messages)
         tables_sql_schemas = {}
         for source_table, source in tables_to_source.items():
             # Look up underlying table name

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -716,7 +716,7 @@ class SQLAgent(LumenBaseAgent):
             tables_sql_schemas[table_name] = {
                 "schema": yaml.dump(table_schema),
                 "sql": source.get_sql_expr(source_table),
-                "source": source,
+                "source": source.name,
             }
         self._memory["tables_sql_schemas"] = tables_sql_schemas
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -716,6 +716,7 @@ class SQLAgent(LumenBaseAgent):
             tables_sql_schemas[table_name] = {
                 "schema": yaml.dump(table_schema),
                 "sql": source.get_sql_expr(source_table),
+                "source": source,
             }
         self._memory["tables_sql_schemas"] = tables_sql_schemas
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -652,7 +652,7 @@ class SQLAgent(LumenBaseAgent):
             log_debug("\033[91mRetry find_tables\033[0m")
 
         sources = {source.name: source for source in self._memory["sources"]}
-        tables = self._memory.get("closest_tables", next(iter(sources)).get_tables()[:5])
+        tables = self._memory.get("closest_tables", next(iter(sources.values())).get_tables()[:5])
         if len(tables) > 1:
             system = await self._render_prompt(
                 "find_tables", messages, separator=SOURCE_TABLE_SEPARATOR

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -672,7 +672,7 @@ class SQLAgent(LumenBaseAgent):
                     if output.potential_join_issues is not None:
                         chain_of_thought += output.potential_join_issues
                     if selected_tables is not None:
-                        chain_of_thought = chain_of_thought + f"\n\nRelevant tables: {selected_tables}"
+                        chain_of_thought = chain_of_thought + f"\n\nRelevant tables: `{'` '.join(selected_tables)}`"
                     step.stream(
                         f'{chain_of_thought}',
                         replace=True
@@ -702,6 +702,7 @@ class SQLAgent(LumenBaseAgent):
                 _, source_table = source_table.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)
             table_schema = await get_schema(source, source_table, include_count=True)
             table_name = source.normalize_table(source_table)
+            table_slug = f"{source.name}{SOURCE_TABLE_SEPARATOR}{table_name}"
             if (
                 'tables' in source.param and
                 isinstance(source.tables, dict) and
@@ -709,7 +710,7 @@ class SQLAgent(LumenBaseAgent):
             ):
                 table_name = source.tables[table_name]
 
-            tables_sql_schemas[table_name] = {
+            tables_sql_schemas[table_slug] = {
                 "schema": yaml.dump(table_schema),
                 "sql": source.get_sql_expr(source_table),
                 "source": source.name,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -671,9 +671,10 @@ class Planner(Coordinator):
                     tables_sql_schemas[normalized_table_name] = {
                         "schema": yaml.dump(table_schema),
                         "sql": source_obj.get_sql_expr(table_name),
+                        "source": source_obj.name,
                     }
                     examined_tables.add(source_table)
-                    step.stream(f"Added schema for {normalized_table_name}", replace=False)
+                    step.stream(f"\n\nAdded schema for {normalized_table_name}", replace=False)
 
                 system = await self._render_prompt(
                     "table_selection",
@@ -698,7 +699,7 @@ class Planner(Coordinator):
                     chain_of_thought = output.chain_of_thought or ""
                     step.stream(chain_of_thought, replace=True)
                 selected_tables = output.selected_tables or []
-                step.stream(f"\nSelected tables: {', '.join(selected_tables)}", replace=False)
+                step.stream(f"\n\nSelected tables: `{'`, `'.join(selected_tables)}`", replace=False)
                 satisfied = output.is_satisfied or not available_tables
                 closest_tables = []
                 if satisfied:
@@ -788,13 +789,14 @@ class Planner(Coordinator):
         step: ChatStep,
     ) -> BaseModel:
         tools = await self._get_tools_context(messages)
+        print(tools)
         reasoning = None
         while reasoning is None:
             system = await self._render_prompt(
                 "main",
                 messages,
                 agents=list(agents.values()),
-                tools=[tool for tool in tools],
+                tools=list(tools),
                 unmet_dependencies=unmet_dependencies,
                 candidates=[agent for agent in agents.values() if not unmet_dependencies or set(agent.provides) & unmet_dependencies],
                 previous_plans=previous_plans,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -701,7 +701,7 @@ class Planner(Coordinator):
                             reverse=True
                         )[:5]
                         step.stream(
-                            f"\n\nSelected tables: `{'`, `'.join(selected_tables)}` based on a similarity "
+                            f"\n\nSelected tables: `{'`\n- `'.join(selected_tables)}` based on a similarity "
                             f"thresold of {self.table_similarity_threshold}", replace=False)
                         fast_track = True
                     else:
@@ -742,8 +742,9 @@ class Planner(Coordinator):
                     response_model=tables_model,
                 )
                 async for output in response:
+                    # the entire string comes out all at once; no point in streaming to step
                     chain_of_thought = output.chain_of_thought or ""
-                    step.stream(chain_of_thought, replace=True)
+                step.stream(chain_of_thought, replace=False)
 
                 selected_tables = output.selected_tables or []
                 step.stream(f"\n\nSelected tables: `{'`, `'.join(selected_tables)}`", replace=False)
@@ -795,8 +796,8 @@ class Planner(Coordinator):
                 max_retries=3,
             )
             async for output in response:
-                if output.chain_of_thought:
-                    step.stream(output.chain_of_thought, replace=True)
+                chain_of_thought = output.chain_of_thought or ""
+            step.stream(chain_of_thought, replace=False)
 
             if not output.needs_lookup:
                 return tools.values()

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -201,10 +201,7 @@ class Coordinator(Viewer, Actor):
             elif isinstance(tool, FunctionType):
                 self._tools["__main__"].append(FunctionTool(tool, llm=llm))
             else:
-                tool_kwargs = {}
-                if tool is TableLookup:
-                    tool_kwargs["n"] = 10
-                self._tools["__main__"].append(tool(llm=llm, **tool_kwargs))
+                self._tools["__main__"].append(tool(llm=llm))
 
         interface.send(
             "Welcome to LumenAI; get started by clicking a suggestion or type your own query below!",
@@ -700,9 +697,11 @@ class Planner(Coordinator):
                             key=lambda x: table_similarities[x],
                             reverse=True
                         )[:5]
+                        table_list = '`\n- `'.join(selected_tables)
                         step.stream(
-                            f"\n\nSelected tables: `{'`\n- `'.join(selected_tables)}` based on a similarity "
-                            f"thresold of {self.table_similarity_threshold}", replace=False)
+                            f"\n\nSelected tables: `{table_list}`\nbased on a similarity threshold of {self.table_similarity_threshold}",
+                            replace=False
+                        )
                         fast_track = True
                     else:
                         # If not, select the top 3 tables to examine

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -642,8 +642,9 @@ class Planner(Coordinator):
         )
         current_query = "\n".join(message["content"] for message in messages)
 
+        selected_tables = None
         for iteration in range(1, max_iterations + 1):
-            iteration += 1
+            # Don't increment iteration since we're using the for loop counter
             with self.interface.add_step(
                 title=f"Iterative table selection ({iteration} / {max_iterations})",
                 user="Assistant",
@@ -658,8 +659,10 @@ class Planner(Coordinator):
                     step.stream("\nNo more tables available to examine")
                     break
 
+                # For the first iteration, select the top 3 tables to examine
+                # For subsequent iterations, the LLM selects tables in the previous iteration
                 if iteration == 1:
-                    selected_tables = available_tables[:3]  # start with a couple
+                    selected_tables = available_tables[:3]
 
                 step.stream(f"\n\nGathering complete schema information for {len(selected_tables)} tables...")
                 for source_table in selected_tables:

--- a/lumen/ai/embeddings.py
+++ b/lumen/ai/embeddings.py
@@ -83,7 +83,7 @@ class AzureOpenAIEmbeddings(Embeddings):
         return [r.embedding for r in response.data]
 
 
-class HuggingFaceEmbeddings:
+class HuggingFaceEmbeddings(Embeddings):
 
     device = param.String(default="cpu", doc="Device to run the model on (e.g., 'cpu' or 'cuda').")
 

--- a/lumen/ai/embeddings.py
+++ b/lumen/ai/embeddings.py
@@ -35,7 +35,7 @@ class NumpyEmbeddings(Embeddings):
 
     def __init__(self, **params):
         super().__init__(**params)
-        self._projection = np.random.Generator(np.random.PCG64).normal(
+        self._projection = np.random.Generator(np.random.PCG64()).normal(
             0, 1, (self.vocab_size, self.embedding_dim)
         )
 

--- a/lumen/ai/embeddings.py
+++ b/lumen/ai/embeddings.py
@@ -13,8 +13,31 @@ class Embeddings(param.Parameterized):
 
 
 class NumpyEmbeddings(Embeddings):
+    """
+    NumpyEmbeddings is a simple embeddings class that uses a hash function
+    to map n-grams to the vocabulary.
 
-    vocab_size = param.Integer(default=1536, doc="The size of the vocabulary.")
+    Note that the default hash function is not stable across different Python
+    sessions. If you need a stable hash function, you can set the `hash_func`,
+    e.g. using murmurhash from the `mmh3` package.
+
+    :Example:
+    >>> embeddings = NumpyEmbeddings()
+    >>> embeddings.embed(["Hello, world!", "Goodbye, world!"])
+    """
+
+    hash_func = param.Callable(default=hash, doc="""
+        The hashing function to use to map n-grams to the vocabulary.""")
+
+    embedding_dim = param.Integer(default=256, doc="The size of the embedding vector")
+
+    vocab_size = param.Integer(default=5000, doc="The size of the vocabulary.")
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        self._projection = np.random.Generator(np.random.PCG64).normal(
+            0, 1, (self.vocab_size, self.embedding_dim)
+        )
 
     def get_char_ngrams(self, text, n=3):
         text = re.sub(r"\W+", "", text.lower())
@@ -25,17 +48,27 @@ class NumpyEmbeddings(Embeddings):
         for text in texts:
             ngrams = self.get_char_ngrams(text)
             vector = np.zeros(self.vocab_size)
+
             for ngram in ngrams:
-                index = hash(ngram) % self.vocab_size
+                index = self.hash_func(ngram) % self.vocab_size
                 vector[index] += 1
-            norm = np.linalg.norm(vector)
+
+            dense_vector = np.dot(vector, self._projection)
+            norm = np.linalg.norm(dense_vector)
             if norm > 0:
-                vector = vector / norm
-            embeddings.append(vector.tolist())
+                dense_vector /= norm
+            embeddings.append(dense_vector.tolist())
         return embeddings
 
 
 class OpenAIEmbeddings(Embeddings):
+    """
+    OpenAIEmbeddings is an embeddings class that uses the OpenAI API to generate embeddings.
+
+    :Example:
+    >>> embeddings = OpenAIEmbeddings()
+    >>> embeddings.embed(["Hello, world!", "Goodbye, world!"])
+    """
 
     api_key = param.String(doc="The OpenAI API key.")
 
@@ -56,7 +89,13 @@ class OpenAIEmbeddings(Embeddings):
 
 
 class AzureOpenAIEmbeddings(Embeddings):
+    """
+    AzureOpenAIEmbeddings is an embeddings class that uses the Azure OpenAI API to generate embeddings.
 
+    :Example:
+    >>> embeddings = AzureOpenAIEmbeddings()
+    >>> embeddings.embed(["Hello, world!", "Goodbye, world!"])
+    """
     api_key = param.String(doc="The Azure API key.")
 
     api_version = param.String(doc="The Azure AI Studio API version.")
@@ -84,7 +123,14 @@ class AzureOpenAIEmbeddings(Embeddings):
 
 
 class HuggingFaceEmbeddings(Embeddings):
+    """
+    HuggingFaceEmbeddings is an embeddings class that uses sentence-transformers plus
+    a tokenizer model downloaded from Hugging Face to generate embeddings.
 
+    :Example:
+    >>> embeddings = HuggingFaceEmbeddings()
+    >>> embeddings.embed(["Hello, world!", "Goodbye, world!"])
+    """
     device = param.String(default="cpu", doc="Device to run the model on (e.g., 'cpu' or 'cuda').")
 
     model = param.String(default="sentence-transformers/all-MiniLM-L6-v2", doc="""
@@ -95,6 +141,7 @@ class HuggingFaceEmbeddings(Embeddings):
         from transformers import AutoModel, AutoTokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(self.model)
         self._model = AutoModel.from_pretrained(self.model).to(self.device)
+        self.embedding_dim = self._model.config.hidden_size
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         import torch

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -57,26 +57,28 @@ class RetrySpec(BaseModel):
     )
 
 
-def make_context_model(tools: list[str], tables: list[str]):
+def make_context_model(tools: list[str], required_tools: list[str]):
     fields = {}
-    if tables:
-        fields['tables'] = (
-            list[Literal[tuple(tables)]],
-            FieldInfo(
-                description="A list of the most relevant tables to explore and load into memory before coming up with a plan. Choose at most three tables. NOTE: Simple queries asking to list the tables/datasets do not require loading the tables. Table names MUST match verbatim including the quotations, apostrophes, periods, or lack thereof."
-            )
-        )
     if tools:
         tool = create_model(
             "Tool",
             name=(Literal[tuple(tools)], FieldInfo(description="The name of the tool.")),
             instruction=(str, FieldInfo(description="Instructions for the tool.")),
         )
-        fields['tools'] = tools=(
+        description = (
+            "A list of tools to call to provide context before launching into the planning stage."
+            "Use tools to gather additional context or clarification, tools should NEVER be used"
+            "to obtain the actual data you will be working with."
+        )
+        if required_tools:
+            description += f" You must include these required tools: {', '.join(required_tools)}"
+        fields["chain_of_thought"] = (
+            str,
+            FieldInfo(description="Explain what tool you'll choose to use based on user query.")
+        )
+        fields['tools'] = (
             list[tool],
-            FieldInfo(
-                description="A list of tools to call to provide context before launching into the planning stage. Use tools to gather additional context or clarification, tools should NEVER be used to obtain the actual data you will be working with."
-            )
+            FieldInfo(description=description)
         )
     return create_model("Context", __base__=PartialBaseModel, **fields)
 
@@ -163,3 +165,61 @@ def make_tables_model(tables):
         __base__=PartialBaseModel
     )
     return table_model
+
+
+def make_coordinator_tables_model(tables):
+    """
+    Creates a model for table selection in the coordinator.
+    This is separate from the SQLAgent's table selection model to focus on context gathering
+    rather than query execution.
+    """
+    table_model = create_model(
+        "CoordinatorTable",
+        chain_of_thought=(str, FieldInfo(
+            description="""
+            Consider which tables would provide the most relevant context for understanding the user query.
+            Think about what information would help you better understand the domain and data relationships.
+            """
+        )),
+        is_satisfied=(bool, FieldInfo(
+            description="""
+            Indicate whether you have sufficient context about the available data structures.
+            Set to True if you understand enough about the data model to proceed with the query.
+            Set to False if you need to examine additional tables to better understand the domain.
+            """
+        )),
+        selected_tables=(list[Literal[tuple(tables)]], FieldInfo(
+            description="""
+            If is satisfied is True, return the closest tables that are most relevant to the user query.
+            If is satisfied is False, return a list of table names that you believe would provide
+            the most relevant context for understanding the user query.
+            Focus on tables that contain key entities, relationships, or metrics mentioned in the query.
+            """
+        )),
+        __base__=PartialBaseModel
+    )
+    return table_model
+
+
+def make_refined_query_model(item_type_name: str = "items"):
+    """
+    Creates a model for refining search queries in vector lookup tools.
+    """
+    return create_model(
+        "RefinedQuery",
+        chain_of_thought=(str, Field(
+            description=f"""
+            Analyze the current search results for {item_type_name}. Consider whether the terms used
+            in the query match the terms that might be found in {item_type_name} names and descriptions.
+            Think about more specific or alternative terms that might yield better results.
+            """
+        )),
+        refined_search_query=(str, Field(
+            description=f"""
+            A refined search query that would help find more relevant {item_type_name}.
+            This should be a focused query with specific terms, entities, or concepts
+            that might appear in relevant {item_type_name}.
+            """
+        )),
+        __base__=PartialBaseModel
+    )

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -190,8 +190,9 @@ def make_coordinator_tables_model(tables):
         )),
         selected_tables=(list[Literal[tuple(tables)]], FieldInfo(
             description="""
-            If is satisfied is True, return the closest tables that are most relevant to the user query.
-            If is satisfied is False, return a list of table names that you believe would provide
+            If is satisfied is True, return the closest tables that are most relevant to the user query,
+            which can be one or more tables. If is satisfied is False,
+            return a list of table names that you believe would provide
             the most relevant context for understanding the user query.
             Focus on tables that contain key entities, relationships, or metrics mentioned in the query.
             """

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -16,9 +16,9 @@ class Sql(BaseModel):
     chain_of_thought: str = Field(
         description="""
         You are a world-class SQL expert, and your fame is on the line so don't mess up.
-        If it's simple, just provide one step. However, if applicable, be sure to carefully
-        study the schema, discuss the values in the columns, and whether you need to
-        wrangle the data before you can use it, before finally writing a correct and valid
+        If it's simple, give at max one sentence about using `SELECT * FROM ...`.
+        However, if applicable, be sure to carefully study the schema, discuss the values in the columns,
+        and whether you need to wrangle the data before you can use it, before finally writing a correct and valid
         SQL query that fully answers the user's query. If using CTEs, comment on the purpose of each.
         Everything should be made as simple as possible, but no simpler.
         """

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -75,15 +75,11 @@ def make_context_model(tools: list[str], required_tools: list[str]):
             )
             )
         )
-        fields["is_asking_availability"] = (
-            bool,
-            FieldInfo(description="Whether the user is asking what tables are available.")
-        )
-
         description = (
             "A list of tools to call to provide context before launching into the planning stage."
             "Use tools to gather additional context or clarification, tools should NEVER be used"
-            "to obtain the actual data you will be working with. Empty if the user query is asking for availability"
+            "to obtain the actual data you will be working with. "
+            "Empty if the user query is asking for availability or if you have enough context to proceed."
         )
         if required_tools:
             description += f" You must include these required tools: {', '.join(required_tools)}"

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -65,17 +65,28 @@ def make_context_model(tools: list[str], required_tools: list[str]):
             name=(Literal[tuple(tools)], FieldInfo(description="The name of the tool.")),
             instruction=(str, FieldInfo(description="Instructions for the tool.")),
         )
+        fields["chain_of_thought"] = (
+            str,
+            FieldInfo(
+            description=(
+                "Explain what tool you'll choose to use based on user query. "
+                "If the user is asking for availability about tables, no tools are needed "
+                "because you'll use TableListAgent."
+            )
+            )
+        )
+        fields["is_asking_availability"] = (
+            bool,
+            FieldInfo(description="Whether the user is asking what tables are available.")
+        )
+
         description = (
             "A list of tools to call to provide context before launching into the planning stage."
             "Use tools to gather additional context or clarification, tools should NEVER be used"
-            "to obtain the actual data you will be working with."
+            "to obtain the actual data you will be working with. Empty if the user query is asking for availability"
         )
         if required_tools:
             description += f" You must include these required tools: {', '.join(required_tools)}"
-        fields["chain_of_thought"] = (
-            str,
-            FieldInfo(description="Explain what tool you'll choose to use based on user query.")
-        )
         fields['tools'] = (
             list[tool],
             FieldInfo(description=description)

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -197,10 +197,10 @@ def make_coordinator_tables_model(tables):
         )),
         selected_tables=(list[Literal[tuple(tables)]], FieldInfo(
             description="""
-            If is satisfied is True, return the closest tables that are most relevant to the user query,
-            which can be one or more tables. If is satisfied is False,
-            return a list of table names that you believe would provide
-            the most relevant context for understanding the user query.
+            If is_satisfied and a join is necessary, return a list of table names that will be used in the join.
+            If is_satisfied and no join is necessary, return a list of a single table name.
+            If not is_satisfied return a list of table names that you believe would provide
+            the most relevant context for understanding the user query that wasn't already seen before.
             Focus on tables that contain key entities, relationships, or metrics mentioned in the query.
             """
         )),

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -192,6 +192,7 @@ def make_coordinator_tables_model(tables):
             description="""
             Consider which tables would provide the most relevant context for understanding the user query.
             Think about what information would help you better understand the domain and data relationships.
+            Please be as concise as possible.
             """
         )),
         is_satisfied=(bool, FieldInfo(

--- a/lumen/ai/prompts/Actor/main.jinja2
+++ b/lumen/ai/prompts/Actor/main.jinja2
@@ -2,15 +2,14 @@
 {%- endblock -%}
 
 {%- block context -%}
-{%- endblock -%}
+{%- endblock %}
 
 {% block tools -%}
-{%- if 'tool_context' in memory -%}
+{%- if 'tools_context' in memory %}
 {#- Context from Coordinator.tools -#}
-{{ memory["tool_context"] }}
-{%- endif -%}
-{%- if tool_context is defined -%}
-{{ tool_context }}
+{% for key, value in memory["tools_context"].items() %}
+`{{ key }}`: {{ value }}
+{% endfor %}
 {% endif -%}
 {%- endblock -%}
 

--- a/lumen/ai/prompts/Agent/main.jinja2
+++ b/lumen/ai/prompts/Agent/main.jinja2
@@ -1,0 +1,9 @@
+{% extends 'Actor/main.jinja2' %}
+
+{% block tools -%}
+{{ super() }}
+{%- if tool_context is defined -%}
+{# Context from agent #}
+{{ tool_context }}
+{% endif -%}
+{%- endblock -%}

--- a/lumen/ai/prompts/AnalysisAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalysisAgent/main.jinja2
@@ -1,4 +1,4 @@
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {%- block instructions -%}
 You are responsible for selecting the appropriate analysis to perform on the data based on the user's query and the available data.

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -1,7 +1,7 @@
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {%- block instructions %}
-You are a world-class data analyst known for your analytical rigor and critical thinking.
+You are a world-class data AnalystAgent known for your analytical rigor and critical thinking.
 
 If the SQL has CTEs, briefly explain each CTE, mentioning its alias; otherwise, skip this step.
 
@@ -27,14 +27,12 @@ Here was the plan that was executed:
 Here is the current dataset:
 {{ memory.data }}
 
-{%- if 'sql' in memory %}
-
+{% if 'sql' in memory %}
 Here is the current SQL query:
 ```sql
 {{ memory.sql }}
 ```
-{% endif %}
-
+{%- endif %}
 {%- if memory.data|length == 0 %}
 The dataset is empty. As the subject matter expert, if this is unexpected, analyze the SQL query,
 and try to make educated guess what other columns or values should be used instead.
@@ -51,6 +49,7 @@ For reference, here's the tables and their schemas:
 
 {% block examples %}
 {% if memory.data|length == 0 %}
+Here's an example...
 User Query:
 What are all the Category 3 hurricanes in the East Pacific since 2000?
 
@@ -75,6 +74,7 @@ fields should be treated as numbers by removing quotes: SEASON >= 2000 instead o
 try
 again!
 {% else %}
+Here's an example...
 User Query:
 Show me subscription trends over the past 12 months with retention rates by plan type.
 

--- a/lumen/ai/prompts/BaseViewAgent/main.jinja2
+++ b/lumen/ai/prompts/BaseViewAgent/main.jinja2
@@ -1,4 +1,4 @@
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {% block context %}
 Available visualization types:

--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -1,4 +1,4 @@
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {%- block instructions %}
 Act as a helpful assistant for high-level data exploration, focusing on available datasets and, only if data is

--- a/lumen/ai/prompts/Planner/context.jinja2
+++ b/lumen/ai/prompts/Planner/context.jinja2
@@ -3,17 +3,12 @@
 {%- block instructions %}
 You are team lead and have to make a plan to solve the user's query but before you start you can look up some context to make informed decisions.
 
-- Only use tables to request info about tables that might contain relevant data.
+- Only use tools to request info about tables that might contain relevant data.
 - You have access to the tables so never invoke a tool with the goal of getting data.
 {% endblock -%}
 
 {% block context -%}
 {%- if 'table' in memory %}- The result of the previous step was the `{{ memory['table'] }}` table. Consider carefully if it contains all the information you need and only request more tables if absolutely necessary.{% endif -%}
-
-{%- if table_info %}
-Here are tables and schemas that are already available to you:
-{{ table_info }}
-{%- endif %}
 
 Here's the choice of tools and their uses:
 {% if tools %}
@@ -25,5 +20,10 @@ Here's a list of tools:
   Description: {{ tool.purpose.strip().split() | join(' ') }}
 {%- endfor -%}
 {%- endif %}
-
+{% if required_tools %}
+You need to use the following tools:
+{%- for tool in required_tools %}
+- `{{ tool }}`
+{%- endfor %}
+{%- endif %}
 {%- endblock -%}

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -22,24 +22,13 @@ Important Agent Rules:
 {% endblock -%}
 
 {% block context -%}
-{%- if tool_context %}
-Note that you previously decided that you required additional context and got the following responses DO NOT invoke the same tools again: {{ tool_context }}
-{% endif %}
-
-{%- if table_info %}
-Here are tables and schemas that are available to you:
-{{ table_info }}
-{%- endif %}
-{%- if tables_schema_str %}
-{{ tables_schema_str }}
-{%- endif -%}
 {% if memory.get('document_sources') %}
 Here are the documents you have access to:
 {%- for document_source in memory['document_sources'] %}
 - '''{{ document_source['text'][:80].replace('\n', ' ') | default('<No text available></No>') }}...''' ({{ document_source['metadata'] | default('Unknown Filename') }})
 
 {%- endfor %}
-{% endif %}
+{%- endif %}
 Here's the choice of experts and their uses:
 {%- for agent in agents %}
 - `{{ agent.name[:-5] }}`
@@ -47,6 +36,7 @@ Here's the choice of experts and their uses:
   Provides: {{ agent.provides }}
   Description: {{ agent.purpose.strip().split() | join(' ') }}
 {%- endfor -%}
+
 {% if tools %}
 Here's a list of tools:
 {%- for tool in tools %}

--- a/lumen/ai/prompts/Planner/table_selection.jinja2
+++ b/lumen/ai/prompts/Planner/table_selection.jinja2
@@ -1,12 +1,18 @@
-You are a data exploration specialist tasked with selecting the most relevant tables for understanding the context of a
-user query.
+You are a data exploration specialist who intelligently selects the most relevant tables to provide context for a user's query.
 
 The user is asking: "{{ current_query }}"
-Analyze the user query carefully and select up to 3 tables that would provide the most useful context for
-understanding the data model and domain relevant to the query
-Don't select tables just because they're available - only choose those that would genuinely help provide context. If the
-table schema is full of invalid values, even if it has the most relevant columns, do not use it for the final selection.
 
+Analyze this query carefully and select up to 3 tables that would provide the most valuable context for understanding both the data model and domain relevant to the query.
+
+## SELECTION CRITERIA
+* Select tables ONLY if they contain information directly relevant to the user's query
+* Prioritize tables that contain columns matching key entities or metrics mentioned in the query
+* Consider relationship tables that connect entities mentioned in the query
+* Avoid tables with predominantly NULL values or invalid data
+* Exclude tables with only one row when time-series analysis is requested
+* Do not select tables without any rows
+
+## EXAMINED SCHEMAS
 You have already examined these tables with their schemas:
 {%- for table_name, table_info in current_schemas.items() %}
 ## `{{ table_info.source }}{{ separator }}{{ table_name }}`
@@ -15,9 +21,12 @@ You have already examined these tables with their schemas:
 ```
 {% endfor %}
 
+## AVAILABLE TABLES
 The following tables are available for selection:
 {%- for table in available_tables -%}
 - {{ table }}
 {% endfor %}
-Remember to consider whether the tables you've already examined provide enough context. Don't select additional tables
-unless they would add significant new information. Do not abbrieviate the table names; they should be verbatim.
+
+## IMPORTANT REMINDERS
+* Use exact table names with no abbreviations
+* Only select additional tables if they add significant new information

--- a/lumen/ai/prompts/Planner/table_selection.jinja2
+++ b/lumen/ai/prompts/Planner/table_selection.jinja2
@@ -2,23 +2,22 @@ You are a data exploration specialist tasked with selecting the most relevant ta
 user query.
 
 The user is asking: "{{ current_query }}"
-Analyze the user query carefully and select approximately 3 tables that would provide the most useful context for
+Analyze the user query carefully and select up to 3 tables that would provide the most useful context for
 understanding the data model and domain relevant to the query
 Don't select tables just because they're available - only choose those that would genuinely help provide context. If the
 table schema is full of invalid values, even if it has the most relevant columns, do not use it for the final selection.
 
 You have already examined these tables with their schemas:
-{% for table_name, table_info in current_schemas.items() %}
-## {{ table_name }}
+{%- for table_name, table_info in current_schemas.items() %}
+## `{{ table_info.source }}{{ separator }}{{ table_name }}`
 ```yaml
 {{ table_info.schema }}
 ```
 {% endfor %}
 
 The following tables are available for selection:
-{% for table in available_tables %}
+{%- for table in available_tables -%}
 - {{ table }}
 {% endfor %}
-
 Remember to consider whether the tables you've already examined provide enough context. Don't select additional tables
-unless they would add significant new information.
+unless they would add significant new information. Do not abbrieviate the table names; they should be verbatim.

--- a/lumen/ai/prompts/Planner/table_selection.jinja2
+++ b/lumen/ai/prompts/Planner/table_selection.jinja2
@@ -28,5 +28,5 @@ The following tables are available for selection:
 {% endfor %}
 
 ## IMPORTANT REMINDERS
-* Use exact table names with no abbreviations
+* Use exact table names with no abbreviations, i.e. SOURCE{{ separator }}TABLE_NAME
 * Only select additional tables if they add significant new information

--- a/lumen/ai/prompts/Planner/table_selection.jinja2
+++ b/lumen/ai/prompts/Planner/table_selection.jinja2
@@ -1,0 +1,24 @@
+You are a data exploration specialist tasked with selecting the most relevant tables for understanding the context of a
+user query.
+
+The user is asking: "{{ current_query }}"
+Analyze the user query carefully and select approximately 3 tables that would provide the most useful context for
+understanding the data model and domain relevant to the query
+Don't select tables just because they're available - only choose those that would genuinely help provide context. If the
+table schema is full of invalid values, even if it has the most relevant columns, do not use it for the final selection.
+
+You have already examined these tables with their schemas:
+{% for table_name, table_info in current_schemas.items() %}
+## {{ table_name }}
+```yaml
+{{ table_info.schema }}
+```
+{% endfor %}
+
+The following tables are available for selection:
+{% for table in available_tables %}
+- {{ table }}
+{% endfor %}
+
+Remember to consider whether the tables you've already examined provide enough context. Don't select additional tables
+unless they would add significant new information.

--- a/lumen/ai/prompts/SQLAgent/find_tables.jinja2
+++ b/lumen/ai/prompts/SQLAgent/find_tables.jinja2
@@ -1,13 +1,8 @@
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {% block instructions %}
 Determine which tables are necessary to answer the user query, paying special attention to the available columns.
 {% if separator %}
 Use table names verbatim, and be sure to include the delimiters {{ separator }}, like '<source>{{ separator }}<table>'
 {% endif %}
-{% endblock %}
-
-{% block context %}
-Available tables and schemas:
-{{ tables_schema_str }}
 {% endblock %}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -34,7 +34,7 @@ Additionally, only if applicable:
 - Specify data types explicitly to avoid type mismatches.
 - Be sure to remove suspiciously large or small values that may be invalid, like -9999.
 - Use Common Table Expressions (CTEs) and subqueries to break down into manageable parts, only if the query requires more than one transformation.
-- Filter and sort data efficiently (e.g., ORDER BY key metrics) and use LIMIT (greater than 1), especially if the data is large, but the lower limit should be at least 100k
+- Filter and sort data efficiently (e.g., ORDER BY key metrics) and use LIMIT (at least 100,000 if unspecified), especially if the data is large
 - If the date columns are separated, e.g. year, month, day, then join them into a single date column.
 
 {%- if has_errors %}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -1,4 +1,4 @@
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {%- block instructions %}
 You are an agent responsible for writing a SQL query that will perform the data transformations the user requested.
@@ -7,16 +7,6 @@ Use `SELECT * FROM table` if there is no specific column selection mentioned in 
 {%- endblock -%}
 
 {% block context -%}
-{%- if tables_sql_schemas -%}
-Here are YAML schemas for currently relevant tables:
-{% for table, details in tables_sql_schemas.items() %}
-- `{{ table }}`:
-```yaml
-{{ details.schema }}
-```
-{% endfor -%}
-{%- endif -%}
-
 Checklist:
 - Use only `{{ dialect }}` SQL syntax.
 - Do NOT include inlined comments in the SQL code, e.g. `-- comment`
@@ -55,12 +45,21 @@ CAST or TO_DATE
 - Capture only the required numeric values while removing all whitespace, like `(\d+)`, or remove characters like `$`, `%`, `,`, etc, only if needed.
 - Ensure robust type conversion using functions like TRY_CAST to avoid query failures due to invalid data.
 {% endif %}
-{%- endblock -%}
-
 {% if comments is defined -%}
 Here's additional guidance:
 {{ comments }}
 {%- endif -%}
+
+{%- if tables_sql_schemas %}
+Here are YAML schemas for currently relevant tables:
+{% for table, details in tables_sql_schemas.items() %}
+- `{{ table }}`:
+```yaml
+{{ details.schema }}
+```
+{% endfor -%}
+{%- endif -%}
+{%- endblock -%}
 
 {%- block examples %}
 {%- if has_errors -%}

--- a/lumen/ai/prompts/VectorLookupTool/refine_query.jinja2
+++ b/lumen/ai/prompts/VectorLookupTool/refine_query.jinja2
@@ -1,0 +1,23 @@
+{% extends 'Actor/main.jinja2' %}
+
+{% block instructions %}
+You are an expert at refining search queries to find relevant {{ item_type }}.
+
+I need to find {{ item_type }} relevant to this query: "{{ original_query }}"
+
+Here are the current search results:
+{{ results_description }}
+
+The current search results are not sufficiently relevant to the query, with similarity scores below the desired
+threshold.
+
+Please suggest a refined search query that would help find more appropriate {{ item_type }}.
+
+Focus on:
+1. More specific terminology that might appear in {{ item_type }} names and descriptions
+2. Alternative phrasings or synonyms for key concepts
+3. Including technical terms that might appear in {{ item_type }}
+4. Removing terms that might be causing confusion or irrelevant matches
+
+Your refined query should be concise and focused on the essential concepts from the original query.
+{% endblock %}

--- a/lumen/ai/prompts/VectorLookupTool/refine_query.jinja2
+++ b/lumen/ai/prompts/VectorLookupTool/refine_query.jinja2
@@ -18,6 +18,8 @@ Focus on:
 2. Alternative phrasings or synonyms for key concepts
 3. Including technical terms that might appear in {{ item_type }}
 4. Removing terms that might be causing confusion or irrelevant matches
+5. For time-based analysis, include granularity keywords (month, quarter, week, daily) to find tables labeled by time periods that can be aggregated to the desired analysis interval.
+6. If business-related, mention business terms like "business", "revenue", "profit", "cost", "sales", "ARR", "MRR", "BI" to find relevant financial tables.
 
 Your refined query should be concise and focused on the essential concepts from the original query.
 {% endblock %}

--- a/lumen/ai/prompts/_Testing/topic.jinja2
+++ b/lumen/ai/prompts/_Testing/topic.jinja2
@@ -1,4 +1,4 @@
-{% extends 'Actor/main.jinja2' %}
+{% extends 'Agent/main.jinja2' %}
 
 {% block instructions %}
 What is the topic of the table?

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -394,13 +394,10 @@ class TableLookup(VectorLookupTool):
     async def _fetch_and_store_metadata(self, source, table_name: str):
         """Fetch metadata for a table and store it in the vector store."""
         async with self._semaphore:
-            if self.batched:
-                source_metadata = self._raw_metadata[source.name]
-                if isinstance(source_metadata, asyncio.Task):
-                    source_metadata = await source_metadata
-                    self._raw_metadata[source.name] = source_metadata
-            else:
-                source_metadata = await asyncio.to_thread(source.get_metadata, table_name, batched=False)
+            source_metadata = self._raw_metadata[source.name]
+            if isinstance(source_metadata, asyncio.Task):
+                source_metadata = await source_metadata
+                self._raw_metadata[source.name] = source_metadata
 
         table_name_key = next((
             key for key in (table_name.upper(), table_name.lower(), table_name)

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -448,7 +448,7 @@ class TableLookup(VectorLookupTool):
         for source in sources:
             if self.include_metadata and self._raw_metadata.get(source.name) is None:
                 metadata_task = asyncio.create_task(
-                    asyncio.to_thread(source.get_metadata, tables=None)
+                    asyncio.to_thread(source.get_metadata)
                 )
                 self._raw_metadata[source.name] = metadata_task
                 all_tasks.append(metadata_task)

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -408,7 +408,7 @@ class TableLookup(VectorLookupTool):
         if not table_name_key:
             return
         table_name = table_name_key
-        table_metadata = source_metadata[table_name]
+        table_metadata = dict(source_metadata[table_name])
 
         # IMPORTANT: re-insert using table slug
         # we need to store a copy of table_metadata so it can be used to inject context into the LLM

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -95,7 +95,7 @@ class VectorLookupTool(Tool):
             Formatted description of results
         """
         return "\n".join(
-            f"- Result {i+1}: {result.get('text', 'No text')} (Similarity: {result.get('similarity', 0):.3f})"
+            f"- {result.get('text', 'No text')} (Similarity: {result.get('similarity', 0):.3f})"
             for i, result in enumerate(results)
         )
 
@@ -271,7 +271,7 @@ class DocumentLookup(VectorLookupTool):
             filename = metadata.get('filename', 'Unknown document')
             text_preview = result.get('text', '')[:150] + '...' if len(result.get('text', '')) > 150 else result.get('text', '')
 
-            description = f"- Document: {filename} (Similarity: {result.get('similarity', 0):.3f})"
+            description = f"- {filename} (Similarity: {result.get('similarity', 0):.3f})"
             if text_preview:
                 description += f"\n  Preview: {text_preview}"
 
@@ -384,7 +384,7 @@ class TableLookup(VectorLookupTool):
             table_name = result['metadata'].get("table_name", "unknown")
             table_slug = f"{source_name}{SOURCE_TABLE_SEPARATOR}{table_name}"
 
-            description = f"- Table: {table_slug} (Similarity: {result.get('similarity', 0):.3f})"
+            description = f"- {table_slug} (Similarity: {result.get('similarity', 0):.3f})"
             if table_metadata := self._table_metadata.get(table_slug):
                 if table_description := table_metadata.get("description"):
                     description += f"\n  Description: {table_description}"

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -510,8 +510,10 @@ class TableLookup(VectorLookupTool):
                     description += f"  Description: {table_description}"
                 columns_description = "Columns:"
                 for i, (col_name, col_info) in enumerate(table_metadata.get("columns", {}).items()):
+                    # Save on tokens by truncating long column names and letting the LLM infer the rest
+                    col_label = col_name if len(col_name) <= 50 else f"{col_name[:15]}...{col_name[-35:]}"
                     col_desc = f": {col_info['description']}" if col_info.get("description") else ""
-                    columns_description += f"\n- {col_name}{col_desc}"
+                    columns_description += f"\n- {col_label}{col_desc}"
                     if i > 10:
                         columns_description += "\n  ... (more columns not shown)"
                         break

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -110,7 +110,7 @@ class TableLookup(VectorLookupTool):
     include_columns = param.Boolean(default=False, doc="""
         Whether to include column names and descriptions in the embeddings.""")
 
-    max_concurrent = param.Integer(default=5, doc="""
+    max_concurrent = param.Integer(default=2, doc="""
         Maximum number of concurrent metadata fetch operations.""")
 
     def __init__(self, **params):

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -330,7 +330,7 @@ class TableLookup(VectorLookupTool):
     requires = param.List(default=["sources"], readonly=True, doc="""
         List of context that this Tool requires to be run.""")
 
-    provides = param.List(default=["closest_tables", "sources_raw_metadata"], readonly=True, doc="""
+    provides = param.List(default=["closest_tables"], readonly=True, doc="""
         List of context values this Tool provides to current working memory.""")
 
     batched = param.Boolean(default=True, doc="""

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -474,7 +474,7 @@ class TableLookup(VectorLookupTool):
             source_name = result['metadata']["source"]
             table_name = result['metadata']["table_name"]
             table_slug = f"{source_name}{SOURCE_TABLE_SEPARATOR}{table_name}"
-            description = f"- `{table_slug}` ({result['similarity']:.3f} similarity):\n"
+            description = f"- `{table_slug}` ({result['similarity']:.3f} similarity):"
             if table_metadata := self._table_metadata.get(table_slug):
                 if table_description := table_metadata.get("description"):
                     description += f"  Description: {table_description}"

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -504,8 +504,8 @@ class TableLookup(VectorLookupTool):
                 continue
             source_name = result['metadata']["source"]
             table_name = result['metadata']["table_name"]
-            table_slug = f"{source_name}{SOURCE_TABLE_SEPARATOR}{table_name}"
-            description = f"- `{table_slug}` ({result['similarity']:.3f} similarity):"
+            table_slug = f"{source_name} - {table_name}"
+            description = f"- `{table_slug}`: {result['similarity']:.3f} similarity"
             table_similarities[table_slug] = result['similarity']
             if table_metadata := self._table_metadata.get(table_slug):
                 if table_description := table_metadata.get("description"):

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -515,7 +515,7 @@ class TableLookup(VectorLookupTool):
                     col_desc = f": {col_info['description']}" if col_info.get("description") else ""
                     columns_description += f"\n- {col_label}{col_desc}"
                     if i > 10:
-                        columns_description += "\n  ... (more columns not shown)"
+                        columns_description += f"\n  ... (out of {len(table_metadata['columns'])} columns)"
                         break
                 description += f"\n{indent(columns_description, ' ' * 2)}"
             closest_tables.append(table_slug)
@@ -531,7 +531,7 @@ class TableLookup(VectorLookupTool):
         self._memory["closest_tables"] = closest_tables
         self._memory["table_similarities"] = table_similarities
         if "refined_search_query" in self._memory and final_query != query:
-            message = f"\n\nRefined search query: '{final_query}'\n" + message
+            message = f"\n\nRefined search query: '{final_query}'\n\n" + message
         return message + "\n".join(descriptions)
 
 

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -448,7 +448,7 @@ class TableLookup(VectorLookupTool):
         for source in sources:
             if self.include_metadata and self._raw_metadata.get(source.name) is None:
                 metadata_task = asyncio.create_task(
-                    asyncio.to_thread(source.get_metadata)
+                    asyncio.to_thread(source.get_metadata, tables=None)
                 )
                 self._raw_metadata[source.name] = metadata_task
                 all_tasks.append(metadata_task)

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -323,7 +323,9 @@ class TableLookup(VectorLookupTool):
     """
 
     purpose = param.String(default="""
-        Looks up relevant tables based on the user query.""")
+        Looks up relevant tables based on the user query. Unnecessary if
+        the table doesn't need to change or the user is requesting a visualization
+        from the previous results.""")
 
     requires = param.List(default=["sources"], readonly=True, doc="""
         List of context that this Tool requires to be run.""")

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -28,6 +28,7 @@ from panel.viewable import Viewer
 from panel.widgets import Button, FileDownload, MultiChoice
 
 from lumen.ai.config import PROVIDED_SOURCE_NAME, SOURCE_TABLE_SEPARATOR
+from lumen.ai.tools import TableLookup
 
 from ..pipeline import Pipeline
 from ..sources import Source
@@ -120,7 +121,7 @@ class UI(Viewer):
 
     title = param.String(default='Lumen UI', doc="Title of the app.")
 
-    tools = param.List(default=[], doc="""
+    tools = param.List(default=[TableLookup], doc="""
        List of Tools that can be invoked by the coordinator.""")
 
     __abstract = True
@@ -189,7 +190,7 @@ class UI(Viewer):
 
     async def _verify_llm(self):
         alert = Alert(
-            'Initializing LLM ⌛',
+            'Initializing LLM and vector store ⌛',
             alert_type='primary',
             margin=5,
             sizing_mode='stretch_width',
@@ -198,6 +199,7 @@ class UI(Viewer):
         self.interface.send(alert, respond=False, user='System')
         try:
             await self.llm.invoke([{'role': 'user', 'content': 'Are you there? YES | NO'}])
+            success = True
         except Exception as e:
             traceback.print_exc()
             alert.param.update(
@@ -209,10 +211,24 @@ class UI(Viewer):
                     'padding-bottom': '0.8em'
                 }
             )
-        else:
+            success = False
+
+        table_lookup = None
+        for tool in self._coordinator._tools["__main__"]:
+            if isinstance(tool, TableLookup):
+                table_lookup = tool
+                break
+
+        if table_lookup is not None:
+            while True:
+                await asyncio.sleep(1)
+                if table_lookup._ready:
+                    break
+
+        if success:
             alert.param.update(
                 alert_type='success',
-                object='Successfully initialized LLM ✅︎',
+                object='Successfully initialized LLM and vector store ✅︎',
                 styles={'background-color': 'var(--success-bg-subtle)'}
             )
 

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -501,7 +501,7 @@ class ExplorerUI(UI):
                     self._root_conversation = self.interface.objects
         if (event.new if event is not None else tab):
             # Explorations Tab
-            if active < len(self._conversations):
+            if self._conversations and active < len(self._conversations):
                 conversation = self._conversations[active]
             else:
                 conversation = self._snapshot_messages()

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -198,7 +198,10 @@ class UI(Viewer):
         )
         self.interface.send(alert, respond=False, user='System')
         try:
-            await self.llm.invoke([{'role': 'user', 'content': 'Are you there? YES | NO'}])
+            await self.llm.invoke(
+                [{'role': 'user', 'content': 'Are you there? YES | NO'}],
+                model_spec="ui"
+            )
             success = True
         except Exception as e:
             traceback.print_exc()

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -229,8 +229,9 @@ async def get_schema(
             for enum in spec["enum"]
         ]
 
-    if count and include_count:
+    if count is not None and include_count:
         schema["__len__"] = count
+    print(count)
     return schema
 
 

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -25,7 +25,6 @@ from jinja2 import (
 from markupsafe import escape
 
 from lumen.pipeline import Pipeline
-from lumen.sources.base import Source
 
 from ..util import log
 from .config import (
@@ -35,6 +34,8 @@ from .config import (
 
 if TYPE_CHECKING:
     from panel.chat.step import ChatStep
+
+    from lumen.sources.base import Source
 
 
 def render_template(template_path: Path, overrides: dict | None = None, relative_to: Path = PROMPTS_DIR, **context):
@@ -490,3 +491,15 @@ def load_json(json_spec: str) -> dict:
     Load a JSON string, handling unicode escape sequences.
     """
     return json.loads(json_spec.encode().decode('unicode_escape'))
+
+
+def separate_source_table(table: str, sources: dict[str, Source], normalize: bool = True) -> tuple[Source | None, str]:
+    if SOURCE_TABLE_SEPARATOR in table:
+        a_source_name, a_table = table.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)
+        a_source_obj = sources.get(a_source_name)
+    else:
+        a_source_obj = next(iter(sources.values()))
+        a_table = table
+    if normalize:
+        a_table = a_source_obj.normalize_table(a_table)
+    return a_source_obj, a_table

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -26,12 +26,11 @@ from markupsafe import escape
 
 from lumen.pipeline import Pipeline
 from lumen.sources.base import Source
-from lumen.sources.duckdb import DuckDBSource
 
 from ..util import log
 from .config import (
-    PROMPTS_DIR, PROVIDED_SOURCE_NAME, SOURCE_TABLE_SEPARATOR,
-    UNRECOVERABLE_ERRORS, RetriesExceededError,
+    PROMPTS_DIR, SOURCE_TABLE_SEPARATOR, UNRECOVERABLE_ERRORS,
+    RetriesExceededError,
 )
 
 if TYPE_CHECKING:
@@ -153,6 +152,7 @@ def retry_llm_output(retries=3, sleep=1):
 async def get_schema(
     source: Source | Pipeline,
     table: str | None = None,
+    include_type: bool = True,
     include_min_max: bool = True,
     include_enum: bool = True,
     include_count: bool = False,
@@ -170,6 +170,11 @@ async def get_schema(
     # first pop regardless to prevent
     # argument of type 'numpy.int64' is not iterable
     count = schema.pop("__len__", None)
+
+    if not include_type:
+        for field, spec in schema.items():
+            if "type" in spec:
+                spec.pop("type")
 
     if include_min_max:
         for field, spec in schema.items():
@@ -205,7 +210,7 @@ async def get_schema(
         limit = get_kwargs.get("limit")
         max_enums = 10
         truncate_limit = min(limit or 5, 5)
-        if not include_enum:
+        if not include_enum or len(spec["enum"]) == 0:
             spec.pop("enum")
             continue
         elif len(spec["enum"]) > max_enums:
@@ -226,6 +231,23 @@ async def get_schema(
     if count and include_count:
         schema["__len__"] = count
     return schema
+
+
+async def format_table_schema(
+    source: Source, table_name: str, prefix_table: bool = True,
+    as_slug: bool = False, limit: int = 5, **get_schema_kwargs
+) -> str:
+    """
+    Format a source schema as a markdown string.
+    """
+    tables_schema_str = ""
+    if prefix_table:
+        table_label = f"{source}{SOURCE_TABLE_SEPARATOR}{table_name}" if as_slug else table_name
+        tables_schema_str += f"`{table_label}`\n"
+    sql = source.get_sql_expr(table_name)
+    schema = await get_schema(source, table_name, limit=limit, **get_schema_kwargs)
+    tables_schema_str += f"Schema:\n```yaml\n{yaml.dump(schema)}```\nSQL:\n```sql\n{sql}\n```"
+    return tables_schema_str
 
 
 async def get_pipeline(**kwargs):
@@ -346,37 +368,6 @@ def report_error(exc: Exception, step: ChatStep, language: str = "python", conte
         error_msg = error_msg[:50] + "..."
     step.failed_title = error_msg
     step.status = "failed"
-
-
-async def gather_table_sources(sources: list[Source], include_provided: bool = True, include_sep: bool = False) -> tuple[dict[str, Source], str]:
-    """
-    Get a dictionary of tables to their respective sources
-    and a markdown string of the tables and their schemas.
-
-    Parameters
-    ----------
-    sources : list[Source]
-        A list of sources to gather tables from.
-    include_provided : bool
-        Whether to include the provided source in the string; will always be included in the dictionary.
-    include_sep : bool
-        Whether to include the source separator in the string.
-    """
-    tables_to_source = {}
-    tables_schema_str = ""
-    for source in sources:
-        for table in source.get_tables():
-            tables_to_source[table] = source
-            if source.name == PROVIDED_SOURCE_NAME and not include_provided:
-                continue
-            label = f"{source}{SOURCE_TABLE_SEPARATOR}{table}" if include_sep else table
-            if isinstance(source, DuckDBSource) and source.ephemeral or "Provided" in source.name:
-                sql = source.get_sql_expr(table)
-                schema = await get_schema(source, table, include_enum=True, limit=5)
-                tables_schema_str += f"- {label}\nSchema:\n```yaml\n{yaml.dump(schema)}```\nSQL:\n```sql\n{sql}\n```\n\n"
-            else:
-                tables_schema_str += f"- {label}\n\n"
-    return tables_to_source, tables_schema_str.strip()
 
 
 def log_debug(msg: str | list, offset: int = 24, prefix: str = "", suffix: str = "", show_sep: Literal["above", "below"] | None = None, show_length: bool = False):

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -231,7 +231,6 @@ async def get_schema(
 
     if count is not None and include_count:
         schema["__len__"] = count
-    print(count)
     return schema
 
 

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -456,7 +456,7 @@ class DuckDBVectorStore(VectorStore):
         vector_store.query('LLM', threshold=0.1)
     """
 
-    uri = param.String(doc="The URI of the DuckDB database")
+    uri = param.String(default=":memory:", doc="The URI of the DuckDB database")
 
     def __init__(self, **params):
         super().__init__(**params)

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -570,15 +570,14 @@ class DuckDBVectorStore(VectorStore):
         """
         if not self._initialized:
             return []
-        query_embedding = np.array(
-            self.embeddings.embed([text])[0], dtype=np.float32
-        ).tolist()
+        query_embedding = np.array(self.embeddings.embed([text])[0], dtype=np.float32).tolist()
+        vector_dim = len(query_embedding)
 
         base_query = f"""
             SELECT id, text, metadata,
-                array_cosine_similarity(embedding, ?::REAL[{self.embeddings.embedding_dim}]) AS similarity
+                array_cosine_similarity(embedding, ?::REAL[{vector_dim}]) AS similarity
             FROM documents
-            WHERE array_cosine_similarity(embedding, ?::REAL[{self.embeddings.embedding_dim}]) >= ?
+            WHERE array_cosine_similarity(embedding, ?::REAL[{vector_dim}]) >= ?
         """
         params = [query_embedding, query_embedding, threshold]
 

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -332,6 +332,8 @@ class NumpyVectorStore(VectorStore):
         -------
         List of results with 'id', 'text', 'metadata', and 'similarity' score.
         """
+        if self.vectors is None:
+            return []
         query_embedding = np.array(self.embeddings.embed([text])[0], dtype=np.float32)
         similarities = self._cosine_similarity(query_embedding, self.vectors)
 
@@ -379,7 +381,7 @@ class NumpyVectorStore(VectorStore):
         -------
         List of results with 'id', 'text', and 'metadata'.
         """
-        if not self.metadata:
+        if not self.metadata or self.vectors is None:
             return []
 
         mask = np.ones(len(self.metadata), dtype=bool)
@@ -411,7 +413,7 @@ class NumpyVectorStore(VectorStore):
         ids: list[int]
             List of IDs to delete.
         """
-        if not ids:
+        if not ids or self.vectors is None:
             return
 
         keep_mask = np.ones(len(self.vectors), dtype=bool)

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -375,6 +375,8 @@ class Source(MultiTypeComponent):
                 if table in schema:
                     continue
                 for col, cschema in tschema.items():
+                    if isinstance(cschema, int):
+                        continue
                     if cschema.get('type') == 'string' and cschema.get('format') == 'datetime':
                         cschema['inclusiveMinimum'] = pd.to_datetime(
                             cschema['inclusiveMinimum']

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -145,7 +145,7 @@ def cached_metadata(method, locks=weakref.WeakKeyDictionary()):
         tables = self.get_tables() if table is None else [table]
         if all(table in metadata for table in tables):
             return metadata if table is None else metadata[table]
-        if batched:
+        if batched and table is None:
             metadata = method(self, table, batched=True)
             return metadata if table is None else metadata[table]
 
@@ -573,11 +573,10 @@ class Source(MultiTypeComponent):
             was provided or individual table metdata.
         """
         tables = [table] if table else self.get_tables()
-        if batched:
+        if batched and len(tables) > 1:
             if self.metadata_func:
                 metadata = self.metadata_func(tables, batched=True)
             else:
-                print("BATCHED", tables)
                 metadata = self._get_table_metadata(tables, batched=True)
             return metadata
         else:

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -488,7 +488,7 @@ class Source(MultiTypeComponent):
                     f"Error during saving process: {e}"
                 )
 
-    def _get_table_metadata(self, table: list[str]) -> dict:
+    def _get_table_metadata(self, tables: list[str]) -> dict:
         return {}
 
     def __contains__(self, table):

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -570,7 +570,6 @@ class Source(MultiTypeComponent):
             table: self.metadata_func(table) if self.metadata_func else self._get_table_metadata(table)
             for table in tables
         }
-        print(metadata, "META")
         return metadata if table is None else metadata[table]
 
     def get(self, table: str, **query) -> DataFrame:

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -196,7 +196,10 @@ class Source(MultiTypeComponent):
 
     metadata_func = param.Callable(default=None, doc="""
         Function that returns a metadata dictionary
-        given nullable table(s) and batched boolean.
+        given nullable `table` and `batched` boolean.
+        If batched, should return a nested dict
+        {"table_name": {"description": ..., "columns": {"column_name": "..."}}}}
+        Or, if not batched, simply {"description": ..., "columns": {"column_name": "..."}}}
         May be used to override the default _get_table_metadata
         implementation of the Source.""")
 
@@ -559,6 +562,23 @@ class Source(MultiTypeComponent):
                 }
             },
             **other_metadata
+        }
+
+        If batched, the metadata is nested one additional level:
+
+        {
+            "table_name": {
+                {
+                    "description": ...,
+                    "columns": {
+                        <COLUMN>: {
+                        "description": ...,
+                        "data_type": ...,
+                        }
+                    },
+                    **other_metadata
+                }
+            }
         }
 
         Parameters

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -486,7 +486,7 @@ class Source(MultiTypeComponent):
                     f"Error during saving process: {e}"
                 )
 
-    def _get_table_metadata(self, table: str | list[str], batched: bool = True) -> dict:
+    def _get_table_metadata(self, table: list[str]) -> dict:
         return {}
 
     def __contains__(self, table):

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -570,6 +570,7 @@ class Source(MultiTypeComponent):
             table: self.metadata_func(table) if self.metadata_func else self._get_table_metadata(table)
             for table in tables
         }
+        print(metadata, "META")
         return metadata if table is None else metadata[table]
 
     def get(self, table: str, **query) -> DataFrame:
@@ -863,7 +864,7 @@ class BaseSQLSource(Source):
         """
         raise NotImplementedError
 
-    def execute(self, sql_query: str) -> pd.DataFrame:
+    def execute(self, sql_query: str, *args, **kwargs) -> pd.DataFrame:
         """
         Executes a SQL query and returns the result as a DataFrame.
 
@@ -871,6 +872,10 @@ class BaseSQLSource(Source):
         ---------
         sql_query : str
             The SQL Query to execute
+        *args : list
+            Positional arguments to pass to the SQL query
+        **kwargs : dict
+            Keyword arguments to pass to the SQL query
 
         Returns
         -------

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -295,23 +295,6 @@ class DuckDBSource(BaseSQLSource):
             table = re.search(r"read_(\w+)\('(.+?)'", table).group(2)
         return table
 
-    def get_sql_expr(self, table: str):
-        if isinstance(self.tables, dict):
-            try:
-                table = self.tables[self.normalize_table(table)]
-            except KeyError:
-                raise KeyError(f"Table {table} not found in {self.tables.keys()}")
-
-        # search if the so-called "table" already contains SELECT ... FROM
-        # if so, we don't need to wrap it in a SELECT * FROM
-        if re.search(r"(?i)\bselect\b[\s\S]+?\bfrom\b", table):
-            sql_expr = table
-        else:
-            if '(' not in table and ')' not in table:
-                table = f'"{table}"'
-            sql_expr = self.sql_expr.format(table=table)
-        return sql_expr.rstrip(";")
-
     @cached
     def get(self, table, **query):
         query.pop('__dask', None)

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -319,7 +319,7 @@ class DuckDBSource(BaseSQLSource):
             df = Filter.apply_to(df, conditions=conditions)
         return df
 
-    def _get_table_metadata(self, table: str | list[str]) -> dict[str, Any]:
+    def _get_table_metadata(self, tables: list[str]) -> dict[str, Any]:
         """
         Generate metadata for all tables or a single table (batched=False) in DuckDB.
         Handles formats: database.schema.table_name, schema.table_name, or table_name.
@@ -331,9 +331,8 @@ class DuckDBSource(BaseSQLSource):
             Dictionary with table metadata including description, columns, row count, etc.
         """
         metadata = {}
-        table_names = table if isinstance(table, list) else [table]
-        for table_name in table_names:
-            sql_expr = self.get_sql_expr(table)
+        for table_name in tables:
+            sql_expr = self.get_sql_expr(table_name)
             schema_expr = SQLLimit(limit=0).apply(sql_expr)
             count_expr = SQLCount().apply(sql_expr)
             schema_result = self.execute(schema_expr)

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -274,8 +274,9 @@ class DuckDBSource(BaseSQLSource):
                     raise e
         return source
 
-    def execute(self, sql_query: str):
-        return self._connection.execute(sql_query).fetch_df()
+    def execute(self, sql_query: str, *args, **kwargs):
+
+        return self._connection.execute(sql_query, *args, **kwargs).fetch_df()
 
     def get_tables(self):
         if isinstance(self.tables, dict | list):

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -280,8 +280,12 @@ class DuckDBSource(BaseSQLSource):
 
     def get_tables(self):
         if isinstance(self.tables, dict | list):
-            return list(self.tables)
-        return [t[0] for t in self._connection.execute('SHOW TABLES').fetchall()]
+            return [t for t in list(self.tables) if not self._is_table_excluded(t)]
+
+        return [
+            t[0] for t in self._connection.execute('SHOW TABLES').fetchall()
+            if not self._is_table_excluded(t[0])
+        ]
 
     def normalize_table(self, table: str):
         tables = self.get_tables()

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -266,19 +266,10 @@ class SnowflakeSource(BaseSQLSource):
             sql_expr = st.apply(sql_expr)
         return self.execute(sql_expr)
 
-    @cached
-    def get_table_metadata(self, table_name: str) -> dict[str, dict]:
+    def _get_metadata(self, table: str) -> dict[str, dict]:
         """
         Generate metadata for a single table in Snowflake.
-
-        Args:
-            table_name: Name of the table to get metadata for
-
-        Returns:
-            A dictionary with table metadata in the format:
-            {"description": ..., "columns": {"column_name": "description", ...}}
         """
-        # Get table description
         table_query = f"""
             SELECT
                 TABLE_NAME,
@@ -286,21 +277,13 @@ class SnowflakeSource(BaseSQLSource):
             FROM
                 {self.database}.INFORMATION_SCHEMA.TABLES
             WHERE
-                TABLE_NAME = '{table_name}'
+                TABLE_NAME = '{table}'
         """
-
         table_metadata = self.execute(table_query)
-
         if table_metadata.empty:
             return {"description": "", "columns": {}}
 
-        description = table_metadata.iloc[0]['TABLE_DESCRIPTION']
-        result = {
-            "description": description if description else "",
-            "columns": {}
-        }
-
-        # Get column metadata
+        description = table_metadata.iloc[0]['TABLE_DESCRIPTION'] or ""
         column_query = f"""
             SELECT
                 COLUMN_NAME,
@@ -308,44 +291,12 @@ class SnowflakeSource(BaseSQLSource):
             FROM
                 {self.database}.INFORMATION_SCHEMA.COLUMNS
             WHERE
-                TABLE_NAME = '{table_name}'
+                TABLE_NAME = '{table}'
             ORDER BY
                 ORDINAL_POSITION
         """
-
+        columns = {}
         columns_info = self.execute(column_query)
-
         for _, row in columns_info.iterrows():
-            column_name = row['COLUMN_NAME']
-            description = row['COMMENT']
-            result["columns"][column_name] = description if description else ""
-
-        return result
-
-    def get_metadata(self, tables: dict[str, str] | None = None) -> dict[str, dict]:
-        """
-        Generate metadata dictionary for multiple tables.
-        Non-cached version that processes a list of tables.
-
-        Args:
-            tables: Optional dictionary of table names to override the class tables.
-                If None, uses self.tables.
-
-        Returns:
-            A dictionary with table metadata in the format:
-            {"table_name": {"description": ..., "columns": {"column_name": "description", ...}}}
-        """
-        tables_to_use = tables if tables is not None else self.tables
-        result = {}
-
-        # If no tables provided, get all tables from the schema
-        if tables_to_use is None:
-            table_list = self.get_tables()
-            # Convert from fully qualified names to simple table names
-            tables_to_use = {t.split('.')[-1]: t for t in table_list}
-
-        # Process one table at a time
-        for table_name in tables_to_use:
-            result[table_name] = self.get_table_metadata(table_name)
-
-        return result
+            columns[row['COLUMN_NAME']] = {"description": row['COMMENT'] or ""}
+        return {"description": description, "columns": columns}

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -250,7 +250,7 @@ class SnowflakeSource(BaseSQLSource):
             sql_expr = st.apply(sql_expr)
         return self.execute(sql_expr)
 
-    def _get_table_metadata(self, table: str | list[str]) -> dict[str, Any]:
+    def _get_table_metadata(self, tables: list[str]) -> dict[str, Any]:
         """
         Generate metadata for tables in Snowflake.
         Handles formats: database.schema.table_name, schema.table_name, or table_name.
@@ -266,10 +266,8 @@ class SnowflakeSource(BaseSQLSource):
             ).set_index("TABLE_SLUG")
             return df
 
-        table_names = table if isinstance(table, list) else [table]
         parsed_tables = []
-
-        for t in table_names:
+        for t in tables:
             parts = t.split(".")
             if len(parts) == 3:
                 parsed_tables.append(parts)  # database.schema.table_name

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -312,8 +312,8 @@ class SnowflakeSource(BaseSQLSource):
             for table_slug, group in table_metadata_columns.groupby("TABLE_SLUG"):
                 # Get metadata from the first row (all rows for a table have the same metadata)
                 first_row = group.iloc[0]
-                description = first_row["TABLE_DESCRIPTION"]
-                rows = first_row["ROW_COUNT"]
+                description = first_row["TABLE_DESCRIPTION"] or ""
+                rows = int(first_row["ROW_COUNT"])
                 updated_at = first_row["LAST_ALTERED"].isoformat()
                 created_at = first_row["CREATED"].isoformat()
                 columns = (
@@ -356,8 +356,8 @@ class SnowflakeSource(BaseSQLSource):
             return {"description": "", "columns": {}, "rows": 0, "updated_at": None, "created_at": None}
 
         actual_schema = table_metadata.iloc[0]['TABLE_SCHEMA']
-        description = table_metadata.iloc[0]['COMMENT']
-        rows = table_metadata.iloc[0]['ROW_COUNT']
+        description = table_metadata.iloc[0]['COMMENT'] or ""
+        rows = int(table_metadata.iloc[0]['ROW_COUNT'])
         updated_at = table_metadata.iloc[0]['LAST_ALTERED'].isoformat()
         created_at = table_metadata.iloc[0]['CREATED'].isoformat()
 

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -266,7 +266,7 @@ class SnowflakeSource(BaseSQLSource):
             sql_expr = st.apply(sql_expr)
         return self.execute(sql_expr)
 
-    def _get_metadata(self, table: str) -> dict[str, dict]:
+    def _get_table_metadata(self, table: str) -> dict[str, dict]:
         """
         Generate metadata for a single table in Snowflake.
         """

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import decimal
 import re
 
 from pathlib import Path

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -313,7 +313,9 @@ class SnowflakeSource(BaseSQLSource):
                 # Get metadata from the first row (all rows for a table have the same metadata)
                 first_row = group.iloc[0]
                 description = first_row["TABLE_DESCRIPTION"] or ""
-                rows = int(first_row["ROW_COUNT"])
+                rows = first_row["ROW_COUNT"]
+                if rows is not None:
+                    rows = int(rows)
                 updated_at = first_row["LAST_ALTERED"].isoformat()
                 created_at = first_row["CREATED"].isoformat()
                 columns = (
@@ -357,7 +359,9 @@ class SnowflakeSource(BaseSQLSource):
 
         actual_schema = table_metadata.iloc[0]['TABLE_SCHEMA']
         description = table_metadata.iloc[0]['COMMENT'] or ""
-        rows = int(table_metadata.iloc[0]['ROW_COUNT'])
+        rows = table_metadata.iloc[0]['ROW_COUNT']
+        if rows is not None:
+            rows = int(rows)
         updated_at = table_metadata.iloc[0]['LAST_ALTERED'].isoformat()
         created_at = table_metadata.iloc[0]['CREATED'].isoformat()
 

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -244,15 +244,14 @@ class SnowflakeSource(BaseSQLSource):
 
     def _get_table_metadata(self, table: str | list[str], batched: bool = False) -> dict[str, dict]:
         """
-        Generate metadata for a single table in Snowflake.
+        Generate metadata for all tables or a single table (batched=False) in Snowflake.
         Handles formats: database.schema.table_name, schema.table_name, or table_name.
         Schema can be None to be used as a wildcard.
         """
+        print("CALLED...")
+        null_result = {"description": "", "columns": {}, "rows": 0, "updated_at": None, "created_at": None}
         if batched:
-            # Process a list of tables in batch mode
             table_list = table if isinstance(table, list) else [table]
-
-            # Parse each table to get their components
             parsed_tables = []
             for t in table_list:
                 parts = t.split(".")
@@ -265,10 +264,8 @@ class SnowflakeSource(BaseSQLSource):
                 else:
                     raise ValueError(f"Invalid table format: {t}")
 
-            # Get all table slugs to filter
-            table_slugs = [".".join(t) for t in parsed_tables]
+            table_slugs = pd.Series([".".join(t) for t in parsed_tables]).str.upper()
 
-            # Query metadata for all tables
             table_metadata = self.execute(
                 """
                 SELECT
@@ -278,16 +275,15 @@ class SnowflakeSource(BaseSQLSource):
             )
             table_metadata["TABLE_SLUG"] = table_metadata[
                 ["TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME"]
-            ].agg(lambda x: ".".join(x), axis=1)
+            ].agg(lambda x: ".".join(x), axis=1).str.upper()
 
-            # Filter to only include requested tables
+            # TODO: maybe do this in SQL?
             table_metadata = table_metadata[table_metadata["TABLE_SLUG"].isin(table_slugs)]
 
             table_metadata = table_metadata.drop(
                 columns=["TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME"]
             ).set_index("TABLE_SLUG")
 
-            # Get columns for the filtered tables
             table_columns = self.execute(
                 """
                 SELECT
@@ -297,9 +293,8 @@ class SnowflakeSource(BaseSQLSource):
             )
             table_columns["TABLE_SLUG"] = table_columns[
                 ["TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME"]
-            ].agg(lambda x: ".".join(x), axis=1)
+            ].agg(lambda x: ".".join(x), axis=1).str.upper()
 
-            # Filter columns to only include requested tables
             table_columns = table_columns[table_columns["TABLE_SLUG"].isin(table_slugs)]
 
             table_columns = table_columns.drop(
@@ -308,14 +303,12 @@ class SnowflakeSource(BaseSQLSource):
 
             table_metadata_columns = table_metadata.join(table_columns).reset_index()
 
-            result = {}
+            result = null_result
             for table_slug, group in table_metadata_columns.groupby("TABLE_SLUG"):
-                # Get metadata from the first row (all rows for a table have the same metadata)
                 first_row = group.iloc[0]
                 description = first_row["TABLE_DESCRIPTION"] or ""
                 rows = first_row["ROW_COUNT"]
-                if rows is not None:
-                    rows = int(rows)
+                rows = None if pd.isna(rows) else int(rows)
                 updated_at = first_row["LAST_ALTERED"].isoformat()
                 created_at = first_row["CREATED"].isoformat()
                 columns = (
@@ -331,9 +324,9 @@ class SnowflakeSource(BaseSQLSource):
                     "updated_at": updated_at,
                     "created_at": created_at,
                 }
-            return result  # Fixed indentation here - was previously inside the loop
+            return result
 
-        # Not batched below...
+        # Not batched below; for quick access to a specific
         parts = table.split(".")
 
         if len(parts) == 3:
@@ -355,17 +348,15 @@ class SnowflakeSource(BaseSQLSource):
 
         table_metadata = self.execute(table_query, params)
         if table_metadata.empty:
-            return {"description": "", "columns": {}, "rows": 0, "updated_at": None, "created_at": None}
+            return null_result
 
         actual_schema = table_metadata.iloc[0]['TABLE_SCHEMA']
         description = table_metadata.iloc[0]['COMMENT'] or ""
         rows = table_metadata.iloc[0]['ROW_COUNT']
-        if rows is not None:
-            rows = int(rows)
+        rows = None if pd.isna(rows) else int(rows)
         updated_at = table_metadata.iloc[0]['LAST_ALTERED'].isoformat()
         created_at = table_metadata.iloc[0]['CREATED'].isoformat()
 
-        # Get column metadata
         column_query = f"""
             SELECT COLUMN_NAME, COMMENT, DATA_TYPE
             FROM {database}.INFORMATION_SCHEMA.COLUMNS

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.serialization import (
     Encoding, NoEncryption, PrivateFormat, load_pem_private_key,
 )
 
-from ..transforms.sql import SQLFilter, SQLSelectFrom
+from ..transforms.sql import SQLFilter
 from .base import BaseSQLSource, cached
 
 # PEM certificates have the pattern:
@@ -237,11 +237,6 @@ class SnowflakeSource(BaseSQLSource):
             for _, row in tables_df.iterrows()
             if not self._is_table_excluded(f'{self.database}.{row.TABLE_SCHEMA}.{row.TABLE_NAME}')
         ]
-
-    def get_sql_expr(self, table: str):
-        if isinstance(self.tables, dict):
-            table = self.tables[table]
-        return SQLSelectFrom(sql_expr=self.sql_expr).apply(table)
 
     @cached
     def get(self, table, **query):

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -4,6 +4,7 @@ import decimal
 import re
 
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 import param
@@ -254,18 +255,17 @@ class SnowflakeSource(BaseSQLSource):
             sql_expr = st.apply(sql_expr)
         return self.execute(sql_expr)
 
-    def _get_table_metadata(self, table: str | list[str], batched: bool = False) -> dict[str, dict]:
+    def _get_table_metadata(self, table: str | list[str], batched: bool = False) -> dict[str, Any]:
         """
         Generate metadata for all tables or a single table (batched=False) in Snowflake.
         Handles formats: database.schema.table_name, schema.table_name, or table_name.
         Schema can be None to be used as a wildcard.
         """
-        print("CALLED...")
         null_result = {"description": "", "columns": {}, "rows": 0, "updated_at": None, "created_at": None}
         if batched:
-            table_list = table if isinstance(table, list) else [table]
+            table_names = table if isinstance(table, list) else [table]
             parsed_tables = []
-            for t in table_list:
+            for t in table_names:
                 parts = t.split(".")
                 if len(parts) == 3:
                     parsed_tables.append(parts)  # database.schema.table_name
@@ -315,7 +315,7 @@ class SnowflakeSource(BaseSQLSource):
 
             table_metadata_columns = table_metadata.join(table_columns).reset_index()
 
-            result = null_result
+            result = {}
             for table_slug, group in table_metadata_columns.groupby("TABLE_SLUG"):
                 first_row = group.iloc[0]
                 description = first_row["TABLE_DESCRIPTION"] or ""
@@ -327,6 +327,7 @@ class SnowflakeSource(BaseSQLSource):
                     group[["COLUMN_NAME", "COLUMN_DESCRIPTION", "DATA_TYPE"]]
                     .rename({"COLUMN_DESCRIPTION": "description", "DATA_TYPE": "data_type"}, axis=1)
                     .set_index("COLUMN_NAME")
+                    .transpose()
                     .to_dict()
                 )
                 result[table_slug] = {
@@ -379,5 +380,5 @@ class SnowflakeSource(BaseSQLSource):
         columns_info = self.execute(column_query, (database, actual_schema, table_name))
         columns = columns_info.set_index("COLUMN_NAME")[["COMMENT", "DATA_TYPE"]].fillna("").rename(
             {"COMMENT": "description", "DATA_TYPE": "data_type"}, axis=1
-        ).to_dict()
+        ).transpose().to_dict()
         return {"description": description, "columns": columns, "rows": rows, "updated_at": updated_at, "created_at": created_at}

--- a/lumen/tests/ai/test_vector_store.py
+++ b/lumen/tests/ai/test_vector_store.py
@@ -89,7 +89,7 @@ class VectorStoreTestKit:
         text = "Food: $10, Drinks: $5, Total: $15"
         metadata = {"title": "receipt", "department": "accounting"}
         stored_embedding_text = store_with_three_docs._join_text_and_metadata(text, metadata)
-        results = store_with_three_docs.query(stored_embedding_text, threshold=1)
+        results = store_with_three_docs.query(stored_embedding_text, threshold=0.99)
         assert len(results) == 1
 
     def test_query_empty_store(self, empty_store):

--- a/lumen/tests/sources/test_snowflake.py
+++ b/lumen/tests/sources/test_snowflake.py
@@ -1,0 +1,333 @@
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+
+try:
+    from lumen.sources.snowflake import SnowflakeSource
+    pytestmark = pytest.mark.xdist_group("snowflake")
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="Snowflake is not installed")
+
+
+@pytest.fixture
+def mock_snowflake_connection():
+    """Fixture to create a mock Snowflake connection and cursor."""
+    # Sample tables data
+    tables_data = pd.DataFrame({
+        'TABLE_NAME': ['CUSTOMERS', 'ORDERS', 'PRODUCTS', 'SALES', 'DEMOGRAPHICS', 'STATISTICS'],
+        'TABLE_SCHEMA': ['PUBLIC', 'PUBLIC', 'ANALYTICS', 'ANALYTICS', 'TPCDS_SF100TCL', 'TPCDS_SF100TCL']
+    })
+
+    # Create mock cursor
+    mock_cursor = Mock()
+    mock_cursor.execute.return_value.fetch_pandas_all.return_value = tables_data
+
+    # Create mock connection
+    mock_conn = Mock()
+    mock_conn.cursor.return_value = mock_cursor
+
+    # Create patcher
+    with patch('snowflake.connector.connect', return_value=mock_conn) as mock_connect:
+        yield mock_connect, mock_conn, mock_cursor
+
+
+def test_init(mock_snowflake_connection):
+    """Test initialization of SnowflakeSource."""
+    mock_connect, _, _ = mock_snowflake_connection
+
+    SnowflakeSource(
+        account='test_account',
+        user='test_user',
+        password='test_password',
+        database='TEST_DB'
+    )
+
+    # Verify snowflake.connector.connect was called with the right parameters
+    mock_connect.assert_called_once()
+    call_kwargs = mock_connect.call_args[1]
+    assert call_kwargs['account'] == 'test_account'
+    assert call_kwargs['user'] == 'test_user'
+    assert call_kwargs['password'] == 'test_password'
+    assert call_kwargs['database'] == 'TEST_DB'
+
+
+def test_get_tables_no_exclusions(mock_snowflake_connection):
+    """Test get_tables method with no excluded tables."""
+    _, _, mock_cursor = mock_snowflake_connection
+
+    source = SnowflakeSource(database='TEST_DB')
+    tables = source.get_tables()
+
+    # Verify the mock was called with the correct SQL
+    mock_cursor.execute.assert_called_with(
+        'SELECT TABLE_NAME, TABLE_SCHEMA FROM TEST_DB.INFORMATION_SCHEMA.TABLES;'
+    )
+
+    # Check the returned table list
+    expected_tables = [
+        'TEST_DB.PUBLIC.CUSTOMERS',
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_exclusions_full_qualified(mock_snowflake_connection):
+    """Test get_tables with fully qualified excluded tables."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TEST_DB.PUBLIC.CUSTOMERS', 'TEST_DB.ANALYTICS.SALES']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_exclusions_schema_qualified(mock_snowflake_connection):
+    """Test get_tables with schema.table excluded tables."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['PUBLIC.ORDERS', 'ANALYTICS.PRODUCTS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.CUSTOMERS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_exclusions_table_name_only(mock_snowflake_connection):
+    """Test get_tables with just table names."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['CUSTOMERS', 'PRODUCTS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_mixed_exclusions(mock_snowflake_connection):
+    """Test get_tables with mixed exclusion formats."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TEST_DB.PUBLIC.CUSTOMERS', 'ANALYTICS.PRODUCTS', 'ORDERS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_explicit_tables_with_exclusions(mock_snowflake_connection):
+    """Test get_tables with explicitly defined tables and exclusions."""
+    tables_list = [
+        'TABLE1',
+        'SCHEMA1.TABLE2',
+        'DB1.SCHEMA2.TABLE3',
+        'DB1.SCHEMA1.TABLE4'
+    ]
+
+    source = SnowflakeSource(
+        tables=tables_list,
+        excluded_tables=['TABLE1', 'SCHEMA1.TABLE2']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'DB1.SCHEMA2.TABLE3',
+        'DB1.SCHEMA1.TABLE4'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_dict_with_exclusions(mock_snowflake_connection):
+    """Test get_tables with dict tables and exclusions."""
+    tables_dict = {
+        'table1': 'SQL1',
+        'schema.table2': 'SQL2',
+        'db.schema.table3': 'SQL3'
+    }
+
+    source = SnowflakeSource(
+        tables=tables_dict,
+        excluded_tables=['table1', 'schema.table2']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = ['db.schema.table3']
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_schema_wildcard_exclusions(mock_snowflake_connection):
+    """Test get_tables with schema wildcard exclusions (schema.*)."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TPCDS_SF100TCL.*']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.CUSTOMERS',
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_fully_qualified_schema_wildcard(mock_snowflake_connection):
+    """Test get_tables with fully qualified schema wildcard exclusions (database.schema.*)."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TEST_DB.ANALYTICS.*']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.CUSTOMERS',
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+def test_get_tables_with_empty_string_exclusions(mock_snowflake_connection):
+    """Test that empty strings in excluded_tables are properly ignored."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['', 'CUSTOMERS', '']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_complex_wildcard_patterns(mock_snowflake_connection):
+    """Test exclusions with more complex wildcard patterns."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['*CUSTOMERS', 'ORDER*', '*STAT*']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_case_sensitivity(mock_snowflake_connection):
+    """Test case sensitivity in excluded_tables patterns."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['customers', 'public.orders']  # lowercase patterns
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_none_in_exclusions(mock_snowflake_connection):
+    """Test that None values in excluded_tables are properly handled."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['CUSTOMERS', None, 'ORDERS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_overlapping_exclusions(mock_snowflake_connection):
+    """Test with overlapping exclusion patterns."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['PUBLIC.*', 'TEST_DB.PUBLIC.CUSTOMERS', 'ORDERS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_nested_wildcard_exclusions(mock_snowflake_connection):
+    """Test get_tables with nested wildcard patterns."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TEST_DB.*.CUST*']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)


### PR DESCRIPTION
Just an initial set up to explore how `get_metadata` could be implemented and used in Lumen AI.

Right now, it's only used in TableLookup, but I think it can be used more widely, like in ChatAgent / SQLAgent, or maybe just Planner?

I imagine it can be used similarly like `DocumentLookup`

I was using this for testing since these were the only tables that were not sensitive and had descriptions...

```python
from lumen.sources.snowflake import SnowflakeSource

source = SnowflakeSource(
    account=account
    authenticator="externalbrowser",
    database="SNOWFLAKE_SAMPLE_DATA",
    user=user
)

tables_to_get = {
    "APPLICABLE_ROLES": "APPLICABLE_ROLES",
    "COLUMNS": "COLUMNS",
    "DATABASES": "DATABASES"
}

all_metadata = source.get_metadata(tables_to_get)

all_metadata
```
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/72f5f964-92d4-4bfe-a657-03f7db3a3582" />
