### PR TITLE
Switch OpenAI default to 4.1-mini

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -377,7 +377,7 @@ class OpenAI(Llm, OpenAIMixin):
     mode = param.Selector(default=Mode.TOOLS)
 
     model_kwargs = param.Dict(default={
-        "default": {"model": "gpt-4o-mini"},
+        "default": {"model": "gpt-4.1-mini"},
         "sql": {"model": "gpt-4.1-mini"},
         "vega_lite": {"model": "gpt-4.1-mini"},
         "edit": {"model": "gpt-4.1-mini"},


### PR DESCRIPTION
The cost differences are not that large and 4.1-mini is both faster and better.