### PR TITLE
Fix the docs build

### DIFF
--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -686,7 +686,9 @@ class SQLSample(SQLTransform):
 
 
 class SQLRemoveSourceSeparator(SQLTransform):
-    """Class to exclude the source and separator."""
+    """
+    Class to exclude the source and separator.
+    """
 
     separator = param.String(default=SOURCE_TABLE_SEPARATOR, doc="""
         Separator used to split the source and table name in the SQL query.""")


### PR DESCRIPTION
The code in `doc/generate_reference.py` expects the docstring summary to be on the second line.