### PR TITLE
Fix parsing sql

### DIFF
--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -400,7 +400,7 @@ class SQLMinMax(SQLTransform):
         for col in self.columns:
             quoted = self.identify or bool(re.search(r'\W', col))
             for agg_func in (Min, Max):
-                alias = Identifier(this=(col + f"_{agg_func.__name__.upper()}"), quoted=quoted)
+                alias = Identifier(this=(col + f"_{agg_func.__name__}"), quoted=quoted)
                 minmax.append(
                     agg_func(this=Column(this=Identifier(this=col, quoted=quoted))).as_(alias)
                 )

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -126,7 +126,11 @@ class SQLTransform(Transform):
             quoted_sql_in = re.sub(
                 pattern, lambda m: f'FROM "{m.group(1)}"', sql_in, flags=re.IGNORECASE
             )
-            expressions = parse(quoted_sql_in)
+            expressions = parse(
+                quoted_sql_in,
+                read=self.read,
+                error_level=self.error_level,
+            )
 
         if len(expressions) > 1:
             raise ValueError(

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -400,7 +400,7 @@ class SQLMinMax(SQLTransform):
         for col in self.columns:
             quoted = self.identify or bool(re.search(r'\W', col))
             for agg_func in (Min, Max):
-                alias = Identifier(this=(col + f"_{agg_func.__name__}"), quoted=quoted)
+                alias = Identifier(this=(col + f"_{agg_func.__name__.lower()}"), quoted=quoted)
                 minmax.append(
                     agg_func(this=Column(this=Identifier(this=col, quoted=quoted))).as_(alias)
                 )


### PR DESCRIPTION
A little disappointed that sqlglot couldn't automagically parse `SELECT * FROM read_csv('life-expectancy')` and column names like `Period life expectancy at birth - Sex: total - Age: 0`, but still okay...

Closes https://github.com/holoviz/lumen/issues/1105