### PR TITLE
Remove consecutive user

### DIFF
--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -287,6 +287,17 @@ class TaskGroup(Task):
         outputs = []
         memory = task.memory or self.memory
         messages = list(self.history)
+        if self.instruction:
+            user_msg = None
+            for msg in messages[::-1]:
+                if msg.get("role") == "user":
+                    user_msg = msg
+                    break
+            if not user_msg:
+                messages.append({"role": "user", "content": self.instruction})
+            elif self.instruction not in user_msg.get("content"):
+                user_msg["content"] = f'{user_msg["content"]}\n\nInstruction: {self.instruction}'
+
         with task.param.update(
             interface=self.interface,
             llm=task.llm or self.llm,

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -287,9 +287,6 @@ class TaskGroup(Task):
         outputs = []
         memory = task.memory or self.memory
         messages = list(self.history)
-        if self.instruction:
-            messages.append({"role": "user", "content": self.instruction})
-
         with task.param.update(
             interface=self.interface,
             llm=task.llm or self.llm,


### PR DESCRIPTION
I think https://github.com/holoviz/lumen/pull/1426 reintroduced
`WARNING: Two consecutive messages from the same role; some providers disallow this.`

```bash

2025-10-06 08:12:36,184 Message 1 (u): User Request: 'Describe the dataset'

Complete the underlined todo:
- [ ] <u>Provide a high-level description of the 'windturbines_parquet' dataset, including its general contents, structure, and purpose.</u>
2025-10-06 08:12:36,184 Message 2 (u): Provide a high-level description of the 'windturbines_parquet' dataset, including its general contents, structure, and purpose.
```