### PR TITLE
Gallery workflow fixes

### DIFF
--- a/.github/workflows/gallery.yaml
+++ b/.github/workflows/gallery.yaml
@@ -69,7 +69,7 @@ jobs:
           github.event.workflow_run.event != 'schedule' &&
           (
             (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
-            (github.event_name == 'workflow_run' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+            (github.event_name == 'workflow_run' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')) && contains(steps.vars.outputs.tag, 'v'))
           )
         run: |
           conda activate test

--- a/.github/workflows/gallery.yaml
+++ b/.github/workflows/gallery.yaml
@@ -52,8 +52,11 @@ jobs:
         run: anaconda-project prepare examples/gallery
       - name: Upload and deploy dev gallery
         if: |
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
-          (github.event_name == 'workflow_run' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          github.event.workflow_run.event != 'schedule' &&
+          (
+            (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
+            (github.event_name == 'workflow_run' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          )
         run: |
           conda activate test
           ae5 login --hostname holoviz-demo.anaconda.com --username ${{ secrets.AE5_USERNAME }} --password ${{ secrets.AE5_PASSWORD }}
@@ -63,8 +66,11 @@ jobs:
           ae5 deployment start lumen-gallery-dev --endpoint lumen-gallery-dev --command default --public --command default --resource-profile default --wait
       - name: Upload and deploy prod gallery
         if: |
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
-          (github.event_name == 'workflow_run' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          github.event.workflow_run.event != 'schedule' &&
+          (
+            (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
+            (github.event_name == 'workflow_run' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          )
         run: |
           conda activate test
           ae5 login --hostname holoviz-demo.anaconda.com --username ${{ secrets.AE5_USERNAME }} --password ${{ secrets.AE5_PASSWORD }}

--- a/.github/workflows/gallery.yaml
+++ b/.github/workflows/gallery.yaml
@@ -48,6 +48,8 @@ jobs:
         run: |
           conda activate test
           conda install -c ae5-admin anaconda-project ae5-tools
+      - name: Prepare environment to check it solves
+        run: anaconda-project prepare examples/gallery
       - name: Upload and deploy dev gallery
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||


### PR DESCRIPTION
- Add a step to prepare the project before attempting, e.g. to deploy it to catch env solving errors before (having to connect to AE5 and fix stuff there is not fun)
- This workflow gets triggered when the build workflow completes, which also happens when the build workflow runs on the week-end, and leads to redeploying the dev gallery every Sunday. Let's avoid that and instead skip deploying on these types of runs.
- Bring this change that Simon made to Panel's gallery workflow https://github.com/holoviz/panel/pull/6779