### PR TITLE
Set temperature=1 for AzureOpenAI

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -427,7 +427,7 @@ class AzureOpenAI(Llm):
 
     mode = param.Selector(default=Mode.TOOLS)
 
-    temperature = param.Number(default=0.2, bounds=(0, None), constant=True)
+    temperature = param.Number(default=1, bounds=(0, None), constant=True)
 
     @property
     def _client_kwargs(self):


### PR DESCRIPTION
Didn't test this, but based on the error from https://github.com/holoviz/lumen/issues/1070
`❌ BadRequestError: Error code: 400 - {'error': {'message': "Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': 'unsupported_value'}}`, azure open ai only supports temp=1