### PR TITLE
Vector store usage

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -29,7 +29,7 @@ from .llm import LlamaCpp, Llm, Message
 from .logs import ChatLogs
 from .models import YesNo, make_agent_model, make_plan_models
 from .tools import (
-    IterativeTableLookup, TableLookup, Tool, ToolUser,
+    IterativeTableLookup, TableLookup, Tool, VectorLookupToolUser,
 )
 from .utils import (
     fuse_messages, log_debug, mutate_user_message, stream_details,
@@ -80,7 +80,7 @@ class ExecutionNode(param.Parameterized):
     render_output = param.Boolean(default=False)
 
 
-class Coordinator(Viewer, ToolUser):
+class Coordinator(Viewer, VectorLookupToolUser):
     """
     A Coordinator is responsible for coordinating the actions
     of a number of agents towards the user defined query by
@@ -125,9 +125,6 @@ class Coordinator(Viewer, ToolUser):
     suggestions = param.List(default=GETTING_STARTED_SUGGESTIONS, doc="""
         Initial list of suggestions of actions the user can take.""")
 
-    tools = param.List(default=[], doc="""
-        List of tools to use to provide context.""")
-
     __abstract = True
 
     def __init__(
@@ -136,6 +133,7 @@ class Coordinator(Viewer, ToolUser):
         interface: ChatFeed | ChatInterface | None = None,
         agents: list[Agent | type[Agent]] | None = None,
         tools: list[Tool | type[Tool]] | None = None,
+        vector_store: Tool | None = None,
         logs_db_path: str = "",
         **params,
     ):
@@ -242,7 +240,7 @@ class Coordinator(Viewer, ToolUser):
         if "tools" not in params["prompts"]["main"]:
             params["prompts"]["main"]["tools"] = []
         params["prompts"]["main"]["tools"] += [tool for tool in tools]
-        super().__init__(llm=llm, agents=instantiated, interface=interface, logs_db_path=logs_db_path, **params)
+        super().__init__(llm=llm, agents=instantiated, interface=interface, logs_db_path=logs_db_path, vector_store=vector_store, **params)
 
         welcome_message = UI_INTRO_MESSAGE if self.within_ui else "Welcome to LumenAI; get started by clicking a suggestion or type your own query below!"
         interface.send(

--- a/lumen/ai/embeddings.py
+++ b/lumen/ai/embeddings.py
@@ -77,7 +77,7 @@ class OpenAIEmbeddings(Embeddings):
     >>> embeddings.embed(["Hello, world!", "Goodbye, world!"])
     """
 
-    api_key = param.String(doc="The OpenAI API key.")
+    api_key = param.String(default=None, doc="The OpenAI API key.")
 
     model = param.String(
         default="text-embedding-3-small", doc="The OpenAI model to use."

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -634,6 +634,7 @@ class TableLookup(VectorLookupTool):
         return {"text": enriched_text, "metadata": vector_metadata}
 
     async def _update_vector_store(self, _, __, sources):
+        await asyncio.sleep(0.5)  # allow main thread time to load UI first
         tasks = []
         for source in sources:
             if self.include_metadata and self._raw_metadata.get(source.name) is None:
@@ -651,6 +652,11 @@ class TableLookup(VectorLookupTool):
                 for table in tables:
                     task = asyncio.create_task(self._enrich_metadata(source, table))
                     tasks.append(task)
+            else:
+                self.vector_store.upsert([
+                    {"text": table_name, "metadata": {"source": source.name, "table_name": table_name}}
+                    for table_name in tables
+                ])
 
         if tasks:
             ready_task = asyncio.create_task(self._mark_ready_when_done(tasks))

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -45,30 +45,64 @@ class ToolUser(Actor):
         super().__init__(**params)
         self._tools = {}
 
-
-
         for prompt_name in self.prompts:
-            prompt_tools = self._lookup_prompt_key(prompt_name, "tools")
-            vector_store = next(
-                (tool.vector_store for tool in prompt_tools if isinstance(tool, VectorLookupTool)), None
-            )
-            self._tools[prompt_name] = []
-            for tool in prompt_tools:
-                if isinstance(tool, Actor):
-                    if tool.llm is None:
-                        tool.llm = self.llm
-                    if tool.interface is None:
-                        tool.interface = self.interface
-                    if hasattr(tool, "vector_store") and vector_store:
-                        tool.vector_store = vector_store
-                    self._tools[prompt_name].append(tool)
-                elif isinstance(tool, FunctionType):
-                    self._tools[prompt_name].append(FunctionTool(tool, llm=self.llm, interface=self.interface))
-                else:
-                    tool_kwargs = dict(llm=self.llm, interface=self.interface)
-                    if hasattr(tool, "vector_store") and vector_store:
-                        tool_kwargs["vector_store"] = vector_store
-                    self._tools[prompt_name].append(tool(**tool_kwargs))
+            self._initialize_tools_for_prompt(prompt_name)
+
+    def _get_tool_kwargs(self, tool, prompt_tools):
+        """
+        Get kwargs for initializing a tool.
+        Subclasses can override to provide additional kwargs.
+
+        Parameters
+        ----------
+        tool : object
+            The tool (class or instance) being initialized
+        prompt_tools : list
+            List of all tools for this prompt
+
+        Returns
+        -------
+        dict
+            Keyword arguments for tool initialization
+        """
+        return {"llm": self.llm, "interface": self.interface}
+
+    def _initialize_tools_for_prompt(self, prompt_name):
+        """
+        Initialize tools for a specific prompt.
+
+        Parameters
+        ----------
+        prompt_name : str
+            The name of the prompt to initialize tools for.
+        """
+        prompt_tools = self._lookup_prompt_key(prompt_name, "tools")
+        self._tools[prompt_name] = []
+
+        # Initialize each tool
+        for tool in prompt_tools:
+            if isinstance(tool, Actor):
+                # For already instantiated Actors, set properties directly
+                if tool.llm is None:
+                    tool.llm = self.llm
+                if tool.interface is None:
+                    tool.interface = self.interface
+
+                # Apply any additional configuration from subclasses
+                tool_kwargs = self._get_tool_kwargs(tool, prompt_tools)
+                for key, value in tool_kwargs.items():
+                    if key not in ('llm', 'interface') and hasattr(tool, key):
+                        setattr(tool, key, value)
+
+                self._tools[prompt_name].append(tool)
+            elif isinstance(tool, FunctionType):
+                # Function tools only get basic kwargs
+                tool_kwargs = self._get_tool_kwargs(tool, prompt_tools)
+                self._tools[prompt_name].append(FunctionTool(tool, **tool_kwargs))
+            else:
+                # For classes that need to be instantiated
+                tool_kwargs = self._get_tool_kwargs(tool, prompt_tools)
+                self._tools[prompt_name].append(tool(**tool_kwargs))
 
     async def _use_tools(self, prompt_name: str, messages: list[Message]) -> str:
         tools_context = ""
@@ -79,6 +113,49 @@ class ToolUser(Actor):
                     if tool_context:
                         tools_context += f"\n{tool_context}"
         return tools_context
+
+
+class VectorLookupToolUser(ToolUser):
+    """
+    VectorLookupToolUser is a mixin class for actors that use vector lookup tools.
+    """
+
+    vector_store = param.ClassSelector(
+        class_=VectorStore, default=None, doc="""
+        The vector store to use for the tools. If not provided, a new one will be created
+        or inferred from the tools provided."""
+    )
+
+    def _get_tool_kwargs(self, tool, prompt_tools):
+        """
+        Override to provide vector_store to applicable tools.
+
+        Parameters
+        ----------
+        tool : object
+            The tool (class or instance) being initialized
+        prompt_tools : list
+            List of all tools for this prompt
+
+        Returns
+        -------
+        dict
+            Keyword arguments for tool initialization including vector_store if applicable
+        """
+        # Get base kwargs from parent
+        kwargs = super()._get_tool_kwargs(tool, prompt_tools)
+
+        # Find vector store from tools if any
+        vector_store = next(
+            (t.vector_store for t in prompt_tools
+             if isinstance(t, VectorLookupTool)),
+            None
+        ) or self.vector_store
+
+        if hasattr(tool, "vector_store") and vector_store is not None:
+            kwargs["vector_store"] = vector_store
+
+        return kwargs
 
 
 class Tool(Actor, ContextProvider):
@@ -367,6 +444,16 @@ class DocumentLookup(VectorLookupTool):
 
         return "\n".join(formatted_results)
 
+    def _handle_ready_task_done(self, task):
+        """Properly handle exceptions from the ready task."""
+        try:
+            # This will re-raise the exception if one occurred
+            if task.exception():
+                raise task.exception()
+        except Exception as e:
+            log_debug(f"Error in ready task: {type(e).__name__} - {e!s}")
+            traceback.print_exc()
+
     async def _update_vector_store(self, _, __, sources):
         for source in sources:
             # Use upsert to add or update documents
@@ -443,7 +530,6 @@ class TableLookup(VectorLookupTool):
         super().__init__(**params)
         self._tables_metadata = {}  # used for storing table metadata for LLM
         self._raw_metadata = {}
-        self._metadata_tasks = set()  # Track ongoing metadata fetch tasks
         self._semaphore = asyncio.Semaphore(self.max_concurrent)
         self._previous_state = None  # used for tracking previous state for _should...
         if self.sync_sources:
@@ -479,8 +565,18 @@ class TableLookup(VectorLookupTool):
             formatted_results.append(description)
         return "\n".join(formatted_results)
 
-    async def _fetch_and_store_metadata(self, source, table_name: str):
-        """Fetch metadata for a table and store it in the vector store."""
+    def _handle_ready_task_done(self, task):
+        """Properly handle exceptions from the ready task."""
+        try:
+            # This will re-raise the exception if one occurred
+            if task.exception():
+                raise task.exception()
+        except Exception as e:
+            log_debug(f"Error in ready task: {type(e).__name__} - {e!s}")
+            traceback.print_exc()
+
+    async def _enrich_metadata(self, source, table_name: str):
+        """Fetch metadata for a table and return enriched entry for batch processing."""
         async with self._semaphore:
             source_metadata = self._raw_metadata[source.name]
             if isinstance(source_metadata, asyncio.Task):
@@ -492,7 +588,7 @@ class TableLookup(VectorLookupTool):
             if key in source_metadata), None
         )
         if not table_name_key:
-            return
+            return None
         table_name = table_name_key
         vector_info = dict(source_metadata[table_name])
 
@@ -515,12 +611,7 @@ class TableLookup(VectorLookupTool):
                 columns.append(column)
 
         vector_metadata = {"source": source.name, "table_name": table_name}
-        if existing_items := self.vector_store.filter_by(vector_metadata):
-            if existing_items and existing_items[0].get("metadata", {}).get("enriched"):
-                return
-
         # the following is for the embeddings/vector store use only (i.e. filter from 1000s of tables)
-        vector_metadata["enriched"] = True
         enriched_text = f"Table: {table_name}"
         if description := vector_info.pop('description', ''):
             enriched_text += f"\nDescription: {description}"
@@ -538,14 +629,12 @@ class TableLookup(VectorLookupTool):
                 if key == "enriched":
                     continue
                 enriched_text += f"\n- {key}: {value}"
-        # Use upsert to add or update the table metadata
-        # This will add new entries or update existing ones as needed
-        self.vector_store.upsert([{"text": enriched_text, "metadata": vector_metadata}])
+
+        # Return the entry instead of upserting directly
+        return {"text": enriched_text, "metadata": vector_metadata}
 
     async def _update_vector_store(self, _, __, sources):
-        # Create a list to track all tasks we're starting in this update
-        all_tasks = []
-
+        tasks = []
         for source in sources:
             if self.include_metadata and self._raw_metadata.get(source.name) is None:
                 if isinstance(source, DuckDBSource):
@@ -555,32 +644,30 @@ class TableLookup(VectorLookupTool):
                         asyncio.to_thread(source.get_metadata)
                     )
                     self._raw_metadata[source.name] = metadata_task
-                    all_tasks.append(metadata_task)
-
+                    tasks.append(metadata_task)
             tables = source.get_tables()
-            # since enriching the metadata might take time, first add basic metadata (table name)
-            for table_name in tables:
-                metadata = {"source": source.name, "table_name": table_name}
-                # Use upsert to add basic table metadata or update if needed
-                self.vector_store.upsert([{"text": table_name, "metadata": metadata}])
-
-            # if metadata is included, upsert the existing
+            table_items = [
+                {"text": table_name, "metadata": {"source": source.name, "table_name": table_name}}
+                for table_name in tables
+            ]
+            self.vector_store.upsert(table_items)
             if self.include_metadata:
                 for table in tables:
-                    task = asyncio.create_task(
-                        self._fetch_and_store_metadata(source, table)
-                    )
-                    self._metadata_tasks.add(task)
-                    task.add_done_callback(lambda t: self._metadata_tasks.discard(t))
-                    all_tasks.append(task)
-
-        if all_tasks:
-            ready_task = asyncio.create_task(self._mark_ready_when_done(all_tasks))
-            ready_task.add_done_callback(lambda t: None if t.exception() else None)
+                    task = asyncio.create_task(self._enrich_metadata(source, table))
+                    tasks.append(task)
+        if tasks:
+            ready_task = asyncio.create_task(self._mark_ready_when_done(tasks))
+            ready_task.add_done_callback(self._handle_ready_task_done)
 
     async def _mark_ready_when_done(self, tasks):
-        """Wait for all tasks to complete and then mark the tool as ready."""
-        await asyncio.gather(*tasks, return_exceptions=True)
+        """Wait for all tasks to complete, collect results for batch upsert, and mark the tool as ready."""
+        enriched_entries = [
+            result for result in await asyncio.gather(*tasks, return_exceptions=True)
+            if isinstance(result, dict) and "text" in result
+        ]
+        if enriched_entries:
+            log_debug(f"Enriching {len(enriched_entries)} table metadata entries.")
+            self.vector_store.upsert(enriched_entries)
         log_debug("All table metadata tasks completed.")
         self._ready = True
 

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -645,16 +645,13 @@ class TableLookup(VectorLookupTool):
                     )
                     self._raw_metadata[source.name] = metadata_task
                     tasks.append(metadata_task)
+
             tables = source.get_tables()
-            table_items = [
-                {"text": table_name, "metadata": {"source": source.name, "table_name": table_name}}
-                for table_name in tables
-            ]
-            self.vector_store.upsert(table_items)
             if self.include_metadata:
                 for table in tables:
                     task = asyncio.create_task(self._enrich_metadata(source, table))
                     tasks.append(task)
+
         if tasks:
             ready_task = asyncio.create_task(self._mark_ready_when_done(tasks))
             ready_task.add_done_callback(self._handle_ready_task_done)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -29,6 +29,7 @@ from panel.widgets import Button, FileDownload, MultiChoice
 
 from lumen.ai.config import PROVIDED_SOURCE_NAME, SOURCE_TABLE_SEPARATOR
 from lumen.ai.tools import TableLookup
+from lumen.ai.vector_store import VectorStore
 
 from ..pipeline import Pipeline
 from ..sources import Source
@@ -117,6 +118,12 @@ class UI(Viewer):
     tools = param.List(doc="""
        List of Tools that can be invoked by the coordinator.""")
 
+    vector_store = param.ClassSelector(
+        class_=VectorStore, default=None, doc="""
+        The vector store to use for the tools. If not provided, a new one will be created
+        or inferred from the tools provided."""
+    )
+
     __abstract = True
 
     def __init__(
@@ -155,6 +162,7 @@ class UI(Viewer):
             tools=self.tools,
             logs_db_path=self.logs_db_path,
             within_ui=True,
+            vector_store=self.vector_store,
             **self.coordinator_params
         )
         self._notebook_export = FileDownload(

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -502,10 +502,18 @@ class NumpyVectorStore(VectorStore):
             metadata = item.get("metadata", {}) or {}
 
             # Check for exact text match
-            if text in text_to_indices:
+            match_indices = text_to_indices.get(text, [])
+
+            # If no exact match found, check for chunked text match
+            if not match_indices:
+                for chunk in self._chunk_text(text):
+                    if chunk in text_to_indices:
+                        match_indices.extend(text_to_indices[chunk])
+
+            if match_indices:
                 match_found = False
 
-                for idx in text_to_indices[text]:
+                for idx in match_indices:
                     existing_id = self.ids[idx]
                     existing_meta = self.metadata[idx]
 
@@ -897,6 +905,10 @@ class DuckDBVectorStore(VectorStore):
                 WHERE text = ?
             """
             result = self.connection.execute(query, [text]).fetchall()
+            # Check for chunked text match
+            if not result:
+                for chunk in self._chunk_text(text):
+                    result.extend(self.connection.execute(query, [chunk]).fetchall())
 
             match_found = False
             for row in result:

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -8,6 +8,7 @@ import numpy as np
 import param
 
 from .embeddings import Embeddings, NumpyEmbeddings
+from .utils import log_debug
 
 
 class VectorStore(param.Parameterized):
@@ -879,6 +880,7 @@ class DuckDBVectorStore(VectorStore):
             return []
 
         if not self._initialized:
+            log_debug("Database not initialized. Adding items directly.")
             return self.add(items)
 
         assigned_ids = []
@@ -932,7 +934,9 @@ class DuckDBVectorStore(VectorStore):
         if items_to_add:
             new_ids = self.add(items_to_add)
             assigned_ids.extend(new_ids)
+            log_debug(f"Added {len(items_to_add)} new items to the vector store.")
 
+        log_debug(len(self))
         return assigned_ids
 
     def __len__(self) -> int:


### PR DESCRIPTION
This PR addresses a few vector store / embeddings issues:

1. Using a DuckDBVectorStore instead of the default NumpyEmbeddings was tedious: one would need to manually instantiate all the vector lookup tools (TableLookup and IterativeTableLookup)--this PR allows users to pass vector_store param, which gets used as the default
2. Previously, we would loop through each table and upsert. This loop kind of blocked the main thread and the UI from loading so now, we batch all the items in a list before calling upsert
3. There was an edge case in previous upserts: long text would get chunked, and when upserted again, it would not detect that it was already in the database and re-insert (duplicate) it.
4. Moved the basic source/table embedding to the else statement of `include_metadata`
5. Added `asyncio.sleep` to let the UI load completely before being blocked by some non-async task (for loop?)