### PR TITLE
Explicit check for table

### DIFF
--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -268,7 +268,7 @@ def test_sql_format():
 
 def test_sql_select_from_basic():
     result = SQLSelectFrom.apply_to("my_table")
-    expected = 'SELECT * FROM "my_table"'
+    expected = 'SELECT * FROM my_table'
     assert result == expected
 
 
@@ -280,7 +280,7 @@ def test_sql_select_from_replace_table():
 
 def test_sql_select_from_custom_expr():
     result = SQLSelectFrom.apply_to("my_table", sql_expr="SELECT id, name FROM {table}")
-    expected = 'SELECT id, name FROM "my_table"'
+    expected = 'SELECT id, name FROM my_table'
     assert result == expected
 
 

--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -284,6 +284,18 @@ def test_sql_select_from_custom_expr():
     assert result == expected
 
 
+def test_sql_select_from_path():
+    result = SQLSelectFrom.apply_to("data/life_expectancy.csv", sql_expr="SELECT id, name FROM {table}")
+    expected = 'SELECT id, name FROM "data/life_expectancy.csv"'
+    assert result == expected
+
+
+def test_sql_select_from_duckdb_path():
+    result = SQLSelectFrom.apply_to("read_csv('data/life_expectancy.csv')", sql_expr="SELECT id, name FROM {table}")
+    expected = "SELECT id, name FROM READ_CSV('data/life_expectancy.csv')"
+    assert result == expected
+
+
 def test_sql_sample_tablesample_percent():
     """Test percent-based sampling with TABLESAMPLE (PostgreSQL, etc.)"""
     result = SQLSample.apply_to("SELECT * FROM TABLE", percent=20, write="postgres")

--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -268,7 +268,7 @@ def test_sql_format():
 
 def test_sql_select_from_basic():
     result = SQLSelectFrom.apply_to("my_table")
-    expected = "SELECT * FROM my_table"
+    expected = 'SELECT * FROM "my_table"'
     assert result == expected
 
 
@@ -280,7 +280,7 @@ def test_sql_select_from_replace_table():
 
 def test_sql_select_from_custom_expr():
     result = SQLSelectFrom.apply_to("my_table", sql_expr="SELECT id, name FROM {table}")
-    expected = "SELECT id, name FROM my_table"
+    expected = 'SELECT id, name FROM "my_table"'
     assert result == expected
 
 

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -235,12 +235,10 @@ class SQLSelectFrom(SQLFormat):
     transform_type: ClassVar[str] = "sql_select_from"
 
     def apply(self, sql_in: str) -> str:
-        try:
-            expression = self.parse_sql(sql_in)
-        except sqlglot.ParseError:
-            # The expression has no SELECT statement, and invalid characters
-            # e.g. read_parquet("/path/to/file.parquet"); so we need to quote
+        if "SELECT" not in sql_in:
             expression = Table(this=Identifier(this=sql_in, quoted=True))
+        else:
+            expression = self.parse_sql(sql_in)
 
         tables = {}
 


### PR DESCRIPTION
sqlglot really doesn't handle file paths well, i.e. data/life-expectancy.csv turns into: `SELECT * FROM "data" [4m/[0m life - expectancy.csv`

So, we need to be more explicit vs a try/except.