### PR TITLE
Update prompts and models

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -373,8 +373,6 @@ class ContextProvider(param.Parameterized):
         )
         if self.conditions:
             string += "  Conditions:\n" + "\n".join(f"  - {condition}" for condition in self.conditions) + "\n"
-        if self.exclusions:
-            string += "  Exclusions:\n" + "\n".join(f"  - {exclusion}" for exclusion in self.exclusions) + "\n"
         if self.not_with:
             string += "  Not with:\n" + "\n".join(f"  - {not_with}" for not_with in self.not_with) + "\n"
         return string

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -366,7 +366,7 @@ class TableListAgent(ListAgent):
     """
 
     conditions = param.List(default=[
-        "For listing available data tables in source",
+        "For listing available data tables in source to the user, but not for planning",
         "Not for showing data table contents",
     ])
 
@@ -510,8 +510,7 @@ class SQLAgent(LumenBaseAgent):
             "Start with this agent if you are unsure what to use",
             "For existing tables, only use if additional calculations are needed",
             "When reusing tables, reference by name rather than regenerating queries",
-            "Commonly used with IterativeTableLookup and AnalystAgent",
-            "Not useful if the user is using the same data for plotting"
+            "Not useful if the user is using the same data for plotting",
         ]
     )
 

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -981,22 +981,22 @@ class Planner(Coordinator):
         last_node = execution_graph[-1] if execution_graph else None
         if last_node and isinstance(last_node.actor, Tool) and not isinstance(last_node.actor, TableLookup):
             if "AnalystAgent" in agents and all(r in provided for r in agents["AnalystAgent"].requires):
-                expert = "AnalystAgent"
+                actor = "AnalystAgent"
             else:
-                expert = "ChatAgent"
+                actor = "ChatAgent"
 
-            # Check if the expert conflicts with any actor in the graph
-            not_with = getattr(agents[expert], 'not_with', [])
+            # Check if the actor conflicts with any actor in the graph
+            not_with = getattr(agents[actor], 'not_with', [])
             conflicts = [actor for actor in actors_in_graph if actor in not_with]
             if conflicts:
                 # Skip the summarization step if there's a conflict
-                log_debug(f"Skipping summarization with {expert} due to conflicts: {conflicts}")
+                log_debug(f"Skipping summarization with {actor} due to conflicts: {conflicts}")
                 plan.steps = steps
                 previous_actors = actors
                 return execution_graph, unmet_dependencies, previous_actors
 
             summarize_step = type(step)(
-                actor=expert,
+                actor=actor,
                 instruction='Summarize the results.',
                 title='Summarizing results',
                 render_output=False
@@ -1004,14 +1004,14 @@ class Planner(Coordinator):
             steps.append(summarize_step)
             execution_graph.append(
                 ExecutionNode(
-                    actor=agents[expert],
-                    provides=agents[expert].provides,
+                    actor=agents[actor],
+                    provides=agents[actor].provides,
                     instruction=summarize_step.instruction,
                     title=summarize_step.title,
                     render_output=summarize_step.render_output
                 )
             )
-            actors_in_graph.add(expert)
+            actors_in_graph.add(actor)
 
         plan.steps = steps
         previous_actors = actors

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -919,7 +919,7 @@ class Planner(Coordinator):
         actors_in_graph = set()
 
         for step in plan.steps:
-            key = step.expert_or_tool
+            key = step.actor
             actors.append(key)
             if key in agents:
                 subagent = agents[key]
@@ -947,7 +947,7 @@ class Planner(Coordinator):
             if "table" in unmet_dependencies and not table_provided and "SQLAgent" in agents and has_table_lookup:
                 provided |= set(agents['SQLAgent'].provides)
                 sql_step = type(step)(
-                    expert_or_tool='SQLAgent',
+                    actor='SQLAgent',
                     instruction='Load the table',
                     title='Loading table',
                     render_output=False
@@ -996,7 +996,7 @@ class Planner(Coordinator):
                 return execution_graph, unmet_dependencies, previous_actors
 
             summarize_step = type(step)(
-                expert_or_tool=expert,
+                actor=expert,
                 instruction='Summarize the results.',
                 title='Summarizing results',
                 render_output=False
@@ -1066,7 +1066,7 @@ class Planner(Coordinator):
                 self._memory["plan"] = plan
                 istep.stream('\n\nHere are the steps:\n\n')
                 for i, step in enumerate(plan.steps):
-                    istep.stream(f"{i+1}. {step.expert_or_tool}: {step.instruction}\n")
+                    istep.stream(f"{i+1}. {step.actor}: {step.instruction}\n")
                 if attempts > 0:
                     istep.success_title = f"Plan with {len(plan.steps)} steps created after {attempts + 1} attempts"
                 else:

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -74,10 +74,10 @@ def make_plan_models(agents: list[str], tools: list[str]):
     # TODO: make this inherit from PartialBaseModel
     step = create_model(
         "Step",
-        expert_or_tool=(Literal[tuple(agents+tools)], FieldInfo(description="The name of the expert or tool to assign a task to.")),
-        instruction=(str, FieldInfo(description="Instructions to the expert to assist in the task, and whether rendering is required.")),
+        actor=(Literal[tuple(agents+tools)], FieldInfo(description="The name of the actor to assign a task to.")),
+        instruction=(str, FieldInfo(description="Instructions to the actor to assist in the task, and whether rendering is required.")),
         title=(str, FieldInfo(description="Short title of the task to be performed; up to three words.")),
-        render_output=(bool, FieldInfo(description="Whether the output of the expert should be rendered. If the user wants to see the table, and the expert is SQL, then this should be `True`.")),
+        render_output=(bool, FieldInfo(description="Whether the output of the actor should be rendered. If the user wants to see the table, and the actor is SQL, then this should be `True`.")),
     )
     reasoning = create_model(
         'Reasoning',
@@ -85,8 +85,9 @@ def make_plan_models(agents: list[str], tools: list[str]):
             str,
             FieldInfo(
                 description="""
-                    Describe succinctly at a high-level how the actions of each expert will solve the user query.
-                    Address previous failures if any.
+                    Briefly summarize the user's goal and categorize the question type:
+                    high-level, data-focused, or other. Identify the most relevant and compatible actors,
+                    explaining their requirements. If there were previous failures, discuss them.
                     """
             ),
         ),

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -87,7 +87,7 @@ def make_plan_models(agents: list[str], tools: list[str]):
                 description="""
                     Briefly summarize the user's goal and categorize the question type:
                     high-level, data-focused, or other. Identify the most relevant and compatible actors,
-                    explaining their requirements. If there were previous failures, discuss them.
+                    explaining their requirements, and what you already have satisfied. If there were previous failures, discuss them.
                     """
             ),
         ),

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -18,16 +18,18 @@ Ground Rules:
 {% endblock -%}
 
 {%- block context %}
-You already have these satisfied:
-{%- for key in memory.keys() %}
-- `{{ key }}`
-{%- endfor %}
 Below are the available actors. Respect the conditions and exclusions.
 
 Provides: Outputs this actor adds to memory
 Requires: Inputs this actor needs from memory or others
 Conditions: When to use this actor
 Not with: agents that can't be used alongside this expert
+
+You already have these keys satisfied in memory:
+{%- for key in memory.keys() %}
+- `{{ key }}`
+{%- endfor %}
+
 {% if tools %}
 🛠️ Tools:
 {%- for tool in tools %}

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -1,45 +1,43 @@
 {% extends 'Actor/main.jinja2' %}
 
 {%- block instructions %}
-You are the team lead responsible for creating a step-by-step plan to address user queries by assigning subtasks to specialized agents and tools.
+You are the team lead responsible for creating a step-by-step plan to address user queries by assigning subtasks to specialized actors (agents and tools).
 
 Ground Rules:
 - Respect dependency chains: assign tasks only when input requirements are met
 - Leverage existing memory instead of regenerating information if possible
 - Stay within scope of the user's request (don't plot unless asked, etc.)
-- Provide necessary context to agents to avoid redundant steps
+- Do not use the same actor twice in a row
 - Plan only rather than executing (avoid details)
-- It's often unnecessary to use the same expert multiple times in a single plan
-- Never mention a lack of data sources or tables in your plan - assume your agents will handle data discovery
+- It's often unnecessary to use the same actor multiple times in a single plan
+- Never mention a lack of data sources or tables in your plan - assume your actors will handle data discovery
+- Do not ignore the actor's exclusions and conditions.
 {%- if tools %}
-- Tools require expert interpretation - always pair tools with agents
-- Place agents AFTER the tools they use in your sequence
+- Tools require actor interpretation - always follow-up tools with agents
 {%- endif %}
 {% endblock -%}
 
-{% block context -%}
-👨‍💻 agents & Tools
-
-Below are the agents and tools available to you; the meaning of each field is as follows:
-Provides: Outputs this expert adds to memory
-Requires: Inputs this expert needs from memory or others
-Conditions: When to use this expert
-Exclusions: Memory values that prevent using this expert
-Not with: agents that can't be used alongside this expert
-
+{%- block context %}
 You already have these satisfied:
 {%- for key in memory.keys() %}
 - `{{ key }}`
 {%- endfor %}
+Below are the available actors. Respect the conditions and exclusions.
 
-{%- for agent in agents %}
-{{ agent }}
-{%- endfor %}
-{%- if tools %}
+Provides: Outputs this actor adds to memory
+Requires: Inputs this actor needs from memory or others
+Conditions: When to use this actor
+Not with: agents that can't be used alongside this expert
+{% if tools %}
+🛠️ Tools:
 {%- for tool in tools %}
 {{ tool }}
 {%- endfor %}
 {% endif %}
+🧑‍💼 Agents:
+{%- for agent in agents %}
+{{ agent }}
+{%- endfor %}
 
 {% if memory.get('document_sources') %}
 📂 Documents:
@@ -73,8 +71,8 @@ From query: "{{ memory['vector_metaset'].query }}"
 👉 New query with existing metadata - evaluate if current data is sufficient before requesting more
 {%- endif %}
 
-Build your plan in dependency order - ensure each expert's requirements are met by previous steps and
-ensure you don't use incompatible agents together.
+Build your plan in dependency order - ensure each actor's requirements are met by previous steps and
+ensure you don't use incompatible actors together.
 
 {% if unmet_dependencies %}
 # Previous failures:

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -592,6 +592,7 @@ class TableLookup(VectorLookupTool):
     conditions = param.List(default=[
         "Best paired with ChatAgent for general conversation about data",
         "Skip if sufficient context already exists in memory",
+        "Not useful for data related queries",
     ])
 
     exclusions = param.List(default=["dbtsl_metaset"])
@@ -599,7 +600,7 @@ class TableLookup(VectorLookupTool):
     not_with = param.List(default=["IterativeTableLookup"])
 
     purpose = param.String(default="""
-        Performs basic vector search to find relevant tables for a user query.""")
+        Discovers relevant tables using vector search, providing context for other agents.""")
 
     requires = param.List(default=["sources"], readonly=True, doc="""
         List of context that this Tool requires to be run.""")
@@ -1054,6 +1055,7 @@ class IterativeTableLookup(TableLookup):
 
     conditions = param.List(default=[
         "Skip if sufficient context already exists in memory",
+        "Useful for answering data queries",
         "Avoid for follow-up questions when existing data is sufficient",
         "Use only when existing information is insufficient for the current query",
     ])
@@ -1061,8 +1063,7 @@ class IterativeTableLookup(TableLookup):
     not_with = param.List(default=["TableLookup"])
 
     purpose = param.String(default="""
-        Performs basic vector search to find relevant tables for a user query
-        with multi-pass selection.""")
+        Looks up the most relevant tables and provides SQL schemas of those tables.""")
 
     provides = param.List(default=["vector_metaset", "sql_metaset"], readonly=True, doc="""
         List of context values this Tool provides to current working memory.""")

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -718,7 +718,7 @@ class ExplorerUI(UI):
             async def render_plan(_, old, new):
                 nonlocal index, new_exploration
                 plan = local_memory["plan"]
-                if any(step.expert_or_tool in ('SQLAgent', 'DbtslAgent') for step in plan.steps):
+                if any(step.actor in ('SQLAgent', 'DbtslAgent') for step in plan.steps):
                     # Expand the sidebar when the first exploration is created
                     await self._add_exploration(plan.title, local_memory)
                     index = len(self._explorations)-1


### PR DESCRIPTION
I've been encountering SQLAgent called with TableListAgent or TableLookup, before Planner revises its plan, at least once per session, so this PR addresses that.

Here it doesn't mention IterativeTableLookup directly, but was able to mention the requirement and fix it in the actual plan.
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/af4dffb8-4036-424d-b8ea-7e02af8a15a2" />


1. Removes exclusions from the prompt to save tokens since that's handled through code (i.e. if actors containing excluded memory keys are automatically removed from the list)
2. Rename expert -> actor since expert isn't the standard terminology we use and it encapsulated tools in the planner prompt, which potentially confused the LLM
3. Update different prompts until planner could one-shot IterativeTableLookup -> SQLAgent