### PR TITLE
fix: Gallery deployment

### DIFF
--- a/examples/gallery/anaconda-project.yml
+++ b/examples/gallery/anaconda-project.yml
@@ -22,7 +22,6 @@ packages:
   - datashader
   - fastparquet
   - altair
-  - numba::llvmlite
   - python-duckdb
   - intake-parquet
   - s3fs


### PR DESCRIPTION
Would not solve with `numba::llvmlite`, causing the session to not start. If I recall correctly, this was a workaround at some point.

The output of the command below:

``` bash
❯ conda create -n tmp_lumen --override-channels --yes  --channel pyviz/label/dev --channel conda-forge --channel defaults numba::llvmlite intake-parquet s3fs datashader fastparquet python-duckdb spatialpandas lumen hvplot panel altair
Retrieving notices: done
Channels:
 - pyviz/label/dev
 - conda-forge
 - defaults
 - numba
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - nothing provides python 3.3* needed by llvmlite-0.1.0-py33_22

Could not solve for environment specs
The following packages are incompatible
└─ llvmlite =* * is not installable because there are no viable options
   ├─ llvmlite [0.1.0|0.10.0|...|0.9.0] conflicts with any installable versions previously reported;
   └─ llvmlite [0.1.0|0.2.0|...|0.9.0] would require
      └─ python =3.3 *, which does not exist (perhaps a missing channel).
```

Have made the change on the deployment: https://lumen-gallery-dev.holoviz-demo.anaconda.com/