### PR TITLE
Address lumen_anndata issues

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -660,7 +660,7 @@ class SourceControls(Viewer):
             for media_controls in all_media_controls:
                 if media_controls.extension.endswith(custom_table_extensions):
                     n_tables += int(table_upload_callbacks[media_controls.extension](
-                        media_controls.file_obj, media_controls.alias
+                        media_controls.file_obj, media_controls.alias, media_controls.filename
                     ))
                 elif media_controls.extension.endswith(TABLE_EXTENSIONS):
                     if source is None:

--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -18,6 +18,15 @@ Here's a summary of the dataset the user just asked about:
 ```
 {{ memory['data'] }}
 ```
+{% elif 'tables_metadata' in memory and memory['tables_metadata']|length > 0 %}
+📊 Tables available:
+{%- set tables_list = memory['tables_metadata'].keys() | list %}
+{%- for table in tables_list[:10] %}
+- {{ table }}
+{%- endfor %}
+{%- if tables_list | length > 10 %}
+- (showing first 10 of {{ tables_list | length }} tables)
+{%- endif %}
 {% else %}
 No dataset has been loaded yet. Please ask the user to load a dataset or provide more context.
 {%- endif %}

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -109,8 +109,8 @@ class UI(Viewer):
 
     table_upload_callbacks = param.Dict(default={}, doc="""
         Dictionary mapping from file extensions to callback function,
-        e.g. {"hdf5": ...}. The callback function should accept the file bytes and
-        table alias, add or modify the `source` in memory, and return a bool
+        e.g. {"hdf5": ...}. The callback function should accept the file bytes,
+        table alias, and filename, add or modify the `source` in memory, and return a bool
         (True if the table was successfully uploaded).""")
 
     template = param.Selector(


### PR DESCRIPTION
Address issues raised in https://github.com/holoviz-topics/lumen-anndata/pull/11

Namely:
1. Right after upload, the ChatAgent didn't have sufficient time to create a vector_metaset and no data has been summarized so it incorrectly states that "No dataset has been loaded yet. Please ask the user to load a dataset or provide more context."
2. Table upload callbacks now pass the filename to the upload extension so that it can be utilized for caching or other purposes