### PR TITLE
Ensure mirrors don't erroneously get added into tables

### DIFF
--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -542,6 +542,6 @@ def test_absolute_vs_relative_paths(sample_csv_files):
 def test_mirrors_not_in_tables_from_spec():
     """Test that mirrors are not included in the tables from_spec."""
     spec = DuckDBSource(tables={"obs": "SELECT * FROM obs"}).to_spec()
-    source = DuckDBSource.from_spec(spec).tables
+    source = DuckDBSource.from_spec(spec)
     assert "mirrors" not in source.tables
     assert source.mirrors == {}

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -536,3 +536,12 @@ def test_absolute_vs_relative_paths(sample_csv_files):
 
     finally:
         os.chdir(original_cwd)
+
+
+
+def test_mirrors_not_in_tables_from_spec():
+    """Test that mirrors are not included in the tables from_spec."""
+    spec = DuckDBSource(tables={"obs": "SELECT * FROM obs"}).to_spec()
+    source = DuckDBSource.from_spec(spec).tables
+    assert "mirrors" not in source.tables
+    assert source.mirrors == {}


### PR DESCRIPTION
I noticed `mirrors` being erroneously added to the `tables`:
```
(Pdb) print(source.tables)
{'obs': 'SELECT * FROM obs', 'obsm_X_pca': 'SELECT * FROM obsm_X_pca', 'obsm_X_tsne': 'SELECT * FROM obsm_X_tsne', 'obsm_X_umap': 'SELECT * FROM obsm_X_umap', 'select_all_obs_from_AnnDataSource00863': 'SELECT * FROM "main"."obs" LIMIT 100000', 'var': 'SELECT * FROM var', 'varm_PCs': 'SELECT * FROM varm_PCs', 'mirrors': {}}  # <-- here
```

So when I was doing `source.create_sql_expr_source(source.tables)`, it was crashing (here, I manually set `mirrors: {}`, but in the code I was using `from_spec(to_spec())`
```
ParserException                           Traceback (most recent call last)
Cell In[7], line 4
      1 from lumen.sources.duckdb import DuckDBSource
      3 src = DuckDBSource(tables={"obs": "SELECT * FROM obs"})
----> 4 src.create_sql_expr_source(tables={"mirrors": {}})

File ~/repos/lumen/lumen/sources/duckdb.py:356, in create_sql_expr_source(self, tables, materialize, **kwargs)
    354 try:
    355     self._connection.execute(table_expr)
--> 356 except duckdb.CatalogException as e:
    357     original_e = e
    358     pattern = r"Table with name\s(\S+)"

ParserException: Parser Error: syntax error at or near "{"
```

And I was really confused how the code ran with a syntax error, then I realized it's actually the SQL...

I think the issue was that the `mirrors` was wrongly added to every recursive call, and so we should be adding it to the top level if I'm not mistaken--however, I'm not 100% sure if this is right.