### PR TITLE
Tweak prompt and increase enum count

### DIFF
--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -7,7 +7,7 @@ Ground Rules:
 - Each of these experts requires certain information and has the ability to provide certain information.
 - Do not perform tasks the user didn't ask for, e.g. do not plot the data unless requested or compute things if the user asked you to summarize the results in words.
 - Ensure that you provide each expert the context they need to ensure they do not repeat previous steps.
-- Do not go in depth to try to solve the problem, just make a plan and let the experts do the work.
+- Do not go in details to try to solve the problem (i.e. you should not mention any specific values), just make a plan and let the experts do the work.
 {%- if tools %}
 - Tools do not interact with a user, assign an expert to report, summarize or use the results.
 - When looking up information with a tool ensure the expert comes AFTER the tool.

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -371,7 +371,7 @@ async def gather_table_sources(sources: list[Source], include_provided: bool = T
             label = f"{source}{SOURCE_TABLE_SEPARATOR}{table}" if include_sep else table
             if isinstance(source, DuckDBSource) and source.ephemeral or "Provided" in source.name:
                 sql = source.get_sql_expr(table)
-                schema = await get_schema(source, table, include_enum=True, limit=3)
+                schema = await get_schema(source, table, include_enum=True, limit=5)
                 tables_schema_str += f"- {label}\nSchema:\n```yaml\n{yaml.dump(schema)}```\nSQL:\n```sql\n{sql}\n```\n\n"
             else:
                 tables_schema_str += f"- {label}\n\n"

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -201,23 +201,20 @@ async def get_schema(
             continue
 
         limit = get_kwargs.get("limit")
+        max_enums = 10
         truncate_limit = min(limit or 5, 5)
         if not include_enum:
             spec.pop("enum")
             continue
-        elif len(spec["enum"]) > truncate_limit:
+        elif len(spec["enum"]) > max_enums:
+            # if there are only 10 enums, fine; let's keep them all
+            # else, that assumes this column is like glasbey 100+ categories vs category10
+            # so truncate to 5 and add "..."
             spec["enum"] = spec["enum"][:truncate_limit] + ["..."]
         elif limit and len(spec["enum"]) == 1 and spec["enum"][0] is None:
-            spec["enum"] = [
-                enum
-                if (
-                    enum is None
-                    or not isinstance(enum, str)
-                    or len(enum) < 100
-                )
-                else f"{enum[:100]} ..."
-                for enum in spec["enum"]
-            ]
+            spec["enum"] = [f"(unknown; truncated to {limit} rows)"]
+            continue
+
         # truncate each enum to 100 characters
         spec["enum"] = [
             enum if enum is None or not isinstance(enum, str) or len(enum) < 100 else f"{enum[:100]} ..."


### PR DESCRIPTION
Having the enum set to 3 basically showed nothing: 1 slot was mostly always taken by an empty space, so I bumped to 10 enums if there are only 10 unique values, and up to 5 enums if theres a lot of categories

```
HKO_CAT:
  enum:
  - ' '
  - TS
  - T
  - '...'
  type: str
```

Also, I think the Planner was giving misleading details (from its limited view of the data), which affected the SQLAgent downstream.

There also was a fishy duplicate introduced in https://github.com/holoviz/lumen/pull/906