### PR TITLE
Simplify schema naming

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -546,7 +546,7 @@ class SQLAgent(LumenBaseAgent):
             for table_slug, vector_metadata in vector_metadata_map.items():
                 table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1]
                 if table_name in tables_to_source:
-                    columns = [col.name for col in vector_metadata.table_cols]
+                    columns = [col.name for col in vector_metadata.columns]
                     columns_context += f"\nSQL: {vector_metadata.base_sql}\nColumns: {', '.join(columns)}\n\n"
             last_query = self._memory["sql"]
             num_errors = len(errors)
@@ -758,7 +758,7 @@ class BaseViewAgent(LumenBaseAgent):
             for table_slug, vector_metadata in vector_metadata_map.items():
                 table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1]
                 if table_name in pipeline.table:
-                    columns = [col.name for col in vector_metadata.table_cols]
+                    columns = [col.name for col in vector_metadata.columns]
                     columns_context += f"\nSQL: {vector_metadata.base_sql}\nColumns: {', '.join(columns)}\n\n"
             messages = mutate_user_message(
                 f"\nNote, your last specification did not work as intended:\n```json\n{json_spec}\n```\n\n"

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -523,7 +523,7 @@ class SQLAgent(LumenBaseAgent):
 
     provides = param.List(default=["table", "sql", "pipeline", "data"], readonly=True)
 
-    requires = param.List(default=["source", "table_sql_metaset"], readonly=True)
+    requires = param.List(default=["source", "sql_metaset"], readonly=True)
 
     _extensions = ('codeeditor', 'tabulator',)
 
@@ -542,7 +542,7 @@ class SQLAgent(LumenBaseAgent):
         if errors:
             # get the head of the tables
             columns_context = ""
-            vector_metadata_map = self._memory["table_sql_metaset"].vector_metaset.vector_metadata_map
+            vector_metadata_map = self._memory["sql_metaset"].vector_metaset.vector_metadata_map
             for table_slug, vector_metadata in vector_metadata_map.items():
                 table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1]
                 if table_name in tables_to_source:
@@ -659,10 +659,10 @@ class SQLAgent(LumenBaseAgent):
             messages = mutate_user_message(content, messages)
 
         sources = {source.name: source for source in self._memory["sources"]}
-        vector_metaset = self._memory["table_sql_metaset"].vector_metaset
+        vector_metaset = self._memory["sql_metaset"].vector_metaset
         selected_slugs = list(
             #  if no tables/cols are subset
-            vector_metaset.sel_tables_cols or
+            vector_metaset.selected_columns or
             vector_metaset.vector_metadata_map
         )
         if len(selected_slugs) == 0:
@@ -721,7 +721,7 @@ class SQLAgent(LumenBaseAgent):
 
 class BaseViewAgent(LumenBaseAgent):
 
-    requires = param.List(default=["pipeline", "table_sql_metaset"], readonly=True)
+    requires = param.List(default=["pipeline", "sql_metaset"], readonly=True)
 
     provides = param.List(default=["view"], readonly=True)
 
@@ -753,7 +753,7 @@ class BaseViewAgent(LumenBaseAgent):
             except Exception:
                 json_spec = ""
 
-            vector_metadata_map = self._memory["table_sql_metaset"].vector_metaset.vector_metadata_map
+            vector_metadata_map = self._memory["sql_metaset"].vector_metaset.vector_metadata_map
             columns_context = ""
             for table_slug, vector_metadata in vector_metadata_map.items():
                 table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1]

--- a/lumen/ai/prompts/BaseViewAgent/main.jinja2
+++ b/lumen/ai/prompts/BaseViewAgent/main.jinja2
@@ -19,5 +19,5 @@ The previous view specification was:
 ```
 {%- endif %}
 
-{{ memory["table_sql_metaset"].sel_context }}
+{{ memory["sql_metaset"].selected_context }}
 {%- endblock %}

--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -1,9 +1,7 @@
 {% extends 'Agent/main.jinja2' %}
 
 {%- block instructions %}
-Act as a helpful assistant for high-level data exploration, focusing on available datasets and, only if data is
-available, explaining the purpose of each column. Offer suggestions for getting started if needed, remaining factual and
-avoiding speculation. Do not write code or give code related suggestions.
+Act as a helpful assistant for high-level data exploration, focusing on available datasets and, only if data is available, explaining the purpose of each column. Offer suggestions for getting started if needed, remaining factual and avoiding speculation. Do not write code or give code related suggestions.
 {%- endblock %}
 
 {% block context %}
@@ -17,8 +15,8 @@ Here's a summary of the dataset the user just asked about:
 {{ memory['data'] }}
 ```
 {%- endif %}
-{%- if 'table_vector_metaset' in memory %}
+{%- if 'vector_metaset' in memory %}
 {# officially not required #}
-{{ memory['table_vector_metaset'].min_context }}
+{{ memory['vector_metaset'].min_context }}
 {%- endif %}
 {% endblock -%}

--- a/lumen/ai/prompts/IterativeTableLookup/iterative_selection.jinja2
+++ b/lumen/ai/prompts/IterativeTableLookup/iterative_selection.jinja2
@@ -24,9 +24,9 @@ Here are the tables available for selection:
 {%- if vector_metadata_map[table_slug].description is defined and vector_metadata_map[table_slug].description -%}
   Description: {{ vector_metadata_map[table_slug].description }}
 {%- endif -%}
-{%- if vector_metadata_map[table_slug].table_cols is defined and vector_metadata_map[table_slug].table_cols|length > 0 %}
+{%- if vector_metadata_map[table_slug].columns is defined and vector_metadata_map[table_slug].columns|length > 0 %}
   Cols:
-  {%- for col in vector_metadata_map[table_slug].table_cols -%}
+  {%- for col in vector_metadata_map[table_slug].columns -%}
   - {{ col.name }}{% if col.description %}: {{ col.description }}{% endif %}
   {% endfor -%}
 {% endif %}

--- a/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
+++ b/lumen/ai/prompts/LumenBaseAgent/retry_output.jinja2
@@ -15,5 +15,5 @@ Original output:
 {{ spec }}
 ```
 
-{{ memory["table_sql_metaset"].sel_context }}
+{{ memory["sql_metaset"].selected_context }}
 {% endblock %}

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -28,7 +28,7 @@ Import Tools Rules:
 {% endblock -%}
 
 {% block context -%}
-{%- if memory.get('vector_metaset') and memory.get('vector_metaset').selected_columns %}
+{%- if 'vector_metaset' in memory and memory.get('vector_metaset').selected_columns %}
 The current selected columns in memory is:
 {{ memory['vector_metaset'].selected_columns }}
 based on the previous query:

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -28,12 +28,12 @@ Import Tools Rules:
 {% endblock -%}
 
 {% block context -%}
-{%- if memory.get('table_vector_metaset') and memory.get('table_vector_metaset').sel_tables_cols %}
+{%- if memory.get('vector_metaset') and memory.get('vector_metaset').selected_columns %}
 The current selected columns in memory is:
-{{ memory['table_vector_metaset'].sel_tables_cols }}
+{{ memory['vector_metaset'].selected_columns }}
 based on the previous query:
 """
-{{ memory['table_vector_metaset'].query }}
+{{ memory['vector_metaset'].query }}
 """
 Please consider whether this is enough information to proceed with the current user query;
 if not use IterativeTableLookup to refresh the available columns in memory.

--- a/lumen/ai/prompts/SQLAgent/find_tables.jinja2
+++ b/lumen/ai/prompts/SQLAgent/find_tables.jinja2
@@ -8,5 +8,5 @@ Use table names verbatim, and be sure to include the delimiters {{ separator }},
 {% endblock %}
 
 {% block context %}
-{{ memory["table_sql_metaset"].max_context }}
+{{ memory["sql_metaset"].max_context }}
 {% endblock %}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -51,7 +51,7 @@ CAST or TO_DATE
 Here's additional guidance:
 {{ comments }}
 {%- endif -%}
-{{ memory["table_sql_metaset"].sel_context }}
+{{ memory["sql_metaset"].selected_context }}
 {%- endblock -%}
 
 {%- block examples %}

--- a/lumen/ai/prompts/TableLookup/select_columns.jinja2
+++ b/lumen/ai/prompts/TableLookup/select_columns.jinja2
@@ -32,9 +32,9 @@ Here is the previous query, tables, and columns:
 {{ previous_state }}
 {% endif %}
 
-{% if memory.get('table_sql_metaset') %}
-{{ memory['table_sql_metaset'].sel_context }}
+{% if memory.get('sql_metaset') %}
+{{ memory['sql_metaset'].selected_context }}
 {% else %}
-{{ memory["table_vector_metaset"].sel_context }}
+{{ memory["vector_metaset"].selected_context }}
 {% endif %}
 {% endblock %}

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -25,7 +25,7 @@ class VectorMetadata:
     similarity: float
     description: str | None = None
     base_sql: str | None = None
-    table_cols: list[Column] = field(default_factory=list)
+    columns: list[Column] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -67,7 +67,7 @@ class VectorMetaset:
                 context += f"Base SQL: {vector_metadata.base_sql}\n"
 
             max_length = 20
-            cols_to_show = vector_metadata.table_cols
+            cols_to_show = vector_metadata.columns
             if truncate is not None:
                 cols_to_show = [col for col in cols_to_show if col.name in self.selected_columns.get(table_slug, [])]
 
@@ -176,7 +176,7 @@ class SQLMetaset:
                     context += f"Row count: {len(sql_data.schema)}\n"
 
             max_length = 20
-            cols_to_show = vector_metadata.table_cols
+            cols_to_show = vector_metadata.columns
             if truncate is not None and vector_metaset.selected_columns:
                 cols_to_show = [col for col in cols_to_show if col.name in vector_metaset.selected_columns.get(table_slug, [])]
 

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from lumen.ai.utils import truncate_iterable, truncate_string
+from ..sources import Source
+from .config import SOURCE_TABLE_SEPARATOR
+from .utils import get_schema, truncate_iterable, truncate_string
 
 
 @dataclass
-class TableColumn:
+class Column:
     """Schema for a column with its description."""
 
     name: str
@@ -16,24 +18,24 @@ class TableColumn:
 
 
 @dataclass
-class TableVectorMetadata:
+class VectorMetadata:
     """Schema for vector lookup data for a single table."""
 
     table_slug: str  # Combined source_name and table_name with separator
     similarity: float
     description: str | None = None
     base_sql: str | None = None
-    table_cols: list[TableColumn] = field(default_factory=list)
+    table_cols: list[Column] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
-class TableVectorMetaset:
+class VectorMetaset:
     """Schema container for vector data for multiple tables_metadata."""
 
     query: str
-    vector_metadata_map: dict[str, TableVectorMetadata]
-    sel_tables_cols: dict[str, list[str]] = field(default_factory=dict)
+    vector_metadata_map: dict[str, VectorMetadata]
+    selected_columns: dict[str, list[str]] = field(default_factory=dict)
 
     def _generate_context(self, truncate: bool | None = None) -> str:
         """
@@ -42,16 +44,16 @@ class TableVectorMetaset:
         Args:
             truncate: Controls truncation behavior.
                     None: Show all tables (max_context)
-                    False: Filter by sel_tables_cols without truncation (sel_context)
-                    True: Filter by sel_tables_cols with truncation (min_context)
+                    False: Filter by selected_columns without truncation (selected_context)
+                    True: Filter by selected_columns with truncation (min_context)
         """
         context = "Below are the relevant tables and columns to use:\n\n"
 
         # Use selected tables if specified, otherwise use all tables
-        tables_to_show = self.sel_tables_cols or self.vector_metadata_map.keys()
+        tables_to_show = self.selected_columns or self.vector_metadata_map.keys()
 
         for table_slug in self.vector_metadata_map.keys():
-            # Skip tables not in the selected list if using sel_context or min_context
+            # Skip tables not in the selected list if using selected_context or min_context
             if truncate is not None and table_slug not in tables_to_show:
                 continue
 
@@ -67,7 +69,7 @@ class TableVectorMetaset:
             max_length = 20
             cols_to_show = vector_metadata.table_cols
             if truncate is not None:
-                cols_to_show = [col for col in cols_to_show if col.name in self.sel_tables_cols.get(table_slug, [])]
+                cols_to_show = [col for col in cols_to_show if col.name in self.selected_columns.get(table_slug, [])]
 
             show_ellipsis = False
             if truncate:
@@ -99,7 +101,7 @@ class TableVectorMetaset:
         return self._generate_context(truncate=None)
 
     @property
-    def sel_context(self) -> str:
+    def selected_context(self) -> str:
         """Generate formatted text representation of the context with selected tables cols"""
         return self._generate_context(truncate=False)
 
@@ -110,11 +112,11 @@ class TableVectorMetaset:
 
     def __str__(self) -> str:
         """String representation is the formatted context."""
-        return self.sel_context
+        return self.selected_context
 
 
 @dataclass
-class TableSQLMetadata:
+class SQLMetadata:
     """Schema for SQL schema data for a single table."""
 
     table_slug: str
@@ -125,11 +127,11 @@ class TableSQLMetadata:
 
 
 @dataclass
-class TableSQLMetaset:
+class SQLMetaset:
     """Schema container for SQL data for multiple tables_metadata that builds on vector context."""
 
-    vector_metaset: TableVectorMetaset
-    sql_metadata_map: dict[str, TableSQLMetadata]
+    vector_metaset: VectorMetaset
+    sql_metadata_map: dict[str, SQLMetadata]
 
     def _generate_context(self, truncate: bool | None = None) -> str:
         """
@@ -138,8 +140,8 @@ class TableSQLMetaset:
         Args:
             truncate: Controls truncation behavior.
                       None: Show all tables (max_context)
-                      False: Filter by sel_tables_cols without truncation (sel_context)
-                      True: Filter by sel_tables_cols with truncation (min_context)
+                      False: Filter by selected_columns without truncation (selected_context)
+                      True: Filter by selected_columns with truncation (min_context)
 
         Returns:
             Formatted context string
@@ -147,7 +149,7 @@ class TableSQLMetaset:
         context = "Below are the relevant tables and columns to use:\n\n"
 
         vector_metaset = self.vector_metaset
-        tables_to_show = vector_metaset.sel_tables_cols or vector_metaset.vector_metadata_map.keys()
+        tables_to_show = vector_metaset.selected_columns or vector_metaset.vector_metadata_map.keys()
 
         for table_slug in self.sql_metadata_map.keys():
             # Skip tables not in selected list for sub/min context
@@ -164,7 +166,7 @@ class TableSQLMetaset:
                 desc = truncate_string(vector_metadata.description, max_length=100) if truncate else vector_metadata.description
                 context += f"Description: {desc}\n"
 
-            sql_data: TableSQLMetadata = self.sql_metadata_map.get(table_slug)
+            sql_data: SQLMetadata = self.sql_metadata_map.get(table_slug)
             if sql_data:
                 base_sql = truncate_string(sql_data.base_sql, max_length=200) if truncate else sql_data.base_sql
                 context += f"Base SQL: {base_sql}\n"
@@ -175,8 +177,8 @@ class TableSQLMetaset:
 
             max_length = 20
             cols_to_show = vector_metadata.table_cols
-            if truncate is not None and vector_metaset.sel_tables_cols:
-                cols_to_show = [col for col in cols_to_show if col.name in vector_metaset.sel_tables_cols.get(table_slug, [])]
+            if truncate is not None and vector_metaset.selected_columns:
+                cols_to_show = [col for col in cols_to_show if col.name in vector_metaset.selected_columns.get(table_slug, [])]
 
             original_indices = []
             show_ellipsis = False
@@ -222,7 +224,7 @@ class TableSQLMetaset:
         return self._generate_context(truncate=None)
 
     @property
-    def sel_context(self) -> str:
+    def selected_context(self) -> str:
         """Generate context with selected tables and columns, without truncation."""
         return self._generate_context(truncate=False)
 
@@ -238,21 +240,21 @@ class TableSQLMetaset:
 
     def __str__(self) -> str:
         """String representation is the formatted context."""
-        return self.sel_context
+        return self.selected_context
 
 @dataclass
 class PreviousState:
     """Schema for previous state data."""
 
     query: str
-    sel_tables_cols: dict[str, list[str]] = field(default_factory=dict)
+    selected_columns: dict[str, list[str]] = field(default_factory=dict)
 
     @property
     def max_context(self) -> str:
         """Generate formatted text representation of the previous state."""
         context = f"Previous query: {self.query}\n\n"
-        if self.sel_tables_cols:
-            for table_slug, cols in self.sel_tables_cols.items():
+        if self.selected_columns:
+            for table_slug, cols in self.selected_columns.items():
                 context += f"Table: {table_slug}\n"
                 for col in cols:
                     context += f"- {col!r}\n"
@@ -261,3 +263,54 @@ class PreviousState:
     def __str__(self) -> str:
         """String representation is the formatted context."""
         return self.max_context
+
+
+async def get_metaset(sources: dict[str, Source], tables: list[str]) -> SQLMetaset:
+    """
+    Get the metaset for the given sources and tables.
+
+    Parameters
+    ----------
+    sources: dict[str, Source]
+        The sources to get the metaset for.
+    tables: list[str]
+        The tables to get the metaset for.
+
+    Returns
+    -------
+    metaset: SQLMetaset
+        The metaset for the given sources and tables.
+    """
+    tables_info, tables_metadata = {}, {}
+    for table_slug in tables:
+        if SOURCE_TABLE_SEPARATOR in table_slug:
+            source_name, table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)
+        elif len(sources) > 1:
+            raise ValueError(
+                f"Cannot resolve table {table_slug} without providing "
+                "the source, when multiple sources are provided. Ensure "
+                f"that you qualify the table name as follows:\n\n"
+                "    <source>{SOURCE_TABLE_SEPARATOR}<table>"
+            )
+        else:
+            source_name = next(iter(sources))
+            table_name = table_slug
+        source = sources[source_name]
+        schema = await get_schema(source, table_name, include_count=True)
+        tables_info[table_name] = SQLMetadata(
+            table_slug=table_slug,
+            schema=schema,
+            base_sql=source.get_sql_expr(source.normalize_table(table_name)),
+            view_definition=None,
+        )
+        metadata = source.get_metadata(table_name)
+        tables_metadata[table_name] = VectorMetadata(
+            table_slug=table_slug,
+            similarity=1,
+            description=metadata['description']
+        )
+    vector_metaset = VectorMetaset(vector_metadata_map=tables_metadata, query=None)
+    return SQLMetaset(
+        vector_metaset=vector_metaset,
+        sql_metadata_map=tables_info,
+    )

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -23,8 +23,8 @@ from .models import (
     make_refined_query_model,
 )
 from .schemas import (
-    PreviousState, TableColumn, TableSQLMetadata, TableSQLMetaset,
-    TableVectorMetadata, TableVectorMetaset,
+    Column, PreviousState, SQLMetadata, SQLMetaset, VectorMetadata,
+    VectorMetaset,
 )
 from .translate import function_to_model
 from .utils import (
@@ -402,7 +402,7 @@ class TableLookup(VectorLookupTool):
     requires = param.List(default=["sources"], readonly=True, doc="""
         List of context that this Tool requires to be run.""")
 
-    provides = param.List(default=["table_vector_metaset"], readonly=True, doc="""
+    provides = param.List(default=["vector_metaset"], readonly=True, doc="""
         List of context values this Tool provides to current working memory.""")
 
     enable_select_columns = param.Boolean(default=True, doc="""
@@ -488,20 +488,20 @@ class TableLookup(VectorLookupTool):
         if not table_name_key:
             return
         table_name = table_name_key
-        table_vector_info = dict(source_metadata[table_name])
+        vector_info = dict(source_metadata[table_name])
 
         # IMPORTANT: re-insert using table slug
         # we need to store a copy of tables_vector_data so it can be used to inject context into the LLM
         table_slug = f"{source.name}{SOURCE_TABLE_SEPARATOR}{table_name}"
-        self._tables_metadata[table_slug] = table_vector_info.copy()
+        self._tables_metadata[table_slug] = vector_info.copy()
         self._tables_metadata[table_slug]["source_name"] = source.name  # need this to rebuild the slug
 
         # Create column schema objects
         table_cols = []
-        if self.include_columns and (columns := table_vector_info.get('columns', {})):
+        if self.include_columns and (columns := vector_info.get('columns', {})):
             for col_name, col_info in columns.items():
                 col_desc = col_info.pop("description", "")
-                column = TableColumn(
+                column = Column(
                     name=col_name,
                     description=col_desc,
                     metadata=col_info.copy() if isinstance(col_info, dict) else {}
@@ -517,9 +517,9 @@ class TableLookup(VectorLookupTool):
         # the following is for the embeddings/vector store use only (i.e. filter from 1000s of tables)
         vector_metadata["enriched"] = True
         enriched_text = f"Table: {table_name}"
-        if description := table_vector_info.pop('description', ''):
+        if description := vector_info.pop('description', ''):
             enriched_text += f"\nDescription: {description}"
-        if self.include_columns and (columns := table_vector_info.pop('columns', {})):
+        if self.include_columns and (columns := vector_info.pop('columns', {})):
             enriched_text += "\nCols:"
             for col_name, col_info in columns.items():
                 col_text = f"\n- {col_name}"
@@ -529,7 +529,7 @@ class TableLookup(VectorLookupTool):
             enriched_text += "\n"
         if self.include_misc:
             enriched_text += "\nMiscellaneous:"
-            for key, value in table_vector_info.items():
+            for key, value in vector_info.items():
                 if key == "enriched":
                     continue
                 enriched_text += f"\n- {key}: {value}"
@@ -683,20 +683,20 @@ class TableLookup(VectorLookupTool):
             content = f"Please address these errors in your previous attempt:\n{errors}"
             messages = mutate_user_message(content, messages)
 
-        vector_metaset: TableVectorMetaset = self._memory.get("table_vector_metaset")
+        vector_metaset: VectorMetaset = self._memory.get("vector_metaset")
         needs_reselection = await self._should_refresh_columns(messages)
-        if not needs_reselection and vector_metaset.sel_tables_cols:
+        if not needs_reselection and vector_metaset.selected_columns:
             with self._add_step(title="Column Selection (Cached)") as step:
                 step.stream("Reusing previous column selection as the query intent is similar.")
-                for table_slug, column_names in vector_metaset.sel_tables_cols.items():
-                    if table_slug in vector_metaset.sel_tables_cols:
+                for table_slug, column_names in vector_metaset.selected_columns.items():
+                    if table_slug in vector_metaset.selected_columns:
                         table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1]
                         stream_details('\n\n'.join(column_names), step, title=f"Selected columns for {table_name}")
-            return vector_metaset.sel_tables_cols
+            return vector_metaset.selected_columns
 
         try:
             with self._add_step(title="Column Selection") as step:
-                sel_tables_cols = {}
+                selected_columns = {}
                 vector_metadata_map = vector_metaset.vector_metadata_map
                 async for output_chunk in self._stream_prompt(
                     "select_columns",
@@ -720,11 +720,11 @@ class TableLookup(VectorLookupTool):
                     table = vector_metadata_map[table_slug]
                     all_columns = [col.name for col in table.table_cols]
                     column_names = [all_columns[idx] for idx in indices if idx < len(all_columns)]
-                    sel_tables_cols[table_slug] = column_names
+                    selected_columns[table_slug] = column_names
                     table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1]
                     stream_details('\n\n'.join(column_names), step, title=f"Selected columns for {table_name}", auto=False)
-                vector_metaset.sel_tables_cols = sel_tables_cols
-            return sel_tables_cols
+                vector_metaset.selected_columns = selected_columns
+            return selected_columns
         except Exception as e:
             with self._add_step(title="Column Selection Error") as step:
                 traceback.print_exc()
@@ -762,14 +762,14 @@ class TableLookup(VectorLookupTool):
 
                 for col_name, col_info in columns.items():
                     col_desc = col_info.pop("description", "")
-                    column_schema = TableColumn(
+                    column_schema = Column(
                         name=col_name,
                         description=col_desc,
                         metadata=col_info.copy() if isinstance(col_info, dict) else {}
                     )
                     table_cols.append(column_schema)
 
-            vector_metadata = TableVectorMetadata(
+            vector_metadata = VectorMetadata(
                 table_slug=table_slug,
                 similarity=similarity_score,
                 description=table_description,
@@ -785,15 +785,15 @@ class TableLookup(VectorLookupTool):
                 if table_slug in vector_metadata_map:
                     vector_metadata_map[table_slug].similarity = 1
 
-        self._memory["table_vector_metaset"] = TableVectorMetaset(
+        self._memory["vector_metaset"] = VectorMetaset(
             vector_metadata_map=vector_metadata_map, query=query)
         return vector_metadata_map
 
     def _format_context(self) -> str:
         """Generate formatted text representation from schema objects."""
         # Get schema objects from memory
-        table_vector_metaset = self._memory.get("table_vector_metaset")
-        return table_vector_metaset.sel_context
+        vector_metaset = self._memory.get("vector_metaset")
+        return vector_metaset.selected_context
 
     async def respond(self, messages: list[Message], **kwargs: dict[str, Any]) -> str:
         """
@@ -811,7 +811,7 @@ class TableLookup(VectorLookupTool):
 
         self._previous_state = PreviousState(
             query=messages[-1]["content"],
-            sel_tables_cols=self._memory.get("table_vector_metaset", {}).sel_tables_cols,
+            selected_columns=self._memory.get("vector_metaset", {}).selected_columns,
         )
         return self._format_context()
 
@@ -829,7 +829,7 @@ class IterativeTableLookup(TableLookup):
         Uses LLM to select tables in multiple passes, examining schemas in detail.
         Useful for SQLAgent, but not for ChatAgent.""")
 
-    provides = param.List(default=["table_vector_metaset", "table_sql_metaset"], readonly=True, doc="""
+    provides = param.List(default=["vector_metaset", "sql_metaset"], readonly=True, doc="""
         List of context values this Tool provides to current working memory.""")
 
     max_selection_iterations = param.Integer(default=3, doc="""
@@ -863,7 +863,7 @@ class IterativeTableLookup(TableLookup):
         4. Repeats until the LLM is satisfied with the context
         """
         vector_metadata_map = await super()._gather_info(messages)
-        vector_metaset = self._memory.get("table_vector_metaset")
+        vector_metaset = self._memory.get("vector_metaset")
 
         sql_metadata_map = {}
         examined_slugs = set(sql_metadata_map.keys())
@@ -974,7 +974,7 @@ class IterativeTableLookup(TableLookup):
                             schema = await get_schema(source_obj, table_name, reduce_enums=False)
 
                         # Create TableSQLMetadata object
-                        sql_metadata = TableSQLMetadata(
+                        sql_metadata = SQLMetadata(
                             table_slug=table_slug,
                             schema=schema,
                             base_sql=source_obj.get_sql_expr(source_obj.normalize_table(table_name)),
@@ -1003,25 +1003,25 @@ class IterativeTableLookup(TableLookup):
 
         # Only keep table schemas that were selected in the final iteration or were fast-tracked
         if satisfied_slugs:
-            # Update sel_tables_cols in vector_metaset
-            vector_metaset.sel_tables_cols = {
-                table_slug: vector_metaset.sel_tables_cols
+            # Update selected_columns in vector_metaset
+            vector_metaset.selected_columns = {
+                table_slug: vector_metaset.selected_columns
                 for table_slug in satisfied_slugs
-                if table_slug in vector_metaset.sel_tables_cols
+                if table_slug in vector_metaset.selected_columns
             }
 
-        # Create TableSQLMetaset object using the vector schema and SQL data
-        table_sql_metaset = TableSQLMetaset(
+        # Create SQLMetaset object using the vector schema and SQL data
+        sql_metaset = SQLMetaset(
             vector_metaset=vector_metaset,
             sql_metadata_map=sql_metadata_map,
         )
-        self._memory["table_sql_metaset"] = table_sql_metaset
+        self._memory["sql_metaset"] = sql_metaset
         return sql_metadata_map
 
     def _format_context(self) -> str:
         """Generate formatted text representation from schema objects."""
-        table_sql_metaset = self._memory.get("table_sql_metaset")
-        return table_sql_metaset.sel_context
+        sql_metaset = self._memory.get("sql_metaset")
+        return sql_metaset.selected_context
 
 
 class FunctionTool(Tool):

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -497,7 +497,7 @@ class TableLookup(VectorLookupTool):
         self._tables_metadata[table_slug]["source_name"] = source.name  # need this to rebuild the slug
 
         # Create column schema objects
-        table_cols = []
+        columns = []
         if self.include_columns and (columns := vector_info.get('columns', {})):
             for col_name, col_info in columns.items():
                 col_desc = col_info.pop("description", "")
@@ -506,7 +506,7 @@ class TableLookup(VectorLookupTool):
                     description=col_desc,
                     metadata=col_info.copy() if isinstance(col_info, dict) else {}
                 )
-                table_cols.append(column)
+                columns.append(column)
 
         vector_metadata = {"source": source.name, "table_name": table_name}
         if existing_items := self.vector_store.filter_by(vector_metadata):
@@ -718,7 +718,7 @@ class TableLookup(VectorLookupTool):
                     if table_slug not in vector_metadata_map:
                         continue
                     table = vector_metadata_map[table_slug]
-                    all_columns = [col.name for col in table.table_cols]
+                    all_columns = [col.name for col in table.columns]
                     column_names = [all_columns[idx] for idx in indices if idx < len(all_columns)]
                     selected_columns[table_slug] = column_names
                     table_name = table_slug.split(SOURCE_TABLE_SEPARATOR)[-1]
@@ -753,7 +753,7 @@ class TableLookup(VectorLookupTool):
             if any_matches and result['similarity'] < self.min_similarity and not same_table:
                 continue
 
-            table_cols = []
+            columns = []
             table_description = None
 
             if table_metadata := self._tables_metadata.get(table_slug):
@@ -767,14 +767,14 @@ class TableLookup(VectorLookupTool):
                         description=col_desc,
                         metadata=col_info.copy() if isinstance(col_info, dict) else {}
                     )
-                    table_cols.append(column_schema)
+                    columns.append(column_schema)
 
             vector_metadata = VectorMetadata(
                 table_slug=table_slug,
                 similarity=similarity_score,
                 description=table_description,
                 base_sql=sql,
-                table_cols=table_cols,
+                columns=columns,
                 metadata=self._tables_metadata.get(table_slug, {}).copy()
             )
             vector_metadata_map[table_slug] = vector_metadata


### PR DESCRIPTION
The naming of the schemas and some of its attributes and properties was confusing, somewhat redundant and in some cases needlessly short. I tried to simplify using three simple principles:

1. We don't need the `Table` and `table_` prefix, it's redundant
2. We don't need to abbreviate column as `col`
3. We don't need to abbreviate selected as `sel`