### PR TITLE
Loosen up find tables

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -657,9 +657,9 @@ class SQLAgent(LumenBaseAgent):
         tables = self._memory.get("closest_tables", next(iter(sources.values())).get_tables()[:5])
         if len(tables) > 1:
             system = await self._render_prompt(
-                "find_tables", messages, separator=SOURCE_TABLE_SEPARATOR
+                "find_tables", messages, tables=tables, separator=SOURCE_TABLE_SEPARATOR
             )
-            tables_model = self._get_model("find_tables", tables=tables)
+            tables_model = self._get_model("find_tables")
             model_spec = self.prompts["find_tables"].get("llm_spec", self.llm_spec_key)
             with self.interface.add_step(title="Determining tables to use", steps_layout=self._steps_layout) as step:
                 response = self.llm.stream(

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -156,7 +156,7 @@ def make_tables_model(tables):
             Concisely consider which tables are necessary to answer the user query.
             """
         )),
-        selected_tables=(list[Literal[tuple(tables)]], FieldInfo(
+        selected_tables=(list[str], FieldInfo(
             description="""
             The most relevant tables based on the user query; if none are relevant,
             use the first table. At least one table must be provided.

--- a/lumen/ai/prompts/SQLAgent/find_tables.jinja2
+++ b/lumen/ai/prompts/SQLAgent/find_tables.jinja2
@@ -5,4 +5,8 @@ Determine which tables are necessary to answer the user query, paying special at
 {% if separator %}
 Use table names verbatim, and be sure to include the delimiters {{ separator }}, like '<source>{{ separator }}<table>'
 {% endif %}
+Here are the tables you should consider:
+{% for table in tables %}
+- {{ table }}
+{% endfor %}
 {% endblock %}


### PR DESCRIPTION
When I was using TableListAgent, it sent "Show the table 'XYZ'", and the LLM obediently obeyed, except, the app crashed because find_tables' tables is a Literal requirement, e.g. 'XYZ' isn't part of the ["A", "B", "C"] closest_tables.