### PR TITLE
Raise errors in agents

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -94,12 +94,9 @@ class Agent(Viewer, ToolUser, ContextProvider):
                 return
 
             import traceback
-
             traceback.print_exception(exception)
             self.interface.send(f"Error cannot be resolved:\n\n{exception}", user="System", respond=False)
 
-        if "interface" not in params:
-            params["interface"] = ChatInterface(callback=self._interface_callback)
         super().__init__(**params)
         if not self.debug:
             pn.config.exception_handler = _exception_handler

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -94,9 +94,12 @@ class Agent(Viewer, ToolUser, ContextProvider):
                 return
 
             import traceback
+
             traceback.print_exception(exception)
             self.interface.send(f"Error cannot be resolved:\n\n{exception}", user="System", respond=False)
 
+        if "interface" not in params:
+            params["interface"] = ChatInterface(callback=self._interface_callback, callback_exception="raise" if self.debug else "summary")
         super().__init__(**params)
         if not self.debug:
             pn.config.exception_handler = _exception_handler


### PR DESCRIPTION
Edit: Nevermind, I remembered that ChatInterface has callback exception... Updating it to `raise` for debug=True works

 but if you don't render the interface, the errors don't ever surface. In Panel, there probably is a way to check if it's rendered; if not set the callback_exception="raise"?

---

~I don't know why, but having interface defined silences all errors... e.g.~

```python
agent = SQLAgent(llm=llm, debug=True)
with agent._add_step():
    raise
```

While this works...
```python
actor = Actor(llm=llm, debug=True)
with actor._add_step():
    raise
```