### PR TITLE
Implement defined queries

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -121,6 +121,7 @@ class Actor(param.Parameterized):
         return nullcontext(self._null_step) if self.interface is None else self.interface.add_step(title=title, **kwargs)
 
     async def _gather_prompt_context(self, prompt_name: str, messages: list[Message], **context):
+        context["actor_name"] = self.name
         context["memory"] = self._memory
         context["actor_name"] = self.name
         return context

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -510,6 +510,7 @@ class SQLAgent(LumenBaseAgent):
             "main": {
                 "response_model": Sql,
                 "template": PROMPTS_DIR / "SQLAgent" / "main.jinja2",
+                "tools": []
             },
             "find_tables": {
                 "response_model": make_find_tables_model,
@@ -521,6 +522,16 @@ class SQLAgent(LumenBaseAgent):
     provides = param.List(default=["table", "sql", "pipeline", "data"], readonly=True)
 
     requires = param.List(default=["source", "table_sql_metaset"], readonly=True)
+
+    # def __init__(self, **params):
+    #     super().__init__(**params)
+        # # Dynamically add QueryLookup to tools if defined_queries is populated
+        # if "defined_queries" in self._memory and self._memory["defined_queries"]:
+        #     from .tools import QueryLookup
+        #     if QueryLookup not in self.prompts['main'].get('tools', []):
+        #         if 'tools' not in self.prompts['main']:
+        #             self.prompts['main']['tools'] = []
+        #         self.prompts['main']['tools'].append(QueryLookup)
 
     _extensions = ('codeeditor', 'tabulator',)
 


### PR DESCRIPTION
This PR implements two new features with predefined SQL queries:

1. A defined_queries parameter for storing predefined SQL queries that users can trigger individually or all together with a click of a button
2. A QueryLookup tool that embeds these queries and suggests relevant ones based on user questions

These defined queries are defined in the Coordinator class which are displayed as clickable buttons under suggestions

The QueryLookup class extends VectorLookupTool for embedding of SQL queries and their descriptions. Not sure if I should just use DocumentLookup...?

If defined queries exist, the SQLAgent could use QueryLookup, but also still debating whether it's a Coordinator/Planner or SQLAgent thing.

Also implements a fast track method to immediately call QueryLookup -> SQLAgent -> VegaLiteAgent