### PR TITLE
Tweak applies

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -851,6 +851,9 @@ class Planner(Coordinator):
             all_provides |= set(provider.provides)
         all_provides |= set(self._memory.keys())
 
+        # filter agents using applies
+        agents = [agent for agent in agents if await agent.applies(self._memory)]
+
         # ensure these candidates are satisfiable
         # e.g. DbtslAgent is unsatisfiable if DbtslLookup was used in planning
         # but did not provide dbtsl_metaset


### PR DESCRIPTION
I noticed that only DependencyResolver uses applies, so I also added it to Planner.

That way, if there's only 1 table across sources, TableListAgent won't be used and it'll directly call SQLAgent, or ChatAgent.

Because of that, if ChatAgent gets called alone, it's not grounded because it doesn't have any schema or data, so I manually build and inject `vector_metaset` to provide context so it's not hallucinating some data.