### PR TITLE
allow_None for SnowflakeSource.authenticator

### DIFF
--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -18,7 +18,7 @@ class SnowflakeSource(BaseSQLSource):
 
     authenticator = param.Selector(default=None, objects=[
         'externalbrowser', 'oauth', 'snowflake', 'username_password_mfa'], doc="""
-        The authentication approach to use.""")
+        The authentication approach to use.""", allow_None=True)
 
     database = param.String(default=None, doc="""
         The database to connect to.""")

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -17,7 +17,7 @@ class SnowflakeSource(BaseSQLSource):
         The account identifier to connect to.""")
 
     authenticator = param.Selector(default=None, objects=[
-        'externalbrowser', 'oauth', 'snowflake', 'username_password_mfa'], doc="""
+        'externalbrowser', 'oauth', 'snowflake', 'username_password_mfa', 'SNOWFLAKE_JWT'], doc="""
         The authentication approach to use.""", allow_None=True)
 
     database = param.String(default=None, doc="""


### PR DESCRIPTION
I couldn't find what the default authenticator was, but create_sql_expr_source crashes without a default because None is not one of those objects.

```
    def create_sql_expr_source(self, tables: dict[str, str], **kwargs):
        """
        Creates a new SQL Source given a set of table names and
        corresponding SQL expressions.
        """
        params = dict(self.param.values(), **kwargs)
        params.pop("name", None)
        params['tables'] = tables
        params['conn'] = self._conn
        return SnowflakeSource(**params)
```