### PR TITLE
Fix Segfaults with DuckDB

### DIFF
--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -10,8 +10,7 @@ import param
 
 from panel.viewable import Viewable
 
-from lumen.sources.duckdb import DuckDBSource
-
+from ..sources.duckdb import DuckDBSource
 from ..views.base import View
 from .actor import Actor, ContextProvider
 from .config import PROMPTS_DIR, SOURCE_TABLE_SEPARATOR


### PR DESCRIPTION
This only applies to DuckDBSource so to keep non-blocking behavior for snowflake:


```
Traceback (most recent call last):
  File "/Users/ahuang/repos/panel/panel/io/server.py", line 157, in wrapped
    return await func(*args, kw)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/tools.py", line 541, in updatevector_store
    self._raw_metadata[source.name] = await asyncio.to_thread(source.get_metadata)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/sources/base.py", line 159, in wrapped
    metadata.update(method(self, missing_tables))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/sources/base.py", line 618, in get_metadata
    metadata = self._get_table_metadata(tables)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/sources/duckdb.py", line 338, in gettable_metadata
    schema_result = self.execute(schema_expr)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/sources/duckdb.py", line 280, in execute
    return self._connection.execute(sql_query, args, **kwargs).fetch_df()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
duckdb.duckdb.InternalException: INTERNAL Error: Attempted to dereference unique_ptr that is NULL!
This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see https://duckdb.org/docs/dev/internal_errors
```