### PR TITLE
Add SQL table to dict

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -714,8 +714,9 @@ class SQLAgent(LumenBaseAgent):
 
             tables_sql_schemas[table_slug] = {
                 "schema": yaml.dump(table_schema),
-                "sql": source.get_sql_expr(source_table),
                 "source": source.name,
+                "sql_table": table_name,
+                "sql": source.get_sql_expr(source_table),
             }
         self._memory["tables_sql_schemas"] = tables_sql_schemas
 

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -638,8 +638,9 @@ class Planner(Coordinator):
         normalized_table_name = source_obj.normalize_table(table_name)
         result = {
             "schema": yaml.dump(table_schema),
-            "sql": source_obj.get_sql_expr(table_name),
             "source": source_obj.name,
+            "sql_table": normalized_table_name,
+            "sql": source_obj.get_sql_expr(table_name),
         }
         table_slug = f"{source_obj.name}{SOURCE_TABLE_SEPARATOR}{normalized_table_name}"
         return table_slug, result, source_table

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -38,8 +38,8 @@ The dataset is empty. As the subject matter expert, if this is unexpected, analy
 and try to make educated guess what other columns or values should be used instead.
 
 For reference, here's the tables and their schemas:
-{% for table_name, table_info in memory.tables_sql_schemas.items() %}
-- **{{ table_name }}**:
+{% for table_info in memory.tables_sql_schemas.values() %}
+- **{{ table_info.sql_table }}**:
 ```yaml
 {{ table_info.schema }}
 ```

--- a/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
+++ b/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
@@ -7,10 +7,10 @@ Original output:
 
 {% if memory["tables_sql_schemas"] %}
 Reference these database schemas for your corrections:
-{% for table, details in memory["tables_sql_schemas"].items() %}
-- `{{ table }}`:
+{% for table_info in memory["tables_sql_schemas"].values() %}
+- `{{ table_info.sql_table }}`:
 ```yaml
-{{ details.schema }}
+{{ table_info.schema }}
 ```
 {% endfor %}
 {% endif %}

--- a/lumen/ai/prompts/Planner/table_selection.jinja2
+++ b/lumen/ai/prompts/Planner/table_selection.jinja2
@@ -14,8 +14,8 @@ Analyze this query carefully and select up to 3 tables that would provide the mo
 
 ## EXAMINED SCHEMAS
 You have already examined these tables with their schemas:
-{%- for table_name, table_info in current_schemas.items() %}
-## `{{ table_info.source }}{{ separator }}{{ table_name }}`
+{%- for table_slug, table_info in current_schemas.items() %}
+## `{{ table_slug }}`
 ```yaml
 {{ table_info.schema }}
 ```

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -52,10 +52,10 @@ Here's additional guidance:
 
 {%- if tables_sql_schemas %}
 Here are YAML schemas for currently relevant tables:
-{% for table, details in tables_sql_schemas.items() %}
-- `{{ table }}`:
+{% for table_info in tables_sql_schemas.values() %}
+- `{{ table_info.sql_table }}`:
 ```yaml
-{{ details.schema }}
+{{ table_info.schema }}
 ```
 {% endfor -%}
 {%- endif -%}

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -517,7 +517,7 @@ class TableLookup(VectorLookupTool):
                 continue
             source_name = result['metadata']["source"]
             table_name = result['metadata']["table_name"]
-            table_slug = f"{source_name} - {table_name}"
+            table_slug = f"{source_name}{SOURCE_TABLE_SEPARATOR}{table_name}"
             description = f"- `{table_slug}`: {result['similarity']:.3f} similarity"
             table_similarities[table_slug] = result['similarity']
             if table_metadata := self._table_metadata.get(table_slug):


### PR DESCRIPTION
Since we're using table_slug https://github.com/holoviz/lumen/pull/1114 as keys in memory, when the LLM was building SQL, it would do something like

`SELECT * FROM ProvidedSource000000__@__read_parquet('windturbines.parquet')` which is invalid. So, we need another reference, `sql_table`. Also this is nice because it highlights to the LLM that there's a difference between the table_slug key and sql table alias.