### PR TITLE
Consecutive Analyses

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -36,7 +36,7 @@ from .tools import (
 from .utils import (
     fuse_messages, log_debug, mutate_user_message, stream_details,
 )
-from .views import LumenOutput
+from .views import AnalysisOutput, LumenOutput
 
 if TYPE_CHECKING:
     from panel.chat.step import ChatStep
@@ -362,6 +362,13 @@ class Coordinator(Viewer, VectorLookupToolUser):
     async def _add_analysis_suggestions(self):
         pipeline = self._memory["pipeline"]
         current_analysis = self._memory.get("analysis")
+
+        # Clear current_analysis unless the last message is the same AnalysisOutput
+        if current_analysis and self.interface.objects:
+            last_message_obj = self.interface.objects[-1].object
+            if not (isinstance(last_message_obj, AnalysisOutput) and last_message_obj.analysis is current_analysis):
+                current_analysis = None
+
         allow_consecutive = getattr(current_analysis, '_consecutive_calls', True)
         applicable_analyses = []
         for analysis in self._analyses:

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -291,10 +291,7 @@ class AnalysisOutput(LumenOutput):
 
         # Set title based on analysis name if not provided
         if 'title' not in params or params['title'] is None:
-            analysis_name = getattr(params['analysis'], '__name__',
-                                   getattr(params['analysis'], 'name',
-                                          type(params['analysis']).__name__))
-            params['title'] = analysis_name
+            params['title'] = type(params['analysis']).__name__
 
         super().__init__(**params)
         controls = self.analysis.controls()

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -288,6 +288,14 @@ class AnalysisOutput(LumenOutput):
     def __init__(self, **params):
         if not params['analysis'].autorun:
             params['active'] = 0
+
+        # Set title based on analysis name if not provided
+        if 'title' not in params or params['title'] is None:
+            analysis_name = getattr(params['analysis'], '__name__',
+                                   getattr(params['analysis'], 'name',
+                                          type(params['analysis']).__name__))
+            params['title'] = analysis_name
+
         super().__init__(**params)
         controls = self.analysis.controls()
         if controls is not None or not self.analysis.autorun:
@@ -310,7 +318,7 @@ class AnalysisOutput(LumenOutput):
                 )
                 self._main.insert(1, ('Config', pn.Column(controls, run_button)))
             with discard_events(self):
-                self._main.active = 1 if self.analysis.autorun else 0
+                self._main.active = 0 if self.analysis.autorun else 1
         self._rendered = True
 
     async def _rerun(self, event):
@@ -324,7 +332,7 @@ class AnalysisOutput(LumenOutput):
             spec = view.to_spec()
             self.param.update(
                 spec=yaml.dump(spec),
-                active=2
+                active=0
             )
 
 


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/1264

Previously, the logic only checked whether there was an analysis, and if so, whether it was the same.

So, that made this not work:
1. Show obs
2. Click ManifoldMap
3. Subset T/B-cells
4. Hoping to click ManifoldMap, but there was no button

This corrects the logic.

It also renames the tab to be less generic (Analysis -> ManifoldMapAnalysis)
<img width="786" alt="image" src="https://github.com/user-attachments/assets/f48fd4a3-3d16-4c29-8e2e-796a028414ba" />
