### PR TITLE
Ensure memory callbacks and rx refs are cleaned up

### DIFF
--- a/lumen/ai/memory.py
+++ b/lumen/ai/memory.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import weakref
+
 from collections import defaultdict
 from functools import partial
 
 import param
+
+from panel.io.state import state
 
 from ..config import SessionCache
 
@@ -12,8 +16,26 @@ class _Memory(SessionCache):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._callbacks = defaultdict(list)
-        self._rx = {}
+        self._session_callbacks = weakref.WeakKeyDictionary()
+        self._global_callbacks = defaultdict(list)
+        self._session_rx = weakref.WeakKeyDictionary()
+        self._global_rx = {}
+
+    @property
+    def _callbacks(self):
+        if state.curdoc:
+            if state.curdoc not in self._session_callbacks:
+                self._session_callbacks[state.curdoc] = defaultdict(list)
+            return self._session_callbacks[state.curdoc]
+        return self._global_callbacks
+
+    @property
+    def _rx(self):
+        if state.curdoc:
+            if state.curdoc not in self._session_rx:
+                self._session_rx[state.curdoc] = {}
+            return self._session_rx[state.curdoc]
+        return self._global_rx
 
     def __setitem__(self, key, new):
         if key in self:
@@ -24,8 +46,12 @@ class _Memory(SessionCache):
         self._trigger_update(key, old, new)
 
     def cleanup(self):
-        self._callbacks.clear()
-        self._rx.clear()
+        if state.curdoc:
+            self._session_callbacks[state.curdoc].clear()
+            self._session_rx[state.curdoc].clear()
+        else:
+            self._global_callbacks.clear()
+            self._global_rx.clear()
 
     def on_change(self, key, callback):
         self._callbacks[key].append(callback)


### PR DESCRIPTION
The `memory` object was holding onto all callbacks and rx references which is the likely cause of a number of memory leaks.