### PR TITLE
Improve translate param to pydantic and vice versa

### DIFF
--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -504,8 +504,15 @@ def param_to_pydantic(
 
 
 def pydantic_to_param_instance(model: BaseModel) -> param.Parameterized:
-    parameterized_class = model._parameterized  # type: ignore
-    valid_param_names = set(parameterized_class.param)
+    """
+    Tries to convert a Pydantic model instance back to a param.Parameterized instance.
+    Only valid if the model was initially translated using `param_to_pydantic`.
+    """
+    try:
+        parameterized_class = model._parameterized  # type: ignore
+        valid_param_names = set(parameterized_class.param)
+    except AttributeError:
+        raise ValueError("The provided model does not have a _parameterized attribute, indicating it was not created from a param.Parameterized class.")
 
     kwargs = {}
     for key, value in model:

--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -9,17 +9,20 @@ from collections.abc import Callable
 from inspect import Signature, signature
 from types import FunctionType
 from typing import (
-    Any, Literal, TypeVar, Union,
+    Any, Literal, TypeVar, Union, get_origin,
 )
 
 import param
 
 from griffe import Docstring, DocstringSectionKind
-from pydantic import BaseModel, ConfigDict, create_model
+from instructor.dsl.partial import \
+    PartialLiteralMixin  # Assuming this is correctly available
+from pydantic import (
+    BaseModel, ConfigDict, Field, PrivateAttr, create_model,
+)
 from pydantic._internal import _typing_extra
 from pydantic.fields import FieldInfo, PydanticUndefined
 from pydantic.json_schema import SkipJsonSchema
-from pydantic_core import core_schema
 from pydantic_extra_types.color import Color
 
 DATE_TYPE = datetime.datetime | datetime.date
@@ -29,6 +32,8 @@ PARAM_TYPE_MAPPING: dict[param.Parameter, type] = {
     param.Number: float,
     param.Boolean: bool,
     param.Event: bool,
+    param.Tuple: tuple,
+    param.NumericTuple: tuple,
     param.Date: DATE_TYPE,
     param.DateRange: tuple[DATE_TYPE],
     param.CalendarDate: DATE_TYPE,
@@ -38,96 +43,89 @@ PARAM_TYPE_MAPPING: dict[param.Parameter, type] = {
     param.Callable: Callable,
 }
 PandasDataFrame = TypeVar("PandasDataFrame")
-DocstringStyle = Literal['google', 'numpy', 'sphinx']
+DocstringStyle = Literal["google", "numpy", "sphinx"]
 
-# See https://github.com/mkdocstrings/griffe/issues/329#issuecomment-2425017804
 _docstring_style_patterns: list[tuple[str, list[str], DocstringStyle]] = [
     (
-        r'\n[ \t]*:{0}([ \t]+\w+)*:([ \t]+.+)?\n',
+        r"\n[ \t]*:{0}([ \t]+\w+)*:([ \t]+.+)?\n",
         [
-            'param',
-            'parameter',
-            'arg',
-            'argument',
-            'key',
-            'keyword',
-            'type',
-            'var',
-            'ivar',
-            'cvar',
-            'vartype',
-            'returns',
-            'return',
-            'rtype',
-            'raises',
-            'raise',
-            'except',
-            'exception',
+            "param",
+            "parameter",
+            "arg",
+            "argument",
+            "key",
+            "keyword",
+            "type",
+            "var",
+            "ivar",
+            "cvar",
+            "vartype",
+            "returns",
+            "return",
+            "rtype",
+            "raises",
+            "raise",
+            "except",
+            "exception",
         ],
-        'sphinx',
+        "sphinx",
     ),
     (
-        r'\n[ \t]*{0}:([ \t]+.+)?\n[ \t]+.+',
+        r"\n[ \t]*{0}:([ \t]+.+)?\n[ \t]+.+",
         [
-            'args',
-            'arguments',
-            'params',
-            'parameters',
-            'keyword args',
-            'keyword arguments',
-            'other args',
-            'other arguments',
-            'other params',
-            'other parameters',
-            'raises',
-            'exceptions',
-            'returns',
-            'yields',
-            'receives',
-            'examples',
-            'attributes',
-            'functions',
-            'methods',
-            'classes',
-            'modules',
-            'warns',
-            'warnings',
+            "args",
+            "arguments",
+            "params",
+            "parameters",
+            "keyword args",
+            "keyword arguments",
+            "other args",
+            "other arguments",
+            "other params",
+            "other parameters",
+            "raises",
+            "exceptions",
+            "returns",
+            "yields",
+            "receives",
+            "examples",
+            "attributes",
+            "functions",
+            "methods",
+            "classes",
+            "modules",
+            "warns",
+            "warnings",
         ],
-        'google',
+        "google",
     ),
     (
-        r'\n[ \t]*{0}\n[ \t]*---+\n',
+        r"\n[ \t]*{0}\n[ \t]*---+\n",
         [
-            'deprecated',
-            'parameters',
-            'other parameters',
-            'returns',
-            'yields',
-            'receives',
-            'raises',
-            'warns',
-            'attributes',
-            'functions',
-            'methods',
-            'classes',
-            'modules',
+            "deprecated",
+            "parameters",
+            "other parameters",
+            "returns",
+            "yields",
+            "receives",
+            "raises",
+            "warns",
+            "attributes",
+            "functions",
+            "methods",
+            "classes",
+            "modules",
         ],
-        'numpy',
+        "numpy",
     ),
 ]
 
-class ArbitraryTypesModel(BaseModel):
-    """
-    A Pydantic model that allows arbitrary types.
-    """
 
+class ArbitraryTypesModel(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 def _create_literal(obj: list[str | type]) -> type:
-    """
-    Create a literal type from a list of objects.
-    """
     enum = []
     for item in obj:
         if item is None:
@@ -142,9 +140,15 @@ def _create_literal(obj: list[str | type]) -> type:
         return str
 
 
-def _get_model(type_, created_models: dict[str, BaseModel]) -> Any:
+def _get_model(type_, created_models: dict[str, type[BaseModel]]) -> Any:
+    if isinstance(type_, tuple):
+        return tuple(_get_model(t, created_models) for t in type_)
     try:
         if issubclass(type_, param.Parameterized):
+            if type_.__name__ not in created_models and hasattr(type_, "param"):
+                # Pass the default base_model (ArbitraryTypesModel) for parent conversion
+                # if not already part of a specific conversion chain.
+                param_to_pydantic(type_, created_models=created_models, process_subclasses=True)
             type_ = created_models.get(type_.__name__, type_.__name__)
     except TypeError:
         pass
@@ -152,64 +156,121 @@ def _get_model(type_, created_models: dict[str, BaseModel]) -> Any:
 
 
 def _infer_docstring_style(doc: str) -> DocstringStyle:
-    """Simplistic docstring style inference."""
     for pattern, replacements, style in _docstring_style_patterns:
-        matches = (
-            re.search(pattern.format(replacement), doc, re.IGNORECASE | re.MULTILINE) for replacement in replacements
-        )
+        matches = (re.search(pattern.format(replacement), doc, re.IGNORECASE | re.MULTILINE) for replacement in replacements)
         if any(matches):
             return style
-    # fallback to google style
-    return 'google'
+    return "google"
 
 
-def parameter_to_field(
-    parameter: param.Parameter, created_models: dict[str, BaseModel],
-    literals: list[str] | None
-) -> (type, FieldInfo):
-    """
-    Translate a parameter to a pydantic field.
-    """
+def parameter_to_field(parameter: param.Parameter, created_models: dict[str, type[BaseModel]], literals: list[str] | None) -> tuple[type, FieldInfo]:
     param_type = parameter.__class__
-    description = " ".join(parameter.doc.split()) if parameter.doc else None
-    field_info = FieldInfo(description=description)
-    if not literals and hasattr(parameter, 'get_range'):
+    field_kwargs = {}
+
+    if parameter.doc:
+        field_kwargs["description"] = " ".join(parameter.doc.split())
+    if not literals and hasattr(parameter, "get_range"):
         literals = list(parameter.get_range())
 
     if param_type in PARAM_TYPE_MAPPING:
         type_ = PARAM_TYPE_MAPPING[param_type]
-        field_info.default = parameter.default
+        if parameter.default is not None and parameter.default is not PydanticUndefined:
+            field_kwargs["default"] = parameter.default
     elif param_type is param.ClassSelector:
-        type_ = _get_model(parameter.class_, created_models)
-        if isinstance(type_, tuple):
-            type_ = Union[tuple([PARAM_TYPE_MAPPING.get(t, t) for t in type_])]  # noqa
-        if parameter.default is not None:
-            default_factory = parameter.default
-            if not callable(default_factory):
-                default_factory = type(default_factory)
-            field_info.default_factory = default_factory
+        if hasattr(parameter, "instantiate") and not parameter.instantiate:
+            if hasattr(parameter.class_, "param"):
+                param_to_pydantic(parameter.class_, created_models=created_models, process_subclasses=True)
+            if parameter.default is not None and inspect.isclass(parameter.default):
+                if hasattr(parameter.default, "param"):
+                    param_to_pydantic(parameter.default, created_models=created_models, process_subclasses=True)
+
+            base_class_name = parameter.class_.__name__
+            # Type should be the Pydantic model class itself, not an instance
+            type_ = created_models.get(base_class_name, parameter.class_)
+
+            if parameter.default is not None:
+                if inspect.isclass(parameter.default):
+                    default_class_name = parameter.default.__name__
+                    # Default should also be the Pydantic model class
+                    field_kwargs["default"] = created_models.get(default_class_name, parameter.default)
+                else:  # Potentially an instance, or other non-class default.
+                    field_kwargs["default"] = parameter.default
+
+        elif isinstance(parameter.class_, tuple):
+            for cls in parameter.class_:
+                if hasattr(cls, "param"):
+                    param_to_pydantic(cls, created_models=created_models, process_subclasses=True)
+            mapped_types = []
+            for cls in parameter.class_:
+                model_name = cls.__name__
+                if hasattr(cls, "param") and model_name in created_models:
+                    mapped_types.append(created_models[model_name])
+                else:  # Not a param class or not converted, use raw type or mapping
+                    mapped_types.append(PARAM_TYPE_MAPPING.get(cls, cls))
+            type_ = Union.__getitem__(tuple(mapped_types))
+            if parameter.default is not None:  # Add default handling for tuple class types
+                field_kwargs["default"] = parameter.default
+
+        else:
+            type_ = _get_model(parameter.class_, created_models)
+            if parameter.default is not None:
+                if callable(parameter.default) and not inspect.isclass(parameter.default):
+                    default_factory = parameter.default
+                    field_kwargs["default_factory"] = default_factory
+                elif isinstance(parameter.default, param.Parameterized):
+                    pass  # Leave default undefined for pydantic to handle via type_
+                else:
+                    field_kwargs["default"] = parameter.default
     elif param_type in [param.List, param.ListSelector]:
         type_ = list
         if parameter.default is not None:
-            field_info.default_factory = parameter.default
+            if callable(parameter.default):
+                field_kwargs["default_factory"] = parameter.default
+            else:
+                field_kwargs["default"] = parameter.default
         if param_type is param.List and parameter.item_type:
-            type_ = list[_get_model(parameter.item_type, created_models)]
+            if isinstance(parameter.item_type, tuple):
+                for cls in parameter.item_type:
+                    if hasattr(cls, "param"):
+                        param_to_pydantic(cls, created_models=created_models)
+                mapped_types = []
+                for cls in parameter.item_type:
+                    model_name = cls.__name__
+                    if hasattr(cls, "param") and model_name in created_models:
+                        mapped_types.append(created_models[model_name])
+                    else:
+                        mapped_types.append(PARAM_TYPE_MAPPING.get(cls, cls))
+                item_type = Union.__getitem__(tuple(mapped_types))
+                type_ = list[item_type]
+            else:
+                type_ = list[_get_model(parameter.item_type, created_models)]
         elif param_type is param.ListSelector:
-            type_ = list[_create_literal(literals)]
+            # Ensure literals is not None; if it's None, this might error or behave unexpectedly
+            type_ = list[_create_literal(literals if literals is not None else [])]
     elif param_type is param.Dict:
         type_ = dict
-        if parameter.default == {}:
-            field_info.default_factory = dict
+        if parameter.default == {}:  # Check for empty dict default specifically
+            field_kwargs["default_factory"] = dict
         elif parameter.default is not None:
-            field_info.default_factory = parameter.default
-    elif param_type in [param.Selector, param.ObjectSelector]:  # ObjectSelector is deprecated
-        field_info.default = parameter.default
-        if literals:
-            type_ = _create_literal(literals)
-        elif parameter.objects:
-            type_ = _create_literal(parameter.objects)
-        else:
-            type_ = str
+            if callable(parameter.default):  # Typically for default_factory, but param.Dict doesn't have it
+                pass  # Let Pydantic handle callable default if it's not default_factory
+            else:
+                field_kwargs["default"] = parameter.default
+        elif parameter.default is None and parameter.allow_None:  # Explicitly handle None default with allow_None
+            field_kwargs["default"] = None
+
+    elif param_type in [param.Selector, param.ObjectSelector]:
+        if parameter.default is not None:
+            field_kwargs["default"] = parameter.default
+
+        current_literals = literals
+        if not current_literals and hasattr(parameter, "objects"):  # Use objects if literals not provided
+            current_literals = parameter.objects
+
+        if current_literals:
+            type_ = _create_literal(current_literals)
+        else:  # Fallback if no literals or objects
+            type_ = Any if parameter.allow_None else str  # Or object, or more specific based on context
     elif issubclass(param_type, param.DataFrame):
         type_ = PandasDataFrame
     elif parameter.name == "align":
@@ -219,210 +280,341 @@ def parameter_to_field(
     elif parameter.name == "margin":
         type_ = float | tuple[float, float] | tuple[float, float, float, float]
     else:
-        raise NotImplementedError(
-            f"Parameter {parameter.name!r} of {param_type.__name__!r} not supported"
-        )
+        raise NotImplementedError(f"Parameter {parameter.name!r} of {param_type.__name__!r} not supported")
 
     if hasattr(parameter, "bounds") and parameter.bounds and type_ in [int, float]:
         try:
-            field_info.ge = parameter.bounds[0]
-            field_info.le = parameter.bounds[1]
-        except Exception:
+            field_kwargs["ge"] = parameter.bounds[0]
+            field_kwargs["le"] = parameter.bounds[1]
+        except (TypeError, IndexError):  # Handle if bounds is not as expected
             pass
 
-    if parameter.allow_None:
-        type_ = type_ | None
+    is_none_default = parameter.default is None
 
+    if parameter.allow_None:
+        type_ = Union[type_, None]  # type: ignore # noqa: UP007
+        if is_none_default and "default" not in field_kwargs and "default_factory" not in field_kwargs:
+            field_kwargs["default"] = None
+
+    field_info = Field(**field_kwargs)
     return type_, field_info
 
 
 def param_to_pydantic(
-    parameterized: type[param.Parameterized],
+    parameterized: type[param.Parameterized] | list[type[param.Parameterized]],
     base_model: type[BaseModel] = ArbitraryTypesModel,
-    created_models: dict[str, BaseModel] | None = None,
+    created_models: dict[str, type[BaseModel]] | None = None,  # MODIFIED type hint
     schema: dict[str, Any] | None = None,
     excluded: str | list[str] = "_internal_params",
     extra_fields: dict[str, tuple[type, FieldInfo]] | None = None,
-) -> dict[str, BaseModel]:
-    """
-    Translate a param Parameterized to a Pydantic BaseModel.
-
-    Parameters
-    ----------
-    parameterized : Type[param.Parameterized]
-        The parameterized class to translate.
-    base_model : Type[BaseModel], optional
-        The base model to use, by default ArbitraryTypesModel
-    created_models : Optional[Dict[str, BaseModel]], optional
-        A dictionary of already created models, by default None
-    excluded : Union[str, List[str]], optional
-        A list of parameters to exclude. If a string is provided,
-        it looks up the parameter on the parameterized class and
-        excludes the parameter's value, by default "_internal_params".
-    extra_fields : Optional[Dict[str, Tuple[Type, FieldInfo]]], optional
-        Extra fields to add to the model, by default None
-    """
-    parameterized_name = parameterized.__name__
+    process_subclasses: bool = True,  # ADDED parameter
+) -> dict[str, type[BaseModel]]:  # MODIFIED return type hint
     if created_models is None:
         created_models = {}
+
+    if isinstance(parameterized, list):
+        for param_class in parameterized:
+            # Propagate process_subclasses when handling a list
+            param_to_pydantic(
+                param_class,
+                base_model=base_model,
+                created_models=created_models,
+                schema=schema,
+                excluded=excluded,
+                extra_fields=extra_fields,
+                process_subclasses=process_subclasses,  # PROPAGATE
+            )
+        return created_models
+
+    parameterized_name = parameterized.__name__
     if parameterized_name in created_models:
         return created_models
 
-    if isinstance(excluded, str) and hasattr(parameterized, excluded):
-        excluded = getattr(parameterized, excluded)
+    pydantic_model_bases = []
+    # Iterate over direct base classes of `parameterized`
+    for param_parent_cls in parameterized.__bases__:
+        # Check if the parent is a param.Parameterized class itself,
+        # but not the root param.Parameterized (to avoid issues if param.Parameterized is in created_models)
+        if issubclass(param_parent_cls, param.Parameterized) and param_parent_cls is not param.Parameterized:
+            # Ensure parent Pydantic model is created if it doesn't exist
+            if param_parent_cls.__name__ not in created_models:
+                # Recursively call param_to_pydantic for the parent.
+                # Propagate `base_model` for consistent ultimate ancestor.
+                # Propagate `process_subclasses`.
+                param_to_pydantic(
+                    param_parent_cls,
+                    base_model=base_model,
+                    created_models=created_models,
+                    # schema, excluded, extra_fields are generally not propagated
+                    # to parents unless explicitly needed, as they are often
+                    # specific to the current class conversion.
+                    process_subclasses=process_subclasses,  # PROPAGATE
+                )
 
-    parameterized_signature = signature(parameterized.__init__)
-    required_args = [
-        arg.name
-        for arg in parameterized_signature.parameters.values()
-        if arg.name not in ["self", "params"] and arg.default == inspect._empty
-    ]
-    field_params = list(getattr(parameterized, '_field_params', []))
+            # If the parent Pydantic model was created or already existed, add it to bases
+            if param_parent_cls.__name__ in created_models:
+                parent_pydantic_cls = created_models[param_parent_cls.__name__]
+                if parent_pydantic_cls not in pydantic_model_bases:  # Avoid duplicates
+                    pydantic_model_bases.append(parent_pydantic_cls)
+
+    # If no direct param parent Pydantic model was added (e.g., `parameterized`
+    # inherits directly from param.Parameterized, or its param parents weren't
+    # converted for some reason), then use the `base_model` argument as the base.
+    if not pydantic_model_bases:
+        if isinstance(base_model, tuple):
+            # If base_model is a tuple of bases, add them all
+            for b_item in base_model:
+                if b_item not in pydantic_model_bases:  # Should be redundant if list is empty
+                    pydantic_model_bases.append(b_item)
+        elif base_model not in pydantic_model_bases:  # Should be redundant if list is empty
+            pydantic_model_bases.append(base_model)
+
+    current_excluded: list[str]
+    if isinstance(excluded, str) and hasattr(parameterized, excluded):
+        current_excluded = getattr(parameterized, excluded, [])
+    elif isinstance(excluded, list):  # If excluded is already a list
+        current_excluded = excluded
+    else:  # Fallback: excluded is a string but not an attribute, or other unexpected type
+        current_excluded = []
+
+    field_params = list(getattr(parameterized, "_field_params", []))
 
     fields = {}
+    private_attrs: dict[str, PrivateAttr] = {}  # Store PrivateAttr objects
+    use_literal_mixin = False
+
     for parameter_name in parameterized.param:
-        if parameter_name in excluded or parameterized_name.lower() == parameter_name.lower():
+        if parameter_name in current_excluded:
             continue
         parameter = parameterized.param[parameter_name]
-        if hasattr(parameter, "class_") and hasattr(parameter.class_, "param"):
-            parameter_class_name = parameter.class_.__name__
-            if parameterized_name != parameter_class_name:
-                param_to_pydantic(parameter.class_, created_models=created_models)
+
+        # Handle nested Parameterized classes in ClassSelector or List item_type
+        classes_to_process_for_field = []
+        if hasattr(parameter, "class_"):  # For param.ClassSelector
+            if isinstance(parameter.class_, tuple):
+                classes_to_process_for_field.extend(c for c in parameter.class_ if inspect.isclass(c))
+            elif inspect.isclass(parameter.class_):
+                classes_to_process_for_field.append(parameter.class_)
+        if hasattr(parameter, "item_type"):  # For param.List
+            if isinstance(parameter.item_type, tuple):
+                classes_to_process_for_field.extend(c for c in parameter.item_type if inspect.isclass(c))
+            elif inspect.isclass(parameter.item_type):
+                classes_to_process_for_field.append(parameter.item_type)
+
+        for cls_to_check in classes_to_process_for_field:
+            if hasattr(cls_to_check, "param") and cls_to_check.__name__ != parameterized_name:
+                if cls_to_check.__name__ not in created_models:
+                    param_to_pydantic(  # Recursive call for nested class types
+                        cls_to_check,
+                        base_model=base_model,
+                        created_models=created_models,
+                        process_subclasses=process_subclasses,  # PROPAGATE
+                    )
 
         literals = list(schema) if schema and parameter_name in field_params else None
-
         type_, field_info = parameter_to_field(parameter, created_models, literals)
+
+        if not use_literal_mixin and get_origin(type_) is Literal:
+            use_literal_mixin = True
+
         if parameter_name == "schema":
-            field_info.alias = "schema"
+            field_info.alias = "schema"  # type: ignore
             parameter_name = "schema_"
         elif parameter_name == "copy":
-            field_info.alias = "copy"
+            field_info.alias = "copy"  # type: ignore
             parameter_name = "copy_"
-        elif parameter_name[0] == "_":
-            field_info.alias = parameter_name
-            parameter_name = parameter_name.lstrip("_")
+        elif parameter_name.startswith("_"):
+            # Ensure default is wrapped in PrivateAttr for private fields
+            private_attrs[parameter_name] = PrivateAttr(default=parameter.default if parameter.default is not None else None)
+            continue  # Skip adding to regular fields
 
-        if parameter_name in required_args:
-            field_info.default = PydanticUndefined
-        elif field_info.default == PydanticUndefined and not field_info.default_factory:
-            field_info.default = None
+        # Pydantic's FieldInfo.from_annotation handles default Undefined for required params.
+        # We only override if param has a specific default that Pydantic might miss.
+        if field_info.default is PydanticUndefined and parameter.default is not None:
+            field_info.default = parameter.default
+        # If allow_None is True, Pydantic will make it Optional if not already.
+        # Explicit `default=None` is set by parameter_to_field if param.default is None and allow_None.
         fields[parameter_name] = (type_, field_info)
 
-    fields["__parameterized__"] = (type, parameterized)
+    if use_literal_mixin:
+        if PartialLiteralMixin not in pydantic_model_bases:
+            pydantic_model_bases.append(PartialLiteralMixin)
+
+    # Deduplicate bases while preserving order (important for MRO)
+    final_model_creation_base: type[BaseModel] | tuple[type[BaseModel], ...]
+    unique_final_bases = []
+    seen_bases = set()
+    for b_item in pydantic_model_bases:
+        if b_item not in seen_bases:
+            unique_final_bases.append(b_item)
+            seen_bases.add(b_item)
+
+    if not unique_final_bases:  # Should ideally not happen if ArbitraryTypesModel is a fallback
+        final_model_creation_base = ArbitraryTypesModel
+    elif len(unique_final_bases) == 1:
+        final_model_creation_base = unique_final_bases[0]
+    else:
+        final_model_creation_base = tuple(unique_final_bases)
+
+    fields["_parameterized"] = (type, parameterized)  # type: ignore
 
     if extra_fields:
         fields.update(extra_fields)
 
-    # ignore RuntimeWarning: fields may not start with an underscore
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", RuntimeWarning)
+        warnings.simplefilter("ignore", RuntimeWarning)  # For `__parameterized__` field
         pydantic_model = create_model(
-            parameterized.__name__, __base__=base_model, **fields
+            parameterized.__name__,
+            __base__=final_model_creation_base,
+            **fields,  # type: ignore
         )
-    created_models[pydantic_model.__name__] = pydantic_model
+
+    # Add private attributes to the model class after creation
+    for attr_name, private_attr_obj in private_attrs.items():
+        setattr(pydantic_model, attr_name, private_attr_obj)
+
+    created_models[pydantic_model.__name__] = pydantic_model  # type: ignore
+
+    if process_subclasses:
+        try:
+            # Use a set to avoid processing the same subclass multiple times
+            subclasses_to_process = set(parameterized.__subclasses__())
+        except TypeError:  # Should not happen for classes, but defensive
+            subclasses_to_process = set()
+
+        for sub_cls in subclasses_to_process:
+            # Check if it's a param.Parameterized class and not yet processed
+            if (
+                inspect.isclass(sub_cls)
+                and issubclass(sub_cls, param.Parameterized)
+                and sub_cls is not param.Parameterized
+                and sub_cls.__name__ not in created_models
+            ):
+                # Recursively call for subclasses
+                param_to_pydantic(
+                    sub_cls,
+                    base_model=base_model,  # Propagate original base_model for consistency
+                    created_models=created_models,  # Pass the same dict to accumulate models
+                    schema=None,  # Schemas are specific, don't propagate by default
+                    excluded=excluded,  # Propagate exclusion rules
+                    extra_fields=None,  # Extra fields are specific
+                    process_subclasses=True,  # Continue processing for sub-subclasses
+                )
     return created_models
 
 
-def pydantic_to_param(model: BaseModel) -> param.Parameterized:
-    """
-    Serialize a Pydantic model to a Parameterized instance.
+def pydantic_to_param_instance(model: BaseModel) -> param.Parameterized:
+    parameterized_class = model._parameterized  # type: ignore
+    valid_param_names = set(parameterized_class.param)
 
-    Parameters
-    ----------
-    model : BaseModel
-        The model to serialize.
-    """
     kwargs = {}
-    for key, value in dict(model).items():
-        if isinstance(value, BaseModel):
-            kwargs[key] = pydantic_to_param(value)
-        elif isinstance(value, Color):
-            kwargs[key] = value.as_hex()
-        elif isinstance(value, dict):
-            sub_kwargs = {}
-            for k, v in value.items():
-                if isinstance(v, BaseModel):
-                    sub_kwargs[k] = pydantic_to_param(v)
-                else:
-                    sub_kwargs[k] = v
-            kwargs[key] = sub_kwargs
-        elif key == "table":
-            # couldn't convince AI to provide path to file for `tables`
-            # but remove the extension for `table`
-            kwargs[key] = value.split(".")[0]
-        else:
-            kwargs[key] = value
+    for key, value in model:
+        original_key = key
+        # Handle aliased fields (schema_ -> schema, copy_ -> copy)
+        if key == "schema_" and "schema" in valid_param_names:
+            original_key = "schema"
+        elif key == "copy_" and "copy" in valid_param_names:
+            original_key = "copy"
 
-    parameterized = model.__parameterized__(**kwargs)
-    return parameterized
+        if original_key not in valid_param_names:
+            continue  # Skip fields not present in the param.Parameterized class
+
+        if isinstance(value, BaseModel):
+            # Recursively convert nested Pydantic models to param.Parameterized instances
+            kwargs[original_key] = pydantic_to_param_instance(value)
+        elif isinstance(value, Color):  # pydantic_extra_types.color.Color
+            kwargs[original_key] = value.as_hex()
+        elif isinstance(value, list):
+            processed_list = []
+            for item in value:
+                if isinstance(item, BaseModel):
+                    processed_list.append(pydantic_to_param_instance(item))
+                else:
+                    # Otherwise, keep the item as is (e.g., str, int, dict if not a model)
+                    processed_list.append(item)
+            kwargs[original_key] = processed_list
+        elif isinstance(value, dict):  # For general dictionaries
+            # Recursively process dictionaries that might contain BaseModel instances
+            # This is important if a dict field itself can contain Pydantic models
+            # (though less common for param.Dict which usually expects simple types or
+            # specific structures not auto-converted to Pydantic models by param_to_pydantic).
+            sub_kwargs = {}
+            for k, v_item in value.items():
+                if isinstance(v_item, BaseModel):
+                    sub_kwargs[k] = pydantic_to_param_instance(v_item)
+                else:
+                    sub_kwargs[k] = v_item
+            kwargs[original_key] = sub_kwargs
+        elif original_key == "table" and isinstance(value, str) and "." in value:
+            # Specific handling for 'table' field as per original code
+            kwargs[original_key] = value.split(".")[0]
+        else:
+            # For all other types, assign the value directly
+            kwargs[original_key] = value
+
+    parameterized_instance = parameterized_class(**kwargs)
+    return parameterized_instance
+
 
 def doc_descriptions(function: FunctionType, sig: Signature | None = None) -> tuple[str, dict[str, str]]:
-    """
-    Parses the docstring and returns the function description and descriptions for each argument.
-
-    Arguments
-    ---------
-    function : FunctionType
-        Function to extract argument descriptions from.
-    sig: inspect.Signature | None
-        Optional Signature of the function
-
-    Returns
-    -------
-    tuple[str, dict[str, str]]
-        Tuple of the main description of the function and dictionary of descriptions per argument
-    """
     doc = function.__doc__
     if doc is None:
-        return '', {}
+        return "", {}
     if sig is None:
         sig = signature(function)
 
     parser = _infer_docstring_style(doc)
-    docstring = Docstring(doc, lineno=1, parser=parser, parent=sig)
+    docstring = Docstring(doc, lineno=1, parser=parser, parent=sig)  # type: ignore
     sections = docstring.parse()
     params = {}
-    if parameters := next((p for p in sections if p.kind == DocstringSectionKind.parameters), None):
-        params = {p.name: p.description for p in parameters.value}
+    if parameters_section := next((p for p in sections if p.kind == DocstringSectionKind.parameters), None):
+        params = {p.name: p.description for p in parameters_section.value}  # type: ignore
 
-    main_desc = ''
-    if main := next((p for p in sections if p.kind == DocstringSectionKind.text), None):
-        main_desc = main.value
+    main_desc = ""
+    if main_section := next((p for p in sections if p.kind == DocstringSectionKind.text), None):
+        main_desc = main_section.value  # type: ignore
 
     return main_desc, params
 
+
 def function_to_model(function: FunctionType, skipped: list[str] | None = None) -> type[BaseModel]:
-    """
-    Translates the arguments to a function into a pydantic Model.
-
-    Arguments
-    ---------
-    function : FunctionType
-        The function to translate.
-    skipped : list[str] | None
-        Arguments that will be skipped when exporting the JSON schema.
-
-    Returns
-    -------
-    pydantic.BaseModel
-        The translated model with fields corresponding to the arguments of the function.
-    """
     skipped = skipped or []
     sig = signature(function)
     type_hints = _typing_extra.get_function_type_hints(function)
-    fields: dict[str, core_schema.TypedDictField] = {}
+    fields: dict[str, tuple[Any, FieldInfo]] = {}  # Changed core_schema.TypedDictField to tuple[Any, FieldInfo] for create_model
     description, field_descriptions = doc_descriptions(function, sig)
+
     for index, (name, p) in enumerate(sig.parameters.items()):
         if p.annotation is sig.empty:
             annotation = Any
         else:
-            annotation = type_hints[name]
+            annotation = type_hints.get(name, Any)  # Use .get for safety
+
         field_name = p.name
-        field_info = FieldInfo.from_annotation(annotation)
-        if field_info.description is None:
-            field_info.description = field_descriptions.get(field_name)
+        # Create FieldInfo from annotation, then update description
+        field_info_kwargs = {}
+        if p.default is not inspect.Parameter.empty:
+            field_info_kwargs["default"] = p.default
+
+        # Get description from docstring
+        doc_desc = field_descriptions.get(field_name)
+        if doc_desc:
+            field_info_kwargs["description"] = doc_desc
+
+        field_info_obj = Field(**field_info_kwargs)
+
+        final_annotation = annotation
         if name in skipped:
-            annotation = SkipJsonSchema[annotation | None]
-        fields[field_name] = (annotation, field_info)
-    model = create_model(function.__name__, __doc__=description, **fields)
+            # Ensure Union with None if original annotation didn't allow it, for SkipJsonSchema
+            if get_origin(annotation) is Union:
+                args = _typing_extra.get_args(annotation)
+                if type(None) not in args:  # type: ignore
+                    final_annotation = Union[annotation, None]  # type: ignore # noqa: UP007
+            elif annotation is not Any and annotation is not type(None):  # type: ignore
+                final_annotation = Union[annotation, None]  # type: ignore # noqa: UP007
+            final_annotation = SkipJsonSchema[final_annotation]  # type: ignore
+
+        fields[field_name] = (final_annotation, field_info_obj)
+
+    model = create_model(function.__name__, __doc__=description, **fields)  # type: ignore
     return model

--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -15,8 +15,7 @@ from typing import (
 import param
 
 from griffe import Docstring, DocstringSectionKind
-from instructor.dsl.partial import \
-    PartialLiteralMixin  # Assuming this is correctly available
+from instructor.dsl.partial import PartialLiteralMixin
 from pydantic import (
     BaseModel, ConfigDict, Field, PrivateAttr, create_model,
 )

--- a/lumen/tests/ai/test_translate.py
+++ b/lumen/tests/ai/test_translate.py
@@ -1,6 +1,11 @@
 import param
 import pytest
 
+try:
+    import lumen.ai
+except ModuleNotFoundError:
+    pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
+
 from pydantic import BaseModel, Field
 
 from lumen.ai.translate import param_to_pydantic, pydantic_to_param_instance

--- a/lumen/tests/ai/test_translate.py
+++ b/lumen/tests/ai/test_translate.py
@@ -1,4 +1,9 @@
+import param
 import pytest
+
+from pydantic import BaseModel, Field
+
+from lumen.ai.translate import param_to_pydantic, pydantic_to_param_instance
 
 try:
     import lumen.ai  # noqa
@@ -24,7 +29,8 @@ def add(a: int, b: int) -> int:
     int
         Result of addition
     """
-    return a+b
+    return a + b
+
 
 def add_google(a: int, b: int) -> int:
     """
@@ -60,17 +66,20 @@ def test_doc_descriptions_numpy():
     assert descriptions["a"] == "Integer A"
     assert descriptions["b"] == "Integer B"
 
+
 def test_doc_descriptions_google():
     main, descriptions = doc_descriptions(add_google)
     assert main == "Adds two integers"
     assert descriptions["a"] == "Integer A"
     assert descriptions["b"] == "Integer B"
 
+
 def test_doc_descriptions_sphinx():
     main, descriptions = doc_descriptions(add_sphinx)
     assert main == "Adds two integers"
     assert descriptions["a"] == "Integer A"
     assert descriptions["b"] == "Integer B"
+
 
 def test_function_to_model_args():
     model = function_to_model(add)
@@ -83,3 +92,449 @@ def test_function_to_model_args():
     assert "b" in fields
     assert fields["b"].annotation is int
     assert fields["b"].description == "Integer B"
+
+
+def test_param_to_pydantic_conversion():
+    """
+    Test that param.Parameterized classes are correctly converted to Pydantic models.
+    This tests our use of Field() instead of FieldInfo in the translate module.
+    """
+
+    # Define direct Pydantic models for comparison
+    class PydanticPet(BaseModel):
+        name: str = Field(..., description="Name of the pet")
+        age: int = Field(..., ge=0, le=20, description="Age of the pet in years")
+
+    class PydanticDog(PydanticPet):
+        bark_volume: int = Field(default=5, ge=0, le=10)
+
+    class PydanticCat(PydanticPet):
+        meow_pitch: float = Field(default=0.5, gt=0, lt=1)
+
+    class PydanticOwner(BaseModel):
+        pet: PydanticDog | PydanticCat
+
+    # Define param.Parameterized classes
+    class Pet(param.Parameterized):
+        name = param.String(doc="Name of the pet")
+        age = param.Integer(default=1, bounds=(0, 20), doc="Age of the pet in years")
+
+    class Dog(Pet):
+        bark_volume = param.Integer(default=5, bounds=(0, 10))
+
+    class Cat(Pet):
+        meow_pitch = param.Number(default=0.5, bounds=(0, 1))
+
+    class Owner(param.Parameterized):
+        pet = param.ClassSelector(class_=(Dog, Cat))
+
+    # Convert param classes to Pydantic models
+    created_models = param_to_pydantic(Owner, excluded=["name"])
+    ParamOwner = created_models["Owner"]
+    ParamDog = created_models["Dog"]
+    ParamCat = created_models["Cat"]
+
+    # Get schemas
+    param_owner_schema = ParamOwner.model_json_schema()
+
+    # Test pet field in Owner
+    assert "pet" in param_owner_schema["properties"]
+
+    # Test field metadata conversion in Dog
+    param_dog_schema = ParamDog.model_json_schema()
+    assert "bark_volume" in param_dog_schema["properties"]
+    bark_volume_prop = param_dog_schema["properties"]["bark_volume"]
+    assert bark_volume_prop["default"] == 5
+    assert "minimum" in bark_volume_prop
+    assert "maximum" in bark_volume_prop
+    assert bark_volume_prop["minimum"] == 0
+    assert bark_volume_prop["maximum"] == 10
+
+    # Test field metadata conversion in Cat
+    param_cat_schema = ParamCat.model_json_schema()
+    assert "meow_pitch" in param_cat_schema["properties"]
+    meow_pitch_prop = param_cat_schema["properties"]["meow_pitch"]
+    assert meow_pitch_prop["default"] == 0.5
+    assert "minimum" in meow_pitch_prop
+    assert "maximum" in meow_pitch_prop
+    assert meow_pitch_prop["minimum"] == 0
+    assert meow_pitch_prop["maximum"] == 1
+
+    # Test description preservation
+    param_pet_schema = param_dog_schema  # Dog inherits from Pet
+    assert "age" in param_pet_schema["properties"]
+    age_prop = param_pet_schema["properties"]["age"]
+    assert "description" in age_prop
+    assert age_prop["description"] == "Age of the pet in years"
+
+
+def test_field_bounds_conversion():
+    """
+    Test that parameter bounds are correctly converted to Field constraints.
+    """
+
+    class NumberModel(param.Parameterized):
+        value = param.Number(default=5, bounds=(0, 10))
+
+    created_models = param_to_pydantic(NumberModel)
+    PydanticNumberModel = created_models["NumberModel"]
+
+    # Create an instance to verify constraints work
+    model = PydanticNumberModel(value=5)
+    assert model.value == 5
+
+    # Check schema
+    schema = PydanticNumberModel.model_json_schema()
+    assert "value" in schema["properties"]
+    value_prop = schema["properties"]["value"]
+    assert value_prop["default"] == 5
+    assert value_prop["minimum"] == 0
+    assert value_prop["maximum"] == 10
+
+    # Verify Field constraints by trying invalid values
+    with pytest.raises(Exception):
+        PydanticNumberModel(value=-1)  # Below minimum
+
+    with pytest.raises(Exception):
+        PydanticNumberModel(value=11)  # Above maximum
+
+
+def test_alias_handling():
+    """
+    Test that reserved field names are correctly aliased.
+    """
+
+    class ReservedNamesModel(param.Parameterized):
+        schema = param.String(default="my_schema")
+        copy = param.Boolean(default=True)
+
+    created_models = param_to_pydantic(ReservedNamesModel)
+    PydanticReservedModel = created_models["ReservedNamesModel"]
+
+    # First, verify the default values
+    model_with_defaults = PydanticReservedModel()
+    assert model_with_defaults.schema_ == "my_schema"
+    assert model_with_defaults.copy_ == True
+
+    # Create a model with custom values using the field aliases
+    # The field name is schema_ but the alias is schema
+    model = PydanticReservedModel()
+    model.schema_ = "test_schema"
+    model.copy_ = False
+
+    # Verify the values were set correctly
+    assert model.schema_ == "test_schema"  # Field renamed to schema_
+    assert model.copy_ == False  # Field renamed to copy_
+
+    # Check schema to verify aliases
+    schema = PydanticReservedModel.model_json_schema()
+    assert "schema_" in schema["properties"]
+    assert "copy_" in schema["properties"]
+
+
+def test_various_param_types_conversion():
+    """
+    Test that various param types are correctly converted to Field objects.
+    """
+
+    class AllParamTypes(param.Parameterized):
+        # Basic types
+        string_param = param.String(default="hello", doc="A string parameter")
+        int_param = param.Integer(default=42, bounds=(0, 100), doc="An integer parameter")
+        float_param = param.Number(default=3.14, bounds=(0.0, 10.0), doc="A float parameter")
+        bool_param = param.Boolean(default=True, doc="A boolean parameter")
+
+        # Collection types
+        list_param = param.List(default=[1, 2, 3], doc="A list parameter")
+        dict_param = param.Dict(default={"a": 1, "b": 2}, doc="A dictionary parameter")
+        tuple_param = param.Tuple(default=(1, "a"), doc="A tuple parameter")
+
+        # Selection types
+        selector_param = param.Selector(default="option1", objects=["option1", "option2", "option3"], doc="A selector parameter")
+
+        # Date and time
+        date_param = param.Date(default=None, doc="A date parameter")
+
+        # Allow None
+        nullable_param = param.String(default=None, allow_None=True, doc="A nullable string parameter")
+
+        # Color param
+        color_param = param.Color(default="#FF0000", doc="A color parameter")
+
+    created_models = param_to_pydantic(AllParamTypes)
+    PydanticAllParams = created_models["AllParamTypes"]
+
+    # Create an instance with defaults - providing values for the required fields
+    instance = PydanticAllParams(date_param=None, nullable_param=None)
+
+    # Check basic types
+    assert instance.string_param == "hello"
+    assert instance.int_param == 42
+    assert instance.float_param == 3.14
+    assert instance.bool_param == True
+
+    # Check collection types
+    assert instance.list_param == [1, 2, 3]
+    assert instance.dict_param == {"a": 1, "b": 2}
+    assert instance.tuple_param == (1, "a")
+
+    # Check selector
+    assert instance.selector_param == "option1"
+
+    # Check nullable param
+    assert instance.nullable_param is None
+
+    # Check schema for bounds and descriptions
+    schema = PydanticAllParams.model_json_schema()
+
+    # Check string param
+    string_prop = schema["properties"]["string_param"]
+    assert string_prop["type"] == "string"
+    assert string_prop["default"] == "hello"
+    assert string_prop["description"] == "A string parameter"
+
+    # Check int param with bounds
+    int_prop = schema["properties"]["int_param"]
+    assert int_prop["type"] == "integer"
+    assert int_prop["default"] == 42
+    assert int_prop["minimum"] == 0
+    assert int_prop["maximum"] == 100
+    assert int_prop["description"] == "An integer parameter"
+
+    # Check selector param becomes enum
+    selector_prop = schema["properties"]["selector_param"]
+    assert selector_prop["default"] == "option1"
+    assert "enum" in selector_prop
+    assert selector_prop["enum"] == ["option1", "option2", "option3"]
+
+    # Check nullable param allows null
+    nullable_prop = schema["properties"]["nullable_param"]
+    # In Pydantic v2, nullable types might be represented as anyOf/oneOf
+    # or with a nullable field instead of type: ["string", "null"]
+    if "type" in nullable_prop and isinstance(nullable_prop["type"], list):
+        assert "null" in nullable_prop["type"]
+    elif "anyOf" in nullable_prop:
+        # Check if any schema in anyOf has type null
+        null_schema_exists = any(schema.get("type") == "null" for schema in nullable_prop["anyOf"])
+        assert null_schema_exists, "No null type found in anyOf schemas"
+    elif "nullable" in nullable_prop:
+        assert nullable_prop["nullable"] is True
+
+
+def test_private_attributes():
+    """
+    Test that attributes with leading underscores are correctly converted to
+    Pydantic PrivateAttr objects.
+    """
+
+    class ModelWithPrivateAttrs(param.Parameterized):
+        _private = param.String(default="private_value")
+        public = param.String(default="public_value")
+
+    created_models = param_to_pydantic(ModelWithPrivateAttrs)
+    PydanticModel = created_models["ModelWithPrivateAttrs"]
+
+    # Create an instance
+    model = PydanticModel()
+
+    # Check that private attributes are directly accessible as attributes
+    assert hasattr(model, "_private")
+    assert model._private.default == "private_value"
+    assert model.public == "public_value"
+
+    # Verify the model schema does NOT include the private attribute
+    schema = PydanticModel.model_json_schema()
+    assert "_private" not in schema["properties"]
+    assert "public" in schema["properties"]
+
+
+# Round Trip Tests
+def test_basic_round_trip():
+    """
+    Test a basic round trip conversion: param -> pydantic -> param
+    """
+
+    # Define a simple Parameterized class
+    class SimpleParamClass(param.Parameterized):
+        name = param.String(default="test", doc="A test parameter")
+        count = param.Integer(default=42, bounds=(0, 100))
+        status = param.Boolean(default=True)
+
+    # Create a param instance to start with
+    original_param = SimpleParamClass(name="original", count=50, status=False)
+
+    # Convert to pydantic
+    created_models = param_to_pydantic(SimpleParamClass)
+    PydanticModel = created_models["SimpleParamClass"]
+
+    # Convert back to param
+    round_trip_param = pydantic_to_param_instance(PydanticModel(
+        name=original_param.name,
+        count=original_param.count,
+        status=original_param.status
+    ))
+
+    # Verify values are preserved
+    assert isinstance(round_trip_param, SimpleParamClass)
+    assert round_trip_param.name == original_param.name
+    assert round_trip_param.count == original_param.count
+    assert round_trip_param.status == original_param.status
+
+    # Verify param behaviors are preserved (e.g., bounds checking)
+    with pytest.raises(ValueError):
+        round_trip_param.count = 101  # Above maximum
+
+    with pytest.raises(ValueError):
+        round_trip_param.count = -1  # Below minimum
+
+
+def test_complex_round_trip():
+    """
+    Test round trip with complex hierarchy and all parameter types.
+    """
+
+    # Define a hierarchy of Parameterized classes
+    class Animal(param.Parameterized):
+        name = param.String(default="unnamed", doc="Animal name")
+        age = param.Integer(default=1, bounds=(0, 30), doc="Age in years")
+
+    class Dog(Animal):
+        breed = param.ObjectSelector(default="mixed", objects=["mixed", "labrador", "shepherd"], doc="Dog breed")
+        size = param.Selector(default="medium", objects=["small", "medium", "large"], doc="Size category")
+
+    class Person(param.Parameterized):
+        name = param.String(default="John Doe", doc="Person name")
+        pets = param.List(default=[], item_type=Animal, doc="List of pets")
+        favorite_colors = param.List(default=["blue", "green"], doc="Favorite colors")
+        preferences = param.Dict(default={"likes_coffee": True, "likes_tea": False}, doc="Preferences")
+        birthday = param.Date(default=None, allow_None=True, doc="Birthday")
+        profile_color = param.Color(default="#1A85FF", doc="Profile color")
+
+    # Create original param instances
+    dog1 = Dog(name="Rex", age=3, breed="labrador", size="large")
+    dog2 = Dog(name="Bella", age=2, breed="shepherd", size="medium")
+    person = Person(
+        name="Alice Smith",
+        pets=[dog1, dog2],
+        favorite_colors=["purple", "orange"],
+        preferences={"likes_coffee": False, "likes_hiking": True},
+        birthday=None,
+        profile_color="#ff5733",
+    )
+
+    # Convert class to pydantic model
+    created_models = param_to_pydantic(Person)
+    PydanticPerson = created_models["Person"]
+    PydanticDog = created_models["Dog"]
+
+    # Convert original dogs to pydantic
+    pydantic_dog1 = PydanticDog(name="Rex", age=3, breed="labrador", size="large")
+
+    pydantic_dog2 = PydanticDog(name="Bella", age=2, breed="shepherd", size="medium")
+
+    # Create pydantic person instance manually
+    pydantic_person = PydanticPerson(
+        name="Alice Smith",
+        pets=[pydantic_dog1, pydantic_dog2],
+        favorite_colors=["purple", "orange"],
+        preferences={"likes_coffee": False, "likes_hiking": True},
+        birthday=None,
+        profile_color="#ff5733",
+    )
+
+    # Convert back to param
+    round_trip_person = pydantic_to_param_instance(pydantic_person)
+
+    # Verify all attributes are preserved
+    assert isinstance(round_trip_person, Person)
+    assert round_trip_person.name == person.name
+    assert len(round_trip_person.pets) == 2
+    assert round_trip_person.profile_color == "#ff5733"
+
+    # Verify nested objects
+    pet1 = round_trip_person.pets[0]
+    assert isinstance(pet1, Dog)
+    assert pet1.name == "Rex"
+    assert pet1.breed == "labrador"
+    assert pet1.size == "large"
+
+    # Verify param behavior is preserved
+    with pytest.raises(ValueError):
+        pet1.age = 31  # Above maximum
+
+    # Verify selector constraint is preserved
+    with pytest.raises(ValueError):
+        pet1.size = "extra-large"  # Not in allowed values
+
+
+def test_round_trip_modifications():
+    """
+    Test round trip with modifications in the pydantic step.
+    """
+
+    # Define a param class
+    class Config(param.Parameterized):
+        name = param.String(default="default-config")
+        timeout = param.Integer(default=30, bounds=(1, 300))
+        retry_count = param.Integer(default=3, bounds=(0, 10))
+        debug_mode = param.Boolean(default=False)
+        log_levels = param.ListSelector(default=["error"], objects=["error", "warn", "info", "debug"])
+
+    # Convert to pydantic
+    created_models = param_to_pydantic(Config)
+    PydanticConfig = created_models["Config"]
+
+    # Create pydantic instance with different values
+    pydantic_config = PydanticConfig(name="modified-config", timeout=60, retry_count=5, debug_mode=True, log_levels=["error", "warn", "debug"])
+
+    # Now convert back to param
+    round_trip_config = pydantic_to_param_instance(pydantic_config)
+
+    # Verify modified values are preserved
+    assert round_trip_config.name == "modified-config"
+    assert round_trip_config.timeout == 60
+    assert round_trip_config.retry_count == 5
+    assert round_trip_config.debug_mode is True
+    assert round_trip_config.log_levels == ["error", "warn", "debug"]
+
+    # Verify param behavior is still intact
+    with pytest.raises(ValueError):
+        round_trip_config.retry_count = 11  # Above maximum
+
+    # Make sure we can modify valid values
+    round_trip_config.retry_count = 7
+    assert round_trip_config.retry_count == 7
+
+
+def test_round_trip_with_default_values():
+    """
+    Test round trip conversion using default values.
+    """
+
+    # Define param class with defaults
+    class Settings(param.Parameterized):
+        name = param.String(default="default-settings")
+        max_connections = param.Integer(default=100, bounds=(10, 1000))
+        enable_cache = param.Boolean(default=True)
+        buffer_size = param.Integer(default=4096)
+
+    # Convert to pydantic model
+    created_models = param_to_pydantic(Settings)
+    PydanticSettings = created_models["Settings"]
+
+    # Create a pydantic instance with default values
+    pydantic_settings = PydanticSettings()
+
+    # Convert back to param
+    round_trip_settings = pydantic_to_param_instance(pydantic_settings)
+
+    # Verify default values are preserved
+    assert isinstance(round_trip_settings, Settings)
+    assert round_trip_settings.name == "default-settings"
+    assert round_trip_settings.max_connections == 100
+    assert round_trip_settings.enable_cache is True
+    assert round_trip_settings.buffer_size == 4096
+
+    # Verify param behavior is preserved
+    with pytest.raises(ValueError):
+        round_trip_settings.max_connections = 5  # Below minimum


### PR DESCRIPTION
Decided to separate out translate improvements from https://github.com/holoviz/lumen/pull/1233 

Now handles super/subclasses/inheritance much better, and also adds tests as mentioned in https://github.com/holoviz/param/issues/828

```python
import param
from lumen.ai.translate import param_to_pydantic, pydantic_to_param_instance

# Define a hierarchy of Parameterized classes
class Animal(param.Parameterized):
    name = param.String(default="unnamed", doc="Animal name")
    age = param.Integer(default=1, bounds=(0, 30), doc="Age in years")

class Dog(Animal):
    breed = param.ObjectSelector(default="mixed", objects=["mixed", "labrador", "shepherd"], doc="Dog breed")
    size = param.Selector(default="medium", objects=["small", "medium", "large"], doc="Size category")

class Person(param.Parameterized):
    name = param.String(default="John Doe", doc="Person name")
    pets = param.List(default=[], item_type=Animal, doc="List of pets")
    favorite_colors = param.List(default=["blue", "green"], doc="Favorite colors")
    preferences = param.Dict(default={"likes_coffee": True, "likes_tea": False}, doc="Preferences")
    birthday = param.Date(default=None, allow_None=True, doc="Birthday")
    profile_color = param.Color(default="#1A85FF", doc="Profile color")


# Create original param instances
dog1 = Dog(name="Rex", age=3, breed="labrador", size="large")
dog2 = Dog(name="Bella", age=2, breed="shepherd", size="medium")
person = Person(
    name="Alice Smith",
    pets=[dog1, dog2],
    favorite_colors=["purple", "orange"],
    preferences={"likes_coffee": False, "likes_hiking": True},
    birthday=None,
    profile_color="#FF5733",
)

created_models = param_to_pydantic(Person)
PydanticPerson = created_models["Person"]
PydanticDog = created_models["Dog"]

pydantic_person = PydanticPerson(
    name="Alice Smith",
    pets=[PydanticDog(name="Rex", age=3, breed="labrador", size="large"),
          PydanticDog(name="Bella", age=2, breed="shepherd", size="medium")],
    favorite_colors=["purple", "orange"],
    preferences={"likes_coffee": False, "likes_hiking": True},
    birthday=None,
    profile_color="#FF5733",
)

# Convert back to param instance
param_person = pydantic_to_param_instance(pydantic_person)
param_person
```