### PR TITLE
Fix environment variable name for Anthropic API key in anthropic.md

### DIFF
--- a/doc/lumen_ai/how_to/llm/anthropic.md
+++ b/doc/lumen_ai/how_to/llm/anthropic.md
@@ -16,7 +16,7 @@ By default Lumen will pick the first LLM provider it can find an API key for. By
 
 1. Set the Environment Variable
 
-Set the OPENAI_API_KEY environment variable in your system. This allows Lumen AI to automatically detect and use Anthropic as the provider.
+Set the ANTHROPIC_API_KEY environment variable in your system. This allows Lumen AI to automatically detect and use Anthropic as the provider.
 
 ::::{tab-set}
 


### PR DESCRIPTION
I updated the environment variable name from `OPENAI_API_KEY` to `ANTHROPIC_API_KEY` in the setup instructions.
Since the section is about configuring Anthropic as the provider, using the correct key name avoids confusion and setup errors.