### PR TITLE
Add SourceCatalog to pick and choose tables

### DIFF
--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -4,7 +4,16 @@ from typing import Any
 import param
 
 from panel.custom import Child, JSComponent
+from panel.layout import Column, HSpacer, Row
+from panel.pane import Markdown
+from panel.viewable import Viewer
 from panel.widgets import Button
+from panel_material_ui import (
+    Card, CheckBoxGroup, IconButton, Switch,
+)
+
+from .config import SOURCE_TABLE_SEPARATOR
+from .memory import memory
 
 CSS = """
 /* Base styles for the split container */
@@ -428,4 +437,204 @@ class StatusBadge(Button):
         self.param.update(
             icon=param.rx(self._status_mapping)[self.param.status]["icon"],
             stylesheets=[self._base_stylesheet, param.rx(self._status_stylesheets)[self.param.status]],
+        )
+
+
+class TableSourceCard(Viewer):
+    """
+    A component that displays a single data source as a card with table selection controls.
+
+    The card includes:
+    - A header with the source name and a checkbox to toggle all tables
+    - A delete button (if multiple sources exist)
+    - Individual checkboxes for each table in the source
+    """
+
+    all_selected = param.Boolean(default=True, doc="""
+        Whether all tables should be selected by default.""")
+
+    collapsed = param.Boolean(default=False, doc="""
+        Whether the card should start collapsed.""")
+
+    deletable = param.Boolean(default=True, doc="""
+        Whether to show the delete button.""")
+
+    delete = param.Action(doc="""Action to delete this source from memory.""")
+
+    selected = param.List(default=None, doc="""
+        List of currently selected table names.""")
+
+    source = param.Parameter(doc="""
+        The data source to display in this card.""")
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        self.all_tables = self.source.get_tables()
+
+        # Determine which tables are currently visible
+        if self.selected is None:
+            visible_tables = []
+            for table in self.all_tables:
+                table_slug = f"{self.source.name}{SOURCE_TABLE_SEPARATOR}{table}"
+                if table_slug in memory.get('visible_slugs', set()):
+                    visible_tables.append(table)
+            self.selected = visible_tables
+
+        # Create widgets once in init
+        self.source_toggle = Switch.from_param(
+            self.param.all_selected,
+            name=f"{self.source.name}",
+            margin=(5, -5, 0, 3),
+            sizing_mode='fixed',
+        )
+
+        self.delete_button = IconButton.from_param(
+            self.param.delete,
+            icon='delete',
+            icon_size='1em',
+            color="danger",
+            margin=(5, 0, 0, 0),
+            sizing_mode='fixed',
+            width=40,
+            height=40,
+            visible=self.param.deletable
+        )
+
+        self.table_checkbox = CheckBoxGroup.from_param(
+            self.param.selected,
+            options=self.all_tables,
+            sizing_mode='stretch_width',
+            margin=(0, 10),
+            name="",
+        )
+
+    @param.depends('all_selected', watch=True)
+    def _on_source_toggle(self):
+        """Handle source checkbox toggle (all tables on/off)."""
+        if not self.all_selected and len(self.selected) == len(self.all_tables):
+            # Important to check to see if all tables are selected for intuitive behavior
+            self.selected = []
+        elif self.all_selected:
+            self.selected = self.all_tables
+
+    @param.depends('selected', watch=True)
+    def _update_visible_slugs(self):
+        """Update visible_slugs in memory based on selected tables."""
+        self.all_selected = len(self.selected) == len(self.all_tables)
+        for table in self.all_tables:
+            table_slug = f"{self.source.name}{SOURCE_TABLE_SEPARATOR}{table}"
+            if table in self.selected:
+                memory['visible_slugs'].add(table_slug)
+            else:
+                memory['visible_slugs'].discard(table_slug)
+        memory.trigger('visible_slugs')
+
+    @param.depends('delete', watch=True)
+    def _delete_source(self):
+        """Handle source deletion via param.Action."""
+        if self.source in memory.get("sources", []):
+            # Remove all tables from this source from visible_slugs
+            for table in self.all_tables:
+                table_slug = f"{self.source.name}{SOURCE_TABLE_SEPARATOR}{table}"
+                memory['visible_slugs'].discard(table_slug)
+
+            memory["sources"].remove(self.source)
+            memory.trigger("sources")
+            memory.trigger("visible_slugs")
+
+            if self.source is memory.get("source"):
+                memory["source"] = next(iter(memory.get("sources", [])), None)
+
+    def __panel__(self):
+        card_header = Row(
+            self.source_toggle,
+            HSpacer(),
+            self.delete_button,
+            sizing_mode='stretch_width',
+            align='start',
+            height=35,
+            margin=0
+        )
+
+        # Create the card
+        return Card(
+            self.table_checkbox,
+            header=card_header,
+            collapsible=True,
+            collapsed=self.param.collapsed,
+            sizing_mode='stretch_width',
+            margin=0,
+        )
+
+
+class SourceCatalog(Viewer):
+    """
+    A component that displays all data sources with table selection controls.
+
+    This component shows each source as a collapsible card with:
+    - A header checkbox to toggle all tables in the source
+    - Individual checkboxes for each table
+    - A delete button to remove the source (if multiple sources exist)
+
+    Tables can be selectively shown/hidden using the checkboxes, which updates
+    the 'visible_slugs' set in memory.
+    """
+
+    sources = param.List(default=[], doc="""
+        List of data sources to display in the catalog.""")
+
+    def trigger(self, sources=None):
+        """
+        Trigger the catalog with new sources.
+
+        Args:
+            sources: Optional list of sources. If None, uses sources from memory.
+        """
+        if sources is not None:
+            self.sources = sources
+        return self.__panel__()
+
+    def __panel__(self):
+        """
+        Create the source catalog UI.
+
+        Returns a Column containing all source cards or a message if no sources exist.
+        """
+        title = Markdown(
+            "## Source Catalog\n\nSelect the table and document sources you want visible to the LLM.",
+            margin=0,
+        )
+
+        sources = self.sources or memory.get('sources', [])
+        if len(sources) == 0:
+            title.object += "\n\n### No sources available. Please upload a data source to get started."
+            return title
+
+        # Initialize visible_slugs if it doesn't exist
+        if 'visible_slugs' not in memory:
+            memory['visible_slugs'] = set()
+
+        # If visible_slugs is empty, populate it with all tables (default all visible)
+        if not memory.get('visible_slugs'):
+            for source in sources:
+                for table in source.get_tables():
+                    table_slug = f"{source.name}{SOURCE_TABLE_SEPARATOR}{table}"
+                    memory['visible_slugs'].add(table_slug)
+
+        # Create source cards
+        source_cards = []
+        for source in sources:
+            # Create a TableSourceCard for each source
+            source_card = TableSourceCard(
+                source=source,
+                deletable=len(sources) > 1,
+                collapsed=False
+            )
+            source_cards.append(source_card)
+
+        return Column(
+            title,
+            *source_cards,
+            margin=(-20, 0, 0, 0),
+            sizing_mode='stretch_width'
         )

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -593,8 +593,7 @@ class SourceControls(Viewer):
         self._memory["source"] = duckdb_source
         self._memory["table"] = table
         if "sources" in self._memory:
-            self._memory["sources"].append(duckdb_source)
-            self._memory.trigger("sources")
+            self._memory["sources"] = self._memory["sources"] + [duckdb_source]
         else:
             self._memory["sources"] = [duckdb_source]
         self._last_table = table

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -258,6 +258,9 @@ class Coordinator(Viewer, VectorLookupToolUser):
         elif "sources" not in self._memory:
             self._memory["sources"] = []
 
+        if "visible_slugs" not in self._memory:
+            self._memory["visible_slugs"] = set()
+
     def __panel__(self):
         return self.interface
 

--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -18,9 +18,9 @@ Here's a summary of the dataset the user just asked about:
 ```
 {{ memory['data'] }}
 ```
-{% elif 'tables_metadata' in memory and memory['tables_metadata']|length > 0 %}
+{% elif 'visible_slugs' in memory and memory['visible_slugs']|length > 0 %}
 📊 Tables available:
-{%- set tables_list = memory['tables_metadata'].keys() | list %}
+{%- set tables_list = memory['visible_slugs'] | list %}
 {%- for table in tables_list[:10] %}
 - {{ table }}
 {%- endfor %}

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -87,9 +87,9 @@ Conditions for use:
 {%- endfor %}
 {% endif %}
 
-{%- if memory.get('tables_metadata') %}
+{%- if memory.get('visible_slugs') %}
 📊 Tables available:
-{%- set tables_list = memory['tables_metadata'].keys() | list %}
+{%- set tables_list = memory['visible_slugs'] | list %}
 {%- for table in tables_list[:10] %}
 - {{ table }}
 {%- endfor %}

--- a/lumen/ai/prompts/SQLAgent/generate_roadmap.jinja2
+++ b/lumen/ai/prompts/SQLAgent/generate_roadmap.jinja2
@@ -30,7 +30,7 @@ Available Schema Context:
 {{ memory["sql_metaset"].compact_context }}
 
 📊 Available Tables:
-{%- set tables_list = memory.get('tables_metadata', {}).keys() | list %}
+{%- set tables_list = memory.get('visible_slugs', set()) | list %}
 {%- for table in tables_list[:10] %}
 - {{ table }}
 {%- endfor %}

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -36,9 +36,9 @@ Write a SQL query for the user's data transformation request, focusing on intent
 {%- endblock %}
 
 {% block context -%}
-{%- if memory.get('tables_metadata') %}
+{%- if memory.get('visible_slugs') %}
 📊 Tables available:
-{%- set tables_list = memory['tables_metadata'].keys() | list %}
+{%- set tables_list = memory['visible_slugs'] | list %}
 {%- for table in tables_list[:10] %}
 - {{ table }}
 {%- endfor %}

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -23,9 +23,9 @@ from panel.util import edit_readonly
 from panel.viewable import Child, Children, Viewer
 from panel_gwalker import GraphicWalker
 from panel_material_ui import (
-    Button, Card, ChatFeed, ChatInterface, ChatMessage, Checkbox,
-    CheckBoxGroup, Column, Dialog, FileDownload, IconButton, MenuList,
-    MultiChoice, Page, Paper, Row, Switch, Tabs, ToggleIcon,
+    Button, ChatFeed, ChatInterface, ChatMessage, Column, Dialog, FileDownload,
+    IconButton, MenuList, MultiChoice, Page, Paper, Row, Switch, Tabs,
+    ToggleIcon,
 )
 
 from ..pipeline import Pipeline
@@ -37,7 +37,7 @@ from .agents import (
     AnalysisAgent, AnalystAgent, ChatAgent, DocumentListAgent, SourceAgent,
     SQLAgent, TableListAgent, ValidationAgent, VegaLiteAgent,
 )
-from .components import SplitJS, StatusBadge
+from .components import SourceCatalog, SplitJS, StatusBadge
 from .config import PROVIDED_SOURCE_NAME, SOURCE_TABLE_SEPARATOR
 from .coordinator import Coordinator, Plan, Planner
 from .export import (
@@ -349,7 +349,8 @@ class UI(Viewer):
         self._table_lookup_tool = None  # Will be set after coordinator is initialized
 
         sources_open_icon = IconButton(icon="topic", color='light')
-        self._sources_dialog_content = Dialog(self._create_sources_dialog_content(init=True), close_on_click=True, show_close_button=True)
+        self._source_catalog = SourceCatalog()
+        self._sources_dialog_content = Dialog(self._source_catalog, close_on_click=True, show_close_button=True)
         sources_open_icon.js_on_click(args={'dialog': self._sources_dialog_content}, code="dialog.data.open = true")
         self._sources_dialog = Column(sources_open_icon, self._sources_dialog_content, sizing_mode="fixed")
         memory.on_change('sources', self._update_sources_dialog)
@@ -443,160 +444,14 @@ class UI(Viewer):
             self._table_lookup_tool.param.unwatch(self._update_vector_store_badge, '_ready')
         memory.remove_on_change('sources', self._update_sources_dialog)
 
-    def _create_sources_dialog_content(self, init: bool = False):
-        """
-        Create the content for the sources dialog showing all memory sources
-        with include/exclude options using Cards and CheckboxGroups.
-        """
-        # On source checkbox, set all table_checkbox = True / False
-        def on_source_toggle(source, value):
-            if value:
-                # Add all tables to visible_slugs
-                for table in source.get_tables():
-                    table_slug = f"{source.name}{SOURCE_TABLE_SEPARATOR}{table}"
-                    memory['visible_slugs'].add(table_slug)
-                table_checkbox.value = source.get_tables()
-            else:
-                # Remove all tables from visible_slugs
-                for table in source.get_tables():
-                    table_slug = f"{source.name}{SOURCE_TABLE_SEPARATOR}{table}"
-                    memory['visible_slugs'].discard(table_slug)
-                table_checkbox.value = []
-            memory.trigger('visible_slugs')
-
-        def on_checkbox_toggle(source, value, options):
-            if len(value) == len(options):
-                source_checkbox.value = True
-            elif len(value) == 0:
-                source_checkbox.value = False
-            elif len(value) < len(options):
-                with param.discard_events(source_checkbox):
-                    source_checkbox.value = False
-
-            # Update visible_slugs based on selection
-            for table in options:
-                table_slug = f"{source.name}{SOURCE_TABLE_SEPARATOR}{table}"
-                if table in value:
-                    # Table is selected, add to visible_slugs
-                    memory['visible_slugs'].add(table_slug)
-                else:
-                    # Table is not selected, remove from visible_slugs
-                    memory['visible_slugs'].discard(table_slug)
-            memory.trigger('visible_slugs')
-
-        def on_source_delete(source, clicks):
-            if source in memory["sources"]:
-                # Remove all tables from this source from visible_slugs
-                for table in source.get_tables():
-                    table_slug = f"{source.name}{SOURCE_TABLE_SEPARATOR}{table}"
-                    memory['visible_slugs'].discard(table_slug)
-
-                memory["sources"].remove(source)
-                memory.trigger("sources")
-                memory.trigger("visible_slugs")
-
-            if source is memory["source"]:
-                memory["source"] = next((iter(memory["sources"]), None))
-
-        sources = memory.get('sources', [])
-        if len(sources) == 0:
-            return "### No sources available. Please upload a data source to get started."
-
-        source_cards = []
-        for i, source in enumerate(sources):
-            # Get source info
-            source_name = getattr(source, 'name', f'Source {i+1}')
-
-            all_tables = source.get_tables()
-            if init:
-                visible_tables = all_tables
-            else:
-                visible_tables = [
-                    table for table in all_tables
-                    if f"{source.name}{SOURCE_TABLE_SEPARATOR}{table}" in memory.get('visible_slugs', set())
-                ]
-
-            # Create include/exclude toggle for header
-            source_checkbox = Checkbox(
-                value=True,
-                margin=(5, 0, 0, 3),
-                sizing_mode='fixed',
-            )
-
-            # Create delete button for header
-            delete_icon = IconButton(
-                icon='delete',
-                icon_size='1em',
-                color="danger",
-                margin=(5, 0, 0, 0),
-                sizing_mode='fixed',
-                width=40,
-                height=40,
-                visible=len(sources) > 1
-            )
-
-            # Create checkbox group for tables
-            table_checkbox = CheckBoxGroup(
-                options=all_tables,
-                value=visible_tables,
-                sizing_mode='stretch_width',
-                margin=(0, 0)
-            )
-
-            param.bind(
-                on_source_toggle,
-                source=source,
-                value=source_checkbox.param.value,
-                watch=True
-            )
-            param.bind(
-                on_checkbox_toggle,
-                source=source,
-                value=table_checkbox.param.value,
-                options=table_checkbox.param.options,
-                watch=True
-            )
-
-            param.bind(
-                on_source_delete,
-                source=source,
-                clicks=delete_icon.param.clicks,
-                watch=True
-            )
-
-            card_header = Row(
-                source_checkbox,
-                Markdown(f"## {source_name}", margin=0, disable_anchors=True),
-                HSpacer(),
-                delete_icon,
-                sizing_mode='stretch_width',
-                align='start',
-                height=35,
-                margin=0
-            )
-
-            source_card = Card(
-                table_checkbox,
-                header=card_header,
-                collapsible=True,
-                collapsed=False,  # Start expanded
-                sizing_mode='stretch_width'
-            )
-            source_cards.append(source_card)
-
-        col = Column(
-            *source_cards,
-            sizing_mode='stretch_width'
-        )
-        return col
 
     def _update_sources_dialog(self, *args, **kwargs):
         """
         Update the sources dialog content when memory sources change.
         """
         # Update the dialog content using the stored reference
-        if hasattr(self, '_sources_dialog_content'):
-            self._sources_dialog_content.objects = [self._create_sources_dialog_content()]
+        if hasattr(self, '_sources_dialog_content') and hasattr(self, '_source_catalog'):
+            self._source_catalog.trigger()
 
     def _export_notebook(self):
         nb = export_notebook(self.interface.objects, preamble=self.notebook_preamble)


### PR DESCRIPTION
Adds a Table Catalog dialog icon to the top right:
<img width="1450" height="1159" alt="image" src="https://github.com/user-attachments/assets/a1bdbf7f-0fa5-42ca-b18f-a205a7035b34" />

This allows users to select the source tables (and in another PR, documents) they want.

Also, table/document list is grouped by source.

Lastly, unifies visible slugs in prompts and code.

Eventually, might combine the upload icon inside here and support a callback function to list remote catalogs.