### PR TITLE
Save tokens

### DIFF
--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -46,7 +46,6 @@ For reference, here's the tables and their schemas:
 {%- endfor %}
 {%- endif %}
 {%- endblock %}
-
 {%- block examples %}
 {%- if memory.data|length == 0 %}
 Here's an example of a good reply...
@@ -111,4 +110,4 @@ changes. This decline represents approximately 2,800 additional churned customer
 warranting immediate investigation. The unusual December retention dip across all plans suggests a potential data
 collection issue or seasonal effect that requires validation before making strategic decisions.
 {%- endif %}
-{% endblock %}
+{%- endblock %}

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -38,18 +38,18 @@ The dataset is empty. As the subject matter expert, if this is unexpected, analy
 and try to make educated guess what other columns or values should be used instead.
 
 For reference, here's the tables and their schemas:
-{% for table_info in memory.tables_sql_schemas.values() %}
+{% for table_info in memory.tables_sql_schemas.values() -%}
 - **{{ table_info.sql_table }}**:
 ```yaml
 {{ table_info.schema }}
 ```
-{% endfor %}
-{% endif %}
-{% endblock %}
+{%- endfor %}
+{%- endif %}
+{%- endblock %}
 
-{% block examples %}
-{% if memory.data|length == 0 %}
-Here's an example...
+{%- block examples %}
+{%- if memory.data|length == 0 %}
+Here's an example of a good reply...
 User Query:
 What are all the Category 3 hurricanes in the East Pacific since 2000?
 
@@ -73,8 +73,8 @@ Additionally, the query treats numeric values as strings with quotes, potentiall
 fields should be treated as numbers by removing quotes: SEASON >= 2000 instead of SEASON >= '2000'. Please request to
 try
 again!
-{% else %}
-Here's an example...
+{%- else %}
+Here's an example of a good reply...
 User Query:
 Show me subscription trends over the past 12 months with retention rates by plan type.
 
@@ -110,5 +110,5 @@ I'm concerned about the Basic plan's downward trend in Q4, where retention dropp
 changes. This decline represents approximately 2,800 additional churned customers compared to expected baseline,
 warranting immediate investigation. The unusual December retention dip across all plans suggests a potential data
 collection issue or seasonal effect that requires validation before making strategic decisions.
-{% endif %}
+{%- endif %}
 {% endblock %}

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -226,7 +226,8 @@ async def get_schema(
             continue
 
         limit = get_kwargs.get("limit")
-        max_enums = 10 if num_cols < 10 else 3
+        # scale the number of enums based on the number of columns
+        max_enums = max(2, min(10, int(10 * math.exp(-0.1 * max(0, num_cols - 10)))))
         truncate_limit = min(limit or 5, max_enums)
         if not include_enum or len(spec["enum"]) == 0:
             spec.pop("enum")

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -315,6 +315,11 @@ async def describe_data(df: pd.DataFrame) -> str:
             if isinstance(df[col].iloc[0], pd.Timestamp):
                 df[col] = pd.to_datetime(df[col])
 
+        sampled_columns = False
+        if len(df.columns) > 10:
+            df = df[df.columns[:10]]
+            sampled_columns = True
+
         describe_df = df.describe(percentiles=[])
         columns_to_drop = ["min", "max"] # present if any numeric
         columns_to_drop = [col for col in columns_to_drop if col in describe_df.columns]
@@ -361,6 +366,7 @@ async def describe_data(df: pd.DataFrame) -> str:
             "summary": {
                 "total_table_cells": size,
                 "total_shape": shape,
+                "sampled_columns": sampled_columns,
                 "is_summarized": is_summarized,
             },
             "stats": df_describe_dict,

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -38,6 +38,18 @@ if TYPE_CHECKING:
     from lumen.sources.base import Source
 
 
+def format_float(num):
+    if pd.isna(num) or math.isinf(num):
+        return num
+    # if is integer, round to 0 decimals
+    if num == int(num):
+        return f"{int(num)}"
+    elif 0.01 <= abs(num) < 100:
+        return f"{num:.1f}"  # Regular floating-point notation with one decimal
+    else:
+        return f"{num:.1e}"  # Exponential notation with one decimal
+
+
 def render_template(template_path: Path, overrides: dict | None = None, relative_to: Path = PROMPTS_DIR, **context):
     try:
         template_path = template_path.relative_to(relative_to).as_posix()
@@ -160,16 +172,6 @@ async def get_schema(
     shuffle: bool = True,
     **get_kwargs
 ):
-    def format_float(num):
-        if pd.isna(num) or math.isinf(num):
-            return num
-        # if is integer, round to 0 decimals
-        if num == int(num):
-            return f"{int(num)}"
-        elif 0.01 <= abs(num) < 100:
-            return f"{num:.1f}"  # Regular floating-point notation with one decimal
-        else:
-            return f"{num:.1e}"  # Exponential notation with one decimal
     if isinstance(source, Pipeline):
         schema = await asyncio.to_thread(source.get_schema)
     else:
@@ -296,17 +298,6 @@ async def get_data(pipeline):
 
 
 async def describe_data(df: pd.DataFrame) -> str:
-    def format_float(num):
-        if pd.isna(num) or math.isinf(num):
-            return num
-        # if is integer, round to 0 decimals
-        if num == int(num):
-            return f"{int(num)}"
-        elif 0.01 <= abs(num) < 100:
-            return f"{num:.1f}"  # Regular floating-point notation with one decimal
-        else:
-            return f"{num:.1e}"  # Exponential notation with one decimal
-
     def describe_data_sync(df):
         size = df.size
         shape = df.shape

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -339,7 +339,9 @@ async def describe_data(df: pd.DataFrame) -> str:
         for col in df.columns:
             if col not in df_describe_dict:
                 df_describe_dict[col] = {}
-            df_describe_dict[col]["nulls"] = int(df[col].isnull().sum())
+            nulls = int(df[col].isnull().sum())
+            if nulls > 0:
+                df_describe_dict[col]["nulls"] = nulls
 
         # select datetime64 columns
         for col in df.select_dtypes(include=["datetime64"]).columns:


### PR DESCRIPTION
Saves token by formatting floats so it's not 1.2521621612 and instead it's 1.2e... or something

Also, scales the number of shown enums based on the number of columns, so if there's fewer columns, up to 10 enums, and if there's more columns, up to 2 enums.

I also truncate current data summary, if there's over 10 columns, reducing the characters from 14k to 4k in a dataset with a bunch of columns.

Finally, tweaked analyst agent's prompt by removing whitespaces.