### PR TITLE
Exclude tables

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -570,7 +570,6 @@ class Source(MultiTypeComponent):
             table: self.metadata_func(table) if self.metadata_func else self._get_table_metadata(table)
             for table in tables
         }
-        print(metadata, "META")
         return metadata if table is None else metadata[table]
 
     def get(self, table: str, **query) -> DataFrame:

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -832,6 +832,10 @@ class BaseSQLSource(Source):
 
     load_schema = param.Boolean(default=True, doc="Whether to load the schema")
 
+    excluded_tables = param.List(default=[], doc="""
+        List of table names that should be excluded from the results.""")
+
+
     # Declare this source supports SQL transforms
     _supports_sql = True
 

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -284,7 +284,7 @@ class DuckDBSource(BaseSQLSource):
 
         return [
             t[0] for t in self._connection.execute('SHOW TABLES').fetchall()
-            if self._is_table_excluded(t[0])
+            if not self._is_table_excluded(t[0])
         ]
 
     def normalize_table(self, table: str):

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -62,9 +62,6 @@ class DuckDBSource(BaseSQLSource):
     tables = param.ClassSelector(class_=(list, dict), doc="""
         List or dictionary of tables.""")
 
-    excluded_tables = param.List(default=[], doc="""
-        List of table names that should be excluded from the results.""")
-
     uri = param.String(doc="The URI of the DuckDB database")
 
     source_type = 'duckdb'
@@ -283,11 +280,11 @@ class DuckDBSource(BaseSQLSource):
 
     def get_tables(self):
         if isinstance(self.tables, dict | list):
-            return [t for t in list(self.tables) if t not in self.excluded_tables]
+            return [t for t in list(self.tables) if not self._is_table_excluded(t)]
 
         return [
             t[0] for t in self._connection.execute('SHOW TABLES').fetchall()
-            if t[0] not in self.excluded_tables
+            if self._is_table_excluded(t[0])
         ]
 
     def normalize_table(self, table: str):

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -84,7 +84,8 @@ class SnowflakeSource(BaseSQLSource):
     excluded_tables = param.List(default=[], doc="""
         List of table names that should be excluded from the results.
         The items can be fully qualified (database.schema.table), partially
-        qualified (schema.table), or just table names.""")
+        qualified (schema.table), simply table names, or wildcards
+        (e.g. database.schema.*).""")
 
     dialect = 'snowflake'
 
@@ -223,32 +224,15 @@ class SnowflakeSource(BaseSQLSource):
         return self._cursor.execute(sql_query, *args, **kwargs).fetch_pandas_all()
 
     def get_tables(self) -> list[str]:
-        def _table_is_excluded(table_slug: str) -> bool:
-            """
-            Check if a table should be excluded based on its name components.
-            Supports matching:
-            - Fully qualified names (database.schema.table)
-            - Partially qualified names (schema.table)
-            - Just table names
-            """
-            parts = table_slug.split('.')
-            formats_to_check = {table_slug}
-            if len(parts) >= 3:  # database.schema.table
-                formats_to_check.add(f"{parts[-2]}.{parts[-1]}")  # schema.table
-                formats_to_check.add(parts[-1])  # table
-            elif len(parts) == 2:  # schema.table
-                formats_to_check.add(parts[-1])  # table
-            return any(excluded in formats_to_check for excluded in self.excluded_tables)
-
         # limited set of tables was provided
         if isinstance(self.tables, dict | list):
-            return [t for t in list(self.tables) if not _table_is_excluded(t)]
+            return [t for t in list(self.tables) if not self._is_table_excluded(t)]
 
         tables_df = self.execute(f'SELECT TABLE_NAME, TABLE_SCHEMA FROM {self.database}.INFORMATION_SCHEMA.TABLES;')
         return [
             f'{self.database}.{row.TABLE_SCHEMA}.{row.TABLE_NAME}'
             for _, row in tables_df.iterrows()
-            if not _table_is_excluded(f'{self.database}.{row.TABLE_SCHEMA}.{row.TABLE_NAME}')
+            if not self._is_table_excluded(f'{self.database}.{row.TABLE_SCHEMA}.{row.TABLE_NAME}')
         ]
 
     def get_sql_expr(self, table: str):

--- a/lumen/tests/sources/test_snowflake.py
+++ b/lumen/tests/sources/test_snowflake.py
@@ -1,0 +1,225 @@
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+
+try:
+    from lumen.sources.snowflake import SnowflakeSource
+    pytestmark = pytest.mark.xdist_group("snowflake")
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="Snowflake is not installed")
+
+
+@pytest.fixture
+def mock_snowflake_connection():
+    """Fixture to create a mock Snowflake connection and cursor."""
+    # Sample tables data
+    tables_data = pd.DataFrame({
+        'TABLE_NAME': ['CUSTOMERS', 'ORDERS', 'PRODUCTS', 'SALES', 'DEMOGRAPHICS', 'STATISTICS'],
+        'TABLE_SCHEMA': ['PUBLIC', 'PUBLIC', 'ANALYTICS', 'ANALYTICS', 'TPCDS_SF100TCL', 'TPCDS_SF100TCL']
+    })
+
+    # Create mock cursor
+    mock_cursor = Mock()
+    mock_cursor.execute.return_value.fetch_pandas_all.return_value = tables_data
+
+    # Create mock connection
+    mock_conn = Mock()
+    mock_conn.cursor.return_value = mock_cursor
+
+    # Create patcher
+    with patch('snowflake.connector.connect', return_value=mock_conn) as mock_connect:
+        yield mock_connect, mock_conn, mock_cursor
+
+
+def test_init(mock_snowflake_connection):
+    """Test initialization of SnowflakeSource."""
+    mock_connect, _, _ = mock_snowflake_connection
+
+    SnowflakeSource(
+        account='test_account',
+        user='test_user',
+        password='test_password',
+        database='TEST_DB'
+    )
+
+    # Verify snowflake.connector.connect was called with the right parameters
+    mock_connect.assert_called_once()
+    call_kwargs = mock_connect.call_args[1]
+    assert call_kwargs['account'] == 'test_account'
+    assert call_kwargs['user'] == 'test_user'
+    assert call_kwargs['password'] == 'test_password'
+    assert call_kwargs['database'] == 'TEST_DB'
+
+
+def test_get_tables_no_exclusions(mock_snowflake_connection):
+    """Test get_tables method with no excluded tables."""
+    _, _, mock_cursor = mock_snowflake_connection
+
+    source = SnowflakeSource(database='TEST_DB')
+    tables = source.get_tables()
+
+    # Verify the mock was called with the correct SQL
+    mock_cursor.execute.assert_called_with(
+        'SELECT TABLE_NAME, TABLE_SCHEMA FROM TEST_DB.INFORMATION_SCHEMA.TABLES;'
+    )
+
+    # Check the returned table list
+    expected_tables = [
+        'TEST_DB.PUBLIC.CUSTOMERS',
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_exclusions_full_qualified(mock_snowflake_connection):
+    """Test get_tables with fully qualified excluded tables."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TEST_DB.PUBLIC.CUSTOMERS', 'TEST_DB.ANALYTICS.SALES']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_exclusions_schema_qualified(mock_snowflake_connection):
+    """Test get_tables with schema.table excluded tables."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['PUBLIC.ORDERS', 'ANALYTICS.PRODUCTS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.CUSTOMERS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_exclusions_table_name_only(mock_snowflake_connection):
+    """Test get_tables with just table names."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['CUSTOMERS', 'PRODUCTS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_mixed_exclusions(mock_snowflake_connection):
+    """Test get_tables with mixed exclusion formats."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TEST_DB.PUBLIC.CUSTOMERS', 'ANALYTICS.PRODUCTS', 'ORDERS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_explicit_tables_with_exclusions(mock_snowflake_connection):
+    """Test get_tables with explicitly defined tables and exclusions."""
+    tables_list = [
+        'TABLE1',
+        'SCHEMA1.TABLE2',
+        'DB1.SCHEMA2.TABLE3',
+        'DB1.SCHEMA1.TABLE4'
+    ]
+
+    source = SnowflakeSource(
+        tables=tables_list,
+        excluded_tables=['TABLE1', 'SCHEMA1.TABLE2']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'DB1.SCHEMA2.TABLE3',
+        'DB1.SCHEMA1.TABLE4'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_dict_with_exclusions(mock_snowflake_connection):
+    """Test get_tables with dict tables and exclusions."""
+    tables_dict = {
+        'table1': 'SQL1',
+        'schema.table2': 'SQL2',
+        'db.schema.table3': 'SQL3'
+    }
+
+    source = SnowflakeSource(
+        tables=tables_dict,
+        excluded_tables=['table1', 'schema.table2']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = ['db.schema.table3']
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_schema_wildcard_exclusions(mock_snowflake_connection):
+    """Test get_tables with schema wildcard exclusions (schema.*)."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TPCDS_SF100TCL.*']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.CUSTOMERS',
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_fully_qualified_schema_wildcard(mock_snowflake_connection):
+    """Test get_tables with fully qualified schema wildcard exclusions (database.schema.*)."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TEST_DB.ANALYTICS.*']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.CUSTOMERS',
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)

--- a/lumen/tests/sources/test_snowflake.py
+++ b/lumen/tests/sources/test_snowflake.py
@@ -223,3 +223,111 @@ def test_get_tables_with_fully_qualified_schema_wildcard(mock_snowflake_connecti
         'TEST_DB.TPCDS_SF100TCL.STATISTICS'
     ]
     assert set(tables) == set(expected_tables)
+
+def test_get_tables_with_empty_string_exclusions(mock_snowflake_connection):
+    """Test that empty strings in excluded_tables are properly ignored."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['', 'CUSTOMERS', '']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_complex_wildcard_patterns(mock_snowflake_connection):
+    """Test exclusions with more complex wildcard patterns."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['*CUSTOMERS', 'ORDER*', '*STAT*']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_case_sensitivity(mock_snowflake_connection):
+    """Test case sensitivity in excluded_tables patterns."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['customers', 'public.orders']  # lowercase patterns
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_none_in_exclusions(mock_snowflake_connection):
+    """Test that None values in excluded_tables are properly handled."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['CUSTOMERS', None, 'ORDERS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_overlapping_exclusions(mock_snowflake_connection):
+    """Test with overlapping exclusion patterns."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['PUBLIC.*', 'TEST_DB.PUBLIC.CUSTOMERS', 'ORDERS']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)
+
+
+def test_get_tables_with_nested_wildcard_exclusions(mock_snowflake_connection):
+    """Test get_tables with nested wildcard patterns."""
+    source = SnowflakeSource(
+        database='TEST_DB',
+        excluded_tables=['TEST_DB.*.CUST*']
+    )
+
+    tables = source.get_tables()
+
+    expected_tables = [
+        'TEST_DB.PUBLIC.ORDERS',
+        'TEST_DB.ANALYTICS.PRODUCTS',
+        'TEST_DB.ANALYTICS.SALES',
+        'TEST_DB.TPCDS_SF100TCL.DEMOGRAPHICS',
+        'TEST_DB.TPCDS_SF100TCL.STATISTICS'
+    ]
+    assert set(tables) == set(expected_tables)


### PR DESCRIPTION
Some tables are off limits and may raise an error if trying to access it. To address that, we may want to pre-compile a list of tables that are inaccessible.

Builds off https://github.com/holoviz/lumen/pull/1074 because that other one is getting big.