### PR TITLE
Fix empty df  due to duckdb not being thread-safe

### DIFF
--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -401,6 +401,12 @@ class DuckDBSource(BaseSQLSource):
         rel = self._connection.execute(sql_expr)
         has_geom = any(d[0] == 'geometry' and d[1] == 'BINARY' for d in rel.description)
         df = rel.fetch_df(date_as_object=True)
+
+        if df.empty:
+            rel = self._connection.execute(sql_expr)
+            has_geom = any(d[0] == 'geometry' and d[1] == 'BINARY' for d in rel.description)
+            df = rel.fetch_df(date_as_object=True)
+
         if has_geom:
             import geopandas as gpd
             geom = self._connection.execute(


### PR DESCRIPTION
Earlier, we saw that `df.empty is True` and we suspected it was due to SQLLimit, but even after disabling that, it was still failing. I've concluded that it's related to duckdb and race conditions or something with pytest starting multiple threads and fetch was not pointed to the right connection?


I've also attempted different variations of `self._connection.sql()` and `self._connection.query()` which result in:

```
Attempting to execute an unsuccessful or closed pending query result
```

From https://github.com/duckdb/duckdb/issues/13498#issuecomment-2540940925
```
duckdb.sql() is not thread safe!
To call .sql() in concurrent threads, create a new connection first and call con.sql() on it, like in the function good()
```

From https://duckdb.org/docs/stable/clients/python/dbapi.html
Connections are closed implicitly when they go out of scope or if they are explicitly closed using close(). Once the last connection to a database instance is closed, the database instance is closed as well.
