### PR TITLE
Targeted retry

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -46,7 +46,7 @@ from .translate import param_to_pydantic
 from .utils import (
     apply_changes, clean_sql, describe_data, get_data, get_pipeline,
     get_root_exception, get_schema, load_json, log_debug, mutate_user_message,
-    report_error, retry_llm_output, stream_details,
+    report_error, retry_llm_output, set_nested, stream_details,
 )
 from .views import (
     AnalysisOutput, LumenOutput, SQLOutput, VegaLiteOutput,
@@ -476,6 +476,8 @@ class LumenBaseAgent(Agent):
         }
     )
 
+    _retry_target_keys = []
+
     _output_type = LumenOutput
 
     _max_width = None
@@ -484,6 +486,64 @@ class LumenBaseAgent(Agent):
         """
         Update the specification in memory.
         """
+
+    @staticmethod
+    def _prepare_lines_for_retry(original_output: str, retry_target_keys: list[str] | None = None) -> tuple[list[str], bool, dict | None]:
+        """
+        Prepare lines for retry by optionally extracting targeted sections from YAML.
+
+        Args:
+            original_output: The original output string to process
+            retry_target_keys: Optional list of keys to target specific sections in YAML
+
+        Returns:
+            Tuple of (lines, targeted, original_spec)
+            - lines: List of lines to be processed
+            - targeted: Whether targeting was applied
+            - original_spec: Original parsed spec if targeting was used, None otherwise
+        """
+        lines = original_output.splitlines()
+        targeted = False
+        original_spec = None
+
+        if retry_target_keys:
+            original_spec = yaml.safe_load(original_output)
+            targeted_output = original_spec.copy()
+            for key in retry_target_keys:
+                targeted_output = targeted_output[key]
+            lines = yaml.dump(targeted_output, default_flow_style=False).splitlines()
+            targeted = True
+
+        return lines, targeted, original_spec
+
+    @staticmethod
+    def _apply_line_changes_to_output(
+        lines: list[str],
+        line_changes: list,
+        targeted: bool,
+        original_spec: dict | None = None,
+        retry_target_keys: list[str] | None = None
+    ) -> str:
+        """
+        Apply line changes to output, handling both targeted and non-targeted cases.
+
+        Args:
+            lines: The lines that were modified
+            line_changes: Changes to apply to the lines
+            targeted: Whether this was a targeted retry
+            original_spec: Original parsed spec for targeted retries
+            retry_target_keys: Keys used for targeting
+
+        Returns:
+            Final output string with changes applied
+        """
+        if targeted:
+            targeted_spec = yaml.safe_load(apply_changes(lines, line_changes))
+            updated_spec = original_spec.copy()
+            set_nested(updated_spec, retry_target_keys, targeted_spec)
+            return yaml.dump(updated_spec)
+        else:
+            return apply_changes(lines, line_changes)
 
     async def _retry_output_by_line(
         self,
@@ -496,10 +556,13 @@ class LumenBaseAgent(Agent):
         """
         Retry the output by line, allowing the user to provide feedback on why the output was not satisfactory, or an error.
         """
-        original_lines = original_output.splitlines()
+        # Prepare lines for retry processing
+        lines, targeted, original_spec = self._prepare_lines_for_retry(
+            original_output, self._retry_target_keys
+        )
+
         with self.param.update(memory=memory):
-            # TODO: only input the inner spec to retry
-            numbered_text = "\n".join(f"{i:2d}: {line}" for i, line in enumerate(original_lines, 1))
+            numbered_text = "\n".join(f"{i:2d}: {line}" for i, line in enumerate(lines, 1))
             system = await self._render_prompt(
                 "retry_output",
                 messages=messages,
@@ -515,7 +578,11 @@ class LumenBaseAgent(Agent):
             model_spec="edit",
         )
         result = await self.llm.invoke(**invoke_kwargs)
-        return apply_changes(original_lines, result.lines_changes)
+
+        # Apply line changes and return result
+        return self._apply_line_changes_to_output(
+            lines, result.lines_changes, targeted, original_spec, self._retry_target_keys
+        )
 
     def _render_lumen(
         self,
@@ -1520,6 +1587,8 @@ class VegaLiteAgent(BaseViewAgent):
     _extensions = ("vega",)
 
     _output_type = VegaLiteOutput
+
+    _retry_target_keys = ["spec"]
 
     async def _update_spec(self, memory: _Memory, event: param.parameterized.Event):
         try:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -12,7 +12,8 @@ import time
 import traceback
 
 from collections.abc import Callable
-from functools import wraps
+from functools import reduce, wraps
+from operator import getitem
 from pathlib import Path
 from shutil import get_terminal_size
 from textwrap import dedent
@@ -943,3 +944,8 @@ def normalized_name(inst: param.Parameterized):
     if re.match('^'+class_name+'[0-9]{5}$', inst.name):
         return class_name
     return inst.name
+
+
+def set_nested(data, keys, value):
+    """Set nested dictionary value"""
+    reduce(getitem, keys[:-1], data)[keys[-1]] = value

--- a/lumen/tests/ai/test_agents_retry.py
+++ b/lumen/tests/ai/test_agents_retry.py
@@ -1,0 +1,96 @@
+import pytest
+import yaml
+
+from lumen.ai.agents import LumenBaseAgent
+
+
+class TestRetryOutputbyLine:
+    """Test cases for the extracted static methods from _retry_output_by_line."""
+
+    def test_prepare_lines_for_retry_without_target_keys(self):
+        """Test _prepare_lines_for_retry when no target keys are specified."""
+        original_output = "line1\nline2\nline3"
+        
+        lines, targeted, original_spec = LumenBaseAgent._prepare_lines_for_retry(
+            original_output, None
+        )
+        
+        assert lines == ["line1", "line2", "line3"]
+        assert targeted is False
+        assert original_spec is None
+
+    def test_prepare_lines_for_retry_with_target_keys(self):
+        """Test _prepare_lines_for_retry when target keys are specified."""
+        original_yaml = """
+        spec:
+          chart:
+            type: bar
+            data: [1, 2, 3]
+        other: value
+        """
+        retry_target_keys = ["spec", "chart"]
+        
+        lines, targeted, original_spec = LumenBaseAgent._prepare_lines_for_retry(
+            original_yaml, retry_target_keys
+        )
+        
+        assert targeted is True
+        assert original_spec is not None
+        assert "spec" in original_spec
+        # The lines should now contain only the targeted section as YAML
+        reconstructed = yaml.safe_load("\n".join(lines))
+        assert reconstructed["type"] == "bar"
+        assert reconstructed["data"] == [1, 2, 3]
+
+    def test_prepare_lines_for_retry_with_invalid_yaml(self):
+        """Test _prepare_lines_for_retry with invalid YAML when targeting."""
+        invalid_yaml = "invalid: yaml: content:"
+        retry_target_keys = ["spec"]
+        
+        with pytest.raises(yaml.YAMLError):
+            LumenBaseAgent._prepare_lines_for_retry(invalid_yaml, retry_target_keys)
+    
+    def test_sql_spec_modification_real_example(self):
+        """Test the complete retry workflow with a real SQL specification example."""
+        original_yaml = 'source:\n  tables:\n    average_sst_during_el_nino_oni_csv: \'SELECT AVG("sst_c") AS "average_sst_el_nino"\n\n      FROM "oni_csv"\n\n      WHERE "oni" = \'\'el_nino\'\'\'\n    oni_csv: oni.csv\n  type: duckdb\n  uri: \':memory:\'\nsql_transforms:\n- limit: 1000000\n  pretty: true\n  read: duckdb\n  type: sql_limit\n  write: duckdb\ntable: average_sst_during_el_nino_oni_csv\n'
+        retry_target_keys = ["source", "tables"]
+
+        # Test prepare_lines_for_retry
+        lines, targeted, original_spec = LumenBaseAgent._prepare_lines_for_retry(
+            original_yaml, retry_target_keys
+        )
+        
+        assert targeted is True
+        assert original_spec is not None
+        assert "source" in original_spec
+        assert "tables" in original_spec["source"]
+        
+        # The lines should contain the extracted tables section
+        reconstructed_tables = yaml.safe_load("\n".join(lines))
+        assert "average_sst_during_el_nino_oni_csv" in reconstructed_tables
+        assert "oni_csv" in reconstructed_tables
+        assert reconstructed_tables["oni_csv"] == "oni.csv"
+        
+        # Test apply_line_changes_to_output with real LineChange
+        from lumen.ai.models import LineChange
+        from lumen.ai.utils import set_nested
+
+        # Simulate the line change that modifies oni_csv
+        line_changes = [LineChange(line_no=5, replacement="oni_csv: SELECT * FROM oni.csv")]
+        
+        # Mock apply_changes to return what it would actually return
+        expected_modified_tables = reconstructed_tables.copy()
+        expected_modified_tables["oni_csv"] = "SELECT * FROM oni.csv"
+        result = LumenBaseAgent._apply_line_changes_to_output(
+            lines, line_changes, targeted=True,
+            original_spec=original_spec, retry_target_keys=retry_target_keys
+        )
+        
+        # Parse the result and verify the modification was applied correctly
+        final_spec = yaml.safe_load(result)
+        assert final_spec["source"]["tables"]["oni_csv"] == "SELECT * FROM oni.csv"
+        # Verify other parts of the spec remain unchanged
+        assert final_spec["sql_transforms"][0]["limit"] == 1000000
+        assert final_spec["table"] == "average_sst_during_el_nino_oni_csv"
+        # Verify the SQL query for the other table is preserved
+        assert "SELECT AVG" in final_spec["source"]["tables"]["average_sst_during_el_nino_oni_csv"]


### PR DESCRIPTION
Previously, when using the edit button:
<img width="426" height="402" alt="image" src="https://github.com/user-attachments/assets/bb45bce8-7a1d-48bc-b56c-33e101027553" />

It would share this whole context with the LLM
```yaml
max_width: 1200
min_height: 300
pipeline:
  source:
    tables:
      top_5_states_by_average_pcap_from_windturbines_parquet: 'SELECT "t_state" AS
        "state", AVG("p_cap") AS "average_pcap"

        FROM "windturbines_parquet"

        GROUP BY "t_state"

        ORDER BY "average_pcap" DESC

        LIMIT 5'
    type: duckdb
    uri: ':memory:'
  sql_transforms:
  - limit: 1000000
    pretty: true
    read: duckdb
    type: sql_limit
    write: duckdb
  table: top_5_states_by_average_pcap_from_windturbines_parquet
sizing_mode: stretch_both
spec:
  $schema: https://vega.github.io/schema/vega-lite/v5.json
  config:
    axis:
      domainColor: '#ddd'
      labelColor: '#666666'
      tickColor: '#ddd'
    background: '#ffffff'
    view:
      stroke: '#ddd'
  data:
    name: top_5_states_by_average_pcap_from_windturbines_parquet
  height: container
  layer:
  - encoding:
      color:
        condition:
          test: datum.state === 'NM'
          value: '#8b0000'
        value: '#d3d3d3'
      tooltip:
      - field: state
        title: State
        type: ordinal
      - field: average_pcap
        format: .2f
        title: Average pcap
        type: quantitative
      x:
        axis:
          domain: false
          labelFontSize: 16
          ticks: false
        field: state
        sort: -y
        title: State
        type: ordinal
      y:
        axis:
          format: .2f
          grid: true
          gridDash:
          - 3
          - 3
          gridOpacity: 0.5
          labelFontSize: 16
          tickCount: 6
        field: average_pcap
        title: Average Power Capacity (pcap)
        type: quantitative
    mark:
      cornerRadius: 1
      opacity: 0.75
      type: bar
  - encoding:
      color:
        value: '#666666'
      text:
        field: average_pcap
        format: .2f
        type: quantitative
      x:
        field: state
        sort: -y
        type: ordinal
      y:
        field: average_pcap
        type: quantitative
    mark:
      align: left
      dx: 5
      fontSize: 16
      type: text
  title:
    anchor: start
    fontSize: 24
    subtitle: New Mexico (NM) leads significantly with an average pcap of 388.84
    subtitleColor: '#666666'
    subtitleFontSize: 20
    text: Top 5 States by Average Power Capacity from Wind Turbines
  transform:
  - as: average_pcap
    calculate: datum.average_pcap
  width: container
type: vegalite
```

This not only uses more input tokens, but there's a lot of unnecessary noise. This PR basically does some pre-processing and post-processing to only pass the `spec` key value:

```yaml
  $schema: https://vega.github.io/schema/vega-lite/v5.json
  config:
    axis:
      domainColor: '#ddd'
      labelColor: '#666666'
      tickColor: '#ddd'
    background: '#ffffff'
    view:
      stroke: '#ddd'
  data:
    name: top_5_states_by_average_pcap_from_windturbines_parquet
  height: container
  layer:
  - encoding:
      color:
        condition:
          test: datum.state === 'NM'
          value: '#8b0000'
        value: '#d3d3d3'
      tooltip:
      - field: state
        title: State
        type: ordinal
      - field: average_pcap
        format: .2f
        title: Average pcap
        type: quantitative
      x:
        axis:
          domain: false
          labelFontSize: 16
          ticks: false
        field: state
        sort: -y
        title: State
        type: ordinal
      y:
        axis:
          format: .2f
          grid: true
          gridDash:
          - 3
          - 3
          gridOpacity: 0.5
          labelFontSize: 16
          tickCount: 6
        field: average_pcap
        title: Average Power Capacity (pcap)
        type: quantitative
    mark:
      cornerRadius: 1
      opacity: 0.75
      type: bar
  - encoding:
      color:
        value: '#666666'
      text:
        field: average_pcap
        format: .2f
        type: quantitative
      x:
        field: state
        sort: -y
        type: ordinal
      y:
        field: average_pcap
        type: quantitative
    mark:
      align: left
      dx: 5
      fontSize: 16
      type: text
  title:
    anchor: start
    fontSize: 24
    subtitle: New Mexico (NM) leads significantly with an average pcap of 388.84
    subtitleColor: '#666666'
    subtitleFontSize: 20
    text: Top 5 States by Average Power Capacity from Wind Turbines
  transform:
  - as: average_pcap
    calculate: datum.average_pcap
  width: container
```