### PR TITLE
Do not normalize twice

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -945,8 +945,9 @@ class BaseSQLSource(Source):
                 table = self.tables[self.normalize_table(table)]
             except KeyError:
                 raise KeyError(f"Table {table} not found in {self.tables.keys()}")
+        else:
+            table = self.normalize_table(table)
 
-        table = self.normalize_table(table)
         sql_expr = SQLSelectFrom(sql_expr=self.sql_expr).apply(table)
         return sql_expr
 


### PR DESCRIPTION
Was confused as to why the SQL statement with a limit wasn't applying (LIMIT 3, but 72357 rows)

<img width="872" alt="image" src="https://github.com/user-attachments/assets/7990f938-8eb2-4c9c-87fd-e5367a1ba49c" />

Realized I was normalizing the table twice, e.g. the first one returned a valid SQL statement `table = self.tables[self.normalize_table(table)]`, but the second time, it extracted the table, then applied the default `sql_expr`.