### PR TITLE
Serializing HoloViews Operations

### DIFF
--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING, Any, ClassVar, Literal,
 )
 
+import holoviews as hv
 import numpy as np
 import pandas as pd
 import panel as pn
@@ -31,6 +32,11 @@ if TYPE_CHECKING:
     DataFrame = pd.DataFrame | dDataFrame
     Series = pd.Series | dSeries
 
+VALID_HV_OPERATIONS = tuple([
+    getattr(hv.operation, op)
+    for op in hv.operation.__all__
+    if issubclass(getattr(hv.operation, op), hv.operation.Operation)
+])
 
 class Transform(MultiTypeComponent):
     """
@@ -927,5 +933,16 @@ class project_lnglat(Transform):
         table[self.latitude] = np.log(np.tan((90 + latitude) * np.pi / 360.0)) * origin_shift / np.pi
         return table
 
+
+class HoloViewsOperation(Transform):
+    """
+    `HoloViewsOperation` applies one or more HoloViews operation to the plot.
+    """
+
+    operation = param.ClassSelector(class_=VALID_HV_OPERATIONS, doc="""
+        Operations to apply to the plot.""")
+
+    def apply(self, plot):
+        return self.operation(plot)
 
 __all__ = [name for name, obj in locals().items() if isinstance(obj, type) and issubclass(obj, Transform)]


### PR DESCRIPTION
Went down the rabbit hole of trying to serialize, deserialize, and now I'm confused.

I was able to make `param` -> `pydantic` -> `param` work successfully in https://github.com/holoviz/lumen/pull/1233, even with nested parameterized, e.g.

```python
class HoloViewsView(View):

    operations = param.List(item_type=[hv.operation.Operation])
```

However, I realized, Lumen works with text specs, and `hv.operation.Operation` does not serialize well into text... so in this PR, I was trying to figure it out and wrap `Operation` into some sort of Lumen component to make serialize/deserialize using to_spec/from_spec.

Initially I created a HoloViewsOperationView, but that didn't seem quite right, even though it outputs a plot, so I created a HoloViewsOperation(Transform), but also questionable.

Would like your advice @philippjfr 