### PR TITLE
Add support for file upload via chat input

### DIFF
--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -502,6 +502,7 @@ class TableSourceCard(Viewer):
             collapsed=self.param.collapsed,
             sizing_mode='stretch_width',
             margin=0,
+            name="TableSourceCard"
         )
 
 

--- a/lumen/ai/components.py
+++ b/lumen/ai/components.py
@@ -387,6 +387,7 @@ class TableSourceCard(Viewer):
                     color="text.secondary",
                     margin=(-10, 10, 0, 42),
                     sizing_mode='stretch_width',
+                    styles={"min-height": "unset"} # Override ChatMessage CSS
                 )
                 table_controls.extend([checkbox, metadata_display])
             else:

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -133,9 +133,9 @@ class SourceControls(Viewer):
 
     input_placeholder = param.String(default="Enter URLs, one per line, and press <Enter> to download")
 
-    trigger_add = param.Event(doc="Use uploaded file(s)")
+    add = param.Event(doc="Use uploaded file(s)")
 
-    trigger_cancel = param.Event(doc="Cancel")
+    cancel = param.Event(doc="Cancel")
 
     memory = param.ClassSelector(class_=_Memory, default=None, doc="""
         Local memory which will be used to provide the agent context.
@@ -190,7 +190,7 @@ class SourceControls(Viewer):
         )
 
         self._add_button = Button.from_param(
-            self.param.trigger_add,
+            self.param.add,
             name="Use file(s)",
             icon="table-plus",
             visible=self._upload_tabs.param["objects"].rx().rx.len() > 0,
@@ -198,7 +198,7 @@ class SourceControls(Viewer):
         )
 
         self._cancel_button = Button.from_param(
-            self.param.trigger_cancel,
+            self.param.cancel,
             name="Cancel",
             icon="circle-x",
             visible=self.param.cancellable.rx().rx.bool() or self._add_button.param.clicks.rx() == 0,
@@ -648,7 +648,7 @@ class SourceControls(Viewer):
             self._memory["document_sources"] = [document]
         return 1
 
-    @param.depends("trigger_add", watch=True)
+    @param.depends("add", watch=True)
     def add_medias(self):
         # Combine both uploaded files and downloaded files for processing
         all_media_controls = self._media_controls + self._downloaded_media_controls

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -143,6 +143,8 @@ class SourceControls(Viewer):
 
     multiple = param.Boolean(default=True, doc="Allow multiple files")
 
+    show_input = param.Boolean(default=True, doc="Whether to show the input controls")
+
     replace_controls = param.Boolean(default=False, doc="Replace controls on add")
 
     table_upload_callbacks = {}
@@ -214,7 +216,7 @@ class SourceControls(Viewer):
         )
 
         self.menu = Column(
-            self._input_tabs,
+            *((self._input_tabs,) if self.show_input else ()),
             self._upload_tabs,
             Row(self._add_button, self._cancel_button),
             self.tables_tabs,
@@ -698,6 +700,7 @@ class SourceControls(Viewer):
                     self.tables_tabs.visible = False
                     self.menu.height = 70
 
+            total_files = len(self._upload_tabs) + len(self._downloaded_media_controls)
             if self.clear_uploads:
                 # Clear uploaded files from view
                 self._upload_tabs.clear()
@@ -716,7 +719,6 @@ class SourceControls(Viewer):
 
             # Clear uploaded files and URLs from memory
             if (n_tables + n_docs) > 0:
-                total_files = len(self._upload_tabs) + len(self._downloaded_media_controls)
                 self._message_placeholder.param.update(
                     object=f"Successfully processed {total_files} files ({n_tables} table(s), {n_docs} document(s)).",
                     visible=True,

--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -234,7 +234,7 @@ class Coordinator(Viewer, VectorLookupToolUser):
                     for source in self._memory.get("sources", []) if source not in old_sources
                 ]
                 if len(source_cards) > 1:
-                    source_view = Accordion(*source_cards, sizing_mode="stretch_width")
+                    source_view = Accordion(*source_cards, sizing_mode="stretch_width", name="TableSourceCard")
                 else:
                     source_view = source_cards[0]
                 msg = Column(chat_input.value, source_view) if user_prompt else source_view
@@ -626,7 +626,7 @@ class Coordinator(Viewer, VectorLookupToolUser):
         if isinstance(obj, (Column, Card, Tabs)):
             string = ""
             for o in obj:
-                if isinstance(o, ChatStep):
+                if isinstance(o, ChatStep) or o.name == "TableSourceCard":
                     # Drop context from steps; should be irrelevant now
                     continue
                 string += self._serialize(o)


### PR DESCRIPTION
Fixes handling of file upload via the chat input area. Previously the `on_submit` callback would be called long before the file uploads would complete. Instead we add an explicit listener for the `value_uploaded` parameter and then render a stripped down `SourceControls` and once fully uploaded we show the `TableSourceCard` corresponding to the newly added source.