### PR TITLE
Duplicate source prefixes

### DIFF
--- a/lumen/ai/prompts/Planner/table_selection.jinja2
+++ b/lumen/ai/prompts/Planner/table_selection.jinja2
@@ -14,8 +14,8 @@ Analyze this query carefully and select up to 3 tables that would provide the mo
 
 ## EXAMINED SCHEMAS
 You have already examined these tables with their schemas:
-{%- for table_name, table_info in current_schemas.items() %}
-## `{{ table_info.source }}{{ separator }}{{ table_name }}`
+{%- for table_slug, table_info in current_schemas.items() %}
+## `{{ table_slug }}`
 ```yaml
 {{ table_info.schema }}
 ```


### PR DESCRIPTION
The keys were already table_slug, e.g. SOURCE__@__TABLE_NAME; did not need to reformat.

Also going forward, for the sake of consistency and reducing confusion, I'd like to have every table reference stored in memory as a table_slug, unless explicitly labeled otherwise.