### PR TITLE
Prompt user to click Rerun if empty

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -302,7 +302,7 @@ class AnalystAgent(ChatAgent):
     ) -> Any:
         messages = super().respond(messages, render_output, step_title)
         if len(self._memory["data"]) == 0 and self._memory.get("sql"):
-            self._memory["sql"] = f"{self._memory['sql']}\n-- No data was returned from the query. Please try a different approach."
+            self._memory["sql"] = f"{self._memory['sql']}\n-- No data was returned from the query."
         return messages
 
 class ListAgent(Agent):

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -294,6 +294,19 @@ class AnalystAgent(ChatAgent):
 
     requires = param.List(default=["source", "pipeline"], readonly=True)
 
+    async def respond(
+        self,
+        messages: list[Message],
+        render_output: bool = False,
+        step_title: str | None = None,
+    ) -> Any:
+        context = {"tool_context": await self._use_tools("main", messages)}
+        system_prompt = await self._render_prompt("main", messages, **context)
+        await self._stream(messages, system_prompt)
+
+        if len(self._memory["data"]) == 0 and self._memory.get("sql"):
+            self._memory["sql"] = f"{self._memory['sql']}\n-- No data was returned from the query. Please try a different approach."
+
 
 class ListAgent(Agent):
     """

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -300,13 +300,10 @@ class AnalystAgent(ChatAgent):
         render_output: bool = False,
         step_title: str | None = None,
     ) -> Any:
-        context = {"tool_context": await self._use_tools("main", messages)}
-        system_prompt = await self._render_prompt("main", messages, **context)
-        await self._stream(messages, system_prompt)
-
+        messages = super().respond(messages, render_output, step_title)
         if len(self._memory["data"]) == 0 and self._memory.get("sql"):
             self._memory["sql"] = f"{self._memory['sql']}\n-- No data was returned from the query. Please try a different approach."
-
+        return messages
 
 class ListAgent(Agent):
     """

--- a/lumen/ai/prompts/AnalystAgent/main.jinja2
+++ b/lumen/ai/prompts/AnalystAgent/main.jinja2
@@ -91,7 +91,11 @@ Here was the plan that was executed:
 """
 
 Here is the current dataset:
+{% if memory.data|length == 0 %}
+The data is empty. Critique the SQL query and suggest what other columns or values should be used instead. Then prompt the user to click the rerun button below if they'd like to try again.
+{% else %}
 {{ memory.data }}
+{% endif %}
 
 {% if 'sql' in memory %}
 Here is the current SQL query:


### PR DESCRIPTION
Improves the UX slightly by offering the user a path forward by injecting an SQL comment mentioning the query is invalid so the Planner and SQLAgent knows on the second try.

Addresses https://github.com/holoviz/lumen/issues/1197

<img width="591" alt="image" src="https://github.com/user-attachments/assets/743915f4-024d-4ea0-8e7b-40feb419d614" />

```
🗃️ Current SQL:
```sql
SELECT * FROM "windturbines.parquet" ORDER BY "p_cap" DESC LIMIT 5
-- No data was returned from the query.
```
📋 Last table: `top_5_pcap`
```