### PR TITLE
Append ChatAgent even if tool is TableLookup

### DIFF
--- a/lumen/ai/coordinator.py
+++ b/lumen/ai/coordinator.py
@@ -1163,7 +1163,7 @@ class Planner(Coordinator):
             actors_in_graph.add(key)
 
         last_task = tasks[-1]
-        if isinstance(last_task.subtasks[0], Tool) and not isinstance(last_task.subtasks[0], TableLookup):
+        if isinstance(last_task.subtasks[0], Tool):
             if "AnalystAgent" in agents and all(r in provided for r in agents["AnalystAgent"].requires):
                 actor = "AnalystAgent"
             else:


### PR DESCRIPTION
Some queries just ended with "IterativeTableLookup" and there wasn't really anything else, which was confusing. Not sure what the reason was to exclude TableLookup.