### PR TITLE
Status badge watch ready

### DIFF
--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -751,6 +751,7 @@ class TableLookup(VectorLookupTool):
         return {"text": enriched_text, "metadata": vector_metadata}
 
     async def _update_vector_store(self, _, __, sources):
+        self._ready = False
         await asyncio.sleep(0.5)  # allow main thread time to load UI first
         tasks = []
         processed_sources = []


### PR DESCRIPTION
Previously, the Table Lookup badge stayed green (ready) even when though it was not while uploading new datasets. This makes it so that it updates accordingly based on its status (not just on initialization)