### PR TITLE
Fix tool use and template rendering

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -131,7 +131,11 @@ class Actor(param.Parameterized):
         context = await self._gather_prompt_context(prompt_name, messages, **context)
 
         prompt_label = f"\033[92m{self.name}.prompts['{prompt_name}']['template']\033[0m"
-        if isinstance(prompt_template, str) and not Path(prompt_template).exists():
+        try:
+            path_exists = Path(prompt_template).exists()
+        except OSError:
+            path_exists = False
+        if isinstance(prompt_template, str) and not path_exists:
             # check if all the format_kwargs keys are contained in prompt_template
             # e.g. the key, "memory", is not used in "string template".format(memory=memory)
             format_kwargs = dict(**overrides, **context)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -240,9 +240,8 @@ class ChatAgent(Agent):
         It can talk about the data, if available. Or, it can also solely talk about documents.
 
         Usually not used concurrently with SQLAgent, unlike AnalystAgent.
-        Can be used concurrently with TableListAgent to describe available tables
-        and potential ideas for analysis, but if only documents are available,
-        then it can be used alone.""")
+        Can be used to describe available tables. Often used together
+        with TableLookup, DocumentLookup, or other tools.""")
 
     prompts = param.Dict(
         default={
@@ -252,7 +251,8 @@ class ChatAgent(Agent):
         }
     )
 
-    requires = param.List(default=[], readonly=True)
+    # technically not required if appended manually with tool in coordinator
+    requires = param.List(default=["table_vector_metaset"], readonly=True)
 
     async def respond(
         self,

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -252,7 +252,7 @@ class ChatAgent(Agent):
         }
     )
 
-    requires = param.List(default=["table_vector_metaset"], readonly=True)
+    requires = param.List(default=[], readonly=True)
 
     async def respond(
         self,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -218,7 +218,7 @@ class Coordinator(Viewer, ToolUser):
             instantiated.append(agent)
 
         # Add user-provided tools to the list of tools of the coordinator
-        self.prompts["main"]["tools"] += [tool for tool in self.tools]
+        self.prompts["main"]["tools"] += [tool for tool in tools]
         super().__init__(llm=llm, agents=instantiated, interface=interface, logs_db_path=logs_db_path, **params)
 
         welcome_message = UI_INTRO_MESSAGE if self.within_ui else "Welcome to LumenAI; get started by clicking a suggestion or type your own query below!"

--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -17,6 +17,7 @@ Here's a summary of the dataset the user just asked about:
 {{ memory['data'] }}
 ```
 {%- endif %}
-
+{%- if 'table_vector_metaset' in memory %}
 {{ memory['table_vector_metaset'].min_context }}
+{%- endif %}
 {% endblock -%}

--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -18,6 +18,7 @@ Here's a summary of the dataset the user just asked about:
 ```
 {%- endif %}
 {%- if 'table_vector_metaset' in memory %}
+{# officially not required #}
 {{ memory['table_vector_metaset'].min_context }}
 {%- endif %}
 {% endblock -%}

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -20,7 +20,7 @@ Important Agent Rules:
 - The SQLAgent usually needs help by *TableLookup if the current columns are insufficient.
 - Only use SQLAgent when working with new data or different analysis requirements. If the user wants to visualize, discuss, or further analyze data that's already been retrieved, use the current SQL rather than executing the query again.
 - When plotting, instruct SQLAgent to select more columns than requested to enable VegaLiteAgent to create faceted, multi-layout, or encoded visualizations.
-- The ChatAgent usually can be used alone, but if the query is related to the data tables, please use AnalystAgent instead.
+- The ChatAgent must be used with TableLookup or other tools, but if the query is related to the data tables, please use AnalystAgent instead.
 
 Import Tools Rules:
 - The TableLookup is ideal for ChatAgent, while IterativeTableLookup is better for SQLAgent.


### PR DESCRIPTION
1. self.tools is not defined yet before super() so custom input tools was not defined
2. ChatAgent is appended if last node is a tool to summarize the results, but make it not a hard requirement by adjusting the prompt to use it only if defined
3. Rendering absolute paths / strings template

```python

        last_node = execution_graph[-1]
        if isinstance(last_node.actor, Tool) and not isinstance(last_node.actor, TableLookup):
            if "AnalystAgent" in agents and all(r in provided for r in agents["AnalystAgent"].requires):
                expert = "AnalystAgent"
            else:
                expert = "ChatAgent"
            summarize_step = type(step)(
                expert_or_tool=expert,
                instruction='Summarize the results.',
                title='Summarizing results',
                render_output=False
            )
            steps.append(summarize_step)
            execution_graph.append(
                ExecutionNode(
                    actor=agents[expert],
                    provides=[],
                    instruction=summarize_step.instruction,
                    title=summarize_step.title,
                    render_output=summarize_step.render_output
                )
            )
```