### PR TITLE
SQLSelectFrom fix

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -754,7 +754,7 @@ class Planner(Coordinator):
                     break
         return {
             table_slug: schema_data for table_slug, schema_data in tables_sql_schemas.items()
-            if not selected_tables or table_slug in selected_tables  # prevent it from getting too big and waste token
+            if table_slug in selected_tables  # prevent it from getting too big and waste token
         }
 
     async def _get_tools_context(self, messages: list[Message]) -> dict:

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -754,7 +754,7 @@ class Planner(Coordinator):
                     break
         return {
             table_slug: schema_data for table_slug, schema_data in tables_sql_schemas.items()
-            if table_slug in selected_tables  # prevent it from getting too big and waste token
+            if not selected_tables or table_slug in selected_tables  # prevent it from getting too big and waste token
         }
 
     async def _get_tools_context(self, messages: list[Message]) -> dict:

--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -426,7 +426,7 @@ class TestSQLSelectFrom:
         """Test dialect-specific behavior."""
         sql_in = "my_table"
         result = SQLSelectFrom.apply_to(sql_in, identify=True, write="postgres")
-        expected = "SELECT * FROM my_table"
+        expected = 'SELECT * FROM "my_table"'
         assert result == expected
 
     def test_complex_query_table_replacement(self):

--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -444,3 +444,9 @@ class TestSQLSelectFrom:
         normalized_result = " ".join(result.split())
         expected = "SELECT t1.col1, t2.col2 FROM new_table1 AS t1 JOIN new_table2 AS t2 ON t1.id = t2.id WHERE t1.col1 > 10 GROUP BY t1.col1"
         assert normalized_result == expected
+
+    def test_table_path(self):
+        sql_in = '/path/to/my_data.parquet'
+        result = SQLSelectFrom.apply_to(sql_in)
+        expected = 'SELECT * FROM "/path/to/my_data.parquet"'
+        assert result == expected


### PR DESCRIPTION
Without these changes, SQLGlot has trouble parsing:
`SQLSelectFrom(sql_expr='SELECT * FROM {table}').apply("/this/path/to_data.parquet")`