### PR TITLE
Order by closest tables

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -370,12 +370,15 @@ class TableListAgent(ListAgent):
         return len(source.get_tables()) > 1
 
     def _get_items(self) -> list[str]:
-        if "closest_tables" in self._memory:
-            return self._memory["closest_tables"]
         tables = []
+        if "closest_tables" in self._memory:
+            tables = self._memory["closest_tables"]
+
         for source in self._memory["sources"]:
             tables += source.get_tables()
-        return tables
+
+        # remove duplicates, keeps order in which they were added
+        return pd.unique(tables).tolist()
 
 
 class DocumentListAgent(ListAgent):


### PR DESCRIPTION
Previously, it only showed closest tables if available, but user may want to see entire list, and there wasn't a way so this PR first shows the closest tables followed by other tables.