### PR TITLE
change instructor import

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -11,8 +11,8 @@ import instructor
 import panel as pn
 import param
 
+from instructor import Mode, patch
 from instructor.dsl.partial import Partial
-from instructor.patch import Mode, patch
 from pydantic import BaseModel
 
 from .interceptor import Interceptor


### PR DESCRIPTION
Updated instructor and it broke:
```python

  File "/usr/local/lib/python3.11/site-packages/lumen/ai/actor.py", line 16, in <module>
    from .llm import Llm, Message
  File "/usr/local/lib/python3.11/site-packages/lumen/ai/llm.py", line 15, in <module>
    from instructor.patch import Mode, patch
ModuleNotFoundError: No module named 'instructor.patch'
```

Tested `from instructor import Mode, patch` in 1.9.0 and 1.11.1 and it seemed to work.