### PR TITLE
fix: Don't directly import chardet

### DIFF
--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -110,6 +110,7 @@ def test_sql_comments():
 
 
 def test_add_encoding_to_read_csv():
+    pytest.importorskip("chardet")
     expression: list = sqlglot.parse("READ_CSV('data/life-expectancy.csv')")
     result = SQLTransform(identify=True)._add_encoding_to_read_csv(expression[0])
     expected = "READ_CSV('data/life-expectancy.csv', encoding='utf-8')"

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from subprocess import check_output
 
 import bokeh
-import chardet
 import pandas as pd
 import panel as pn
 import param
@@ -354,19 +353,21 @@ def slugify(value, allow_unicode=False) -> str:
     return re.sub(r"[-\s]+", "-", value).strip("-_")
 
 
-def detect_file_encoding(file_obj: Path | io.BytesIO | io.StringIO) -> str:
+def detect_file_encoding(file_obj: Path | io.BytesIO | io.StringIO | str | bytes) -> str:
     """
     Detects the given file object's encoding.
 
     Parameters
     ----------
-    file_obj : Path | io.BytesIO | io.StringIO
+    file_obj : Path | io.BytesIO | io.StringIO | str | bytes
         File object or path object to detect encoding.
 
     Returns
     -------
     str
     """
+    import chardet
+
     if isinstance(file_obj, str):
         try:
             path_exists = Path(file_obj).exists()

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,6 @@ bq-dev = ["py313", "ai", "ai-local", "ai-llama", "bigquery", "lint", "sql", "tes
 
 [dependencies]
 bokeh = "*"
-chardet = "*"
 holoviews = ">=1.17.0"
 hvplot = "*"
 intake = "<2"
@@ -53,6 +52,7 @@ python = "3.13.*"
 COVERAGE_CORE = "sysmon"
 
 [feature.ai.dependencies]
+chardet = "*"
 duckdb = ">=1.2.0"
 griffe = "*"
 instructor = ">=1.6.4"


### PR DESCRIPTION
Lumen has an `entry_point` in Panel, and chardet is not a required dependency for Lumen. This would give an import error when running `panel serve` with a clean Lumen install. 

Procedure:
``` bash
❯ mamba env create --name "tmp_lumen" python=3.13
❯ conda activate tmp_lumen
❯ pip install git+https://github.com/holoviz/lumen
❯ panel serve
Traceback (most recent call last):
  File "/home/shh/.local/conda/envs/tmp_lumen/bin/panel", line 5, in <module>
    from panel.command import main
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/panel/command/__init__.py", line 19, in <module>
    from .serve import Serve
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/panel/command/serve.py", line 40, in <module>
    from ..io.rest import REST_PROVIDERS
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/panel/io/rest.py", line 182, in <module>
    REST_PROVIDERS[entry_point.name] = entry_point.load()
                                       ~~~~~~~~~~~~~~~~^^
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/importlib/metadata/__init__.py", line 179, in load
    module = import_module(match.group('module'))
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/lumen/__init__.py", line 3, in <module>
    from .dashboard import Dashboard  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/lumen/dashboard.py", line 23, in <module>
    from .auth import Auth
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/lumen/auth.py", line 11, in <module>
    from .base import MultiTypeComponent
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/lumen/base.py", line 22, in <module>
    from .state import state
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/lumen/state.py", line 9, in <module>
    from .util import extract_refs, is_ref
  File "/home/shh/.local/conda/envs/tmp_lumen/lib/python3.13/site-packages/lumen/util.py", line 17, in <module>
    import chardet
ModuleNotFoundError: No module named 'chardet'
```

I also updated the type annotation. I don't see how the function handles `io.BytesIO | io.StringIO`, but I haven't removed those annotation. 