### PR TITLE
Try one-shotting before planning for SQLAgent 

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -627,7 +627,7 @@ def log_debug(msg: str | list, offset: int = 24, prefix: str = "", suffix: str =
         log.debug(f"\033[90m{delimiter}\033[0m")
 
 
-def mutate_user_message(content: str, messages: list[dict[str, str]], suffix: bool = True, wrap: bool | str = False, inplace: bool = True):
+def mutate_user_message(content: str, messages: list[dict[str, str]], suffix: bool = True, wrap: bool | str = False, inplace: bool = True) -> list[dict[str, str]]:
     """
     Helper to mutate the last user message in a list of messages. Suffixes the content by default, else prefixes.
     """


### PR DESCRIPTION
We noticed that the planning mode could take an extremely long time to finish, and in cases 

with a long context, it might even get stuck in a loop—likely because the model struggles to handle all the information.

To address this, I’ve refactored the logic to first try a one-shot SQL execution instead. This approach is faster, and if it fails (e.g., due to an empty result or an actual error), we at least get a concrete failure message like: `f"\nQuery `{result['sql']}` returned empty results; ensure all the WHERE filter values exist in the dataset."` which can be fed back into the model so it narrows down its search.

It works really nicely imo. For most queries, it's done in a few seconds, and the planning maybe under a minute

One shot failed:
<img width="1502" height="678" alt="image" src="https://github.com/user-attachments/assets/88724d05-2bc2-4484-9a8c-7c97bf8b286e" />

Starts planning:
<img width="1426" height="1184" alt="image" src="https://github.com/user-attachments/assets/cb4cd1d6-25d5-40e7-82a7-3c4aee5cca27" />

Gets correct answer
<img width="2628" height="1620" alt="image" src="https://github.com/user-attachments/assets/4ffc95f2-13fe-4a96-92bc-8f1c342a2e95" />
