### PR TITLE
Reinforce in SQL model to not apply limits unless specified

### DIFF
--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -28,7 +28,7 @@ class SqlQuery(PartialBaseModel):
     """A single SQL query with its associated metadata."""
 
     query: str = Field(description="""
-        One, correct, valid SQL query that answers the user's question;
+        One, correct, valid SQL query that answers the user's question without limits unless specified;
         should only be one query and do NOT add extraneous comments; no multiple semicolons""")
 
     expr_slug: str = Field(


### PR DESCRIPTION
In the system prompt, we specify:
```
5. No LIMIT clauses unless explicitly requested by the user - Pagination is automatically handled
```

However, I still see it LIMIT 10 probably because those instructions are up top--so added some prompt reinforcement in the model.