### PR TITLE
Fix empty metaset

### DIFF
--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -47,7 +47,7 @@ class VectorMetaset:
                     False: Filter by selected_columns without truncation (selected_context)
                     True: Filter by selected_columns with truncation (min_context)
         """
-        context = "Below are the relevant tables and columns to use:\n\n"
+        context = "Below are the relevant tables and columns available:\n\n"
 
         # Use selected tables if specified, otherwise use all tables
         tables_to_show = self.selected_columns or self.vector_metadata_map.keys()
@@ -84,7 +84,7 @@ class VectorMetaset:
                     context += "...\n"
 
                 if i == 0:
-                    context += "Columns:\n"
+                    context += "Cols:\n"
 
                 col_name = truncate_string(col.name) if truncate else col.name
                 context += f"{orig_idx}. {col_name!r}"
@@ -149,7 +149,7 @@ class SQLMetaset:
         Returns:
             Formatted context string
         """
-        context = "Below are the relevant tables and columns to use:\n\n"
+        context = "Below are the relevant tables and columns available:\n\n"
 
         vector_metaset = self.vector_metaset
         tables_to_show = vector_metaset.selected_columns or vector_metaset.vector_metadata_map.keys()


### PR DESCRIPTION
Fixes major bug where if LLM selects table in one iteration, it doesn't gather the schemas, which leads to downstream calls to have insufficient context (know what tables and columns are available)
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/74c63f86-56cb-41aa-9a9a-b5d54f2ea8d5" />

Also if LLM chooses more tables unavailable in vector_metaset.selected_columns, it adds to it 

Lastly tweaks language (rather than `to use` -> `is available`
