### PR TITLE
Fix persisting duckdb and prevent crashes

### DIFF
--- a/lumen/ai/embeddings.py
+++ b/lumen/ai/embeddings.py
@@ -85,7 +85,7 @@ class OpenAIEmbeddings(Embeddings):
         self.client = OpenAI(api_key=self.api_key)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
-        texts = [text.replace("\n", " ") for text in texts]
+        texts = [text.replace("\n", " ").strip() for text in texts]
         response = self.client.embeddings.create(input=texts, model=self.model)
         return [r.embedding for r in response.data]
 


### PR DESCRIPTION
To resolve DuckDB crashes related to HNSW index 
```
InternalException: INTERNAL Error: Failure while replaying WAL file "/Users/ahuang/repos/lumen/embeddings.db.wal": Index type "HNSW" not recognized
```
and segfaults, I implemented the following workaround based on
https://duckdb.org/docs/stable/extensions/vss.html#persistence

1. Initialize a temporary in-memory connection first and load all required extensions
2. Only then attach to the desired database URI
3. Implement a verification step to check if previously the index was already initialized (`CREATE INDEX IF NOT EXISTS embedding_index` even with the if not exists, it would segfault)

