### PR TITLE
Move examples block above

### DIFF
--- a/lumen/ai/prompts/Actor/main.jinja2
+++ b/lumen/ai/prompts/Actor/main.jinja2
@@ -8,6 +8,9 @@ The current date time is {{ current_datetime.strftime('%b %d, %Y %I:%M %p') }}
 {%- block instructions -%}
 {%- endblock -%}
 
+{%- block examples -%}
+{%- endblock -%}
+
 {%- block context -%}
 {%- endblock %}
 
@@ -19,9 +22,6 @@ The current date time is {{ current_datetime.strftime('%b %d, %Y %I:%M %p') }}
 {% endfor %}
 {% else %}
 {% endif -%}
-{%- endblock -%}
-
-{%- block examples -%}
 {%- endblock -%}
 
 {%- block errors -%}

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -18,26 +18,6 @@ unexpected results.
 Keep your response under three paragraphs top, unless elaboration is requested.
 {% endblock %}
 
-{% block context %}
-Here was the plan that was executed:
-"""
-{{ memory.reasoning }}
-"""
-
-Here is the current dataset:
-{{ memory.data }}
-
-{% if 'sql' in memory %}
-Here is the current SQL query:
-```sql
-{{ memory.sql }}
-```
-{%- endif -%}
-{%- if memory.data|length == 0 -%}
-The dataset is empty. As the subject matter expert, if this is unexpected, analyze the SQL query,
-and try to make educated guess what other columns or values should be used instead.
-{%- endif -%}
-{%- endblock -%}
 {%- block examples -%}
 {%- if memory.data|length == 0 -%}
 Here's an example of a good reply...
@@ -103,3 +83,24 @@ warranting immediate investigation. The unusual December retention dip across al
 collection issue or seasonal effect that requires validation before making strategic decisions.
 {%- endif -%}
 {%- endblock %}
+
+{% block context %}
+Here was the plan that was executed:
+"""
+{{ memory.reasoning }}
+"""
+
+Here is the current dataset:
+{{ memory.data }}
+
+{% if 'sql' in memory %}
+Here is the current SQL query:
+```sql
+{{ memory.sql }}
+```
+{%- endif -%}
+{%- if memory.data|length == 0 -%}
+The dataset is empty. As the subject matter expert, if this is unexpected, analyze the SQL query,
+and try to make educated guess what other columns or values should be used instead.
+{%- endif -%}
+{%- endblock -%}

--- a/lumen/ai/prompts/Coordinator/tool_relevance.jinja2
+++ b/lumen/ai/prompts/Coordinator/tool_relevance.jinja2
@@ -15,14 +15,6 @@ Determine if a tool will help an actor complete its task by evaluating:
 - Contains potentially misleading or irrelevant data
 {% endblock %}
 
-{% block context %}
-Task: {{ actor_task }}
-Actor: {{ actor_name }} | Purpose: {{ actor_purpose }}
-Tool: {{ tool_name }} | Purpose: {{ tool_purpose }}
-{% if tool_output %}
-Output: """{{ tool_output }}"""
-{%- endif -%}
-{%- endblock %}
 {%- block examples %}
 # Examples
 
@@ -39,3 +31,12 @@ Actor: Planner | Purpose: "Develops plan to solve user query step-by-step"
 Tool: DbtslLookup | Purpose: "Looks up dbt semantic layer metrics"
 -> YES (provides metric information directly related to the query)
 {% endblock %}
+
+{% block context %}
+Task: {{ actor_task }}
+Actor: {{ actor_name }} | Purpose: {{ actor_purpose }}
+Tool: {{ tool_name }} | Purpose: {{ tool_purpose }}
+{% if tool_output %}
+Output: """{{ tool_output }}"""
+{%- endif -%}
+{%- endblock %}

--- a/lumen/ai/prompts/DbtslAgent/main.jinja2
+++ b/lumen/ai/prompts/DbtslAgent/main.jinja2
@@ -5,26 +5,6 @@ You are an agent responsible for creating dbt Semantic Layer query parameters th
 Try not to take the query too literally, but instead focus on the user's intent and the business metrics required.
 {% endblock -%}
 
-{% block context -%}
-Checklist:
-- Only use metrics and dimensions explicitly available in the dbt Semantic Layer.
-- If referencing a dimension in the WHERE clause, be sure the dimension is also included in the GROUP BY clause.
-- When using time dimensions, always specify both the dimension name and granularity: `dimension_name__granularity`.
-- Always include a limit (default to 10000 if not specified) to avoid excessive data return.
-- For time filtering, use SQL date functions like `date_trunc('year', metric_time__month)`.
-
-{{ tool_context | default('') }}
-
-{% if memory["dbtsl_metaset"] %}
-# Available Metrics and Dimensions
-{{ memory["dbtsl_metaset"] }}
-{% endif %}
-
-{% if "dbtsl_query_params" in memory %}
-# Previous dbt Semantic Layer query parameters
-{{ memory["dbtsl_query_params"] }}
-{% endif %}
-{%- endblock -%}
 
 {%- block examples %}
 # Examples
@@ -57,3 +37,24 @@ Checklist:
 `invalid identifier` might indicate you left out the time granularity or forgot to include it in group_by, i.e. metric_time -> metric_time__month"
 {% endif %}
 {% endblock -%}
+
+{% block context -%}
+Checklist:
+- Only use metrics and dimensions explicitly available in the dbt Semantic Layer.
+- If referencing a dimension in the WHERE clause, be sure the dimension is also included in the GROUP BY clause.
+- When using time dimensions, always specify both the dimension name and granularity: `dimension_name__granularity`.
+- Always include a limit (default to 10000 if not specified) to avoid excessive data return.
+- For time filtering, use SQL date functions like `date_trunc('year', metric_time__month)`.
+
+{{ tool_context | default('') }}
+
+{% if memory["dbtsl_metaset"] %}
+# Available Metrics and Dimensions
+{{ memory["dbtsl_metaset"] }}
+{% endif %}
+
+{% if "dbtsl_query_params" in memory %}
+# Previous dbt Semantic Layer query parameters
+{{ memory["dbtsl_query_params"] }}
+{% endif %}
+{%- endblock -%}

--- a/lumen/ai/prompts/DbtslLookup/main.jinja2
+++ b/lumen/ai/prompts/DbtslLookup/main.jinja2
@@ -17,11 +17,6 @@ Answer YES if ANY metric can provide what the user needs, even if it requires co
 Answer NO only if no available metric can measure what the user is asking about.
 {% endblock %}
 
-{% block context %}
-Available metrics and their dimensions:
-{{ dbtsl_metaset }}
-{% endblock %}
-
 {% block examples %}
 # Examples:
 """
@@ -41,4 +36,9 @@ Query: What's our customer satisfaction by product category?
 
 Reasoning: None of our metrics measure customer satisfaction. While we have product category dimensions on other metrics, without a satisfaction metric, we cannot answer this query. Answer: NO
 """
+{% endblock %}
+
+{% block context %}
+Available metrics and their dimensions:
+{{ dbtsl_metaset }}
 {% endblock %}

--- a/lumen/ai/prompts/Planner/follow_up.jinja2
+++ b/lumen/ai/prompts/Planner/follow_up.jinja2
@@ -19,6 +19,25 @@ Rules:
 Ground your reasoning in specific elements of both the current query and previously selected columns.
 {%- endblock -%}
 
+{% block examples %}
+# Examples
+
+✅ FOLLOW-UP (YES):
+User query: "Can you create a time series?"
+Data in memory: Annual revenue data with time and dollars columns
+-> YES (query is asking to visualize the existing time-based data already in memory)
+
+✅ FOLLOW-UP (YES):
+User query: "Show only the last 3 months"
+Data in memory: Data with time column extending to the last 3 months
+-> YES (can be done with existing data)
+
+❌ NOT FOLLOW-UP (NO):
+User query: "What's the total capacity?"
+Data in memory: Only revenue data
+-> NO (explicitly asking for new/refreshed data)
+{% endblock %}
+
 {% block context -%}
 {%- if 'vector_metaset' in memory and memory.get('vector_metaset').selected_columns %}
 📃 Selected columns:
@@ -39,22 +58,3 @@ From query: "{{ memory['vector_metaset'].query }}"
 {%- endif %}
 
 {%- endblock -%}
-
-{% block examples %}
-# Examples
-
-✅ FOLLOW-UP (YES):
-User query: "Can you create a time series?"
-Data in memory: Annual revenue data with time and dollars columns
--> YES (query is asking to visualize the existing time-based data already in memory)
-
-✅ FOLLOW-UP (YES):
-User query: "Show only the last 3 months"
-Data in memory: Data with time column extending to the last 3 months
--> YES (can be done with existing data)
-
-❌ NOT FOLLOW-UP (NO):
-User query: "What's the total capacity?"
-Data in memory: Only revenue data
--> NO (explicitly asking for new/refreshed data)
-{% endblock %}

--- a/lumen/ai/prompts/VectorStore/main.jinja2
+++ b/lumen/ai/prompts/VectorStore/main.jinja2
@@ -1,0 +1,60 @@
+{%- block instructions -%}
+Create a concise context description (15-20 words) for this document chunk that:
+1. Uses abbreviated terms where possible (docs, ref, info, etc.)
+2. Precisely identifies the document source/type
+3. Describes the chunk's specific content
+4. Resolves ambiguous references
+
+Use shorthand and terse phrasing while maintaining critical information.
+{%- endblock -%}
+
+{%- block examples %}
+# Examples
+
+Don't do this:
+Document: HoloViews integration guide
+Chunk: "To link a HoloViews plot with Panel widgets, use the pn.bind method."
+Response: "This chunk comes from the HoloViews integration guide documentation and it is discussing how to connect or link HoloViews plots with Panel widgets by utilizing the pn.bind method to establish the connection between these two components."
+
+Example 1:
+Document: SEC Filing for ACME Corp, Q2 2023
+Chunk: "The company's revenue grew by 3% over the previous quarter."
+Response: "ACME Q2'23 report: 3% revenue growth vs Q1'23."
+
+Example 2:
+Document: Panel Developer Experience Best Practices
+Chunk: "Be sure to bind obj.param.{parameter} (the Parameter object), not just {parameter} (the current Parameter value)."
+Response: "Panel dev best practices: binding to Parameter objects (obj.param.parameter) instead of values for reactive updates."
+
+Example 3:
+Document: HoloViews User Guide - Customization
+Chunk: ```python
+def hook(plot, element):
+    print('plot.state:   ', plot.state)
+    print('plot.handles: ', sorted(plot.handles.keys()))
+    plot.handles['xaxis'].axis_label_text_color = 'red'
+    plot.handles['yaxis'].axis_label_text_color = 'blue'
+
+hv.Curve([1, 2, 3]).opts(hooks=[hook])
+```
+Response: "HoloViews docs: plot hooks for low-level backend customization that HoloViews doesn't expose directly to customize the x and y axis labels' colors."
+
+Example 4:
+Document: Climate impact assessment on agriculture
+Chunk: "They found yields decreased by 17% compared to the control group."
+Response: "Climate impact study: crop yields decreased 17% vs control in drought conditions."
+{%- endblock -%}
+
+{%- block context %}
+# Full Document
+
+"""
+{{ document }}
+"""
+{% if metadata %}
+Metadata:
+{% for key, value in metadata.items() %}
+- {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
+{%- endblock %}


### PR DESCRIPTION
To take advantage of prompt caching, at least with OpenAI, I believe we should be putting static examples before context because from https://platform.openai.com/docs/guides/prompt-caching: 

> To realize caching benefits, place static content like instructions and examples at the beginning of your prompt, and put variable content, such as user-specific information, at the end
