### PR TITLE
Remove consecutive messages

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -65,9 +65,9 @@ class Plan(Section):
                 user_query = msg
                 break
         todos = '\n'.join(
-            f"- [{'x' if idx < i else ' '}] {task.instruction}\n" for idx, task in enumerate(self.subtasks)
+            f"- [{'x' if idx < i else ' '}] {task.instruction}" for idx, task in enumerate(self.subtasks)
         )
-        formatted_content = f"User Request: {user_query['content']}\n\nTodos:\n\n{todos}"
+        formatted_content = f"User Request: {user_query['content']!r}\n\nComplete the next unchecked todo:\n{todos}"
         return [
             {'content': formatted_content, 'role': 'user'} if msg is user_query else msg
             for msg in self.history

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -97,7 +97,7 @@ class Task(Viewer):
         pre = len(self.memory['outputs'])
         outputs = []
         memory = task.memory or self.memory
-        messages = self.history + [{'content': self.instruction, 'role': 'user'}]
+        messages = self.history
 
         with task.param.update(
             interface=self.interface, llm=task.llm or self.llm, memory=memory,


### PR DESCRIPTION
This PR addresses:

"""
2025-08-22 14:22:14,771 WARNING: Two consecutive messages from the same role; some providers disallow this.
"""

For example:
```
2025-08-22 14:22:14,771 Message 2 (u): User Request: Show me total token usage by each model

Todos:

[x] Look up the relevant tables and provide SQL schemas for token usage data.

[ ] Query the total token usage by each model from the available data.

[ ] Validate whether the executed plan fully answered the user's original query.

**2025-08-22 14:22:14,771 Message 3 (u): Query the total token usage by each model from the available data.**
```

Now, it becomes:
```
2025-08-22 14:22:14,771 Message 2 (u): User Request: Show me total token usage by each model

Complete the next unchecked todo:
[x] Look up the relevant tables and provide SQL schemas for token usage data.
[ ] Query the total token usage by each model from the available data.
[ ] Validate whether the executed plan fully answered the user's original query.
```