### PR TITLE
Clarify prefix

### DIFF
--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -50,7 +50,7 @@ class VectorMetaset:
 
         for table_slug, vector_metadata in self.vector_metadata_map.items():
             base_sql = truncate_string(vector_metadata.base_sql, max_length=200) if truncate else vector_metadata.base_sql
-            context += f"{table_slug!r} (to access this slug, use: {base_sql})\n"
+            context += f"{table_slug!r} (access this table with: {base_sql})\n"
 
             if vector_metadata.description:
                 desc = truncate_string(vector_metadata.description, max_length=100) if truncate else vector_metadata.description
@@ -138,7 +138,7 @@ class SQLMetaset:
                 continue
 
             base_sql = truncate_string(vector_metadata.base_sql, max_length=200) if truncate else vector_metadata.base_sql
-            context += f"{table_slug!r} (to access this slug, use: {base_sql})\n"
+            context += f"{table_slug!r} (access this table with: {base_sql})\n"
 
             if vector_metadata.description:
                 desc = truncate_string(vector_metadata.description, max_length=100) if truncate else vector_metadata.description

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -50,7 +50,7 @@ class VectorMetaset:
 
         for table_slug, vector_metadata in self.vector_metadata_map.items():
             base_sql = truncate_string(vector_metadata.base_sql, max_length=200) if truncate else vector_metadata.base_sql
-            context += f"{table_slug!r}\nUse SQL: {base_sql}\n"
+            context += f"{table_slug!r} (to access this slug, use: {base_sql})\n"
 
             if vector_metadata.description:
                 desc = truncate_string(vector_metadata.description, max_length=100) if truncate else vector_metadata.description
@@ -138,7 +138,7 @@ class SQLMetaset:
                 continue
 
             base_sql = truncate_string(vector_metadata.base_sql, max_length=200) if truncate else vector_metadata.base_sql
-            context += f"{table_slug!r}\nUse SQL: {base_sql}\n"
+            context += f"{table_slug!r} (to access this slug, use: {base_sql})\n"
 
             if vector_metadata.description:
                 desc = truncate_string(vector_metadata.description, max_length=100) if truncate else vector_metadata.description


### PR DESCRIPTION
Makes it clear that the agent should NOT use windturbines_parquet, and instead SELECT ...

**Available Schema:**
Below are the relevant tables available:

'ProvidedSource00000 ⦙ windturbines_parquet' (access this table with: SELECT * FROM READ_PARQUET('windturbines.parquet'))