### PR TITLE
Prompting fixes

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -550,12 +550,11 @@ class LumenBaseAgent(Agent):
 class SQLAgent(LumenBaseAgent):
     conditions = param.List(
         default=[
-            "Use for displaying, examining, or querying data",
+            "Use for displaying, examining, or querying data resulting in a data pipeline",
             "Use for calculations that require data (e.g., 'calculate average', 'sum by category')",
             "Commonly used with AnalystAgent to analyze query results",
             "NOT for non-data questions or technical programming help",
             "NOT useful if the user is using the same data for plotting",
-            "If sql_metaset is not in memory, use with IterativeTableLookup",
         ]
     )
 
@@ -1035,7 +1034,7 @@ class SQLAgent(LumenBaseAgent):
 
             step.status = "success"
             step.success_title = "One-shot SQL generation successful"
-            return pipeline
+        return pipeline
 
     async def _execute_planning_mode(
         self,

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -4,7 +4,7 @@
 You are the team lead responsible for creating a step-by-step plan to address user queries by assigning subtasks to specialized actors (agents and tools).
 
 🎯 CRITICAL: Dependency Management
-- ALWAYS check if an agent's "Requires" are satisfied before including it in your plan
+- ALWAYS check if an agent's requirements are satisfied before including it in your plan
 - If requirements are missing, FIRST include the actor that "Provides" those requirements
 - Dependencies must be resolved in the correct order - providers before consumers
 
@@ -27,12 +27,9 @@ Ground Rules:
 # Available Actors with Dependency Analysis
 {%- if tools %}
 ## 🛠️ Tools
-{%- for tool in tools %}
-
-{{ tool.__class__.__name__ }} provides: {{ tool.provides | join('`, `') or ' responses' }}
-{{ ' '.join(tool.purpose.strip().split()) }}
-Conditions for use:
-{{ tool.conditions | join('\n') }}
+{% for tool in tools %}
+### `{{ tool.__class__.__name__ }}`
+{{ ' '.join(dedent(tool.purpose).strip().split()) }}
 {%- set missing_reqs = [] %}
 {%- for req in tool.requires %}
   {%- if req not in memory.keys() or memory[req] is none %}
@@ -42,17 +39,20 @@ Conditions for use:
 {%- if missing_reqs %}
 ❌ BLOCKED: Missing requirements: `{{ missing_reqs | join('`, `') }}`
 {%- else %}
-✅ Ready!
+✅ All requirements met.
 {%- endif %}
+{% if tool.provides -%}Provides: `{{ tool.provides | join('`, `') }}`{%- endif %}
+Conditions for use:
+{%- for condition in tool.conditions %}
+  - {{ dedent(condition) }}
+{%- endfor -%}
 {%- endfor %}
 {% endif %}
 
 ## 🧑‍💼 Agents
-{%- for agent in agents %}
-{{ agent.name[:-5] }} provides {{ agent.provides | join('`, `') or 'None' }}
-{{- agent.purpose }}
-Conditions for use:
-{{ agent.conditions | join('\n') }}
+{% for agent in agents %}
+### `{{ agent.__class__.__name__ }}`
+{{ ' '.join(dedent(agent.purpose).strip().split()) }}
 {%- set missing_reqs = [] %}
 {%- for req in agent.requires %}
   {%- if req not in memory.keys() or memory[req] is none %}
@@ -75,8 +75,14 @@ Conditions for use:
     {%- endfor %}
   {%- endfor %}
 {%- else %}
-✅ Ready!
+✅ All requirements met.
 {%- endif %}
+{% if agent.provides -%}Provides: `{{ agent.provides | join('`, `') or 'None' }}`{%- endif %}
+Conditions for use:
+{%- for condition in agent.conditions %}
+  - {{ dedent(condition) }}
+{%- endfor -%}
+{% if agent.not_with -%}Should never be used together with: `{{ agent.not_with | join('`, `') }}`{%- endif %}
 {% endfor %}
 # Current Data Context
 

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -24,11 +24,11 @@ Write a SQL query for the user's data transformation request, focusing on intent
   - Consider common abbreviations and variations and case sensitivity
   - **Format variation checking**: When initial discovery fails, immediately check for format variations, underscores vs spaces using `ILIKE`
 - Limits can be applied to discovery steps
-{% else %}- Set LIMIT 100000, unless specified, efficient ORDER BY, filter early
+{% else %}- Unless requested to return a subset never set a LIMIT
 {% endif %}
 - Temporal Data Handling:
   - **Date range discovery**: Always check MIN/MAX dates before joining temporal datasets
-  - **Period matching**: For seasonal/periodic data (e.g., ONI seasons JAS, ASO), understand the full period coverage
+  - **Period matching**: For seasonal/periodic data, understand the full period coverage
   - **Overlap validation**: Ensure temporal datasets have overlapping date ranges before attempting joins
   - **Flexible matching**: Consider all relevant time periods, not just exact matches
 - Only filter by confirmed values from previous results

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -235,7 +235,7 @@ async def get_metaset(sources: list[Source], tables: list[str]) -> SQLMetaset:
             table_name = table_slug
         source = next((s for s in sources if s.name == source_name), None)
         schema = await get_schema(source, table_name, include_count=True)
-        tables_info[table_name] = SQLMetadata(
+        tables_info[table_slug] = SQLMetadata(
             table_slug=table_slug,
             schema=schema,
         )

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import math
 import re
+import textwrap
 import time
 import traceback
 
@@ -154,6 +155,7 @@ def render_template(template_path: Path | str, overrides: dict | None = None, re
     else:
         env = Environment(loader=fs_loader, undefined=StrictUndefined)
 
+    env.globals["dedent"] = lambda text: textwrap.dedent(text).strip()
     template = env.get_template(template_name)
     return template.render(**context)
 


### PR DESCRIPTION
A bunch of fixes but primarily this resolves two issues:

1. The Planner was confused about what constructing a pipeline meant OR assumed that SQLAgent requires a Pipeline as input, this meant that it would frequently generate a plan with successive SQLAgents where the first instruction would just be "Create a Pipeline"
2. The `get_metaset` utility did not index the vector data and the schemas under the same keys, which meant that the context summary would be empty.

Full change list:

- The `Planner` prompt was inconsistently formatted and confused the LLM by making it not recognize which `requires` belonged to which agent
- Add `not_with` to Planner agent summary to avoid making invalid plans 
- Removed superfluous instructions
- Removed request for SQLAgent to LIMIT output 
- Ensure SQLMetaset vector and schema mappings are indexed the same (otherwise the schema is not used)