### PR TITLE
Ensure current session memory is copied on clone

### DIFF
--- a/lumen/config.py
+++ b/lumen/config.py
@@ -94,7 +94,7 @@ class SessionCache:
         new._global_context = self._global_context.copy()
         new._session_contexts = self._session_contexts.copy()
         if state.curdoc and state.curdoc in self._session_contexts:
-            new._session_contexts[state.curdoc] = self._curcontext
+            new._session_contexts[state.curdoc] = self._curcontext.copy()
         return new
 
 

--- a/lumen/config.py
+++ b/lumen/config.py
@@ -93,6 +93,8 @@ class SessionCache:
         new = type(self)()
         new._global_context = self._global_context.copy()
         new._session_contexts = self._session_contexts.copy()
+        if state.curdoc and state.curdoc in self._session_contexts:
+            new._session_contexts[state.curdoc] = self._curcontext
         return new
 
 


### PR DESCRIPTION
Major bug in `memory.clone()` meant that session memory was not actually copied on clone so when context switching between different explorations the memory would leak between them.