### PR TITLE
Add examples to analyst prompt

### DIFF
--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -8,7 +8,8 @@ If the SQL has CTEs, briefly explain each CTE, mentioning its alias; otherwise, 
 Then, analyze the data and deliver precise, actionable insights in clear, non-technical language.
 
 - Distill complexity into straightforward, meaningful takeaways, while maintaining depth and precision.
-- Do not always take results at face value; identify and question anomalies—highlighting potential outliers or unexpected results, addressing the SQL if necessary.
+- Do not always take results at face value; identify and question anomalies—highlighting potential outliers or
+unexpected results.
 - Avoid generic summaries—instead, emphasize specific patterns, column interactions, and a couple actionable insights.
 - Break up long prose into shorter, digestible chunks.
 - Sparingly bold phrases of the most critical insights.
@@ -18,17 +19,96 @@ Keep your response under three paragraphs top, unless elaboration is requested.
 {% endblock %}
 
 {% block context %}
+Here was the plan that was executed:
+"""
+{{ memory.reasoning }}
+"""
+
+Here is the current dataset:
+{{ memory.data }}
+
 {%- if 'sql' in memory %}
+
 Here is the current SQL query:
 ```sql
 {{ memory.sql }}
 ```
 {% endif %}
-Here is the current dataset:
-{{ memory.data }}
 
-Here was the plan that was executed:
-"""
-{{ memory.reasoning }}
-"""
+{%- if memory.data|length == 0 %}
+The dataset is empty. As the subject matter expert, if this is unexpected, analyze the SQL query,
+and try to make educated guess what other columns or values should be used instead.
+
+For reference, here's the tables and their schemas:
+{% for table_name, table_info in memory.tables_sql_schemas.items() %}
+- **{{ table_name }}**:
+```yaml
+{{ table_info.schema }}
+```
+{% endfor %}
+{% endif %}
+{% endblock %}
+
+{% block examples %}
+{% if memory.data|length == 0 %}
+User Query:
+What are all the Category 3 hurricanes in the East Pacific since 2000?
+
+Columns Available:
+NAME, BASIN, SEASON, USA_SSHS, CMA_CAT
+
+Current SQL:
+```sql
+SELECT
+*
+FROM hurricanes
+WHERE
+"CMA_CAT" = '1' AND "BASIN" = 'SP' AND "SEASON" >= '2000'
+```
+
+Good Response:
+The query returns an empty dataset due to multiple errors. It uses CMA_CAT = '1' instead of USA_SSHS = 3 - USA_SSHS
+should be used because we're specifically looking for hurricanes classified by the U.S. Saffir-Simpson Hurricane Scale,
+the standard system for East Pacific hurricanes. Also, BASIN = 'SP' refers to South Pacific, not East Pacific (EP).
+Additionally, the query treats numeric values as strings with quotes, potentially causing comparison issues. Numeric
+fields should be treated as numbers by removing quotes: SEASON >= 2000 instead of SEASON >= '2000'. Please request to
+try
+again!
+{% else %}
+User Query:
+Show me subscription trends over the past 12 months with retention rates by plan type.
+
+Columns Available:
+
+month, plan_type, new_subs, churned, retained, retention_rate
+Current SQL:
+```
+WITH monthly_metrics AS (
+SELECT
+month,
+plan_type,
+new_subs,
+churned,
+retained,
+ROUND(retained * 100.0 / (retained + churned), 1) AS retention_rate
+FROM subscription_data
+WHERE month >= DATE_SUB(CURRENT_DATE(), INTERVAL 12 MONTH)
+ORDER BY month, plan_type
+)
+SELECT * FROM monthly_metrics
+```
+
+Good Response:
+Looking at the monthly_metrics CTE, we're calculating retention rates across different subscription plans over the past
+year, with a focus on new subscribers, churn, and retained customers.
+The data reveals a stark contrast between our Premium and Basic plans. Premium plans consistently maintain 87-92%
+retention rates while Basic plans fluctuate between 62-71%. Notably, there was a significant retention spike for Premium
+plans in October (92.7%), coinciding with our loyalty program launch, suggesting this initiative resonated strongly with
+higher-tier customers.
+
+I'm concerned about the Basic plan's downward trend in Q4, where retention dropped from 68% to 62% despite no price
+changes. This decline represents approximately 2,800 additional churned customers compared to expected baseline,
+warranting immediate investigation. The unusual December retention dip across all plans suggests a potential data
+collection issue or seasonal effect that requires validation before making strategic decisions.
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
I think adding examples to LLM system prompts help a lot, especially for the cases where the data is empty (due to bad SQL).

However, I use `if` statements to select the prompts, so it's not too overwhelming.

Also, something I didn't really appreciate, until now, is that the input token cost is much lower than the output token (4 times), meaning we should optimize for shorter, succinct responses, and worry less about context input
<img width="365" alt="image" src="https://github.com/user-attachments/assets/5d0fcf94-c41f-46c9-9b50-5c235cc23f91" />
