### PR TITLE
Ensure TableLookup tool vector_store is shared

### DIFF
--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -166,7 +166,7 @@ class VectorLookupToolUser(ToolUser):
         kwargs = super()._get_tool_kwargs(tool, prompt_tools, **params)
 
         # If the tool is already instantiated and has a vector_store, use it
-        if not isinstance(tool, VectorLookupTool) or (isinstance(tool, VectorLookupTool) and tool.vector_store is not None):
+        if (not issubclass(tool, VectorLookupTool) and not isinstance(tool, VectorLookupTool)) or (isinstance(tool, VectorLookupTool) and tool.vector_store is not None):
             return kwargs
         elif isinstance(tool, VectorLookupTool) and tool._item_type_name == "document" and self.document_vector_store is not None:
             kwargs["vector_store"] = self.document_vector_store

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -1,0 +1,38 @@
+import pytest
+
+try:
+    import lumen.ai  # noqa
+except ModuleNotFoundError:
+    pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
+
+from lumen.ai.coordinator import Planner
+from lumen.ai.tools import IterativeTableLookup, TableLookup
+from lumen.ai.vector_store import NumpyVectorStore
+
+
+async def test_planner_instantiate():
+    Planner()
+
+
+async def test_planner_instantiate_tools_shared_vector_store():
+    planner = Planner()
+
+    assert len(planner._tools['main']) == 2
+    tool1, tool2 = planner._tools['main']
+    assert isinstance(tool1, TableLookup)
+    assert isinstance(tool2, IterativeTableLookup)
+
+    assert tool1.vector_store is tool2.vector_store
+
+
+async def test_planner_instantiate_tools_provided_vector_store():
+    vector_store = NumpyVectorStore()
+    planner = Planner(vector_store=vector_store)
+
+    assert len(planner._tools['main']) == 2
+    tool1, tool2 = planner._tools['main']
+    assert isinstance(tool1, TableLookup)
+    assert isinstance(tool2, IterativeTableLookup)
+
+    assert tool1.vector_store is vector_store
+    assert tool2.vector_store is vector_store


### PR DESCRIPTION
Previously `TableLookup` and `IterativeTableLookup` would end up with independent vector stores and `IterativeTableLookup` would be completely useless since it never synced the sources.