### PR TITLE
Revert hyphen

### DIFF
--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -517,7 +517,7 @@ class TableLookup(VectorLookupTool):
                 continue
             source_name = result['metadata']["source"]
             table_name = result['metadata']["table_name"]
-            table_slug = f"{source_name} - {table_name}"
+            table_slug = f"{source_name}{SOURCE_TABLE_SEPARATOR}{table_name}"
             description = f"- `{table_slug}`: {result['similarity']:.3f} similarity"
             table_similarities[table_slug] = result['similarity']
             if table_metadata := self._table_metadata.get(table_slug):


### PR DESCRIPTION
Using a hyphen was picked up by the LLM, and it led to SQL errors.