### PR TITLE
Use model n ctx

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -263,7 +263,6 @@ class LlamaCpp(Llm):
             "repo": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
             "model_file": "qwen2.5-coder-7b-instruct-q5_k_m.gguf",
             "chat_format": "qwen",
-            "n_ctx": 131072,
         },
     })
 
@@ -283,6 +282,10 @@ class LlamaCpp(Llm):
                 model_file = model_spec
             model_kwargs["repo"] = repo
             model_kwargs["model_file"] = model_file
+
+        if "n_ctx" not in model_kwargs:
+            # 0 = from model
+            model_kwargs["n_ctx"] = 0
         return dict(model_kwargs)
 
     @property


### PR DESCRIPTION
Was looking through Llama Cpp Python's docs to see if there has been any magic breakthroughs for making the models run faster, and stumbled upon `n_ctx ([int](https://docs.python.org/3/library/functions.html#int), default: 512 ) – Text context, 0 = from model` and realized this could simplify specifying separate models.

However, I couldn't find anything new that we could use to squeeze performance. Was hoping speculative decoding to speed things up, but using it makes it run slower on my machine. Also tested batch size and use_mmap but those didn't seem to help either in this case.

```python
llama = llama_cpp.Llama(
    model_path=model_path,
    n_gpu_layers=-1,
    chat_format="qwen",
    n_ctx=2048,
    logits_all=True,
    verbose=False,
    draft_model=llama_cpp.llama_speculative.LlamaPromptLookupDecoding(
        num_pred_tokens=1
    )
)
create = instructor.patch(
    create=llama.create_chat_completion_openai_v1,
    mode=instructor.Mode.JSON_SCHEMA,  # (2)!
)
message = {"role": "user", "content": "Teach me how to say `Hello` in three languages!"}
```