### PR TITLE
DuckDB create views of filesystem tables

### DIFF
--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import os
+import tempfile
 
 import pandas as pd
 import pytest
@@ -186,3 +187,303 @@ def test_duckdb_source_ephemeral_roundtrips(duckdb_memory_source, mixed_df):
 def test_duckdb_source_mirrors_source(duckdb_source):
     mirrored = DuckDBSource(uri=':memory:', mirrors={'mixed': (duckdb_source, 'test_sql')})
     pd.testing.assert_frame_equal(duckdb_source.get('test_sql'), mirrored.get('mixed'))
+
+
+@pytest.fixture
+def sample_csv_files():
+    """Create temporary CSV files for testing."""
+    test_dir = tempfile.mkdtemp()
+
+    # Sample data
+    customers_data = pd.DataFrame({
+        'id': [1, 2, 3],
+        'name': ['Alice', 'Bob', 'Charlie'],
+        'city': ['NYC', 'LA', 'Chicago']
+    })
+
+    orders_data = pd.DataFrame({
+        'id': [101, 102, 103],
+        'customer_id': [1, 2, 1],
+        'total': [250.5, 150.75, 300.0]
+    })
+
+    # Save to CSV files
+    customers_path = os.path.join(test_dir, 'customers.csv')
+    orders_path = os.path.join(test_dir, 'orders.csv')
+    test_path = os.path.join(test_dir, 'test.csv')
+    test2_path = os.path.join(test_dir, 'test2.csv')
+
+    customers_data.to_csv(customers_path, index=False)
+    orders_data.to_csv(orders_path, index=False)
+    customers_data.to_csv(test_path, index=False)  # For user's examples
+    orders_data.to_csv(test2_path, index=False)   # For user's examples
+
+    files_dict = {
+        'dir': test_dir,
+        'customers': customers_path,
+        'orders': orders_path,
+        'test': test_path,
+        'test2': test2_path,
+        'customers_data': customers_data,
+        'orders_data': orders_data
+    }
+
+    yield files_dict
+
+    # Cleanup
+    import shutil
+    shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_file_path_detection():
+    """Test the _is_file_path method with various inputs."""
+    source = DuckDBSource(uri=':memory:', tables={})
+
+    # Should detect as file paths
+    assert source._is_file_path('customers.csv') == True
+    assert source._is_file_path('data/orders.parquet') == True
+    assert source._is_file_path('products.json') == True
+    assert source._is_file_path('/absolute/path/data.csv') == True
+
+    # Should detect as SQL
+    assert source._is_file_path('SELECT * FROM customers') == False
+    assert source._is_file_path('SELECT * FROM READ_CSV(\'data.csv\')') == False
+    assert source._is_file_path('WITH cte AS (SELECT * FROM orders) SELECT * FROM cte') == False
+    assert source._is_file_path('INSERT INTO customers VALUES (1, \'John\')') == False
+
+    # Edge cases - these could go either way depending on SQLGlot parsing
+    # Just ensure they don't crash
+    try:
+        source._is_file_path('customers')
+        source._is_file_path('data')
+        source._is_file_path('')
+    except Exception as e:
+        pytest.fail(f"_is_file_path should handle edge cases gracefully: {e}")
+
+
+def test_automatic_csv_view_creation(sample_csv_files):
+    """Test automatic view creation from CSV file paths."""
+    files = sample_csv_files
+
+    # Change to test directory so relative paths work
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(files['dir'])
+
+        # Test automatic file detection - your simplified syntax
+        source = DuckDBSource(
+            uri=':memory:',
+            tables={
+                'customers': 'customers.csv',  # File path -> automatic view
+                'orders': 'orders.csv'         # File path -> automatic view
+            }
+        )
+
+        # Check tables are available
+        tables = source.get_tables()
+        assert 'customers' in tables
+        assert 'orders' in tables
+
+        # Test querying the views
+        customers_result = source.execute("SELECT * FROM customers")
+        orders_result = source.execute("SELECT * FROM orders")
+
+        # Verify data matches
+        pd.testing.assert_frame_equal(
+            customers_result.sort_values('id').reset_index(drop=True),
+            files['customers_data'].sort_values('id').reset_index(drop=True)
+        )
+        pd.testing.assert_frame_equal(
+            orders_result.sort_values('id').reset_index(drop=True),
+            files['orders_data'].sort_values('id').reset_index(drop=True)
+        )
+
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_user_examples(sample_csv_files):
+    """Test the exact examples from the user's code."""
+    files = sample_csv_files
+    original_cwd = os.getcwd()
+
+    try:
+        os.chdir(files['dir'])
+
+        # Example 1: Traditional approach (still works)
+        source1 = DuckDBSource(
+            uri=':memory:',
+            tables={
+                "test": "SELECT * FROM READ_CSV('test.csv')",
+                "test2": "SELECT * FROM READ_CSV('test2.csv')",
+                "test 3": "SELECT * FROM READ_CSV('test.csv')",  # Space in name
+            }
+        )
+
+        # Example 2: New simplified approach
+        source2 = DuckDBSource(
+            uri=':memory:',
+            tables={
+                "test": "test.csv",    # File path detected -> creates view
+                "test2": "test2.csv",  # File path detected -> creates view
+                "test_3": "test.csv",  # Space in name -> creates view
+            }
+        )
+
+        # All should work and produce same results
+        result1_test = source1.execute("SELECT * FROM test")
+        result1_test2 = source1.execute("SELECT * FROM test2")
+        result1_test3 = source1.execute("SELECT * FROM 'test_3'")  # Space in name
+
+        result2_test = source2.execute("SELECT * FROM test")
+        result2_test2 = source2.execute("SELECT * FROM test2")
+        result2_test3 = source2.execute("SELECT * FROM 'test_3'")
+
+        # Compare results (should be identical)
+        pd.testing.assert_frame_equal(
+            result1_test.sort_values('id').reset_index(drop=True),
+            result2_test.sort_values('id').reset_index(drop=True)
+        )
+        pd.testing.assert_frame_equal(
+            result1_test2.sort_values('id').reset_index(drop=True),
+            result2_test2.sort_values('id').reset_index(drop=True)
+        )
+        pd.testing.assert_frame_equal(
+            result1_test3.sort_values('id').reset_index(drop=True),
+            result2_test3.sort_values('id').reset_index(drop=True)
+        )
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_mixed_file_paths_and_sql(sample_csv_files):
+    """Test mixing file paths with SQL expressions."""
+    files = sample_csv_files
+    original_cwd = os.getcwd()
+
+    try:
+        os.chdir(files['dir'])
+
+        source = DuckDBSource(
+            uri=':memory:',
+            tables={
+                # File paths - should create views
+                'customers': 'customers.csv',
+                'orders': 'orders.csv',
+
+                # SQL expressions - should be processed normally
+                'high_value_orders': 'SELECT * FROM orders WHERE total > 200',
+                'customer_count': 'SELECT COUNT(*) as count FROM customers',
+
+                # Complex SQL
+                'customer_orders': '''
+                    SELECT c.name, COUNT(o.id) as order_count
+                    FROM customers c
+                    LEFT JOIN orders o ON c.id = o.customer_id
+                    GROUP BY c.name
+                '''
+            }
+        )
+
+        # Test all table types work
+        tables = source.get_tables()
+        expected_tables = {'customers', 'orders', 'high_value_orders', 'customer_count', 'customer_orders'}
+        assert set(tables) == expected_tables
+
+        # Test file-based views
+        customers = source.execute("SELECT * FROM customers")
+        assert len(customers) == 3
+
+        # Test SQL-based tables
+        high_value = source.execute("SELECT * FROM high_value_orders")
+        assert len(high_value) == 2  # Orders with total > 200
+
+        count_result = source.execute("SELECT * FROM customer_count")
+        assert count_result.iloc[0, 0] == 3  # 3 customers
+
+        # Test complex join
+        customer_orders = source.execute("SELECT * FROM customer_orders ORDER BY name")
+        assert len(customer_orders) == 3  # 3 customers
+
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_fallback_behavior_missing_files():
+    """Test fallback behavior when files don't exist."""
+    source = DuckDBSource(
+        uri=':memory:',
+        tables={
+            'missing_file': 'nonexistent.csv',  # Should fallback to SQL expression
+            'valid_sql': 'SELECT 1 as test_col'  # Should work normally
+        }
+    )
+
+    # Valid SQL should work
+    result = source.execute("SELECT * FROM valid_sql")
+    assert result.iloc[0, 0] == 1
+
+    # Missing file handling depends on implementation details
+    # At minimum, it shouldn't crash the entire source creation
+    tables = source.get_tables()
+    assert 'valid_sql' in tables
+
+
+def test_different_file_extensions():
+    """Test detection of different file extensions."""
+    source = DuckDBSource(uri=':memory:', tables={})
+
+    # Test various extensions are detected as file paths
+    file_extensions = [
+        'data.csv',
+        'data.parquet',
+        'data.json',
+        'data.jsonl',
+        'data.ndjson'
+    ]
+
+    for file_path in file_extensions:
+        assert source._is_file_path(file_path) == True, f"{file_path} should be detected as file path"
+
+
+def test_table_key_naming():
+    """Test that dict keys become table names correctly."""
+    # Test with sample data since we can't rely on external files
+    df = pd.DataFrame({'col1': [1, 2, 3], 'col2': ['a', 'b', 'c']})
+
+    source = DuckDBSource.from_df({'my_custom_table_name': df})
+
+    tables = source.get_tables()
+    assert 'my_custom_table_name' in tables
+
+    result = source.execute("SELECT * FROM my_custom_table_name")
+    pd.testing.assert_frame_equal(result, df)
+
+
+def test_absolute_vs_relative_paths(sample_csv_files):
+    """Test handling of absolute vs relative file paths."""
+    files = sample_csv_files
+    original_cwd = os.getcwd()
+
+    try:
+        os.chdir(files['dir'])
+
+        source = DuckDBSource(
+            uri=':memory:',
+            tables={
+                'relative_path': 'customers.csv',              # Relative path
+                'absolute_path': files['customers'],           # Absolute path
+            }
+        )
+
+        # Both should work and give same results
+        result_relative = source.execute("SELECT * FROM relative_path")
+        result_absolute = source.execute("SELECT * FROM absolute_path")
+
+        pd.testing.assert_frame_equal(
+            result_relative.sort_values('id').reset_index(drop=True),
+            result_absolute.sort_values('id').reset_index(drop=True)
+        )
+
+    finally:
+        os.chdir(original_cwd)


### PR DESCRIPTION
LLMs sometimes are still a bit flakey on adding READ_CSV('table.csv') and instead reference as table, so I thought maybe we should make it easier on the LLMs by making a view of the file rather than have it retry...

e.g. making this work
```python

import asyncio
from lumen.sources.duckdb import DuckDBSource
from lumen.ai.llm import OpenAI
from lumen.ai_v2.sql import SQLAgent


# Create DuckDB source with CSV files
source = DuckDBSource(
    tables={
        "customers": "SELECT * FROM READ_CSV('customers.csv')",
        "orders": "SELECT * FROM READ_CSV('orders.csv')",
        "products": "SELECT * FROM READ_CSV('products.csv')",
        "suppliers": "SELECT * FROM READ_CSV('suppliers.csv')"
    }
)
source.execute("SELECT * FROM customers")
```