### PR TITLE
Should not depend on interface

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -649,7 +649,7 @@ class Coordinator(Viewer, VectorLookupToolUser):
 
             # TODO INVESTIGATE
             messages = fuse_messages(
-                self.interface.serialize(custom_serializer=self._serialize, limit=10),
+                self.interface.serialize(custom_serializer=self._serialize, limit=10) or messages,
                 max_user_messages=self.history
             )
 


### PR DESCRIPTION
```python
f"User Request: {user_query['content']!r}\n\nComplete the next unchecked todo:\n{todos}" ~~~~~~~~~~^^^^^^^^^^^  TypeError: 'NoneType' object is not subscriptable
```

user_query was None because `messages == []` because Planner was depending on a message on an interface, but I bypassed that step with:
```python

planner = Planner(agents=[agent], llm=llm, interface=interface)
await planner.respond([{"role": "user", "content": "find first row in oni"}])
```