### PR TITLE
Ensure consistent embeddings are used

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -241,7 +241,7 @@ class ChatAgent(Agent):
         "Best for high-level information about data or general conversation",
         "Can be used to describe available tables",
         "Not useful for answering data specific questions",
-        "Must be paired with TableLookup or DocumentLookup",
+        "Can be paired with TableLookup or DocumentLookup",
     ])
 
     purpose = param.String(default="""
@@ -257,7 +257,7 @@ class ChatAgent(Agent):
     )
 
     # technically not required if appended manually with tool in coordinator
-    requires = param.List(default=["vector_metaset"], readonly=True)
+    requires = param.List(default=[], readonly=True)
 
     async def respond(
         self,

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -241,7 +241,7 @@ class ChatAgent(Agent):
         "Best for high-level information about data or general conversation",
         "Can be used to describe available tables",
         "Not useful for answering data specific questions",
-        "Can be paired with TableLookup or DocumentLookup",
+        "Must be paired with TableLookup or DocumentLookup",
     ])
 
     purpose = param.String(default="""
@@ -257,7 +257,7 @@ class ChatAgent(Agent):
     )
 
     # technically not required if appended manually with tool in coordinator
-    requires = param.List(default=[], readonly=True)
+    requires = param.List(default=["vector_metaset"], readonly=True)
 
     async def respond(
         self,

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -87,9 +87,6 @@ class VectorStore(LLMUser):
 
     def __init__(self, **params):
         super().__init__(**params)
-        # If embeddings is None, use NumpyEmbeddings as default
-        if self.embeddings is None:
-            self.embeddings = NumpyEmbeddings()
         if self.chunk_func is None:
             self.chunk_func = semchunk.chunkerify(
                 self.chunk_tokenizer, chunk_size=self.chunk_size
@@ -1211,7 +1208,6 @@ class DuckDBVectorStore(VectorStore):
 
         try:
             result = self.connection.execute(base_query, params).fetchall()
-            print(result)
             return [
                 {
                     "id": row[0],

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -1046,7 +1046,7 @@ class DuckDBVectorStore(VectorStore):
         for param_name, stored_value in stored_params.items():
             if hasattr(self.embeddings, param_name):
                 current_value = getattr(self.embeddings, param_name)
-                if current_value != stored_value and param_name in ['model', 'dimensions', 'chunk_size']:
+                if current_value != stored_value and param_name in ['model', 'embedding_dim', 'chunk_size']:
                     raise ValueError(
                         f"Provided embeddings parameter '{param_name}' value '{current_value}' "
                         f"does not match stored value '{stored_value}'. This would result in "

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -1010,24 +1010,7 @@ class DuckDBVectorStore(VectorStore):
         Raises ValueError if there's a mismatch that would cause empty query results.
         """
         # Check if metadata table exists
-        has_metadata = (
-            self.connection.execute(
-                "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'vector_store_metadata';"
-            ).fetchone()[0]
-            > 0
-        )
-
-        if not has_metadata:
-            return  # No metadata table, can't check consistency
-
-        result = self.connection.execute(
-            "SELECT value FROM vector_store_metadata WHERE key = 'embeddings';"
-        ).fetchone()
-
-        if not result:
-            return
-
-        stored_config = json.loads(result[0])
+        stored_config = self._get_embeddings_config() or {"class": "", "params": {}}
         stored_class = stored_config["class"]
         stored_params = stored_config["params"]
 

--- a/lumen/tests/ai/test_vector_store.py
+++ b/lumen/tests/ai/test_vector_store.py
@@ -549,11 +549,11 @@ class TestDuckDBVectorStore(VectorStoreTestKit):
     async def test_check_embeddings_consistency(self, tmp_path):
         db_path = str(tmp_path / "test_duckdb.db")
         store = DuckDBVectorStore(uri=db_path, embeddings=NumpyEmbeddings())
-        store.add([{"text": "First doc"}])
+        await store.add([{"text": "First doc"}])
         store.close()
 
         store = DuckDBVectorStore(uri=db_path, embeddings=NumpyEmbeddings())
-        assert len(store.query("First doc")) == 1
+        assert len(await store.query("First doc")) == 1
         store.close()
 
         with pytest.raises(ValueError, match="Provided embeddings class"):


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/1210

If stored chunks was embedded with a certain embeddings model, but re-opened with another embeddings model, on query, it'll return no results.