### PR TITLE
Suppress SourceAgent 

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -183,8 +183,8 @@ class SourceAgent(Agent):
 
     conditions = param.List(
         default=[
-            "Use when user wants to upload or connect to new data sources",
-            "Do not use to see if there are any relevant data sources available",
+            "Use ONLY when user explicitly asks to upload or connect to NEW data sources",
+            "Do NOT use if data sources already exist UNLESS user explicitly requests upload",
         ])
 
     table_upload_callbacks = param.Dict(default={}, doc="""


### PR DESCRIPTION
Was testing with

```python
import lumen.ai as lmai

# Multiple files with mixed types
ui = lmai.ExplorerUI(data=[
    'https://raw.githubusercontent.com/vega/vega-datasets/master/data/cars.json',
    'https://raw.githubusercontent.com/vega/vega-datasets/master/data/stocks.csv'
], log_level="debug")
ui.servable()
```

It would insist on uploading these datasets when I already have them loaded, but with the prompt changes, it doesn't insist on uploading anymore.