### PR TITLE
Add _llm_spec_key for granular LLM control

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -32,8 +32,6 @@ class Actor(param.Parameterized):
         and the block names as the inner keys with the new content as the
         values.""")
 
-    _llm_spec_key = "default"
-
     def __init__(self, **params):
         super().__init__(**params)
         self._validate_template_overrides()
@@ -174,6 +172,18 @@ class Actor(param.Parameterized):
         """
         return cls._lookup_prompt_key(cls, key, "template").read_text()
 
+    @property
+    def llm_spec_key(self):
+        name = self.__class__.__name__.replace("Agent", "")
+        result = ""
+        for i, char in enumerate(name):
+            if char.isupper():
+                if i > 0:
+                    result += "_"
+                result += char.lower()
+            else:
+                result += char
+        return result
 
 class ContextProvider(param.Parameterized):
     """

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -32,6 +32,8 @@ class Actor(param.Parameterized):
         and the block names as the inner keys with the new content as the
         values.""")
 
+    _llm_spec_key = "default"
+
     def __init__(self, **params):
         super().__init__(**params)
         self._validate_template_overrides()

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -566,7 +566,7 @@ class SQLAgent(LumenBaseAgent):
             has_errors=bool(errors),
         )
         with self.interface.add_step(title=title or "SQL query", steps_layout=self._steps_layout) as step:
-            model_spec = self.prompts["main"].get("llm_spec", "default")
+            model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
             response = self.llm.stream(messages, system=system_prompt, model_spec=model_spec, response_model=self._get_model("main"))
             sql_query = None
             try:
@@ -798,7 +798,7 @@ class BaseViewAgent(LumenBaseAgent):
             doc=doc,
         )
 
-        model_spec = self.prompts["main"].get("llm_spec", "default")
+        model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
         response = self.llm.stream(
             messages,
             system=system,
@@ -1023,7 +1023,7 @@ class AnalysisAgent(LumenBaseAgent):
                     analyses=analyses,
                     data=self._memory.get("data"),
                 )
-                model_spec = self.prompts["main"].get("llm_spec", "default")
+                model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
                 analysis_name = (await self.llm.invoke(
                     messages,
                     system=system_prompt,

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -81,6 +81,8 @@ class Agent(Viewer, Actor, ContextProvider):
     # Panel extensions this agent requires to be loaded
     _extensions = ()
 
+    _llm_spec_key = "agent"
+
     # Maximum width of the output
     _max_width = 1200
 
@@ -127,7 +129,7 @@ class Agent(Viewer, Actor, ContextProvider):
 
     async def _stream(self, messages: list[Message], system_prompt: str) -> Any:
         message = None
-        model_spec = self.prompts["main"].get("llm_spec", "default")
+        model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
         async for output_chunk in self.llm.stream(
             messages, system=system_prompt, model_spec=model_spec, field="output"
         ):
@@ -250,6 +252,8 @@ class ChatAgent(Agent):
 
     requires = param.List(default=[], readonly=True)
 
+    _llm_spec_key = "chat"
+
     async def respond(
         self,
         messages: list[Message],
@@ -294,6 +298,8 @@ class AnalystAgent(ChatAgent):
         }
     )
 
+    _llm_spec_key = "analyst"
+
 
 class TableListAgent(Agent):
 
@@ -306,6 +312,8 @@ class TableListAgent(Agent):
     requires = param.List(default=["source"], readonly=True)
 
     _extensions = ('tabulator',)
+
+    _llm_spec_key = "table_list"
 
     @classmethod
     async def applies(cls, memory: _Memory) -> bool:
@@ -363,6 +371,8 @@ class DocumentListAgent(Agent):
 
     _extensions = ('tabulator',)
 
+    _llm_spec_key = "document_list"
+
     @classmethod
     async def applies(cls, memory: _Memory) -> bool:
         sources = memory.get("document_sources")
@@ -417,6 +427,8 @@ class LumenBaseAgent(Agent):
     _output_type = LumenOutput
 
     _max_width = None
+
+    _llm_spec_key = "lumen_base"
 
     def _update_spec(self, memory: _Memory, event: param.parameterized.Event):
         """
@@ -506,6 +518,8 @@ class SQLAgent(LumenBaseAgent):
     requires = param.List(default=["source"], readonly=True)
 
     _extensions = ('codeeditor', 'tabulator',)
+
+    _llm_spec_key = "sql"
 
     _output_type = SQLOutput
 
@@ -741,6 +755,8 @@ class BaseViewAgent(LumenBaseAgent):
 
     provides = param.List(default=["view"], readonly=True)
 
+    _llm_spec_key = "base_view"
+
     prompts = param.Dict(
         default={
             "main": {"template": PROMPTS_DIR / "BaseViewAgent" / "main.jinja2"},
@@ -855,6 +871,8 @@ class hvPlotAgent(BaseViewAgent):
         }
     )
 
+    _llm_spec_key = "hv_plot"
+
     view_type = hvPlotUIView
 
     def _get_model(self, prompt_name: str, schema: dict[str, Any]) -> type[BaseModel]:
@@ -916,6 +934,8 @@ class VegaLiteAgent(BaseViewAgent):
 
     _extensions = ('vega',)
 
+    _llm_spec_key = "vega_lite"
+
     _output_type = VegaLiteOutput
 
     async def _update_spec(self, memory: _Memory, event: param.parameterized.Event):
@@ -963,6 +983,8 @@ class AnalysisAgent(LumenBaseAgent):
     provides = param.List(default=['view'])
 
     requires = param.List(default=['pipeline'])
+
+    _llm_spec_key = "analysis"
 
     _output_type = AnalysisOutput
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -675,7 +675,7 @@ class SQLAgent(LumenBaseAgent):
             "find_tables", messages, separator=sep, tables_schema_str=tables_schema_str
         )
         tables_model = self._get_model("find_tables", tables=tables)
-        model_spec = self.prompts["find_tables"].get("llm_spec", "default")
+        model_spec = self.prompts["find_tables"].get("llm_spec", self._llm_spec_key)
         with self.interface.add_step(title="Determining tables to use", steps_layout=self._steps_layout) as step:
             response = self.llm.stream(
                 messages,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -90,6 +90,8 @@ class Coordinator(Viewer, Actor):
 
     tools = param.List(default=[])
 
+    _llm_spec_key = "coordinator"
+
     __abstract = True
 
     def __init__(

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -90,8 +90,6 @@ class Coordinator(Viewer, Actor):
 
     tools = param.List(default=[])
 
-    _llm_spec_key = "coordinator"
-
     __abstract = True
 
     def __init__(
@@ -323,7 +321,7 @@ class Coordinator(Viewer, Actor):
                 messages
             )
 
-        model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
+        model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
         out = await self.llm.invoke(
             messages=messages,
             system=system,
@@ -645,7 +643,7 @@ class Planner(Coordinator):
         if not tools and not tables:
             return table_info, ''
         context_model = make_context_model(tools=list(tools), tables=tables)
-        model_spec = self.prompts["context"].get("llm_spec", self._llm_spec_key)
+        model_spec = self.prompts["context"].get("llm_spec", self.llm_spec_key)
         system = await self._render_prompt(
             "context",
             messages,
@@ -717,7 +715,7 @@ class Planner(Coordinator):
                 tables_schema_str=tables_schema_str,
                 tool_context=tool_context
             )
-            model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
+            model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
             async for reasoning in self.llm.stream(
                 messages=messages,
                 system=system,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -321,7 +321,7 @@ class Coordinator(Viewer, Actor):
                 messages
             )
 
-        model_spec = self.prompts["main"].get("llm_spec", "default")
+        model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
         out = await self.llm.invoke(
             messages=messages,
             system=system,
@@ -715,7 +715,7 @@ class Planner(Coordinator):
                 tables_schema_str=tables_schema_str,
                 tool_context=tool_context
             )
-            model_spec = self.prompts["main"].get("llm_spec", "default")
+            model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
             async for reasoning in self.llm.stream(
                 messages=messages,
                 system=system,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -102,6 +102,8 @@ class Coordinator(Viewer, Actor):
         logs_db_path: str = "",
         **params,
     ):
+        log_debug("New Session: \033[92mStarted\033[0m", show_sep="above")
+
         def on_message(message, instance):
             def update_on_reaction(reactions):
                 if not self._logs:
@@ -309,7 +311,7 @@ class Coordinator(Viewer, Actor):
         )
 
     async def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface):
-        log_debug("\033[94mNEW\033[0m", show_sep=True)
+        log_debug(f"New Message: \033[91m{contents!r}\033[0m", show_sep="above")
         await self.respond(contents)
 
     @retry_llm_output()
@@ -384,7 +386,7 @@ class Coordinator(Viewer, Actor):
                 except Exception as e:
                     self._memory['__error__'] = str(e)
                     raise e
-                log_debug(f"\033[96m{agent_name} successfully completed\033[0m", show_sep=False, show_length=False)
+                log_debug(f"\033[96mCompleted: {agent_name}\033[0m", show_length=False)
 
             unprovided = [p for p in subagent.provides if p not in self._memory]
             if (unprovided and agent_name != "Source") or (len(unprovided) > 1 and agent_name == "Source"):
@@ -485,7 +487,7 @@ class Coordinator(Viewer, Actor):
                     break
             if "pipeline" in self._memory:
                 await self._add_analysis_suggestions()
-            log_debug("\033[92mDONE\033[0m\n\n", show_sep=True)
+            log_debug("\033[92mCompleted: Coordinator\033[0m", show_sep="below")
 
         for message_obj in self.interface.objects[::-1]:
             if isinstance(message_obj.object, Card):

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -643,7 +643,7 @@ class Planner(Coordinator):
         if not tools and not tables:
             return table_info, ''
         context_model = make_context_model(tools=list(tools), tables=tables)
-        model_spec = self.prompts["context"].get("llm_spec", "default")
+        model_spec = self.prompts["context"].get("llm_spec", self._llm_spec_key)
         system = await self._render_prompt(
             "context",
             messages,

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -23,7 +23,11 @@ from lumen.ai.utils import log_debug
 from .interceptor import Interceptor
 
 if TYPE_CHECKING:
-    MODEL_TYPE = Literal["default" | "reasoning" | "sql"]
+    MODEL_TYPE = Literal[
+        "default", "reasoning", "coordinator", "agent", "chat", "analyst", "table_list",
+        "document_list", "lumen_base", "sql", "base_view", "hv_plot", "vega_lite", "analysis",
+        "tool", "function_tool"
+    ]
 
 
 class Message(TypedDict):

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -26,14 +26,6 @@ class Message(TypedDict):
     content: str
     name: str | None
 
-
-KNOWN_LLM_SPEC_KEYS = (
-    "default", "reasoning", "coordinator", "agent", "chat", "analyst", "table_list",
-    "document_list", "lumen_base", "sql", "base_view", "hv_plot", "vega_lite", "analysis",
-    "tool", "function_tool"
-)
-MODEL_TYPE = Literal[KNOWN_LLM_SPEC_KEYS]
-
 BASE_MODES = list(Mode)
 
 
@@ -81,7 +73,7 @@ class Llm(param.Parameterized):
                 f"parameter for {self.__class__.__name__}."
             )
 
-    def _get_model_kwargs(self, model_spec: MODEL_TYPE | dict) -> dict[str, Any]:
+    def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
         """
         Can specify model kwargs as a dict or as a string that is a key in the model_kwargs
         or as a string that is a model type; else the actual name of the model.
@@ -89,11 +81,8 @@ class Llm(param.Parameterized):
         if isinstance(model_spec, dict):
             return model_spec
 
-        if model_spec in self.model_kwargs or model_spec in KNOWN_LLM_SPEC_KEYS:
-            model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
-        else:
-            model_kwargs = self.model_kwargs["default"]
-            model_kwargs["model"] = model_spec  # override the default model with user provided model
+        model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
+        log_debug(f"LLM Model: \033[96m{model_kwargs.get('model')!r}\033[0m")
         return dict(model_kwargs)
 
     @property
@@ -124,7 +113,7 @@ class Llm(param.Parameterized):
         system: str = "",
         response_model: BaseModel | None = None,
         allow_partial: bool = False,
-        model_spec: MODEL_TYPE | dict = "default",
+        model_spec: str | dict = "default",
         **input_kwargs,
     ) -> BaseModel:
         """
@@ -239,29 +228,30 @@ class Llm(param.Parameterized):
                 else:
                     yield getattr(chunk, field) if field is not None else chunk
 
-    async def run_client(self, model_spec: MODEL_TYPE | dict, messages: list[Message], **kwargs):
-        if response_model := kwargs.get("response_model"):
-            log_debug(f"\033[93m{response_model.__name__}\033[0m model used")
-
+    async def run_client(self, model_spec: str | dict, messages: list[Message], **kwargs):
+        log_debug(f"Input messages: \033[95m{len(messages)} messages\033[0m including system")
         previous_role = None
         for i, message in enumerate(messages):
             role = message["role"]
             if role == "system":
                 continue
             if role == "user":
-                log_debug(f"\033[95m{i} (u)\033[0m. {message['content']}")
+                log_debug(f"Message \033[95m{i} (u)\033[0m: {message['content']}")
             else:
-                log_debug(f"\033[95m{i} (a)\033[0m. {message['content']}")
+                log_debug(f"Message \033[95m{i} (a)\033[0m: {message['content']}")
             if previous_role == role:
                 log_debug(
                     "\033[91mWARNING: Two consecutive messages from the same role; "
                     "some providers disallow this.\033[0m"
                 )
             previous_role = role
-        log_debug(f"Length is \033[94m{len(messages)} messages\033[0m including system")
-        log_debug(f"Model used {model_spec}")
+
         client = await self.get_client(model_spec, **kwargs)
-        return await client(messages=messages, **kwargs)
+        result = await client(messages=messages, **kwargs)
+        if response_model := kwargs.get("response_model"):
+            log_debug(f"Response model: \033[93m{response_model.__name__!r}\033[0m")
+        log_debug(f"LLM Response: \033[90m{str(result)[:100]}...\033[0m\n---")
+        return result
 
 
 class LlamaCpp(Llm):
@@ -284,12 +274,12 @@ class LlamaCpp(Llm):
         },
     })
 
-    def _get_model_kwargs(self, model_spec: MODEL_TYPE | dict) -> dict[str, Any]:
+    def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
         if isinstance(model_spec, dict):
             return model_spec
 
-        if model_spec in self.model_kwargs or model_spec in KNOWN_LLM_SPEC_KEYS or "/" not in model_spec:
-            model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
+        if model_spec in self.model_kwargs or "/" not in model_spec:
+            return super()._get_model_kwargs()
         else:
             model_kwargs = self.model_kwargs["default"]
             repo, model_spec = model_spec.rsplit("/", 1)
@@ -310,7 +300,7 @@ class LlamaCpp(Llm):
     def _client_kwargs(self) -> dict[str, Any]:
         return {"temperature": self.temperature}
 
-    def _cache_model(self, model_spec: MODEL_TYPE | dict, **kwargs):
+    def _cache_model(self, model_spec: str | dict, **kwargs):
         from llama_cpp import Llama as LlamaCpp
         llm = LlamaCpp(**kwargs)
 
@@ -342,7 +332,7 @@ class LlamaCpp(Llm):
             model_file = kwargs.get('model_file')
             hf_hub_download(repo, model_file)
 
-    async def get_client(self, model_spec: MODEL_TYPE | dict, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: str | dict, response_model: BaseModel | None = None, **kwargs):
         if client_callable := pn.state.cache.get(model_spec):
             return client_callable
         model_kwargs = self._get_model_kwargs(model_spec)
@@ -371,7 +361,7 @@ class LlamaCpp(Llm):
         client_callable = await asyncio.to_thread(self._cache_model, model_spec, **llm_kwargs)
         return client_callable
 
-    async def run_client(self, model_spec: MODEL_TYPE | dict, messages: list[Message], **kwargs):
+    async def run_client(self, model_spec: str | dict, messages: list[Message], **kwargs):
         client = await self.get_client(model_spec, **kwargs)
         return client(messages=messages, **kwargs)
 
@@ -403,7 +393,7 @@ class OpenAI(Llm):
     def _client_kwargs(self):
         return {"temperature": self.temperature}
 
-    async def get_client(self, model_spec: MODEL_TYPE | dict, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: str | dict, response_model: BaseModel | None = None, **kwargs):
         import openai
 
         model_kwargs = self._get_model_kwargs(model_spec)
@@ -454,7 +444,7 @@ class AzureOpenAI(Llm):
     def _client_kwargs(self):
         return {"temperature": self.temperature}
 
-    async def get_client(self, model_spec: MODEL_TYPE | dict, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: str | dict, response_model: BaseModel | None = None, **kwargs):
         import openai
 
         model_kwargs = self._get_model_kwargs(model_spec)
@@ -599,7 +589,7 @@ class AnthropicAI(Llm):
     def _client_kwargs(self):
         return {"temperature": self.temperature, "max_tokens": 1024}
 
-    async def get_client(self, model_spec: MODEL_TYPE | dict, response_model: BaseModel | None = None, **kwargs):
+    async def get_client(self, model_spec: str | dict, response_model: BaseModel | None = None, **kwargs):
         if self.interceptor:
             raise NotImplementedError("Interceptors are not supported for AnthropicAI.")
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -6,9 +6,7 @@ import os
 
 from functools import partial
 from types import SimpleNamespace
-from typing import (
-    TYPE_CHECKING, Any, Literal, TypedDict,
-)
+from typing import Any, Literal, TypedDict
 
 import instructor
 import panel as pn
@@ -22,19 +20,18 @@ from lumen.ai.utils import log_debug
 
 from .interceptor import Interceptor
 
-if TYPE_CHECKING:
-    MODEL_TYPE = Literal[
-        "default", "reasoning", "coordinator", "agent", "chat", "analyst", "table_list",
-        "document_list", "lumen_base", "sql", "base_view", "hv_plot", "vega_lite", "analysis",
-        "tool", "function_tool"
-    ]
-
 
 class Message(TypedDict):
     role: Literal["system", "user", "assistant"]
     content: str
     name: str | None
 
+
+MODEL_TYPE = Literal[
+    "default", "reasoning", "coordinator", "agent", "chat", "analyst", "table_list",
+    "document_list", "lumen_base", "sql", "base_view", "hv_plot", "vega_lite", "analysis",
+    "tool", "function_tool"
+]
 
 BASE_MODES = list(Mode)
 
@@ -79,7 +76,14 @@ class Llm(param.Parameterized):
         super().__init__(**params)
 
     def _get_model_kwargs(self, model_spec: MODEL_TYPE | dict) -> dict[str, Any]:
-        if model_spec in self.model_kwargs:
+        """
+        Can specify model kwargs as a dict or as a string that is a key in the model_kwargs
+        or as a string that is a model type; else the actual name of the model.
+        """
+        if isinstance(model_spec, dict):
+            return model_spec
+
+        if model_spec in self.model_kwargs or model_spec in MODEL_TYPE:
             model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
         else:
             model_kwargs = self.model_kwargs["default"]
@@ -278,7 +282,7 @@ class LlamaCpp(Llm):
         if isinstance(model_spec, dict):
             return model_spec
 
-        if model_spec in self.model_kwargs or "/" not in model_spec:
+        if model_spec in self.model_kwargs or model_spec in MODEL_TYPE or "/" not in model_spec:
             model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
         else:
             model_kwargs = self.model_kwargs["default"]

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -75,6 +75,11 @@ class Llm(param.Parameterized):
             if isinstance(params["mode"], str):
                 params["mode"] = Mode[params["mode"].upper()]
         super().__init__(**params)
+        if not self.model_kwargs.get("default"):
+            raise ValueError(
+                f"Please specify a 'default' model in the model_kwargs "
+                f"parameter for {self.__class__.__name__}."
+            )
 
     def _get_model_kwargs(self, model_spec: MODEL_TYPE | dict) -> dict[str, Any]:
         """
@@ -86,7 +91,6 @@ class Llm(param.Parameterized):
 
         if model_spec in self.model_kwargs or model_spec in KNOWN_LLM_SPEC_KEYS:
             model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
-            print(model_kwargs)
         else:
             model_kwargs = self.model_kwargs["default"]
             model_kwargs["model"] = model_spec  # override the default model with user provided model
@@ -237,7 +241,7 @@ class Llm(param.Parameterized):
 
     async def run_client(self, model_spec: MODEL_TYPE | dict, messages: list[Message], **kwargs):
         if response_model := kwargs.get("response_model"):
-            log_debug(f"\033[93m{response_model.__name__}\033[0m model used", show_sep=True)
+            log_debug(f"\033[93m{response_model.__name__}\033[0m model used")
 
         previous_role = None
         for i, message in enumerate(messages):
@@ -255,7 +259,7 @@ class Llm(param.Parameterized):
                 )
             previous_role = role
         log_debug(f"Length is \033[94m{len(messages)} messages\033[0m including system")
-
+        log_debug(f"Model used {model_spec}")
         client = await self.get_client(model_spec, **kwargs)
         return await client(messages=messages, **kwargs)
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -27,11 +27,12 @@ class Message(TypedDict):
     name: str | None
 
 
-MODEL_TYPE = Literal[
+KNOWN_LLM_SPEC_KEYS = (
     "default", "reasoning", "coordinator", "agent", "chat", "analyst", "table_list",
     "document_list", "lumen_base", "sql", "base_view", "hv_plot", "vega_lite", "analysis",
     "tool", "function_tool"
-]
+)
+MODEL_TYPE = Literal[KNOWN_LLM_SPEC_KEYS]
 
 BASE_MODES = list(Mode)
 
@@ -83,8 +84,9 @@ class Llm(param.Parameterized):
         if isinstance(model_spec, dict):
             return model_spec
 
-        if model_spec in self.model_kwargs or model_spec in MODEL_TYPE:
+        if model_spec in self.model_kwargs or model_spec in KNOWN_LLM_SPEC_KEYS:
             model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
+            print(model_kwargs)
         else:
             model_kwargs = self.model_kwargs["default"]
             model_kwargs["model"] = model_spec  # override the default model with user provided model
@@ -282,7 +284,7 @@ class LlamaCpp(Llm):
         if isinstance(model_spec, dict):
             return model_spec
 
-        if model_spec in self.model_kwargs or model_spec in MODEL_TYPE or "/" not in model_spec:
+        if model_spec in self.model_kwargs or model_spec in KNOWN_LLM_SPEC_KEYS or "/" not in model_spec:
             model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
         else:
             model_kwargs = self.model_kwargs["default"]

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -24,6 +24,7 @@ class Tool(Actor, ContextProvider):
     interact with or on behalf of a user directly.
     """
 
+    _llm_spec_key = "tool"
 
 class VectorLookupTool(Tool):
     """
@@ -179,6 +180,8 @@ class FunctionTool(Tool):
             },
         }
     )
+
+    _llm_spec_key = "function_tool"
 
     def __init__(self, function, **params):
         model = function_to_model(function, skipped=self.requires)

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -197,7 +197,7 @@ class FunctionTool(Tool):
         prompt = await self._render_prompt("main", messages)
         kwargs = {}
         if any(field not in self.requires for field in self._model.model_fields):
-            model_spec = self.prompts["main"].get("llm_spec", "default")
+            model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
             kwargs = await self.llm.invoke(
                 messages,
                 system=prompt,

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -24,7 +24,6 @@ class Tool(Actor, ContextProvider):
     interact with or on behalf of a user directly.
     """
 
-    _llm_spec_key = "tool"
 
 class VectorLookupTool(Tool):
     """
@@ -181,8 +180,6 @@ class FunctionTool(Tool):
         }
     )
 
-    _llm_spec_key = "function_tool"
-
     def __init__(self, function, **params):
         model = function_to_model(function, skipped=self.requires)
         super().__init__(
@@ -197,7 +194,7 @@ class FunctionTool(Tool):
         prompt = await self._render_prompt("main", messages)
         kwargs = {}
         if any(field not in self.requires for field in self._model.model_fields):
-            model_spec = self.prompts["main"].get("llm_spec", self._llm_spec_key)
+            model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
             kwargs = await self.llm.invoke(
                 messages,
                 system=prompt,

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -13,7 +13,7 @@ from functools import wraps
 from pathlib import Path
 from shutil import get_terminal_size
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from urllib.parse import parse_qs
 
 import pandas as pd
@@ -379,15 +379,15 @@ async def gather_table_sources(sources: list[Source], include_provided: bool = T
     return tables_to_source, tables_schema_str.strip()
 
 
-def log_debug(msg: str | list, offset: int = 24, prefix: str = "", suffix: str = "", show_sep: bool = False, show_length: bool = False):
+def log_debug(msg: str | list, offset: int = 24, prefix: str = "", suffix: str = "", show_sep: Literal["above", "below"] | None = None, show_length: bool = False):
     """
     Log a debug message with a separator line above and below.
     """
     terminal_cols, _ = get_terminal_size()
     terminal_cols -= offset  # Account for the timestamp and log level
-    delimiter = "*" * terminal_cols
-    if show_sep:
-        log.debug(f"\033[91m{delimiter}\033[0m")
+    delimiter = "_" * terminal_cols
+    if show_sep == "above":
+        log.debug(f"\033[90m{delimiter}\033[0m")
     if prefix:
         log.debug(prefix)
 
@@ -397,9 +397,11 @@ def log_debug(msg: str | list, offset: int = 24, prefix: str = "", suffix: str =
     else:
         log.debug(msg)
     if show_length:
-        log.debug(f"Length is \033[94m{len(msg)}\033[0m")
+        log.debug(f"Characters: \033[94m{len(msg)}\033[0m")
     if suffix:
         log.debug(suffix)
+    if show_sep == "below":
+        log.debug(f"\033[90m{delimiter}\033[0m")
 
 
 def mutate_user_message(content: str, messages: list[dict[str, str]], suffix: bool = True, wrap: bool | str = False, inplace: bool = True):


### PR DESCRIPTION
Allows user to specify something like

```
OpenAI(
   models={"reasoning": ..., "chat": ..., "sql": ..., "base_view": ...}
)
```

So that the developers can specify very granular control per agent/tool/coordinator.