### PR TITLE
Refactor lookup

### DIFF
--- a/doc/lumen_ai/how_to/template_prompts.md
+++ b/doc/lumen_ai/how_to/template_prompts.md
@@ -39,27 +39,29 @@ For example, the `ChatAgent`'s prompt template uses `instructions` and `context`
 ```jinja2
 {% extends 'Agent/main.jinja2' %}
 
-{% block instructions %}
+{%- block instructions %}
 Act as a helpful assistant for high-level data exploration, focusing on available datasets and, only if data is
-available, explaining the purpose of each column. Offer suggestions for getting started if needed, remaining factual and avoiding speculation. Do not write code or give code related suggestions.
-{% endblock %}
+available, explaining the purpose of each column. Offer suggestions for getting started if needed, remaining factual and
+avoiding speculation. Do not write code or give code related suggestions.
+{%- endblock %}
 
 {% block context %}
-{% if 'data' in memory %}
+{%- if 'data' in memory %}
 Here's a summary of the dataset the user just asked about:
-\```
+```
 {{ memory['data'] }}
-\```
-{% endif %}
-{% if tables_schemas is defined %}
+```
+{%- endif %}
 Available tables:
-{% for table, schema in tables_schemas %}
-- **{{ table }}** with schema: {{ schema }}
+{% for table, info in memory['tables_vector_info'].items() %}
+- {{ table }}`
+  {{ info.caption }}
 {% endfor %}
-{% elif table is defined and schema is defined %}
-{{ table }} with schema: {{ schema }}
-{% endif %}
-{% endblock %}
+Here was the plan that was executed:
+"""
+{{ memory.reasoning }}
+"""
+{% endblock -%}
 ```
 
 Here, the instructions are:

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -606,8 +606,8 @@ class SQLAgent(LumenBaseAgent):
             if sql_query != sql_clean:
                 stream_details(f'\n\nSQL was cleaned up and prettified.\n```sql\n{sql_clean}\n```', step)
                 sql_query = sql_clean
-        except Exception:
-            pass
+        except Exception as e:
+            print(e)
         try:
             # TODO: if original sql expr matches, don't recreate a new one!
             sql_expr_source = source.create_sql_expr_source({expr_slug: sql_query})

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -25,7 +25,7 @@ from ..pipeline import Pipeline
 from ..sources.base import BaseSQLSource
 from ..sources.duckdb import DuckDBSource
 from ..state import state
-from ..transforms.sql import SQLLimit, SQLTransform
+from ..transforms.sql import SQLLimit
 from ..views import (
     Panel, VegaLiteView, View, hvPlotUIView,
 )
@@ -601,13 +601,6 @@ class SQLAgent(LumenBaseAgent):
 
         # check whether the SQL query is valid
         expr_slug = output.expr_slug
-        try:
-            sql_clean = SQLTransform(sql_query, write=source.dialect, pretty=True, identify=False).to_sql()
-            if sql_query != sql_clean:
-                stream_details(f'\n\nSQL was cleaned up and prettified.\n```sql\n{sql_clean}\n```', step)
-                sql_query = sql_clean
-        except Exception as e:
-            print(e)
         try:
             # TODO: if original sql expr matches, don't recreate a new one!
             sql_expr_source = source.create_sql_expr_source({expr_slug: sql_query})

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -37,7 +37,7 @@ from .memory import _Memory
 from .models import (
     PartialBaseModel, RetrySpec, Sql, VegaLiteSpec, make_find_tables_model,
 )
-from .tools import DocumentLookup, ToolUser
+from .tools import ToolUser
 from .translate import param_to_pydantic
 from .utils import (
     clean_sql, describe_data, get_data, get_pipeline, get_schema, load_json,
@@ -248,12 +248,11 @@ class ChatAgent(Agent):
         default={
             "main": {
                 "template": PROMPTS_DIR / "ChatAgent" / "main.jinja2",
-                "tools": [DocumentLookup]
             },
         }
     )
 
-    requires = param.List(default=["tables_info"], readonly=True)
+    requires = param.List(default=["tables_vector_info"], readonly=True)
 
     async def respond(
         self,
@@ -520,7 +519,7 @@ class SQLAgent(LumenBaseAgent):
 
     provides = param.List(default=["table", "sql", "pipeline", "data"], readonly=True)
 
-    requires = param.List(default=["source", "tables_info"], readonly=True)
+    requires = param.List(default=["source", "tables_sql_info"], readonly=True)
 
     _extensions = ('codeeditor', 'tabulator',)
 
@@ -555,7 +554,6 @@ class SQLAgent(LumenBaseAgent):
             "main",
             messages,
             join_required=join_required,
-            tables_info=self._memory["tables_info"],
             dialect=dialect,
             comments=comments,
             has_errors=bool(errors),
@@ -654,7 +652,7 @@ class SQLAgent(LumenBaseAgent):
             messages = mutate_user_message(content, messages)
 
         sources = {source.name: source for source in self._memory["sources"]}
-        selected_slugs = list(self._memory["tables_info"])
+        selected_slugs = list(self._memory["tables_sql_info"])
 
         chain_of_thought = ""
         if len(selected_slugs) > 1:

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -28,7 +28,9 @@ from .config import DEMO_MESSAGES, GETTING_STARTED_SUGGESTIONS, PROMPTS_DIR
 from .llm import LlamaCpp, Llm, Message
 from .logs import ChatLogs
 from .models import make_agent_model, make_plan_models
-from .tools import IterativeTableLookup, Tool, ToolUser
+from .tools import (
+    IterativeTableLookup, TableLookup, Tool, ToolUser,
+)
 from .utils import (
     fuse_messages, log_debug, mutate_user_message, retry_llm_output,
     stream_details,
@@ -406,7 +408,7 @@ class Coordinator(Viewer, ToolUser):
             if isinstance(subagent, Tool):
                 if isinstance(result, str) and result:
                     self._memory["tools_context"][subagent.name] = result
-                    stream_details(result, step)
+                    stream_details(result, step, title="Results", auto=False)
                 elif isinstance(result, (View, Viewable)):
                     if isinstance(result, Viewable):
                         result = Panel(object=result, pipeline=self._memory.get('pipeline'))
@@ -588,7 +590,7 @@ class Planner(Coordinator):
             "main": {
                 "template": PROMPTS_DIR / "Planner" / "main.jinja2",
                 "response_model": make_plan_models,
-                "tools": [IterativeTableLookup]
+                "tools": [TableLookup, IterativeTableLookup]
             },
         }
     )

--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -13,14 +13,11 @@ Here's a summary of the dataset the user just asked about:
 {{ memory['data'] }}
 ```
 {%- endif %}
-{% if tables_schemas is defined %}
-Available table schemas:
-{% for table, schema in tables_schemas %}
-- `{{ table }}`: {{ schema }}
+Available tables:
+{% for table, info in memory['tables_vector_info'].items() %}
+- {{ table }}`
+  {{ info.caption }}
 {% endfor %}
-{% elif table is defined and schema is defined %}
-- `{{ table }}`: {{ schema }}
-{% endif -%}
 Here was the plan that was executed:
 """
 {{ memory.reasoning }}

--- a/lumen/ai/prompts/IterativeTableLookup/iterative_selection.jinja2
+++ b/lumen/ai/prompts/IterativeTableLookup/iterative_selection.jinja2
@@ -20,13 +20,23 @@ You need to select tables from a database to help answer this query:
 
 {{ current_query }}
 
+{% if available_slugs|length > 0 %}
+Here are the tables available for selection:
+{% for table_slug in available_slugs %}
+{{ table_slug }} (Similarity: {{ tables_vector_info[table_slug].similarity | round(3) }})
+{{ tables_vector_info[table_slug].caption }}
+{% endfor %}
+{% else %}
+No tables are available for selection.
+{% endif %}
+
 {% if examined_slugs|length > 0 %}
-You have already examined these tables and their schemas:
+You have already examined these tables and their schemas; there's no need to select them again:
 {% for table_slug in examined_slugs %}
 {{ table_slug }}
 {% if table_slug in selected_slugs %}
-```yaml
-{{ tables_info[table_slug] }}
+```json
+{{ tables_sql_info[table_slug].schema }}
 ```
 {% endif %}
 {% endfor %}

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -757,15 +757,17 @@ class IterativeTableLookup(TableLookup):
         tables_sql_info = self._memory.get("tables_sql_info", {})
         context = "Below are the relevant tables and their descriptions."
         for table_slug, table_vector_info in tables_vector_info.items():
+            if table_slug not in tables_sql_info:
+                continue
             table_description = table_vector_info.get("description", "")
             context += f"\n{table_slug} (Similarity: {table_vector_info['similarity']:.3f}) {table_description}"
             for col, col_description in table_vector_info.get("columns_description", {}).items():
                 context += f"\n- {col}{col_description}"
                 schema = tables_sql_info.get(table_slug, {}).get("schema", {})
                 if "view_definition" in schema:
-                    context += f"\n  View definition: {schema['view_definition']}"
+                    context += f"\n  View definition:\n```sql\n{schema['view_definition'][:4000]}\n```"
                 elif col in schema:
-                    context += str(schema)
+                    context += f": {schema[col]}"
         return context
 
 

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -17,7 +17,7 @@ from .embeddings import NumpyEmbeddings
 from .llm import Message
 from .models import make_iterative_selection_model, make_refined_query_model
 from .translate import function_to_model
-from .utils import fetch_table_info, log_debug, stream_details
+from .utils import fetch_table_sql_info, log_debug, stream_details
 from .vector_store import NumpyVectorStore, VectorStore
 
 
@@ -358,14 +358,14 @@ class TableLookup(VectorLookupTool):
     """
 
     purpose = param.String(default="""
-        Looks up relevant tables based on the user query. Unnecessary if
-        the table doesn't need to change or the user is requesting a visualization
-        from the previous results.""")
+        Looks up relevant tables based on the user query with a vector store.
+        Useful for quickly gathering information about tables and their columns
+        to chat about.""")
 
     requires = param.List(default=["sources"], readonly=True, doc="""
         List of context that this Tool requires to be run.""")
 
-    provides = param.List(default=["tables_info"], readonly=True, doc="""
+    provides = param.List(default=["tables_vector_info"], readonly=True, doc="""
         List of context values this Tool provides to current working memory.""")
 
     include_metadata = param.Boolean(default=True, doc="""
@@ -388,7 +388,7 @@ class TableLookup(VectorLookupTool):
 
     def __init__(self, **params):
         super().__init__(**params)
-        self._table_metadata = {}
+        self._tables_metadata = {}
         self._raw_metadata = {}
         self._metadata_tasks = set()  # Track ongoing metadata fetch tasks
         self._semaphore = asyncio.Semaphore(self.max_concurrent)
@@ -417,8 +417,8 @@ class TableLookup(VectorLookupTool):
             table_slug = f"{source_name}{SOURCE_TABLE_SEPARATOR}{table_name}"
 
             description = f"- {table_slug} (Similarity: {result.get('similarity', 0):.3f})"
-            if table_metadata := self._table_metadata.get(table_slug):
-                if table_description := table_metadata.get("description"):
+            if tables_vector_info := self._tables_metadata.get(table_slug):
+                if table_description := tables_vector_info.get("description"):
                     description += f"\n  Description: {table_description}"
             formatted_results.append(description)
         return "\n".join(formatted_results)
@@ -438,13 +438,13 @@ class TableLookup(VectorLookupTool):
         if not table_name_key:
             return
         table_name = table_name_key
-        table_metadata = dict(source_metadata[table_name])
+        table_vector_info = dict(source_metadata[table_name])
 
         # IMPORTANT: re-insert using table slug
-        # we need to store a copy of table_metadata so it can be used to inject context into the LLM
+        # we need to store a copy of tables_vector_info so it can be used to inject context into the LLM
         table_slug = f"{source.name}{SOURCE_TABLE_SEPARATOR}{table_name}"
-        self._table_metadata[table_slug] = table_metadata.copy()
-        self._table_metadata[table_slug]["source_name"] = source.name  # need this to rebuild the slug
+        self._tables_metadata[table_slug] = table_vector_info.copy()
+        self._tables_metadata[table_slug]["source_name"] = source.name  # need this to rebuild the slug
 
         vector_metadata = {"source": source.name, "table_name": table_name}
         if existing_items := self.vector_store.filter_by(vector_metadata):
@@ -455,9 +455,9 @@ class TableLookup(VectorLookupTool):
         # the following is for the embeddings/vector store use only (i.e. filter from 1000s of tables)
         vector_metadata["enriched"] = True
         enriched_text = f"Table: {table_name}"
-        if description := table_metadata.pop('description', ''):
+        if description := table_vector_info.pop('description', ''):
             enriched_text += f"\nDescription: {description}"
-        if self.include_columns and (columns := table_metadata.pop('columns', {})):
+        if self.include_columns and (columns := table_vector_info.pop('columns', {})):
             enriched_text += "\nColumns:"
             for col_name, col_info in columns.items():
                 col_text = f"\n- {col_name}"
@@ -467,7 +467,7 @@ class TableLookup(VectorLookupTool):
             enriched_text += "\n"
         if self.include_misc:
             enriched_text += "\nMiscellaneous:"
-            for key, value in table_metadata.items():
+            for key, value in table_vector_info.items():
                 if key == "enriched":
                     continue
                 enriched_text += f"\n- {key}: {value}"
@@ -514,45 +514,12 @@ class TableLookup(VectorLookupTool):
         log_debug("All table metadata tasks completed.")
         self._ready = True
 
-    async def _select_tables(self, sources, messages, closest_tables, table_similarities):
-        """Select tables to include in the response."""
-        with self._add_step(title="Fetching schemas", success_title="Fetching completed") as step:
-            step.stream(f"Fetching schemas for {len(closest_tables[:3])} tables\n")
-            tables_info = {}
-            for table_slug in closest_tables[:3]:
-                table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1].split(".")[-1]
-                table_similarity = table_similarities[table_slug]
-                step.stream(f"`{table_name}` (Similarity: {table_similarity:.2f})")
-                try:
-                    table_info = await fetch_table_info(sources, table_slug, include_count=True)
-                    tables_info[table_slug] = table_info
-                    schema = table_info["schema"]
-                    stream_details(f"```yaml\n{schema}\n```", step, title="Schema")
-                except Exception as e:
-                    stream_details(f"Error fetching schema: {e}", step, title="Error", auto=False)
-        return tables_info
-
-    async def respond(self, messages: list[Message], **kwargs: dict[str, Any]) -> str:
-        """
-        Fetches the closest tables based on the user query, with query refinement
-        if enabled and initial results don't meet threshold.
-        """
+    async def _gather_info(self, messages: list[dict[str, str]]) -> dict:
+        """Gather relevant information about the tables based on the user query."""
         query = messages[-1]["content"]
-        results = []
-        table_similarities = {}
-        if len(self._table_metadata) <= 5:
-            table_similarities = {table_slug: 1 for table_slug in self._table_metadata}
-        else:
-            table_similarities = {
-                table_slug: 1
-                for table_slug in self._table_metadata
-                if table_slug.split(SOURCE_TABLE_SEPARATOR)[-1].lower() in query.lower()
-            }
+        results = await self._perform_search_with_refinement(query)
 
-        closest_tables = list(table_similarities)
-        if not closest_tables:
-            results = await self._perform_search_with_refinement(query)
-
+        tables_vector_info = {}
         any_matches = any(result['similarity'] >= self.min_similarity for result in results)
         for result in results:
             if any_matches and result['similarity'] < self.min_similarity:
@@ -560,34 +527,62 @@ class TableLookup(VectorLookupTool):
             source_name = result['metadata']["source"]
             table_name = result['metadata']["table_name"]
             table_slug = f"{source_name}{SOURCE_TABLE_SEPARATOR}{table_name}"
-            description = f"- `{table_slug}`: {result['similarity']:.3f} similarity"
-            table_similarities[table_slug] = result['similarity']
-            if table_metadata := self._table_metadata.get(table_slug):
+            similarity_score = result['similarity']
+
+            if table_slug not in tables_vector_info:
+                tables_vector_info[table_slug] = {}
+            tables_vector_info[table_slug]["similarity"] = similarity_score
+            table_caption = ""
+            if table_metadata := self._tables_metadata.get(table_slug):
                 if table_description := table_metadata.get("description"):
-                    description += f"  Description: {table_description}"
-                columns_description = "Columns:"
-                for i, (col_name, col_info) in enumerate(table_metadata.get("columns", {}).items()):
-                    # Save on tokens by truncating long column names and letting the LLM infer the rest
-                    col_label = col_name if len(col_name) <= 50 else f"{col_name[:15]}...{col_name[-35:]}"
+                    table_caption += f"  Description: {table_description}"
+                    tables_vector_info[table_slug]["description"] = table_description
+
+                columns = table_metadata.get("columns", {})
+                columns_description = "Columns:" if columns else ""
+                tables_vector_info[table_slug]["columns_description"] = {}
+                already_truncated = False
+                for i, (col_name, col_info) in enumerate(columns.items()):
                     col_desc = f": {col_info['description']}" if col_info.get("description") else ""
-                    columns_description += f"\n- {col_label}{col_desc}"
-                    if i > 10:
+                    tables_vector_info[table_slug]["columns_description"][col_name] = col_desc
+                    if already_truncated:
+                        # Skip if already truncated
+                        continue
+                    if i <= 15:
+                        # Save on tokens by truncating long column names and letting the LLM infer the rest
+                        col_label = col_name if len(col_name) <= 20 else f"{col_name[:10]}...{col_name[-10:]}"
+                        columns_description += f"\n- {col_label}{col_desc}"
+                    else:
                         columns_description += f"\n  ... (out of {len(table_metadata['columns'])} columns)"
-                        break
-                description += f"\n{indent(columns_description, ' ' * 2)}"
-            closest_tables.append(table_slug)
+                        already_truncated = True
 
-        sources = {source.name: source for source in self._memory.get("sources", [])}
-        tables_info = await self._select_tables(sources, messages, closest_tables, table_similarities)
+                table_caption += f"\n{indent(columns_description, ' ' * 2)}"
+                tables_vector_info[table_slug]["caption"] = table_caption
 
-        self._memory["tables_info"] = tables_info
-        tables_info_str = ""
-        for table_slug, table_info in tables_info.items():
-            sql = table_info["sql"]
-            tables_info_str += f"\n```\n{table_slug}\n`{sql}`\n{table_info['schema']}\n```\n"
-        context = (
-            "\n\nBelow are the relevant tables and their schemas.\n" + tables_info_str
-        )
+        # If query contains an exact table name, mark it as max similarity
+        for table_slug in self._tables_metadata:
+            if table_slug.split(SOURCE_TABLE_SEPARATOR)[-1].lower() in query.lower():
+                tables_vector_info[table_slug]["similarity"] = 1
+
+        self._memory["tables_vector_info"] = tables_vector_info
+        return tables_vector_info
+
+    def _format_context(self) -> str:
+        tables_vector_info = self._memory.get("tables_vector_info", {})
+        context = "Below are the relevant tables and their descriptions."
+        for table_slug, table_info in tables_vector_info.items():
+            context += f"\n{table_slug} (Similarity: {table_info['similarity']:.3f})"
+            if caption := table_info.get("caption", "").strip():
+                context += f"\n```\n{caption}\n```\n"
+        return context
+
+    async def respond(self, messages: list[Message], **kwargs: dict[str, Any]) -> str:
+        """
+        Fetches the closest tables based on the user query, with query refinement
+        if enabled and initial results don't meet threshold.
+        """
+        await self._gather_info(messages)
+        context = self._format_context()
         return context
 
 
@@ -598,8 +593,12 @@ class IterativeTableLookup(TableLookup):
     """
 
     purpose = param.String(default="""
-        Looks up relevant tables based on the user query with an iterative selection process.
-        Uses LLM to select tables in multiple passes, examining schemas in detail.""")
+        Looks up relevant tables based on the user query with a vector store and iterative selection process.
+        Uses LLM to select tables in multiple passes, examining schemas in detail.
+        Useful for SQLAgent, but not for ChatAgent.""")
+
+    provides = param.List(default=["tables_vector_info", "tables_sql_info"], readonly=True, doc="""
+        List of context values this Tool provides to current working memory.""")
 
     max_selection_iterations = param.Integer(default=3, doc="""
         Maximum number of iterations for the iterative table selection process.""")
@@ -622,7 +621,7 @@ class IterativeTableLookup(TableLookup):
         },
     )
 
-    async def _select_tables(self, sources, messages, closest_tables, table_similarities):
+    async def _gather_info(self, messages: list[dict[str, str]]) -> dict:
         """
         Performs an iterative table selection process to gather context.
         This function:
@@ -631,25 +630,21 @@ class IterativeTableLookup(TableLookup):
         3. Gets complete schemas for these tables
         4. Repeats until the LLM is satisfied with the context
         """
-        if not sources:
-            return {}
+        tables_vector_info = await super()._gather_info(messages)
 
-        # # For small number of tables, just use the basic approach
-        if len(closest_tables) <= 5:
-            return await super()._select_tables(sources, messages, closest_tables, table_similarities)
-
-        max_iterations = self.max_selection_iterations
-        tables_info = self._memory.get("tables_info", {})
-        examined_slugs = set(tables_info.keys())
+        tables_sql_info = self._memory.get("tables_sql_info", {})
+        examined_slugs = set(tables_sql_info.keys())
+        all_slugs = list(tables_vector_info.keys())
         failed_slugs = []
-
         satisfied_slugs = []
         selected_slugs = []
         chain_of_thought = ""
+        max_iterations = self.max_selection_iterations
+        sources = {source.name: source for source in self._memory["sources"]}
         for iteration in range(1, max_iterations + 1):
             with self._add_step(title=f"Iterative table selection {iteration} / {max_iterations}", success_title=f"Selection iteration {iteration} / {max_iterations} completed") as step:
                 available_slugs = [
-                    table_slug for table_slug in closest_tables
+                    table_slug for table_slug in all_slugs
                     if table_slug not in examined_slugs
                 ]
                 log_debug(available_slugs)
@@ -661,10 +656,10 @@ class IterativeTableLookup(TableLookup):
                 if iteration == 1:
                     # For the first iteration, select tables based on similarity
                     # If any tables have a similarity score above the threshold, select up to 5 of those tables
-                    if any(similarity > self.table_similarity_threshold for similarity in table_similarities.values()):
-                        closest_tables = selected_slugs = sorted(
-                            table_similarities,
-                            key=lambda x: table_similarities[x],
+                    if any(meta.get('similarity', 0) > self.table_similarity_threshold for meta in tables_vector_info.values()):
+                        selected_slugs = sorted(
+                            tables_vector_info,
+                            key=lambda x: tables_vector_info[x].get('similarity', 0),
                             reverse=True
                         )[:5]
                         step.stream("Selected tables based on similarity threshold.\n\n")
@@ -684,7 +679,8 @@ class IterativeTableLookup(TableLookup):
                             selected_slugs=selected_slugs,
                             failed_slugs=failed_slugs,
                             separator=SOURCE_TABLE_SEPARATOR,
-                            tables_info=tables_info,
+                            tables_sql_info=tables_sql_info,
+                            tables_vector_info=tables_vector_info,
                             iteration=iteration,
                             max_iterations=max_iterations,
                         )
@@ -707,24 +703,33 @@ class IterativeTableLookup(TableLookup):
                             step.stream("Selection process complete - model is satisfied with selected tables")
                             satisfied_slugs = selected_slugs
                             break
-                        if iteration != max_iterations:
-                            step.stream("Unsatisfied with selected tables - continuing selection process")
-                        else:
+                        if iteration != 1:
+                            step.stream("Unsatisfied with selected tables - continuing selection process...")
+                        elif iteration == max_iterations:
                             step.stream("Maximum iterations reached - stopping selection process")
                     except Exception as e:
                         stream_details(f"Error selecting tables: {e}", step, title="Error", auto=False)
                         break
 
-                step.stream("\nFetching detailed schema information for tables\n")
+                step.stream("\n\nFetching detailed schema information for tables\n")
                 for table_slug in selected_slugs:
                     table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1]
-                    table_similarity = table_similarities.get(table_slug, 0)
-                    step.stream(f"`{table_name}` (Similarity: {table_similarity:.2f})")
+                    vector_info = tables_vector_info[table_slug]
+                    similarity = vector_info["similarity"]
+                    caption = vector_info["caption"]
+                    step.stream(f"`{table_name}` (Similarity: {similarity:.2f})")
+                    stream_details(caption, step, title="Caption", auto=False)
                     try:
-                        table_info = await fetch_table_info(sources, table_slug, include_count=True)
-                        tables_info[table_slug] = table_info
+                        view_definition = self._tables_metadata.get(table_slug, {}).get("view_definition", "")
+                        table_sql_info = await fetch_table_sql_info(
+                            sources,
+                            table_slug,
+                            view_definition=view_definition,
+                            include_count=True
+                        )
+                        tables_sql_info[table_slug] = table_sql_info
                         examined_slugs.add(table_slug)
-                        stream_details(f"```yaml\n{table_info['schema']}\n```", step, title="Schema")
+                        stream_details(f"```yaml\n{table_sql_info['schema']}\n```", step, title="Schema")
                     except Exception as e:
                         failed_slugs.append(table_slug)
                         stream_details(f"Error fetching schema: {e}", step, title="Error", auto=False)
@@ -738,12 +743,30 @@ class IterativeTableLookup(TableLookup):
                     # based on similarity search alone, if we have selected tables, we're done!!
                     break
 
-        tables_info = {
-            table_slug: schema_data for table_slug, schema_data in tables_info.items()
+        tables_sql_info = {
+            table_slug: schema_data for table_slug, schema_data in tables_sql_info.items()
             # Only include tables that were selected in the final iteration or were fast-tracked
             if len(satisfied_slugs) == 0 or table_slug in satisfied_slugs
         }
-        return tables_info
+        self._memory["tables_sql_info"] = tables_sql_info
+        return tables_sql_info
+
+    def _format_context(self) -> str:
+        """Combines tables vector and sql info into a single context string."""
+        tables_vector_info = self._memory.get("tables_vector_info", {})
+        tables_sql_info = self._memory.get("tables_sql_info", {})
+        context = "Below are the relevant tables and their descriptions."
+        for table_slug, table_vector_info in tables_vector_info.items():
+            table_description = table_vector_info.get("description", "")
+            context += f"\n{table_slug} (Similarity: {table_vector_info['similarity']:.3f}) {table_description}"
+            for col, col_description in table_vector_info.get("columns_description", {}).items():
+                context += f"\n- {col}{col_description}"
+                schema = tables_sql_info.get(table_slug, {}).get("schema", {})
+                if "view_definition" in schema:
+                    context += f"\n  View definition: {schema['view_definition']}"
+                elif col in schema:
+                    context += str(schema)
+        return context
 
 
 class FunctionTool(Tool):

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -596,8 +596,6 @@ class TableLookup(VectorLookupTool):
             context += f"\n{table_slug} (Similarity: {table_info['similarity']:.3f})"
             if caption := table_info.get("caption", "").strip():
                 context += f"\n```\n{caption}\n```\n"
-            else:
-                breakpoint()
         return context
 
     async def respond(self, messages: list[Message], **kwargs: dict[str, Any]) -> str:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import parse_qs
 
 import pandas as pd
-import yaml
 
 from jinja2 import (
     ChoiceLoader, DictLoader, Environment, FileSystemLoader, StrictUndefined,
@@ -312,7 +311,7 @@ async def get_schema(
     return schema
 
 
-async def fetch_table_info(sources: list[Source], table_slug: str, **get_schema_kwargs) -> dict:
+async def fetch_table_sql_info(sources: dict[str, Source], table_slug: str, view_definition: str = "", **get_schema_kwargs) -> dict:
     """
     Fetch the schema for a single table from a data source.
 
@@ -320,6 +319,8 @@ async def fetch_table_info(sources: list[Source], table_slug: str, **get_schema_
     ----------
     table_slug : str
         Table name in format "source_name{SEP}table_name"
+    view_definition : str
+        Optional view definition for the table to override the schema
     **get_schema_kwargs
         Additional keyword arguments to pass to the get_schema method
 
@@ -337,32 +338,18 @@ async def fetch_table_info(sources: list[Source], table_slug: str, **get_schema_
         table_name = table_slug
         table_slug = f"{source_obj.name}{SOURCE_TABLE_SEPARATOR}{table_name}"
 
-    table_info = await get_schema(source_obj, table_name, **get_schema_kwargs)
+    if view_definition:
+        schema = {"view_definition": view_definition}
+    else:
+        schema = await get_schema(source_obj, table_name, **get_schema_kwargs)
     normalized_table_name = source_obj.normalize_table(table_name)
     result = {
-        "schema": yaml.dump(table_info),
+        "schema": schema,
         "source": source_obj.name,
         "sql_table": normalized_table_name,
         "sql": source_obj.get_sql_expr(normalized_table_name),
     }
     return result
-
-
-async def format_table_info(
-    source: Source, table_name: str, prefix_table: bool = True,
-    as_slug: bool = False, limit: int = 5, **get_schema_kwargs
-) -> str:
-    """
-    Format a source schema as a markdown string.
-    """
-    tables_schema_str = ""
-    if prefix_table:
-        table_label = f"{source}{SOURCE_TABLE_SEPARATOR}{table_name}" if as_slug else table_name
-        tables_schema_str += f"`{table_label}`\n"
-    sql = source.get_sql_expr(table_name)
-    schema = await get_schema(source, table_name, limit=limit, **get_schema_kwargs)
-    tables_schema_str += f"Schema:\n```yaml\n{yaml.dump(schema)}```\nSQL:\n```sql\n{sql}\n```"
-    return tables_schema_str
 
 
 async def get_pipeline(**kwargs):
@@ -482,7 +469,7 @@ def report_error(exc: Exception, step: ChatStep, language: str = "python", conte
     step.status = "failed"
 
 
-def stream_details(content: Any, step: Any, title: str | None = None, auto: bool = True, **stream_kwargs) -> str:
+def stream_details(content: Any, step: Any, title: str = "Expand for details", auto: bool = True, **stream_kwargs) -> str:
     """
     Process content to place code blocks inside collapsible details elements
 
@@ -511,7 +498,7 @@ def stream_details(content: Any, step: Any, title: str | None = None, auto: bool
     pattern = r'```([\w-]*)\n(.*?)```'
     last_end = 0
     if not auto:
-        details = Details(content, title=title, collapsed=True, margin=(-5, 20, 5, 20), sizing_mode="stretch_width")
+        details = Details(content, title=title, collapsed=True, margin=(0, 20, 5, 20), sizing_mode="stretch_width")
         step.append(details, **stream_kwargs)
         return content
 
@@ -524,9 +511,9 @@ def stream_details(content: Any, step: Any, title: str | None = None, auto: bool
 
         details = Details(
             f"```{language}\n\n{code}\n\n```",
-            title=title or "Expand to see details",
+            title=title,
             collapsed=True,
-            margin=(-5, 20, 0, 20),
+            margin=(0, 20, 5, 20),
             sizing_mode="stretch_width",
         )
         step.append(details)

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -339,7 +339,7 @@ async def fetch_table_sql_info(sources: dict[str, Source], table_slug: str, view
         table_slug = f"{source_obj.name}{SOURCE_TABLE_SEPARATOR}{table_name}"
 
     if view_definition:
-        schema = {"view_definition": view_definition}
+        schema = {"view_definition": view_definition[:4000]}
     else:
         schema = await get_schema(source_obj, table_name, **get_schema_kwargs)
     normalized_table_name = source_obj.normalize_table(table_name)

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -672,6 +672,9 @@ def format_info(tables_vector_info: dict, tables_sql_info: dict) -> str:
             continue
         table_description = table_vector_info.get("description", "")
         context += f"\n{table_slug} (Similarity: {table_vector_info['similarity']:.3f}) {table_description}"
+        sql = tables_sql_info[table_slug].get("sql", "")
+        if sql:
+            context += f"\n  SQL:\n```sql\n{sql}\n```"
         schema = tables_sql_info.get(table_slug, {}).get("schema", {})
         if "view_definition" in schema:
             context += f"\n  View definition:\n```sql\n{schema['view_definition']}\n```"

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -656,3 +656,10 @@ def parse_table_slug(table: str, sources: dict[str, Source], normalize: bool = T
     if normalize:
         a_table = a_source_obj.normalize_table(a_table)
     return a_source_obj, a_table
+
+
+def truncate_string(s, max_length=20, ellipsis="..."):
+    if len(s) <= max_length:
+        return s
+    part_length = (max_length - len(ellipsis)) // 2
+    return f"{s[:part_length]}{ellipsis}{s[-part_length:]}"

--- a/lumen/sources/bigquery.py
+++ b/lumen/sources/bigquery.py
@@ -191,7 +191,7 @@ class BigQuerySource(BaseSQLSource):
             }
         return data
 
-    def _get_tables_metadata(self, project_id: str, dataset_id: str, tables: list[str] | None = None) -> dict:
+    def _get_table_metadata(self, project_id: str, dataset_id: str, tables: list[str] | None = None) -> dict:
         """Get metadata for all tables associated with the given dataset.
 
         Parameters
@@ -254,7 +254,7 @@ class BigQuerySource(BaseSQLSource):
         metadata = {}
         for dataset in datasets:
             if self.datasets is None or dataset in self.datasets:
-                metadata.update(self._get_tables_metadata(self.project_id, dataset, tables))
+                metadata.update(self._get_table_metadata(self.project_id, dataset, tables))
         return metadata
 
     def _get_table(self, table: str):

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -381,7 +381,11 @@ class SnowflakeSource(BaseSQLSource):
             }
             if table_type == "VIEW" and "INFORMATION_SCHEMA" not in table_slug:
                 try:
-                    result[table_slug]["view_definition"] = self.execute("SELECT GET_DDL('VIEW', %s)", ('.'.join(table_slug.split(".")[1:]),)).iloc[0, 0]
+                    # DATABASE.SCHEMA.TABLE -> SCHEMA.TABLE
+                    table_schema_slug = '.'.join(table_slug.split(".")[1:])
+                    result[table_slug]["view_definition"] = self.execute(
+                        "SELECT GET_DDL('VIEW', %s)", (table_schema_slug,)
+                    ).iloc[0, 0]
                 except Exception:
                     result[table_slug]["view_definition"] = "N/A"
         return result

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -382,6 +382,6 @@ class SnowflakeSource(BaseSQLSource):
             if table_type == "VIEW" and "INFORMATION_SCHEMA" not in table_slug:
                 try:
                     result[table_slug]["view_definition"] = self.execute("SELECT GET_DDL('VIEW', %s)", ('.'.join(table_slug.split(".")[1:]),)).iloc[0, 0]
-                except Exception as e:
-                    print(f"Error retrieving view definition for {table_slug}: {e}")
+                except Exception:
+                    result[table_slug]["view_definition"] = "N/A"
         return result

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -90,7 +90,7 @@ class SnowflakeSource(BaseSQLSource):
         qualified (schema.table), simply table names, or wildcards
         (e.g. database.schema.*).""")
 
-    schema_timeout_seconds = param.Integer(default=30, doc="""
+    schema_timeout_seconds = param.Integer(default=600, doc="""
         Timeout in seconds for schema retrieval. If None, no timeout is applied.""")
 
     dialect = 'snowflake'

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -232,11 +232,11 @@ class SnowflakeSource(BaseSQLSource):
     def get_tables(self) -> list[str]:
         # limited set of tables was provided
         if isinstance(self.tables, dict | list):
-            return [t for t in list(self.tables) if not self._is_table_excluded(t)]
+            return [t.upper() for t in list(self.tables) if not self._is_table_excluded(t)]
 
         tables_df = self.execute(f'SELECT TABLE_NAME, TABLE_SCHEMA FROM {self.database}.INFORMATION_SCHEMA.TABLES;')
         return [
-            f'{self.database}.{row.TABLE_SCHEMA}.{row.TABLE_NAME}'
+            f'{self.database}.{row.TABLE_SCHEMA}.{row.TABLE_NAME}'.upper()
             for _, row in tables_df.iterrows()
             if not self._is_table_excluded(f'{self.database}.{row.TABLE_SCHEMA}.{row.TABLE_NAME}')
         ]
@@ -340,7 +340,7 @@ class SnowflakeSource(BaseSQLSource):
         table_metadata = self.execute(
             """
             SELECT
-            TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COMMENT as TABLE_DESCRIPTION, ROW_COUNT, LAST_ALTERED, CREATED
+            TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, COMMENT as TABLE_DESCRIPTION, ROW_COUNT, LAST_ALTERED, CREATED
             FROM INFORMATION_SCHEMA.TABLES
             """
         )
@@ -364,6 +364,7 @@ class SnowflakeSource(BaseSQLSource):
             rows = None if pd.isna(rows) else int(rows)
             updated_at = first_row["LAST_ALTERED"].isoformat()
             created_at = first_row["CREATED"].isoformat()
+            table_type = first_row["TABLE_TYPE"]
             columns = (
                 group[["COLUMN_NAME", "COLUMN_DESCRIPTION", "DATA_TYPE"]]
                 .rename({"COLUMN_DESCRIPTION": "description", "DATA_TYPE": "data_type"}, axis=1)
@@ -378,4 +379,9 @@ class SnowflakeSource(BaseSQLSource):
                 "updated_at": updated_at,
                 "created_at": created_at,
             }
+            if table_type == "VIEW" and "INFORMATION_SCHEMA" not in table_slug:
+                try:
+                    result[table_slug]["view_definition"] = self.execute("SELECT GET_DDL('VIEW', %s)", ('.'.join(table_slug.split(".")[1:]),)).iloc[0, 0]
+                except Exception as e:
+                    print(f"Error retrieving view definition for {table_slug}: {e}")
         return result

--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -168,7 +168,7 @@ def test_sql_columns():
 
 def test_sql_distinct():
     result = SQLDistinct.apply_to("SELECT * FROM TABLE", columns=["A", "B"])
-    expected = "SELECT DISTINCT A, B FROM (SELECT * FROM TABLE)"
+    expected = 'SELECT DISTINCT "A", "B" FROM (SELECT * FROM TABLE)'
     assert result == expected
 
 

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -381,7 +381,7 @@ class SQLDistinct(SQLTransform):
             return sql_in
 
         subquery = self.parse_sql(sql_in).subquery()
-        expression = select(*self.columns).from_(subquery).distinct()
+        expression = select(*[Identifier(this=col, quoted=True) for col in self.columns]).from_(subquery).distinct()
         return self.to_sql(expression)
 
 


### PR DESCRIPTION
Finally semi-satisfied with TableLookup.

1. Separates out TableLookup and IterativeTableLookup purpose. TableLookup is suitable for ChatAgent because it just uses vector store queries to quickly find all the relevant tables & columns + descriptions if available, while IterativeTableLookup is suitable for SQLAgent because it additionally makes database calls to look up schema, e.g. min/max of column values
2. Rather than try to look up schemas for tables that are actually views (taking 30 seconds or longer), uses the view definition (the SQL) as context.
3. Renames table_info to tables_sql_info for clarity to differentiate against tables_vector_info.

Next steps are:
ColumnLookup and Gated propagation for tool context