### PR TITLE
Optimize run

### DIFF
--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -18,10 +18,12 @@ class YesNo(BaseModel):
     yes: bool = Field(description="True if yes, otherwise False.")
 
 
-class ThinkingYesNo(YesNo):
+class ThinkingYesNo(BaseModel):
 
     chain_of_thought: str = Field(
-        description="Explain concisely how you arrived at your answer in under a sentence, or even a phrase.")
+        description="Explain your reasoning as to why you will be answering yes or no.")
+
+    yes: bool = Field(description="True if yes, otherwise False.")
 
 
 class Sql(BaseModel):

--- a/lumen/ai/prompts/TableLookup/should_refresh_columns.jinja2
+++ b/lumen/ai/prompts/TableLookup/should_refresh_columns.jinja2
@@ -9,8 +9,8 @@ First, compare the two queries. Consider whether:
 3. The new query is asking about different attributes or metrics
 4. The new query has a fundamentally different intent
 
-If the new query has a significantly different intent or asks for different attributes/columns than the previous query, respond with "yes".
-If the new query is essentially asking for the same information, just phrased differently, respond with "no".
+Return yes=True if the new query has a significantly different intent or asks for different attributes/columns than the previous query.
+Return yes=False if the new query is essentially asking for the same information, just phrased differently.
 
 Provide a response indicating whether to rerun column selection (yes/no).
 {% endblock %}

--- a/lumen/ai/prompts/TableLookup/should_refresh_tables.jinja2
+++ b/lumen/ai/prompts/TableLookup/should_refresh_tables.jinja2
@@ -9,6 +9,9 @@ First, analyze both queries and determine if the current query is likely to requ
 2. Is the current query asking about different tables that weren't mentioned in the previous query?
 3. Does the current query have a fundamentally different intent that would require different tables?
 4. Would the previously selected tables be insufficient to answer the current query?
+
+Return yes=True if the current query requires different tables than the previous query.
+Return yes=False if the current query can be answered using the same tables as the previous query.
 {% endblock %}
 
 {% block context %}

--- a/lumen/ai/prompts/TableLookup/should_select_columns.jinja2
+++ b/lumen/ai/prompts/TableLookup/should_select_columns.jinja2
@@ -4,13 +4,13 @@
 You need to determine if the user is asking for specific columns or fields from the dataset, or if they are just asking
 about general information about available datasets/tables.
 
-When the user is asking questions like "what datasets do you have?", "show me available tables", "what columns are in X
-table?", or similar exploratory questions about the database structure, you should NOT subset columns because the user
-wants to see all columns.
-
-When the user is asking specific questions about certain fields or relationships, like "tell me about the correlation
-between X and Y", "analyze the trend of Z over time", "calculate the average of A grouped by B", etc., then you should
+Return yes=True ONLY when the user is asking specific questions about certain fields or relationships, like "tell me about the correlation
+between X and Y", "analyze the trend of Z over time", "calculate the average of A grouped by B", etc. In these cases, you should
 subset columns to focus on the relevant ones.
+
+Return yes=False when the user is asking questions like "what datasets do you have?", "show me table", "what columns are in X
+table?", or similar exploratory questions about the database structure. In these cases, you should NOT subset columns because the user
+wants to see all columns.
 {% endblock %}
 
 {% block context %}

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -263,20 +263,17 @@ class UI(Viewer):
             self._vector_store_status_badge.param.update(
                 status="running", name="Tables Vector Store Pending", description="Pending initialization"
             )
-            self.interface.loading = True
         elif ready_state is True:
             # Ready - show as success
             num_tables = len(memory["tables_metadata"])
             self._vector_store_status_badge.param.update(
                 status="success", name="Tables Vector Store Ready", description=f"Embedded {num_tables} table(s)"
             )
-            self.interface.loading = False
         elif ready_state is None:
             # Error state
             self._vector_store_status_badge.param.update(
                 status="danger", name="Tables Vector Store Error", description="Error initializing tables vector store"
             )
-            self.interface.loading = False
 
     def _destroy(self, session_context):
         """


### PR DESCRIPTION
I noticed that previously, the LLM provided the `yes` field before `chain_of_thought`.

```
"Response: yes=True chain_of_thought="The user is asking to show the entire 'obs' table, indicating they want to see all columns.""
```

So rather than making ThinkingYesNo subclass YesNo, I separated it so that `yes` comes after `chain_of_thought.

Secondly, I clarified the prompts.

Third, I don't think the interface should be blocked while the table vector store is loading.

Here's the updated response:
```
2025-06-11 18:03:40,631 IterativeTableLookup00482.prompts['should_select_columns']['template']:
The current date time is Jun 11, 2025 06:03 PM
You need to determine if the user is asking for specific columns or fields from the dataset, or if they are just asking
about general information about available datasets/tables.

Return yes=True ONLY when the user is asking specific questions about certain fields or relationships, like "tell me about the correlation
between X and Y", "analyze the trend of Z over time", "calculate the average of A grouped by B", etc. In these cases, you should
subset columns to focus on the relevant ones.

Return yes=False when the user is asking questions like "what datasets do you have?", "show me table", "what columns are in X
table?", or similar exploratory questions about the database structure. In these cases, you should NOT subset columns because the user
wants to see all columns.
2025-06-11 18:03:40,631 Characters: 918
2025-06-11 18:03:40,632 Input messages: 2 messages including system
2025-06-11 18:03:40,632 Message 1 (u): 'Show obs' -- For context...
Here's part of the multi-step plan: 'Look up the most relevant tables and provide SQL schemas of those tables.', but as the expert, you may need to deviate from it if you notice any inconsistencies or issues.
2025-06-11 18:03:40,632 LLM Model: 'gpt-4o-mini'
2025-06-11 18:03:42,272 Response model: 'ThinkingYesNo'
2025-06-11 18:03:42,273 LLM Response: chain_of_thought="The user is asking to 'show obs', which suggests they are looking for a general overview or exploratory information about the dataset rather than specific analysis or relationships between fields. This indicates they want to see the structure or contents of the dataset rather than focusing on specific columns or calculations." yes=False
```