### PR TITLE
Remove del method

### DIFF
--- a/lumen/sources/bigquery.py
+++ b/lumen/sources/bigquery.py
@@ -397,9 +397,3 @@ class BigQuerySource(BaseSQLSource):
         # Clear credentials
         self._credentials = None
         self._cached_tables = None
-
-    def __del__(self):
-        """
-        Ensures resources are cleaned up when the object is garbage collected.
-        """
-        self.close()

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -362,9 +362,3 @@ class DuckDBSource(BaseSQLSource):
         if self._connection is not None:
             self._connection.close()
             self._connection = None
-
-    def __del__(self):
-        """
-        Ensures resources are cleaned up when the object is garbage collected.
-        """
-        self.close()

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -434,9 +434,3 @@ class SnowflakeSource(BaseSQLSource):
         if self._conn is not None:
             self._conn.close()
             self._conn = None
-
-    def __del__(self):
-        """
-        Ensures resources are cleaned up when the object is garbage collected.
-        """
-        self.close()


### PR DESCRIPTION
After merging https://github.com/holoviz/lumen/pull/1238 I've been experiencing `connection is already closed!` in Lumen. I suspect it's because `memory` is a WeakRefDictionary so it has been `del memory["source"]`, which closes the connection.