### PR TITLE
Separate sql models for one shot vs discovery

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -652,7 +652,7 @@ class SQLAgent(LumenBaseAgent):
             raise ValueError("No output was generated.")
 
         sql_queries = {}
-        for query_obj in ([output.query] if isinstance(output, SqlQuery) else output.queries):
+        for query_obj in ([output] if isinstance(output, SqlQuery) else output.queries):
             if query_obj.query and query_obj.expr_slug:
                 sql_queries[query_obj.expr_slug.strip()] = query_obj.query.strip()
 

--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -37,7 +37,7 @@ from .llm import Llm, Message
 from .memory import _Memory
 from .models import (
     DbtslQueryParams, NextStep, PartialBaseModel, QueryCompletionValidation,
-    RetrySpec, SQLRoadmap, VegaLiteSpec, make_sql_model,
+    RetrySpec, SqlQuery, SQLRoadmap, VegaLiteSpec, make_sql_model,
 )
 from .schemas import get_metaset
 from .services import DbtslMixin
@@ -648,17 +648,13 @@ class SQLAgent(LumenBaseAgent):
             model_spec=model_spec,
             response_model=sql_response_model,
         )
+        if not output:
+            raise ValueError("No output was generated.")
 
         sql_queries = {}
-        if hasattr(output, "queries"):
-            for query_obj in (output.queries if output else []):
-                if query_obj.query and query_obj.expr_slug:
-                    sql_queries[query_obj.expr_slug.strip()] = query_obj.query.strip()
-        else:
-            sql_queries[output.expr_slug.strip()] = output.query.strip()
-
-        if not sql_queries:
-            raise ValueError("No SQL queries were generated.")
+        for query_obj in ([output.query] if isinstance(output, SqlQuery) else output.queries):
+            if query_obj.query and query_obj.expr_slug:
+                sql_queries[query_obj.expr_slug.strip()] = query_obj.query.strip()
 
         return sql_queries
 

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -41,7 +41,7 @@ class SqlQuery(PartialBaseModel):
     )
 
 
-class Sql(PartialBaseModel):
+class SqlQueries(PartialBaseModel):
     """Multiple SQL queries to execute in sequence."""
 
     queries: list[SqlQuery] = Field(
@@ -53,6 +53,12 @@ class Sql(PartialBaseModel):
         """
     )
 
+
+def make_sql_model(is_final: bool = False):
+    if is_final:
+        return SqlQuery
+    else:
+        return SqlQueries
 
 
 class SQLRoadmap(PartialBaseModel):

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -46,11 +46,7 @@ class SqlQueries(PartialBaseModel):
 
     queries: list[SqlQuery] = Field(
         default_factory=list,
-        description="""
-        List of SQL queries to execute. For discovery steps, include multiple queries
-        to explore different aspects (e.g., distinct values from different columns).
-        For final steps, only one query is allowed.
-        """
+        description="""List of SQL queries to execute."""
     )
 
 


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/1402

For a while, I was wondering why gpt-4.1-mini SQL was terrible--turns out it's actually not following the model prompt too deeply: `For final steps, only one query is allowed.`

I found out it had been generated 6 queries, and the code only grabs the first one:
<img width="476" height="898" alt="image" src="https://github.com/user-attachments/assets/02069a1f-b269-4119-b7de-5ea4b75ed2c6" />

So you end up with results like:
<img width="476" height="193" alt="image" src="https://github.com/user-attachments/assets/a0e5ebaa-fe6e-4170-91cb-e6ce0084dcd6" />

By separating out the model, the LLM has less choices to make, and properly writes SQL that is more useful:
<img width="929" height="169" alt="image" src="https://github.com/user-attachments/assets/8259e0b4-eeba-45b9-8871-79509da3c7e1" />

