### PR TITLE
Single source

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -742,11 +742,7 @@ class SQLAgent(LumenBaseAgent):
         )
 
         if should_materialize:
-            if isinstance(self._memory["sources"], dict):
-                self._memory["sources"][expr_slug] = sql_expr_source
-            else:
-                self._memory["sources"].append(sql_expr_source)
-            self._memory.trigger("sources")
+            self._memory["source"] = sql_expr_source
 
         # Create pipeline
         if is_final:
@@ -1174,7 +1170,7 @@ class SQLAgent(LumenBaseAgent):
     ) -> Any:
         """Execute SQL generation with one-shot attempt first, then iterative refinement if needed."""
         # Setup sources
-        sources = self._memory["sources"] if isinstance(self._memory["sources"], dict) else {source.name: source for source in self._memory["sources"]}
+        sources = self._memory["sources"]
         tables_to_source, source = self._setup_source(sources)
 
         try:
@@ -1335,13 +1331,11 @@ class DbtslAgent(LumenBaseAgent, DbtslMixin):
 
             # Update memory
             self._memory["data"] = await describe_data(df)
-            self._memory["sources"].append(sql_expr_source)
             self._memory["source"] = sql_expr_source
             self._memory["pipeline"] = pipeline
             self._memory["table"] = pipeline.table
             self._memory["dbtsl_vector_metaset"] = vector_metaset
             self._memory["dbtsl_sql_metaset"] = sql_metaset
-            self._memory.trigger("sources")
             return sql_query, pipeline
         except Exception as e:
             report_error(e, step)

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -255,7 +255,7 @@ class ChatAgent(Agent):
         if "vector_metaset" not in self._memory and "source" in self._memory and "table" in self._memory:
             source = self._memory["source"]
             self._memory["vector_metaset"] = await get_metaset(
-                {source.name: source}, [f"{source.name}{SOURCE_TABLE_SEPARATOR}{self._memory['table']}"],
+                [source], [f"{source.name}{SOURCE_TABLE_SEPARATOR}{self._memory['table']}"],
             )
         system_prompt = await self._render_prompt("main", messages, **context)
         return await self._stream(messages, system_prompt)
@@ -1294,7 +1294,7 @@ class DbtslAgent(LumenBaseAgent, DbtslMixin):
             pipeline = await get_pipeline(source=sql_expr_source, table=expr_slug, sql_transforms=sql_transforms)
 
             df = await get_data(pipeline)
-            sql_metaset = await get_metaset({sql_expr_source.name: sql_expr_source}, [expr_slug])
+            sql_metaset = await get_metaset([sql_expr_source], [expr_slug])
             vector_metaset = sql_metaset.vector_metaset
 
             # Update memory

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -609,42 +609,6 @@ class SQLAgent(LumenBaseAgent):
 
     _output_type = SQLOutput
 
-    def __init__(self, **params):
-        super().__init__(**params)
-        # SQLAgent watches visible_slugs and filters its sql_metaset accordingly
-        self._memory.on_change('visible_slugs', self._filter_sql_metaset_by_visibility)
-
-    def _filter_sql_metaset_by_visibility(self, key, old_slugs, new_slugs):
-        """
-        Filter sql_metaset when visible_slugs changes.
-        This ensures SQL operations only work with visible tables.
-        """
-        if new_slugs is None:
-            new_slugs = set()
-
-        sql_metaset = self._memory.get('sql_metaset')
-        if not sql_metaset:
-            return  # No sql_metaset to filter
-
-        # Filter vector metadata to only include visible tables
-        if sql_metaset.vector_metaset and sql_metaset.vector_metaset.vector_metadata_map:
-            sql_metaset.vector_metaset.vector_metadata_map = {
-                slug: metadata
-                for slug, metadata in sql_metaset.vector_metaset.vector_metadata_map.items()
-                if slug in new_slugs
-            }
-
-        # Filter SQL metadata to only include visible tables
-        if sql_metaset.sql_metadata_map:
-            sql_metaset.sql_metadata_map = {
-                slug: metadata
-                for slug, metadata in sql_metaset.sql_metadata_map.items()
-                if slug in new_slugs
-            }
-
-        # Trigger memory update to notify other components that depend on sql_metaset
-        self._memory.trigger('sql_metaset')
-
     def _update_spec(self, memory: _Memory, event: param.parameterized.Event):
         memory["sql"] = event.new
 

--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -385,8 +385,6 @@ class TableSourceCard(Viewer):
                 source for source in memory.get("sources", [])
                 if source is not self.source
             ]
-            if self.source is memory.get("source"):
-                memory["source"] = next(iter(memory.get("sources", [])), None)
 
     def __panel__(self):
         card_header = Row(

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -608,10 +608,6 @@ class SourceControls(Viewer):
         duckdb_source.tables[table] = sql_expr
         self._memory["source"] = duckdb_source
         self._memory["table"] = table
-        if "sources" in self._memory:
-            self._memory["sources"] = self._memory["sources"] + [duckdb_source]
-        else:
-            self._memory["sources"] = [duckdb_source]
         self._last_table = table
         return 1
 

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -85,7 +85,7 @@ class TableControls(MediaControls):
     def __init__(self, file_obj: io.BytesIO, **params):
         super().__init__(file_obj, **params)
         self._name_input = TextInput.from_param(
-            self.param.alias, name="Table alias", allow_upload=False
+            self.param.alias, name="Table alias",
         )
         self._sheet_select = Select.from_param(
             self.param.sheet, name="Sheet", visible=False
@@ -179,7 +179,7 @@ class SourceControls(Viewer):
         self._url_input.param.watch(self._handle_urls, "enter_pressed")
 
         self._input_tabs = Tabs(
-            ("Upload File", self._file_input),
+            ("Upload Files", self._file_input),
             ("Download from URL", self._url_input),
             sizing_mode="stretch_both",
             dynamic=True,

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -10,7 +10,7 @@ import aiohttp
 import pandas as pd
 import param
 
-from panel.pane.markup import HTML, Markdown
+from panel.pane.markup import HTML
 from panel.viewable import Viewer
 from panel.widgets import FileDropper, Tabulator, Tqdm
 from panel_material_ui import (
@@ -85,7 +85,7 @@ class TableControls(MediaControls):
     def __init__(self, file_obj: io.BytesIO, **params):
         super().__init__(file_obj, **params)
         self._name_input = TextInput.from_param(
-            self.param.alias, name="Table alias",
+            self.param.alias, name="Table alias", allow_upload=False
         )
         self._sheet_select = Select.from_param(
             self.param.sheet, name="Sheet", visible=False
@@ -127,6 +127,8 @@ class SourceControls(Viewer):
 
     disabled = param.Boolean(default=False, doc="Disable controls")
 
+    downloaded_files = param.Dict(default={}, doc="Downloaded files to add as tabs")
+
     download_url = param.String(default="", doc="URL input for downloading files")
 
     input_placeholder = param.String(default="Enter URLs, one per line, and press <Enter> to download")
@@ -148,8 +150,6 @@ class SourceControls(Viewer):
     _last_table = param.String(default="", doc="Last table added")
 
     _count = param.Integer(default=0, doc="Count of sources added")
-
-    downloaded_files = param.Dict(default={}, doc="Downloaded files to add as tabs")
 
     def __init__(self, **params):
         super().__init__(**params)
@@ -179,8 +179,8 @@ class SourceControls(Viewer):
         self._url_input.param.watch(self._handle_urls, "enter_pressed")
 
         self._input_tabs = Tabs(
-            ("File Input", self._file_input),
-            ("Text Input", self._url_input),
+            ("Upload File", self._file_input),
+            ("Download from URL", self._url_input),
             sizing_mode="stretch_both",
             dynamic=True,
             active=self.param.active,
@@ -213,7 +213,6 @@ class SourceControls(Viewer):
         )
 
         self.menu = Column(
-            Markdown("## Source Input", margin=0),
             self._input_tabs,
             self._upload_tabs,
             Row(self._add_button, self._cancel_button),

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -250,7 +250,7 @@ async def get_metaset(sources: list[Source], tables: list[str]) -> SQLMetaset:
             base_sql=source.get_sql_expr(source.normalize_table(table_name)),
             description=metadata.get("description"),
             columns=[
-                Column(name=col_name, description=col_values.pop("description"), metadata=col_values)
+                Column(name=col_name, description=col_values.pop("description", None), metadata=col_values)
                 for col_name, col_values in metadata.get("columns").items()
             ],
         )

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -203,13 +203,13 @@ class SQLMetaset:
         return self.table_context
 
 
-async def get_metaset(sources: dict[str, Source], tables: list[str]) -> SQLMetaset:
+async def get_metaset(sources: list[Source], tables: list[str]) -> SQLMetaset:
     """
     Get the metaset for the given sources and tables.
 
     Parameters
     ----------
-    sources: dict[str, Source]
+    sources: list[Source]
         The sources to get the metaset for.
     tables: list[str]
         The tables to get the metaset for.
@@ -233,7 +233,7 @@ async def get_metaset(sources: dict[str, Source], tables: list[str]) -> SQLMetas
         else:
             source_name = next(iter(sources))
             table_name = table_slug
-        source = sources[source_name]
+        source = next((s for s in sources if s.name == source_name), None)
         schema = await get_schema(source, table_name, include_count=True)
         tables_info[table_name] = SQLMetadata(
             table_slug=table_slug,

--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -627,9 +627,9 @@ class TableLookup(VectorLookupTool):
         self._raw_metadata = {}
         self._semaphore = asyncio.Semaphore(self.max_concurrent)
         if self.sync_sources:
-            self._memory.on_change('sources', self._update_vector_store)
+            self._memory.on_change("sources", self._update_vector_store)
         if "sources" in self._memory:
-            state.execute(partial(self._update_vector_store, None, None, self._memory['sources']))
+            state.execute(partial(self._update_vector_store, None, None, self._memory["sources"]))
 
     def _format_results_for_refinement(self, results: list[dict[str, Any]]) -> str:
         """

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -94,6 +94,11 @@ EXPLORATIONS_INTRO = """
 
 
 class TableExplorer(Viewer):
+    """
+    TableExplorer provides a high-level entrypoint to explore tables in a split UI.
+    It allows users to load tables, explore them using Graphic Walker, and then
+    interrogate the data via a chat interface.
+    """
 
     interface = param.ClassSelector(class_=ChatFeed, doc="""
         The interface for the Coordinator to interact with.""")
@@ -126,26 +131,17 @@ class TableExplorer(Viewer):
         deduplicate = len(sources) > 1
         new = {}
 
-        all_slugs = set()
+        # Build the source map for UI display
         for source in sources:
             tables = source.get_tables()
-            for t in tables:
-                original_table = t
+            for table in tables:
                 if deduplicate:
-                    t = f'{source.name}{SOURCE_TABLE_SEPARATOR}{t}'
+                    table = f'{source.name}{SOURCE_TABLE_SEPARATOR}{table}'
 
-                # Always use the full slug for checking visibility
-                table_slug = f'{source.name}{SOURCE_TABLE_SEPARATOR}{original_table}'
-                all_slugs.add(table_slug)
-
-                if (t.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)[-1] not in self._source_map and
+                if (table.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)[-1] not in self._source_map and
                     not init and not len(selected) > self._table_select.max_items and state.loaded):
-                    selected.append(t)
-                new[t] = source
-
-        # Ensure visible_slugs doesn't contain removed tables
-        if 'visible_slugs' in memory:
-            memory['visible_slugs'] = memory['visible_slugs'].intersection(all_slugs)
+                    selected.append(table)
+                new[table] = source
 
         self._source_map.clear()
         self._source_map.update(new)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -383,18 +383,18 @@ class UI(Viewer):
         self._source_agent = next((agent for agent in self._coordinator.agents if isinstance(agent, SourceAgent)), None)
         # Create LLM status chip
         self._llm_chip = Chip(
-            object="Manage LLM:",
+            object="Manage LLM: Loading...",
             icon="auto_awesome",
             align="center",
             color="light",
             margin=(0, 5, 0, 10),
             on_click=self._open_llm_dialog,
             loading=True,
-            variant="outlined"
+            variant="outlined",
         )
 
         self._data_sources_chip = Chip(
-            object="Loading Data Sources",
+            object="Manage Data",
             icon="cloud_upload",
             align="center",
             color="light",
@@ -406,7 +406,7 @@ class UI(Viewer):
         self._table_lookup_tool = None  # Will be set after coordinator is initialized
         self._source_catalog = SourceCatalog()
         self._sources_dialog_content = Dialog(
-            Tabs(("Input", self._source_controls), ("Catalog", self._source_catalog), margin=(-30, 0, 0, 0), sizing_mode="stretch_both"),
+            Tabs(("Add Sources", self._source_controls), ("View Sources", self._source_catalog), margin=(-30, 0, 0, 0), sizing_mode="stretch_both"),
             close_on_click=True, show_close_button=True, sizing_mode='stretch_width', width_option='lg'
         )
 
@@ -463,7 +463,7 @@ class UI(Viewer):
             )
         else:
             self._llm_chip.param.update(
-                object="Loading LLM",
+                object="Manage LLM: Loading...",
                 loading=True
             )
 
@@ -518,7 +518,7 @@ class UI(Viewer):
 
         if not self._table_lookup_tool:
             self._data_sources_chip.param.update(
-                object='Manage Data Sources',
+                object='Manage Data',
                 icon="storage",
                 color="primary",
             )
@@ -546,7 +546,7 @@ class UI(Viewer):
         elif ready_state is True:
             # Ready - show as success
             self._data_sources_chip.param.update(
-                object="Manage Data Sources",
+                object="Manage Data",
                 loading=False,
             )
         elif ready_state is None:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -116,7 +116,7 @@ class TableExplorer(Viewer):
         )
         self._input_row = Row(self._table_select, self._explore_button)
         self._source_map = {}
-        memory.on_change('sources', self._update_source_map)
+        memory.on_change("sources", self._update_source_map)
         self._update_source_map(init=True)
 
         self._tabs = Tabs(dynamic=True, sizing_mode='stretch_both')
@@ -126,7 +126,7 @@ class TableExplorer(Viewer):
 
     def _update_source_map(self, key=None, old=None, sources=None, init=False):
         if sources is None:
-            sources = memory['sources']
+            sources = memory["sources"]
         selected = list(self._table_select.value)
         deduplicate = len(sources) > 1
         new = {}
@@ -607,9 +607,7 @@ class UI(Viewer):
                 uri=':memory:'
             )
             sources.append(source)
-        memory['sources'] = sources
-        if sources:
-            memory['source'] = sources[0]
+        memory["sources"] = sources
 
     def show(self, **kwargs):
         return self._create_view(server=True).show(**kwargs)
@@ -653,7 +651,7 @@ class UI(Viewer):
         """
         Update the sources dialog content when memory sources change.
         """
-        self._source_catalog.sources = memory['sources']
+        self._source_catalog.sources = memory["sources"]
 
     def servable(self, title: str | None = None, **kwargs):
         if (state.curdoc and state.curdoc.session_context):

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -743,12 +743,12 @@ def load_json(json_spec: str) -> dict:
     return json.loads(json_spec.encode().decode('unicode_escape'))
 
 
-def parse_table_slug(table: str, sources: dict[str, Source], normalize: bool = True) -> tuple[Source | None, str]:
+def parse_table_slug(table: str, sources: list[Source], normalize: bool = True) -> tuple[Source | None, str]:
     if SOURCE_TABLE_SEPARATOR in table:
         a_source_name, a_table = table.split(SOURCE_TABLE_SEPARATOR, maxsplit=1)
-        a_source_obj = sources.get(a_source_name)
+        a_source_obj = next((s for s in sources if s.name == a_source_name), None)
     else:
-        a_source_obj = next(iter(sources.values()))
+        a_source_obj = sources[0] if sources else None
         a_table = table
     if normalize:
         a_table = a_source_obj.normalize_table(a_table)

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -133,7 +133,7 @@ class TestSoloAgentRespond:
     async def test_sql_agent(self, mock_llm, mock_memory, duckdb_source, test_messages):
         """Test SQLAgent instantiation and respond"""
         mock_memory["source"] = duckdb_source
-        mock_memory["sources"] = sources = {"duckdb": duckdb_source}
+        mock_memory["sources"] = sources = [duckdb_source]
         mock_memory["sql_metaset"] = await get_metaset(sources, ["test_sql"])
 
         agent = SQLAgent(llm=mock_llm, memory=mock_memory)
@@ -170,7 +170,7 @@ class TestSoloAgentRespond:
         mock_memory["source"] = duckdb_source
         mock_memory["pipeline"] = Pipeline(source=duckdb_source, table="test_sql")
         mock_memory["table"] = "test_sql"
-        mock_memory["sources"] = sources = {"duckdb": duckdb_source}
+        mock_memory["sources"] = sources = [duckdb_source]
         mock_memory["sql_metaset"] = await get_metaset(sources, ["test_sql"])
         mock_memory["data"] = duckdb_source.get("test_sql")
 


### PR DESCRIPTION
In https://github.com/holoviz-topics/lumen-anndata/pull/31 @philippjfr identifies an issue with having to set multiple memory values to get a source to properly propagate.

This PR addresses that by ensuring all source-related memory values are linked up.

Namely adding `memory.on_change`:
```
        self._memory.on_change("source", self._sync_source_to_sources)
        self._memory.on_change("sources", self._sync_sources_to_source)
        self._memory.on_change("sources", self._update_visible_slugs)
```

This means that it's no longer necessary for devs to manually do:
```
            self._memory["sources"].append(sql_expr_source)
            self._memory["source"] = sql_expr_source
            self._memory.trigger("sources")
```

It'll be done automatically when:
```
self._memory["source"] = sql_expr_source
```

This PR also addresses:
1. consistent `sources` type: `List[Source]` (no longer a dict)
2. better separation of concerns (previously ui.py handled visible_slugs, but visible_slugs is a core functionality of Planner and subagents like SQLAgent and ChatAgent
3. cleans up unnecessary complexity: `_setup_source` 
4. adds `applies` classmethod to `Tool` equivalent to `Agent` and make IterativeTableLookup use it