### PR TITLE
Drop "type" key value in prompt depending on num

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -41,15 +41,28 @@ if TYPE_CHECKING:
 
 
 def format_float(num):
+    """
+    Process a float value, returning numeric types instead of strings.
+    For very large/small numbers, returns a float that will display in scientific notation.
+    """
     if pd.isna(num) or math.isinf(num):
         return num
-    # if is integer, round to 0 decimals
+
+    # For integers, return as int
     if num == int(num):
-        return f"{int(num)}"
-    elif 0.01 <= abs(num) < 100:
-        return f"{num:.1f}"  # Regular floating-point notation with one decimal
+        # But if it's a very large integer, keep as float for potential sci notation
+        if abs(num) >= 1e5:
+            return f"{num:.1e}"  # Format as scientific notation
+        return int(num)
+
+    # For normal range numbers, round but keep as float
+    elif 0.01 <= abs(num) < 1e6:
+        return round(num, 1)
+
+    # For very small or very large numbers, return as-is
+    # These will naturally display in scientific notation when converted to string
     else:
-        return f"{num:.1e}"  # Exponential notation with one decimal
+        return f"{num:.1e}"  # Format as scientific notation
 
 
 def fuse_messages(messages: list[dict], max_user_messages: int = 2) -> list[dict]:
@@ -372,6 +385,12 @@ async def get_schema(
                 spec["type"] = "num"
             elif spec["type"] == "boolean":
                 spec["type"] = "bool"
+
+            # If it's obvious that this is a numeric range, remove type
+            # Yes `{'min': 2017, 'max': 2020}`  # implicitly infer
+            # Not `{'type': 'num', 'min': '2.0e+06', 'max': '6.2e+06'}`  # explicitly show type
+            if isinstance(spec.get("min"), (int, float)) and isinstance(spec.get("max"), (int, float)):
+                spec.pop("type")
 
         # Process enums using the extracted function
         if "enum" in spec:


### PR DESCRIPTION
Previously, the output format was: `{'type': 'num', 'min': '303', 'max': '48166'}` (including the type field and quotes around values). Now it displays as: `{'min': 303, 'max': 48166}`. This optimization reduces token usage by 200-400 per LLM call, as most calls utilize the schema.

When the type cannot be inferred from the format, it's retained: `{'type': 'int', 'min': '3.0e+06', 'max': '3.1e+06'}` (scientific notation requires quotes for proper representation).


Here's a full example output:
```
0. case_id:  `{'type': 'int', 'min': '3.0e+06', 'max': '3.1e+06'}`
1. faa_ors:  `{'enum': ['38-020299', '19-002776', '...']}`
2. faa_asn:  `{'enum': ['2008-AGL-3119-OE', '2017-WTE-3557-OE', '...']}`
3. usgs_pr_id:  `{'min': 303, 'max': 48166}`
4. eia_id:  `{'min': 7526, 'max': 65059}`
5. t_state:  `{'enum': ['ND', 'IA', '...']}`
6. t_county:  `{'enum': ['Barnes County', 'Wright County', '...']}`
7. t_fips:  `{'min': 4005, 'max': 72133}`
8. p_name:  `{'enum': ['Ashtabula Wind Center', 'Century', '...']}`
9. p_year:  `{'min': 1982, 'max': 2022}`
10. p_tnum:  `{'min': 1, 'max': 713}`
11. p_cap:  `{'min': 0.1, 'max': 994.7}`
12. t_manu:  `{'enum': ['GE Wind', 'Siemens', '...']}`
13. t_model:  `{'enum': ['GE1.5-91', 'GE1.5-82.5', '...']}`
14. t_cap:  `{'min': 65, 'max': 5000}`
15. t_hh:  `{'min': 24.6, 'max': 108}`
16. t_rd:  `{'min': 16, 'max': 149}`
17. t_rsa:  `{'min': 201.1, 'max': 17436.6}`
18. t_ttlh:  `{'min': 32.6, 'max': 182.5}`
19. retrofit:  `{'min': 0, 'max': 1}`
20. retrofit_year:  `{'min': 2017, 'max': 2020}`
21. t_conf_atr:  `{'min': 1, 'max': 3}`
22. t_conf_loc:  `{'min': 1, 'max': 3}`
23. t_img_date:  `{'format': 'datetime', 'min': '2010-01-01T00:00:00', 'max': '2022-06-20T00:00:00'}`
24. t_img_srce:  `{'enum': ['NAIP', 'Digital Globe', '...']}`
25. xlong:  `{'min': -122.6, 'max': -66.4}`
26. ylat:  `{'min': 18, 'max': 48.8}`
27. easting:  `{'type': 'num', 'min': '-1.4e+07', 'max': '-7.4e+06'}`
28. northing:  `{'type': 'num', 'min': '2.0e+06', 'max': '6.2e+06'}`
29. ```