### PR TITLE
Handle empty tables

### DIFF
--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -879,7 +879,7 @@ class TableLookup(VectorLookupTool):
                     continue
                 cols_lengths.add(len(vector_metadata.columns))
 
-        if max(cols_lengths) <= 30 and sum(cols_lengths) <= 70:
+        if not cols_lengths or (max(cols_lengths) <= 30 and sum(cols_lengths) <= 70):
             return False
 
         try:


### PR DESCRIPTION
`max([])` -> `ValueError: max() iterable argument is empty`