### PR TITLE
Reorder SQLAgent conditions

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -562,12 +562,12 @@ class SQLAgent(LumenBaseAgent):
             "Use when user asks about data contained in tables (e.g., 'show me sales data', 'filter by date')",
             "Use for calculations that require data from tables (e.g., 'calculate average', 'sum by category')",
             "Use when user wants to display or examine table contents",
-            "If sql_metaset is not in memory, use with IterativeTableLookup",
             "Commonly used with AnalystAgent to analyze query results",
             "For existing tables, only use if additional calculations are needed",
             "NOT for technical questions about programming, functions, or libraries",
             "NOT for questions that don't require data table access",
             "NOT useful if the user is using the same data for plotting",
+            "If sql_metaset is not in memory, use with IterativeTableLookup",
         ]
     )
 


### PR DESCRIPTION
When I tried renaming sql_metaset -> sql_context in https://github.com/holoviz/lumen/compare/rename_metaset?expand=1, it still was having trouble fulfilling that dependency, so I changed the order, and it seems to be better.


Closes https://github.com/holoviz/lumen/issues/1325