### PR TITLE
Optimize detect encoding for faster startups

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -307,7 +307,7 @@ class UI(Viewer):
                 if src.endswith(('.parq', '.parquet')):
                     table = f"read_parquet('{src}')"
                 elif src.endswith(".csv"):
-                    encoding = detect_file_encoding(file_obj=src)
+                    encoding = detect_file_encoding(src)
                     table = f"read_csv('{src}', encoding='{encoding}')"
                 elif src.endswith(".json"):
                     table = f"read_json_auto('{src}')"

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -375,8 +375,11 @@ def detect_file_encoding(file_obj: Path | str | io.BytesIO | io.StringIO, sample
     if isinstance(file_obj, (str, Path)):
         # File path
         file_path = Path(file_obj)
-        with file_path.open("rb") as f:
-            data = f.read(sample_size)
+        if not file_path.exists():
+            data = None
+        else:
+            with file_path.open("rb") as f:
+                data = f.read(sample_size)
     elif isinstance(file_obj, io.BytesIO):
         # BytesIO - preserve position
         pos = file_obj.tell()


### PR DESCRIPTION
While loading a 19Mb CSV, the Lumen interface was taking a while to load. I thought it was because of the vector store, but discovered it was trying to detect file encoding, the bottleneck being:

```
        with file_obj.open("rb") as f:
            data = f.read()
```

Added sample_size and a few quick checks before using chardet. 