### PR TITLE
Check if tool context is relevant only if > 1000 characters 

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -531,6 +531,8 @@ class Coordinator(Viewer, VectorLookupToolUser):
                 log_debug(f"Direct dependency detected: {tool.name} provides at least one requirement for {agent.name}")
                 # The agent already has it formatted in its template
                 continue
+            elif len(result) < 1000:
+                is_relevant = True
             else:
                 # Otherwise, check semantic relevance
                 is_relevant = await self._check_tool_relevance(


### PR DESCRIPTION
Will automatically inject it if it's less than 1000 characters so that it doesn't require a separate call to the LLM.