### PR TITLE
Stretch TableListAgent Tabulator

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -339,7 +339,8 @@ class TableListAgent(Agent):
             widths={'Table': '90%'},
             disabled=True,
             page_size=10,
-            header_filters=len(tables) > 10
+            header_filters=len(tables) > 10,
+            sizing_mode="stretch_width",
         )
         table_list.on_click(self._use_table)
         self.interface.stream(table_list, user="Lumen")


### PR DESCRIPTION
Snowflake tables are long and the names were truncated without any option of seeing the full name.