### PR TITLE
Optimization tweaks

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -404,7 +404,8 @@ class OpenAI(Llm):
     model_kwargs = param.Dict(default={
         "default": {"model": "gpt-4o-mini"},
         "sql": {"model": "gpt-4.1-mini"},
-        "reasoning": {"model": "gpt-4o"},
+        "vega_lite": {"model": "gpt-4.1-mini"},
+        "reasoning": {"model": "gpt-4.1-mini"},
     })
 
     use_logfire = param.Boolean(default=False, doc="""

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -39,7 +39,11 @@ Additionally, only if applicable:
 - If the date columns are separated, e.g. year, month, day, then join them into a single date column.
 - If plotting, be sure to select all the columns that are required for the plot, including the x and y columns and any tooltips.
 
+{% if errors is defined and errors %}
+{{ memory["sql_metaset"].max_context }}
+{% else %}
 {{ memory["sql_metaset"].selected_context }}
+{% endif %}
 {%- endblock -%}
 
 {%- block errors %}

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -25,9 +25,9 @@ class VectorMetadata:
 
     table_slug: str  # Combined source_name and table_name with separator
     similarity: float
+    columns: list[Column]
     description: str | None = None
     base_sql: str | None = None
-    columns: list[Column] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
 
 


### PR DESCRIPTION
I've found gpt-4.1-mini performance to be decent for its price so defaulting to that vs gpt-4o.

Also, use max_context instead of selected_context if there are errors.

Do not make columns optional because that's critical to context.

Skip query refinement if there are only a limited number of tables to select from.