### PR TITLE
Add xarray-sql support

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -22,7 +22,13 @@ from ..sources.duckdb import DuckDBSource
 from ..util import detect_file_encoding
 from .memory import _Memory, memory
 
-TABLE_EXTENSIONS = ("csv", "parquet", "parq", "json", "xlsx", "geojson", "wkt", "zip")
+try:
+    from ..sources.xarray_sql import XArraySource
+    XARRAY_AVAILABLE = True
+except ImportError:
+    XARRAY_AVAILABLE = False
+
+TABLE_EXTENSIONS = ("csv", "parquet", "parq", "json", "xlsx", "geojson", "wkt", "zip", "nc", "zarr")
 
 # Download configuration constants
 class DownloadConfig:
@@ -594,6 +600,55 @@ class SourceControls(Viewer):
             conn.execute(init[0])
             cols = ', '.join(f'"{c}"' for c in df.columns if c != 'geometry')
             conversion = f'CREATE TEMP TABLE {table} AS SELECT {cols}, ST_GeomFromWKB(geometry) as geometry FROM {table}_temp'
+        elif extension.endswith(('nc', 'zarr')):
+            # Handle NetCDF and Zarr files with XArraySource
+            if not XARRAY_AVAILABLE:
+                self._error_placeholder.object += f"\nCannot process {table_controls.filename}.{extension}: xarray-sql is not installed."
+                self._error_placeholder.visible = True
+                return 0
+
+            # Save file temporarily and create XArraySource
+            import os
+            import tempfile
+
+            # Create temporary file with appropriate extension
+            with tempfile.NamedTemporaryFile(delete=False, suffix=f'.{extension}') as tmp:
+                file.seek(0)
+                tmp.write(file.read())
+                tmp_path = tmp.name
+
+            try:
+                # Create XArraySource for this file
+                xarray_source = XArraySource(
+                    tables={table: tmp_path},
+                    chunks={'time': 24},  # Default chunking
+                    name=f'XArraySource_{table}'
+                )
+
+                # Add to memory sources
+                if 'sources' in self._memory:
+                    # Check if source already exists
+                    existing_sources = self._memory['sources']
+                    # Remove any existing source with the same table name
+                    self._memory['sources'] = [
+                        s for s in existing_sources
+                        if not (isinstance(s, XArraySource) and table in s.get_tables())
+                    ]
+                    self._memory['sources'].append(xarray_source)
+                else:
+                    self._memory['sources'] = [xarray_source]
+
+                self._memory['source'] = xarray_source
+                self._memory['table'] = table
+                self._last_table = table
+                return 1
+            except Exception as e:
+                self._error_placeholder.object += f"\nCould not load {table_controls.filename}.{extension}: {e}"
+                self._error_placeholder.visible = True
+                # Clean up temp file on error
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+                return 0
         else:
             self._error_placeholder.object += f"\nCould not convert {table_controls.filename}.{extension}."
             self._error_placeholder.visible = True

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -1,7 +1,9 @@
 import asyncio
 import io
+import os
 import pathlib
 import re
+import tempfile
 import zipfile
 
 from urllib.parse import urlparse
@@ -606,10 +608,6 @@ class SourceControls(Viewer):
                 self._error_placeholder.object += f"\nCannot process {table_controls.filename}.{extension}: xarray-sql is not installed."
                 self._error_placeholder.visible = True
                 return 0
-
-            # Save file temporarily and create XArraySource
-            import os
-            import tempfile
 
             # Create temporary file with appropriate extension
             with tempfile.NamedTemporaryFile(delete=False, suffix=f'.{extension}') as tmp:

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -723,7 +723,7 @@ class SQLSample(SQLTransform):
         expression = self.parse_sql(sql_in)
         dialect = self.write or self.read
 
-        if dialect in ('sqlserver', 'duckdb') or (dialect in ('postgres', 'redshift', 'snowflake', 'bigquery')):
+        if dialect in ('sqlserver', 'duckdb') or (dialect in ('redshift', 'snowflake', 'bigquery')):
             return self._apply_tablesample_dialect(expression)
         elif dialect in ('mysql', 'mariadb'):
             return self._apply_mysql_dialect(expression)

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,6 +32,7 @@ panel = ">=1.7.5"
 param = ">=2.2.1"
 pip = "*"
 sqlglot = "*"
+sqlglotrs = "*"
 
 [feature.py310.dependencies]
 python = "3.10.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "panel >=1.7.5",
     "param >=2.2.1",
     "sqlglot",
+    "sqlglotrs",
 ]
 
 [project.urls]


### PR DESCRIPTION

Just a proof of concept integrating https://github.com/alxmrs/xarray-sql 

```
import xarray as xr
ds = xr.tutorial.open_dataset('air_temperature')
ds.to_netcdf('air.nc')
```

`lumen-ai serve air.nc`

<img width="1599" height="1185" alt="image" src="https://github.com/user-attachments/assets/45c69337-3a21-4016-b815-58094625378e" />
<img width="1589" height="1007" alt="image" src="https://github.com/user-attachments/assets/c07121b8-0d36-484c-be5c-93f231adcc73" />
<img width="1599" height="1184" alt="image" src="https://github.com/user-attachments/assets/d243c225-0e5b-4252-a342-5a6c90a4d9af" />

I wonder if this should be a lumen extension, like lumen-anndata. Part of me feels like it should be in core, so it works like hvplot.xarray, but at the same time, unsure about the limitations about the SQL & xarray.

I think if xarray-sql supported xarray-datatrees, then it's possible to rebuild AnndataSource on this since xarray is a generalized library supporting n-D dimension datasets.