### PR TITLE
Improve initial entry

### DIFF
--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -90,7 +90,7 @@ ul.nav.flex-column {
 }
 
 .collapsed-content {
-    display: none !important;  /* required to expand / collapse properly */
+    display: none;
 }
 
 /* Ensure the right panel and its contents are visible when expanded */

--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -173,9 +173,9 @@ class SplitJS(JSComponent):
             self.expanded_sizes = (right_exp, left_exp)
 
     @param.depends("collapsed", watch=True)
-    def _send_collapsed_update(self, event):
+    def _send_collapsed_update(self):
         """Send message to JS when collapsed state changes in Python"""
-        self._send_msg({"type": "update_collapsed", "collapsed": event.new})
+        self._send_msg({"type": "update_collapsed", "collapsed": self.collapsed})
 
     def _handle_msg(self, msg):
         """Handle messages from JS"""

--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -5,80 +5,95 @@ import param
 from panel.custom import Child, JSComponent
 
 CSS = """
-/* Max width for comfortable reading */
-.left-panel-content {
-    max-width: clamp(450px, 95vw, 1200px);
-    margin: 0px auto;  /* Center the content */
-    padding: 0px;
-}
-
-@keyframes jumpLeftRight {
-    0%, 100% { transform: translateY(-50%); }
-    25% { transform: translate(-4px, -50%); }
-    50% { transform: translateY(-50%); }
-    75% { transform: translate(4px, -50%); }
-}
-
+/* Base styles for the split container */
 .split {
     display: flex;
     flex-direction: row;
     height: 100%;
     width: 100%;
-}
-
-.gutter {
     background-color: var(--panel-surface-color);
-    background-repeat: no-repeat;
-    background-position: 50%;
-    cursor: col-resize;
+    overflow-y: clip; /* Clip overflow to prevent scrollbars; inner content will have their own */
 }
 
-.gutter.gutter-horizontal {
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
-    z-index: 1;
+/* Style for initial load to prevent FOUC */
+.split.loading {
+    visibility: hidden;
 }
 
-ul.nav.flex-column {
-    padding-inline-start: 0;
-    margin: 0;
+/* Max width for comfortable reading */
+.left-panel-content {
+    max-width: clamp(450px, 95vw, 1200px);
+    margin: 0px auto;  /* Center the content */
+    background-color: var(--panel-background-color); /* Use theme variable for content background */
+    border-radius: 10px; /* Slight rounded corners */
+    overflow-y: auto;   /* Enable scrolling if content is taller than the area */
+    box-sizing: border-box; /* Include padding in size calculations */
 }
 
+/* Split panel styles */
+.split > div {
+    position: relative;
+}
+
+.split > div:nth-child(2) {
+    overflow: visible;
+    position: relative;
+    width: 100%;
+}
+
+/* Content wrapper styles */
+.content-wrapper {
+    width: 100%;
+    height: 100%;
+    display: block;
+    background-color: var(--panel-background-color);
+}
+
+.left-content-wrapper {
+    width: 100%;
+    height: 100%;
+}
+
+/* Toggle icon basic styles */
+.toggle-icon, .toggle-icon-inverted {
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 10;
+    opacity: 0.75;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+/* Regular toggle icon */
 .toggle-icon {
-    position: absolute;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    z-index: 10;
-    opacity: 0.65;
     transition: opacity 0.2s, left 0.3s ease;
-    left: -30px; /* Default position - will be updated by JS */
-    top: 50%;
-    transform: translateY(-50%);
+    left: 5px; /* Default expanded position */
 }
 
+.toggle-icon.collapsed {
+    left: -30px; /* Position when collapsed */
+}
+
+/* Inverted toggle icon */
 .toggle-icon-inverted {
-    position: absolute;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    z-index: 10;
-    opacity: 0.65;
     transition: opacity 0.2s, right 0.3s ease;
-    right: -30px; /* Default position - will be updated by JS */
-    top: 50%;
-    transform: translateY(-50%);
+    right: 5px; /* Default expanded position */
+}
+
+.toggle-icon-inverted.collapsed {
+    right: -30px; /* Position when collapsed */
 }
 
 .toggle-icon:hover, .toggle-icon-inverted:hover {
     opacity: 1;
 }
 
+/* SVG icon styling */
 .toggle-icon svg, .toggle-icon-inverted svg {
     width: 50px;
     height: 50px;
@@ -89,14 +104,28 @@ ul.nav.flex-column {
     stroke-linejoin: round;
 }
 
+/* Collapsed state */
 .collapsed-content {
     display: none;
 }
 
-/* Ensure the right panel and its contents are visible when expanded */
-.split > div:nth-child(2) {
-    overflow: visible;
-    position: relative;
+/* Gutter styles */
+.gutter {
+    background-color: var(--panel-surface-color);
+    background-repeat: no-repeat;
+    background-position: 50%;
+    cursor: col-resize;
+    transition: background-color 0.2s;
+}
+
+.gutter:hover {
+    background-color: var(--panel-border-color);
+}
+
+.gutter.gutter-horizontal {
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
+    z-index: 1;
+    width: 8px !important;
 }
 
 .split > div:nth-child(2) > div:not(.toggle-icon) {
@@ -104,6 +133,27 @@ ul.nav.flex-column {
     height: 100%;
     overflow: auto;
     padding-top: 36px; /* Space for the toggle icon */
+}
+
+/* Animation for toggle icon */
+@keyframes jumpLeftRight {
+    0%, 100% { transform: translateY(-50%); }
+    25% { transform: translate(-4px, -50%); }
+    50% { transform: translateY(-50%); }
+    75% { transform: translate(4px, -50%); }
+}
+
+.toggle-icon.animated, .toggle-icon-inverted.animated {
+    animation-name: jumpLeftRight;
+    animation-duration: 0.5s;
+    animation-timing-function: ease;
+    animation-iteration-count: 3;
+}
+
+/* List navigation styles */
+ul.nav.flex-column {
+    padding-inline-start: 0;
+    margin: 0;
 }
 """
 

--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -3,6 +3,21 @@ import param
 from panel.custom import Child, JSComponent
 
 CSS = """
+/* Max width for comfortable reading */
+.left-panel-content {
+    max-width: clamp(400px, 100vw, 1500px);
+    margin: 0 auto;
+    padding: 0 20px;
+    box-sizing: border-box;
+}
+
+@keyframes jumpLeftRight {
+    0%, 100% { transform: translateY(-50%); }
+    25% { transform: translate(-4px, -50%); }
+    50% { transform: translateY(-50%); }
+    75% { transform: translate(4px, -50%); }
+}
+
 .split {
     display: flex;
     flex-direction: row;
@@ -19,22 +34,97 @@ CSS = """
 
 .gutter.gutter-horizontal {
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
+    z-index: 1;
 }
 
 ul.nav.flex-column {
     padding-inline-start: 0 !important;
     margin: 0 !important;
 }
+
+.toggle-icon {
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 10;
+    opacity: 0.65;
+    transition: opacity 0.2s;
+    left: -30px; /* Position it to the left of the gutter with more offset */
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.toggle-icon-inverted {
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 10;
+    opacity: 0.65;
+    transition: opacity 0.2s;
+    right: -30px; /* Position it to the right of the gutter with offset */
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.toggle-icon:hover, .toggle-icon-inverted:hover {
+    opacity: 1;
+}
+
+.toggle-icon svg, .toggle-icon-inverted svg {
+    width: 50px;
+    height: 50px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2px;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.collapsed-content {
+    display: none !important;
+}
+
+/* Ensure the right panel and its contents are visible when expanded */
+.split > div:nth-child(2) {
+    overflow: visible;
+    position: relative;
+}
+
+.split > div:nth-child(2) > div:not(.toggle-icon) {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    padding-top: 36px; /* Space for the toggle icon */
+}
 """
 
 
 class SplitJS(JSComponent):
-    """Custom component for resizable and collapsible sidebar."""
+    """
+    Professional split panel component with collapsible sidebar.
+
+    The component uses an icon in the top-right corner of each panel section
+    for toggling between expanded and collapsed states.
+    """
 
     left = Child()
     right = Child()
-    sizes = param.NumericTuple(default=(60, 40), length=2)
-    min_sizes = param.NumericTuple(default=(300, 200), length=2)
+    sizes = param.NumericTuple(default=(100, 0), length=2)
+    expanded_sizes = param.NumericTuple(default=(35, 65), length=2)
+    min_sizes = param.NumericTuple(default=(300, 0), length=2)
+    collapsed = param.Boolean(default=True)
+    invert = param.Boolean(default=False, doc="""
+        Whether to invert the layout, changing the toggle button side and panel styles.
+        This is useful for supporting different panel layouts like chat-left vs chat-right.
+        """)
 
     _esm = """
     import Split from 'https://esm.sh/split.js@1.6.5'
@@ -48,21 +138,173 @@ class SplitJS(JSComponent):
       const split1 = document.createElement('div');
       splitDiv.append(split0, split1);
 
+      split1.style.position = 'relative';
+      split1.style.width = '100%';
+
+      // Create content wrapper for right panel
+      const contentWrapper = document.createElement('div');
+      // In inverted mode, the right content should always be visible when collapsed
+      contentWrapper.style.width = '100%';
+      contentWrapper.style.height = '100%';
+      contentWrapper.style.display = 'block';
+
+      // Apply background color based on invert parameter
+      if (model.invert) {
+        split0.style.backgroundColor = 'whitesmoke';
+      } else {
+        contentWrapper.style.backgroundColor = 'whitesmoke';
+      }
+
+      // Create toggle icon for panel toggling
+      const toggleIcon = document.createElement('div');
+
+      // Set class and initial arrow direction based on invert parameter
+      if (model.invert) {
+        toggleIcon.className = 'toggle-icon-inverted';
+        toggleIcon.innerHTML = model.collapsed
+          ? `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`  // Right arrow when collapsed
+          : `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`;  // Left arrow when expanded
+      } else {
+        toggleIcon.className = 'toggle-icon';
+        toggleIcon.innerHTML = model.collapsed
+          ? `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`  // Left arrow when collapsed
+          : `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`;  // Right arrow when expanded
+      }
+
+      // Determine which panel gets the toggle based on invert parameter
+      const togglePanel = model.invert ? split0 : split1;
+      const toggleTarget = model.invert ? split1 : split0;
+
+      // Add the toggle icon to the appropriate panel but positioned relative to the gutter
+      togglePanel.style.position = 'relative'; // Ensure the container has relative positioning
+      togglePanel.appendChild(toggleIcon);
+
+      // Determine initial state based on the invert parameter
+      let initSizes;
+      if (model.invert) {
+        // In inverted mode, right panel is shown first
+        initSizes = model.collapsed ? [0, 100] : model.expanded_sizes;
+      } else {
+        // In normal mode, left panel is shown first
+        initSizes = model.collapsed ? [100, 0] : model.expanded_sizes;
+      }
+
       const splitInstance = Split([split0, split1], {
-        sizes: model.sizes,
+        sizes: initSizes,
         minSize: model.min_sizes,
-        gutterSize: 10,
+        gutterSize: 6,
         onDragEnd: (sizes) => {
           view.invalidate_layout();
+
+          // Update collapsed state based on panel size and invert parameter
+          if (model.invert ? sizes[0] <= 5 : sizes[1] <= 5) {
+            model.collapsed = true;
+
+            // Set arrow direction based on invert parameter
+            if (model.invert) {
+              toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+            } else {
+              toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+            }
+          } else {
+            model.collapsed = false;
+            contentWrapper.className = '';
+            contentWrapper.style.display = 'block';
+
+            // Set arrow direction based on invert parameter
+            if (model.invert) {
+              toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+            } else {
+              toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+            }
+          }
         },
       });
 
-      model.on("after_layout", () => {
-        setTimeout(() => { splitDiv.style.visibility = 'visible'; }, 100);
-      })
+      // Toggle button event listener
+      toggleIcon.addEventListener('click', () => {
+        if (model.collapsed) {
+          // Expand
+          splitInstance.setSizes(model.expanded_sizes);
+          model.collapsed = false;
 
-      split0.append(model.get_child("left"));
-      split1.append(model.get_child("right"));
+          // Make sure content is visible when expanding
+          contentWrapper.className = '';
+          contentWrapper.style.display = 'block';
+
+          // Set arrow direction based on invert parameter
+          if (model.invert) {
+            toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+          } else {
+            toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+          }
+        } else {
+          // Collapse with appropriate sizes based on invert parameter
+          if (model.invert) {
+            splitInstance.setSizes([0, 100]);
+          } else {
+            splitInstance.setSizes([100, 0]);
+          }
+          model.collapsed = true;
+
+          // Only hide content in non-inverted mode
+          if (!model.invert) {
+            contentWrapper.className = 'collapsed-content';
+            contentWrapper.style.display = 'none';
+          }
+
+          // Set arrow direction based on invert parameter
+          if (model.invert) {
+            toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+          } else {
+            toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+          }
+        }
+        view.invalidate_layout();
+      });
+
+      model.on("after_layout", () => {
+        setTimeout(() => {
+          splitDiv.style.visibility = 'visible';
+
+          // Only add animation on initial load
+          if (!window._toggleAnimationShown) {
+            // Add animation on first load only
+            toggleIcon.style.animationName = 'jumpLeftRight';
+            toggleIcon.style.animationDuration = '0.5s';
+            toggleIcon.style.animationTimingFunction = 'ease';
+            toggleIcon.style.animationIterationCount = '3';
+
+            // Remove animation after it completes and set flag
+            setTimeout(() => {
+              toggleIcon.style.animationName = '';
+              toggleIcon.style.animationDuration = '';
+              toggleIcon.style.animationTimingFunction = '';
+              toggleIcon.style.animationIterationCount = '';
+              window._toggleAnimationShown = true;
+            }, 1500);
+          }
+
+          window.dispatchEvent(new Event('resize'));
+        }, 100);
+      });
+
+      // Create a centered content wrapper for the left panel
+      const leftContentWrapper = document.createElement('div');
+
+      // Apply left-panel-content class to the appropriate panel based on invert parameter
+      if (model.invert) {
+        contentWrapper.className += ' left-panel-content';
+      } else {
+        leftContentWrapper.className = 'left-panel-content';
+      }
+
+      leftContentWrapper.style.width = '100%';
+      leftContentWrapper.style.height = '100%';
+      leftContentWrapper.append(model.get_child("left"));
+      split0.append(leftContentWrapper);
+      contentWrapper.append(model.get_child("right"));
+      split1.append(contentWrapper);
 
       return splitDiv;
     }"""

--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -163,10 +163,6 @@ class SplitJS(JSComponent):
 
     def __init__(self, **params):
         super().__init__(**params)
-        # Set up a watcher for the collapsed parameter
-        self.param.watch(self._send_collapsed_update, 'collapsed')
-
-        # Auto-adjust parameters based on invert value
         if self.invert:
             # Swap min_sizes when inverted
             left_min, right_min = self.min_sizes
@@ -176,6 +172,7 @@ class SplitJS(JSComponent):
             left_exp, right_exp = self.expanded_sizes
             self.expanded_sizes = (right_exp, left_exp)
 
+    @param.depends("collapsed", watch=True)
     def _send_collapsed_update(self, event):
         """Send message to JS when collapsed state changes in Python"""
         self._send_msg({"type": "update_collapsed", "collapsed": event.new})
@@ -185,4 +182,6 @@ class SplitJS(JSComponent):
         if 'collapsed' in msg:
             collapsed = msg['collapsed']
             with param.discard_events(self):
+                # Important to discard so when user drags the panel, it doesn't
+                # expand to the expanded sizes
                 self.collapsed = collapsed

--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -274,6 +274,21 @@ class SplitJS(JSComponent):
         view.invalidate_layout();
       });
 
+      // Listen for parameter changes as they're the proper way to update
+      model.on(['collapsed', 'sizes'], () => {
+        if (!model.collapsed) {
+          splitInstance.setSizes(model.sizes || model.expanded_sizes);
+        } else {
+          // When collapsing, use the appropriate sizes based on invert parameter
+          if (model.invert) {
+            splitInstance.setSizes([0, 100]);
+          } else {
+            splitInstance.setSizes([100, 0]);
+          }
+        }
+        view.invalidate_layout();
+      });
+
       model.on("after_layout", () => {
         setTimeout(() => {
           splitDiv.style.visibility = 'visible';

--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -5,10 +5,9 @@ from panel.custom import Child, JSComponent
 CSS = """
 /* Max width for comfortable reading */
 .left-panel-content {
-    max-width: clamp(400px, 100vw, 1500px);
-    margin: 0 auto;
-    padding: 0 20px;
-    box-sizing: border-box;
+    max-width: clamp(450px, 95vw, 1200px);
+    margin: 0px auto;  /* Center the content */
+    padding: 0px;
 }
 
 @keyframes jumpLeftRight {
@@ -52,8 +51,8 @@ ul.nav.flex-column {
     cursor: pointer;
     z-index: 10;
     opacity: 0.65;
-    transition: opacity 0.2s;
-    left: -30px; /* Position it to the left of the gutter with more offset */
+    transition: opacity 0.2s, left 0.3s ease;
+    left: -30px; /* Default position - will be updated by JS */
     top: 50%;
     transform: translateY(-50%);
 }
@@ -68,8 +67,8 @@ ul.nav.flex-column {
     cursor: pointer;
     z-index: 10;
     opacity: 0.65;
-    transition: opacity 0.2s;
-    right: -30px; /* Position it to the right of the gutter with offset */
+    transition: opacity 0.2s, right 0.3s ease;
+    right: -30px; /* Default position - will be updated by JS */
     top: 50%;
     transform: translateY(-50%);
 }
@@ -164,11 +163,15 @@ class SplitJS(JSComponent):
         toggleIcon.innerHTML = model.collapsed
           ? `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`  // Right arrow when collapsed
           : `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`;  // Left arrow when expanded
+        // Set initial position based on collapsed state
+        toggleIcon.style.right = model.collapsed ? '-30px' : '5px';
       } else {
         toggleIcon.className = 'toggle-icon';
         toggleIcon.innerHTML = model.collapsed
           ? `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`  // Left arrow when collapsed
           : `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`;  // Right arrow when expanded
+        // Set initial position based on collapsed state
+        toggleIcon.style.left = model.collapsed ? '-30px' : '5px';
       }
 
       // Determine which panel gets the toggle based on invert parameter
@@ -202,10 +205,12 @@ class SplitJS(JSComponent):
 
             // Set arrow direction based on invert parameter
             if (model.invert) {
-              toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+            toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+              toggleIcon.style.right = '-30px'; // Adjust position when collapsed
             } else {
               toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
-            }
+            toggleIcon.style.left = '-30px'; // Adjust position when collapsed
+          }
           } else {
             model.collapsed = false;
             contentWrapper.className = '';
@@ -213,10 +218,12 @@ class SplitJS(JSComponent):
 
             // Set arrow direction based on invert parameter
             if (model.invert) {
-              toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+            toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+              toggleIcon.style.right = '5px'; // Adjust position when expanded
             } else {
               toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
-            }
+            toggleIcon.style.left = '5px'; // Adjust position when expanded
+          }
           }
         },
       });
@@ -235,8 +242,10 @@ class SplitJS(JSComponent):
           // Set arrow direction based on invert parameter
           if (model.invert) {
             toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+            toggleIcon.style.right = '5px'; // Adjust position when expanded
           } else {
             toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+            toggleIcon.style.left = '5px'; // Adjust position when expanded
           }
         } else {
           // Collapse with appropriate sizes based on invert parameter
@@ -256,8 +265,10 @@ class SplitJS(JSComponent):
           // Set arrow direction based on invert parameter
           if (model.invert) {
             toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+            toggleIcon.style.right = '-30px'; // Adjust position when collapsed
           } else {
             toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+            toggleIcon.style.left = '-30px'; // Adjust position when collapsed
           }
         }
         view.invalidate_layout();

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -46,6 +46,30 @@ if TYPE_CHECKING:
     from panel.chat.step import ChatStep
 
 
+UI_INTRO_MESSAGE = """
+👋 Click a suggestion below or upload a data source to get started!
+
+Lumen AI combines large language models (LLMs) with specialized agents to help you explore, analyze,
+and visualize data without writing code.
+
+On the chat interface...
+
+💬 Ask questions in plain English to generate SQL queries and visualizations
+🔍 Inspect and validate results through conversation
+📝 Get summaries and key insights from your data
+🧩 Apply custom analyses with a click of a button
+
+Click the toggle, or drag the edge, to expand the sidebar and...
+
+📚 Upload sources (tables and documents) by dragging or selecting files
+🌐 Explore data with [Graphic Walker](https://docs.kanaries.net/graphic-walker) - filter, sort, download
+💾 Access all generated tables and visualizations under tabs
+📤 Export your session as a reproducible notebook
+
+📖 Learn more about [Lumen AI](https://lumen.holoviz.org/lumen_ai/getting_started/using_lumen_ai.html)
+"""
+
+
 class ExecutionNode(param.Parameterized):
     """
     Defines a node in an execution graph.
@@ -69,6 +93,9 @@ class Coordinator(Viewer, Actor):
     computing an execution graph and then executing each
     step along the graph.
     """
+
+    within_ui = param.Boolean(default=False, constant=True, doc="""
+        Whether this coordinator is being used within the UI.""")
 
     agents = param.List(default=[ChatAgent], doc="""
         List of agents to coordinate.""")
@@ -199,8 +226,9 @@ class Coordinator(Viewer, Actor):
             else:
                 self._tools["__main__"].append(tool(llm=llm))
 
+        welcome_message = UI_INTRO_MESSAGE if self.within_ui else "Welcome to LumenAI; get started by clicking a suggestion or type your own query below!"
         interface.send(
-            "Welcome to LumenAI; get started by clicking a suggestion or type your own query below!",
+            welcome_message,
             user="Help", respond=False, show_reaction_icons=False, show_copy_icon=False
         )
         interface.button_properties={

--- a/lumen/ai/models/split.js
+++ b/lumen/ai/models/split.js
@@ -1,0 +1,228 @@
+import Split from 'https://esm.sh/split.js@1.6.5'
+
+export function render({ model, view }) {
+    const splitDiv = document.createElement('div');
+    splitDiv.className = 'split';
+    splitDiv.style.visibility = 'hidden';
+
+    const split0 = document.createElement('div');
+    const split1 = document.createElement('div');
+    splitDiv.append(split0, split1);
+
+    split1.style.position = 'relative';
+    split1.style.width = '100%';
+
+    // Create content wrapper for right panel
+    const contentWrapper = document.createElement('div');
+    contentWrapper.style.width = '100%';
+    contentWrapper.style.height = '100%';
+    contentWrapper.style.display = 'block';
+
+    // Apply background color based on invert parameter
+    if (model.invert) {
+    split0.style.backgroundColor = 'whitesmoke';
+    } else {
+    contentWrapper.style.backgroundColor = 'whitesmoke';
+    }
+
+    // Create toggle icon for panel toggling
+    const toggleIcon = document.createElement('div');
+
+    // Set class and initial arrow direction based on invert parameter
+    if (model.invert) {
+    toggleIcon.className = 'toggle-icon-inverted';
+    toggleIcon.innerHTML = model.collapsed
+        ? `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`  // Right arrow when collapsed
+        : `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`;  // Left arrow when expanded
+    // Set initial position based on collapsed state
+    toggleIcon.style.right = model.collapsed ? '-30px' : '5px';
+    } else {
+    toggleIcon.className = 'toggle-icon';
+    toggleIcon.innerHTML = model.collapsed
+        ? `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`  // Left arrow when collapsed
+        : `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`;  // Right arrow when expanded
+    // Set initial position based on collapsed state
+    toggleIcon.style.left = model.collapsed ? '-30px' : '5px';
+    }
+
+    // Determine which panel gets the toggle based on invert parameter
+    const togglePanel = model.invert ? split0 : split1;
+    const toggleTarget = model.invert ? split1 : split0;
+
+    // Add the toggle icon to the appropriate panel but positioned relative to the gutter
+    togglePanel.style.position = 'relative'; // Ensure the container has relative positioning
+    togglePanel.appendChild(toggleIcon);
+
+    // Determine initial state based on the invert parameter
+    let initSizes;
+    if (model.invert) {
+    // In inverted mode, right panel is shown first
+    initSizes = model.collapsed ? [0, 100] : model.expanded_sizes;
+    } else {
+    // In normal mode, left panel is shown first
+    initSizes = model.collapsed ? [100, 0] : model.expanded_sizes;
+    }
+
+    const splitInstance = Split([split0, split1], {
+    sizes: initSizes,
+    minSize: model.min_sizes,
+    gutterSize: 6,
+    onDragEnd: (sizes) => {
+        view.invalidate_layout();
+
+        // Update collapsed state based on panel size and invert parameter
+        const newCollapsedState = model.invert ? sizes[0] <= 5 : sizes[1] <= 5;
+
+        if (model.collapsed !== newCollapsedState) {
+        // Send message to Python about collapsed state change
+        model.send_msg({ collapsed: newCollapsedState });
+
+        model.collapsed = newCollapsedState;
+
+        // Update UI based on new collapsed state
+        updateUIForCollapsedState(newCollapsedState);
+        }
+    },
+    });
+
+    // Function to update UI elements based on collapsed state
+    function updateUIForCollapsedState(isCollapsed) {
+    if (isCollapsed) {
+        // Collapsed state UI updates
+        if (model.invert) {
+        toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+        toggleIcon.style.right = '-30px'; // Adjust position when collapsed
+        // Hide left content (which is the target content in inverted mode)
+        leftContentWrapper.className = 'collapsed-content';
+        leftContentWrapper.style.display = 'none';
+        } else {
+        toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+        toggleIcon.style.left = '-30px'; // Adjust position when collapsed
+        contentWrapper.className = 'collapsed-content';
+        contentWrapper.style.display = 'none';
+        }
+    } else {
+        // Expanded state UI updates
+        if (model.invert) {
+        leftContentWrapper.className = '';
+        leftContentWrapper.style.display = 'block';
+        toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+        toggleIcon.style.right = '5px'; // Adjust position when expanded
+        } else {
+        contentWrapper.className = '';
+        contentWrapper.style.display = 'block';
+        toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+        toggleIcon.style.left = '5px'; // Adjust position when expanded
+        }
+    }
+    }
+
+    // Toggle button event listener
+    toggleIcon.addEventListener('click', () => {
+    const newCollapsedState = !model.collapsed;
+
+    if (newCollapsedState) {
+        // Collapse with appropriate sizes based on invert parameter
+        if (model.invert) {
+        splitInstance.setSizes([0, 100]);
+        } else {
+        splitInstance.setSizes([100, 0]);
+        }
+    } else {
+        // Expand
+        splitInstance.setSizes(model.expanded_sizes);
+    }
+
+    // Send message to Python about collapsed state change
+    model.send_msg({ collapsed: newCollapsedState });
+
+    // Update model and UI
+    model.collapsed = newCollapsedState;
+    updateUIForCollapsedState(newCollapsedState);
+
+    view.invalidate_layout();
+    });
+
+    // Listen for collapsed state changes from Python
+    model.on("msg:custom", (event) => {
+    if (event.type === "update_collapsed") {
+        const newCollapsedState = event.collapsed;
+
+        model.collapsed = newCollapsedState;
+        console.log('Received collapsed state update:', event.collapsed);
+
+        // Update split sizes based on new collapsed state
+        if (newCollapsedState) {
+        // Collapse
+        if (model.invert) {
+            splitInstance.setSizes([0, 100]);
+        } else {
+            splitInstance.setSizes([100, 0]);
+        }
+        } else {
+        // Expand
+        splitInstance.setSizes(model.expanded_sizes);
+        }
+
+        // Update UI elements
+        updateUIForCollapsedState(newCollapsedState);
+        view.invalidate_layout();
+    }
+    });
+
+    model.on("after_layout", () => {
+    setTimeout(() => {
+        splitDiv.style.visibility = 'visible';
+
+        // Only add animation on initial load
+        if (!window._toggleAnimationShown) {
+        // Add animation on first load only
+        toggleIcon.style.animationName = 'jumpLeftRight';
+        toggleIcon.style.animationDuration = '0.5s';
+        toggleIcon.style.animationTimingFunction = 'ease';
+        toggleIcon.style.animationIterationCount = '3';
+
+        // Remove animation after it completes and set flag
+        setTimeout(() => {
+            toggleIcon.style.animationName = '';
+            toggleIcon.style.animationDuration = '';
+            toggleIcon.style.animationTimingFunction = '';
+            toggleIcon.style.animationIterationCount = '';
+            window._toggleAnimationShown = true;
+        }, 1500);
+        }
+
+        window.dispatchEvent(new Event('resize'));
+    }, 100);
+    });
+
+    // Create a centered content wrapper for the left panel
+    const leftContentWrapper = document.createElement('div');
+
+    // Set initial display based on collapsed state and invert parameter
+    if (model.collapsed) {
+    if (model.invert) {
+        leftContentWrapper.className = 'collapsed-content';
+        leftContentWrapper.style.display = 'none';
+    } else {
+        contentWrapper.className = 'collapsed-content';
+        contentWrapper.style.display = 'none';
+    }
+    }
+
+    // Apply left-panel-content class to the appropriate panel based on invert parameter
+    if (model.invert) {
+    contentWrapper.className += ' left-panel-content';
+    } else {
+    leftContentWrapper.className = 'left-panel-content';
+    }
+
+    leftContentWrapper.style.width = '100%';
+    leftContentWrapper.style.height = '100%';
+    leftContentWrapper.append(model.get_child("left"));
+    split0.append(leftContentWrapper);
+    contentWrapper.append(model.get_child("right"));
+    split1.append(contentWrapper);
+
+    return splitDiv;
+}

--- a/lumen/ai/models/split.js
+++ b/lumen/ai/models/split.js
@@ -3,46 +3,36 @@ import Split from 'https://esm.sh/split.js@1.6.5'
 export function render({ model, view }) {
     const splitDiv = document.createElement('div');
     splitDiv.className = 'split';
-    splitDiv.style.visibility = 'hidden';
+    splitDiv.classList.add('loading');
 
     const split0 = document.createElement('div');
     const split1 = document.createElement('div');
     splitDiv.append(split0, split1);
 
-    split1.style.position = 'relative';
-    split1.style.width = '100%';
+    // position and width now handled by CSS
 
     // Create content wrapper for right panel
     const contentWrapper = document.createElement('div');
-    contentWrapper.style.width = '100%';
-    contentWrapper.style.height = '100%';
-    contentWrapper.style.display = 'block';
-
-    // Apply background color based on invert parameter
-    if (model.invert) {
-    split0.style.backgroundColor = 'whitesmoke';
-    } else {
-    contentWrapper.style.backgroundColor = 'whitesmoke';
-    }
+    contentWrapper.classList.add('content-wrapper');
 
     // Create toggle icon for panel toggling
     const toggleIcon = document.createElement('div');
 
     // Set class and initial arrow direction based on invert parameter
     if (model.invert) {
-    toggleIcon.className = 'toggle-icon-inverted';
-    toggleIcon.innerHTML = model.collapsed
-        ? `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`  // Right arrow when collapsed
-        : `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`;  // Left arrow when expanded
-    // Set initial position based on collapsed state
-    toggleIcon.style.right = model.collapsed ? '-30px' : '5px';
+        // For inverted layout, toggle icon is on the left panel
+        toggleIcon.className = 'toggle-icon-inverted';
+        if (model.collapsed) toggleIcon.classList.add('collapsed');
+        toggleIcon.innerHTML = model.collapsed
+            ? `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`  // Right arrow when collapsed
+            : `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`;  // Left arrow when expanded
     } else {
-    toggleIcon.className = 'toggle-icon';
-    toggleIcon.innerHTML = model.collapsed
-        ? `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`  // Left arrow when collapsed
-        : `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`;  // Right arrow when expanded
-    // Set initial position based on collapsed state
-    toggleIcon.style.left = model.collapsed ? '-30px' : '5px';
+        // For regular layout, toggle icon is on the right panel
+        toggleIcon.className = 'toggle-icon';
+        if (model.collapsed) toggleIcon.classList.add('collapsed');
+        toggleIcon.innerHTML = model.collapsed
+            ? `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`  // Left arrow when collapsed
+            : `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`;  // Right arrow when expanded
     }
 
     // Determine which panel gets the toggle based on invert parameter
@@ -50,175 +40,165 @@ export function render({ model, view }) {
     const toggleTarget = model.invert ? split1 : split0;
 
     // Add the toggle icon to the appropriate panel but positioned relative to the gutter
-    togglePanel.style.position = 'relative'; // Ensure the container has relative positioning
+    // Position handled by CSS
     togglePanel.appendChild(toggleIcon);
 
     // Determine initial state based on the invert parameter
     let initSizes;
     if (model.invert) {
-    // In inverted mode, right panel is shown first
-    initSizes = model.collapsed ? [0, 100] : model.expanded_sizes;
+        // In inverted mode, right panel is shown first
+        initSizes = model.collapsed ? [0, 100] : model.expanded_sizes;
     } else {
-    // In normal mode, left panel is shown first
-    initSizes = model.collapsed ? [100, 0] : model.expanded_sizes;
+        // In normal mode, left panel is shown first
+        initSizes = model.collapsed ? [100, 0] : model.expanded_sizes;
     }
 
     const splitInstance = Split([split0, split1], {
-    sizes: initSizes,
-    minSize: model.min_sizes,
-    gutterSize: 6,
-    onDragEnd: (sizes) => {
-        view.invalidate_layout();
+        sizes: initSizes,
+        minSize: model.min_sizes,
+        gutterSize: 8, // Match the 8px width in CSS
+        onDragEnd: (sizes) => {
+            view.invalidate_layout();
 
-        // Update collapsed state based on panel size and invert parameter
-        const newCollapsedState = model.invert ? sizes[0] <= 5 : sizes[1] <= 5;
+            // Update collapsed state based on panel size and invert parameter
+            const newCollapsedState = model.invert ? sizes[0] <= 5 : sizes[1] <= 5;
 
-        if (model.collapsed !== newCollapsedState) {
-        // Send message to Python about collapsed state change
-        model.send_msg({ collapsed: newCollapsedState });
+            if (model.collapsed !== newCollapsedState) {
+                // Send message to Python about collapsed state change
+                model.send_msg({ collapsed: newCollapsedState });
 
-        model.collapsed = newCollapsedState;
+                model.collapsed = newCollapsedState;
 
-        // Update UI based on new collapsed state
-        updateUIForCollapsedState(newCollapsedState);
-        }
-    },
+                // Update UI based on new collapsed state
+                updateUIForCollapsedState(newCollapsedState);
+            }
+        },
     });
 
     // Function to update UI elements based on collapsed state
     function updateUIForCollapsedState(isCollapsed) {
-    if (isCollapsed) {
-        // Collapsed state UI updates
-        if (model.invert) {
-        toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
-        toggleIcon.style.right = '-30px'; // Adjust position when collapsed
-        // Hide left content (which is the target content in inverted mode)
-        leftContentWrapper.className = 'collapsed-content';
-        leftContentWrapper.style.display = 'none';
+        if (isCollapsed) {
+            // Collapsed state UI updates
+            if (model.invert) {
+                toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+                toggleIcon.classList.add('collapsed');
+                // Hide left content (which is the target content in inverted mode)
+                leftContentWrapper.className = 'collapsed-content';
+            } else {
+                toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+                toggleIcon.classList.add('collapsed');
+                contentWrapper.className = 'collapsed-content';
+            }
         } else {
-        toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
-        toggleIcon.style.left = '-30px'; // Adjust position when collapsed
-        contentWrapper.className = 'collapsed-content';
-        contentWrapper.style.display = 'none';
+            // Expanded state UI updates
+            if (model.invert) {
+                leftContentWrapper.className = 'left-content-wrapper';
+                toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
+                toggleIcon.classList.remove('collapsed');
+            } else {
+                contentWrapper.className = 'content-wrapper';
+                toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
+                toggleIcon.classList.remove('collapsed');
+            }
         }
-    } else {
-        // Expanded state UI updates
-        if (model.invert) {
-        leftContentWrapper.className = '';
-        leftContentWrapper.style.display = 'block';
-        toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>`; // Left arrow
-        toggleIcon.style.right = '5px'; // Adjust position when expanded
-        } else {
-        contentWrapper.className = '';
-        contentWrapper.style.display = 'block';
-        toggleIcon.innerHTML = `<svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"></polyline></svg>`; // Right arrow
-        toggleIcon.style.left = '5px'; // Adjust position when expanded
-        }
-    }
     }
 
     // Toggle button event listener
     toggleIcon.addEventListener('click', () => {
-    const newCollapsedState = !model.collapsed;
+        const newCollapsedState = !model.collapsed;
 
-    if (newCollapsedState) {
-        // Collapse with appropriate sizes based on invert parameter
-        if (model.invert) {
-        splitInstance.setSizes([0, 100]);
+        if (newCollapsedState) {
+            // Collapse with appropriate sizes based on invert parameter
+            if (model.invert) {
+                splitInstance.setSizes([0, 100]);
+            } else {
+                splitInstance.setSizes([100, 0]);
+            }
         } else {
-        splitInstance.setSizes([100, 0]);
+            // Expand
+            splitInstance.setSizes(model.expanded_sizes);
         }
-    } else {
-        // Expand
-        splitInstance.setSizes(model.expanded_sizes);
-    }
 
-    // Send message to Python about collapsed state change
-    model.send_msg({ collapsed: newCollapsedState });
+        // Send message to Python about collapsed state change
+        model.send_msg({ collapsed: newCollapsedState });
 
-    // Update model and UI
-    model.collapsed = newCollapsedState;
-    updateUIForCollapsedState(newCollapsedState);
+        // Update model and UI
+        model.collapsed = newCollapsedState;
+        updateUIForCollapsedState(newCollapsedState);
 
-    view.invalidate_layout();
+        view.invalidate_layout();
     });
 
     // Listen for collapsed state changes from Python
     model.on("msg:custom", (event) => {
-    if (event.type === "update_collapsed") {
-        const newCollapsedState = event.collapsed;
+        if (event.type === "update_collapsed") {
+            const newCollapsedState = event.collapsed;
 
-        model.collapsed = newCollapsedState;
-        console.log('Received collapsed state update:', event.collapsed);
+            model.collapsed = newCollapsedState;
+            console.log('Received collapsed state update:', event.collapsed);
 
-        // Update split sizes based on new collapsed state
-        if (newCollapsedState) {
-        // Collapse
-        if (model.invert) {
-            splitInstance.setSizes([0, 100]);
-        } else {
-            splitInstance.setSizes([100, 0]);
+            // Update split sizes based on new collapsed state
+            if (newCollapsedState) {
+                // Collapse
+                if (model.invert) {
+                    splitInstance.setSizes([0, 100]);
+                } else {
+                    splitInstance.setSizes([100, 0]);
+                }
+            } else {
+                // Expand
+                splitInstance.setSizes(model.expanded_sizes);
+            }
+
+            // Update UI elements
+            updateUIForCollapsedState(newCollapsedState);
+            view.invalidate_layout();
         }
-        } else {
-        // Expand
-        splitInstance.setSizes(model.expanded_sizes);
-        }
-
-        // Update UI elements
-        updateUIForCollapsedState(newCollapsedState);
-        view.invalidate_layout();
-    }
     });
 
     model.on("after_layout", () => {
-    setTimeout(() => {
-        splitDiv.style.visibility = 'visible';
-
-        // Only add animation on initial load
-        if (!window._toggleAnimationShown) {
-        // Add animation on first load only
-        toggleIcon.style.animationName = 'jumpLeftRight';
-        toggleIcon.style.animationDuration = '0.5s';
-        toggleIcon.style.animationTimingFunction = 'ease';
-        toggleIcon.style.animationIterationCount = '3';
-
-        // Remove animation after it completes and set flag
         setTimeout(() => {
-            toggleIcon.style.animationName = '';
-            toggleIcon.style.animationDuration = '';
-            toggleIcon.style.animationTimingFunction = '';
-            toggleIcon.style.animationIterationCount = '';
-            window._toggleAnimationShown = true;
-        }, 1500);
-        }
+            splitDiv.classList.remove('loading');
 
-        window.dispatchEvent(new Event('resize'));
-    }, 100);
+            // Only add animation on initial load
+            if (!window._toggleAnimationShown) {
+                // Add animation on first load only
+                toggleIcon.classList.add('animated');
+
+                // Remove animation after it completes and set flag
+                setTimeout(() => {
+                    toggleIcon.classList.remove('animated');
+                    window._toggleAnimationShown = true;
+                }, 1500);
+            }
+
+            window.dispatchEvent(new Event('resize'));
+        }, 100);
     });
 
     // Create a centered content wrapper for the left panel
     const leftContentWrapper = document.createElement('div');
+    leftContentWrapper.classList.add('left-content-wrapper');
 
     // Set initial display based on collapsed state and invert parameter
     if (model.collapsed) {
-    if (model.invert) {
-        leftContentWrapper.className = 'collapsed-content';
-        leftContentWrapper.style.display = 'none';
-    } else {
-        contentWrapper.className = 'collapsed-content';
-        contentWrapper.style.display = 'none';
-    }
+        if (model.invert) {
+            leftContentWrapper.className = 'collapsed-content';
+        } else {
+            contentWrapper.className = 'collapsed-content';
+        }
     }
 
     // Apply left-panel-content class to the appropriate panel based on invert parameter
     if (model.invert) {
-    contentWrapper.className += ' left-panel-content';
+        contentWrapper.classList.add('left-panel-content');
+        // Background color handled by split container
     } else {
-    leftContentWrapper.className = 'left-panel-content';
+        leftContentWrapper.classList.add('left-panel-content');
+        // Background color handled by split container
     }
 
-    leftContentWrapper.style.width = '100%';
-    leftContentWrapper.style.height = '100%';
+    // Append children to the appropriate containers
     leftContentWrapper.append(model.get_child("left"));
     split0.append(leftContentWrapper);
     contentWrapper.append(model.get_child("right"));

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -640,15 +640,7 @@ class ExplorerUI(UI):
                 tabs.objects = explorers + [controls]
                 table_select.value = []
 
-        # The intro message is handled by the coordinator now
-        self._overview_intro = Markdown(
-            "",
-            margin=(0, 0, 10, 15),
-            sizing_mode='stretch_width',
-            visible=self.interface.param["objects"].rx.len() <= 2
-        )
         return Column(
-            self._overview_intro,
             input_row,
             tabs,
             sizing_mode='stretch_both',

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -54,16 +54,6 @@ if TYPE_CHECKING:
 
 DataT = str | Path | Source | Pipeline
 
-
-OVERVIEW_INTRO = """
-👋 **Start chatting to get started!**
-
-- Ask for summaries, ask for plots, ask for inspiration--query away!
-- Select a table, or upload one, to explore the table with [Graphic Walker](https://docs.kanaries.net/graphic-walker).
-- Download the chat into a reproducible notebook to share with others!
-- Check out [Using Lumen AI](https://holoviz-dev.github.io/lumen/lumen_ai/getting_started/using_lumen_ai.html) for more tips & tricks!
-"""
-
 EXPLORATIONS_INTRO = """
 🧪 **Explorations**
 
@@ -159,7 +149,8 @@ class UI(Viewer):
             interface=self.interface,
             llm=self.llm,
             tools=self.tools,
-            logs_db_path=self.logs_db_path
+            logs_db_path=self.logs_db_path,
+            within_ui=True
         )
         self._notebook_export = FileDownload(
             icon="notebook",
@@ -641,8 +632,9 @@ class ExplorerUI(UI):
                 tabs.objects = explorers + [controls]
                 table_select.value = []
 
+        # The intro message is handled by the coordinator now
         self._overview_intro = Markdown(
-            OVERVIEW_INTRO,
+            "",
             margin=(0, 0, 10, 15),
             sizing_mode='stretch_width',
             visible=self.interface.param["objects"].rx.len() <= 2

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -436,22 +436,10 @@ class ExplorerUI(UI):
         )
         output = Column(self._global_notebook_export, self._output, styles={'overflow-x': 'auto', 'overflow-y': 'auto'}, sizing_mode='stretch_both')
         chat = Column(self._exports, self._coordinator)
-        if self.chat_ui_position == 'left':
-            left, right = chat, output
-            invert_param = False
-            min_sizes = (300, 0)
-            expanded_sizes = (35, 65)
-        else:
-            left, right = output, chat
-            invert_param = True
-            min_sizes = (0, 300)
-            expanded_sizes = (65, 35)
         self._split = SplitJS(
-            left=left,
-            right=right,
-            invert=invert_param,
-            min_sizes=min_sizes,
-            expanded_sizes=expanded_sizes,
+            left=chat,
+            right=output,
+            invert=self.chat_ui_position != 'left',
             sizing_mode='stretch_both'
         )
         self._main = Column(self._split)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -447,13 +447,15 @@ class ExplorerUI(UI):
         chat = Column(self._exports, self._coordinator)
         if self.chat_ui_position == 'left':
             left, right = chat, output
-            sizes = (40, 60)
-            min_sizes = (200, 300)
+            invert_param = False
+            min_sizes = (300, 0)
+            expanded_sizes = (35, 65)
         else:
             left, right = output, chat
-            sizes = (60, 40)
-            min_sizes = (300, 200)
-        self._main = Column(SplitJS(left=left, right=right, sizes=sizes, min_sizes=min_sizes, sizing_mode='stretch_both'))
+            invert_param = True
+            min_sizes = (0, 300)
+            expanded_sizes = (65, 35)
+        self._main = Column(SplitJS(left=left, right=right, invert=invert_param, min_sizes=min_sizes, expanded_sizes=expanded_sizes, sizing_mode='stretch_both'))
         self._idle = asyncio.Event()
         self._idle.set()
         self._last_synced = None

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -695,8 +695,6 @@ class ExplorerUI(UI):
         tabs.active = len(tabs)-1
 
     def _wrap_callback(self, callback):
-        self._first_exploration_created = False
-
         async def wrapper(contents: list | str, user: str, instance: ChatInterface):
             if not self._explorations:
                 prev_memory = memory


### PR DESCRIPTION
Cleaned up the initial load experience
1. added a toggle button to the SplitJS component
2. animated it a few times on load to indicate to the user that it's there
3. used [clamp](https://www.smashingmagazine.com/2022/01/modern-fluid-typography-css-clamp/
) in css to limit the max width of the chat interface 
4. On the first exploration, expand the sidebar
5. Improve the intro message

https://github.com/user-attachments/assets/68ccc601-5a0b-4679-8e1b-8e2d7b5a7cbe

