### PR TITLE
Set vector store to read only for VegaLite

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -1547,7 +1547,8 @@ class VegaLiteAgent(BaseViewAgent):
                 response = requests.get(f"{VECTOR_STORE_ASSETS_URL}{db_file}", timeout=5)
                 response.raise_for_status()
                 uri.write_bytes(response.content)
-        self._vector_store = DuckDBVectorStore(uri=str(uri))
+        # Use a read-only connection to avoid lock conflicts
+        self._vector_store = DuckDBVectorStore(uri=str(uri), read_only=True)
         return self._vector_store
 
     def _deep_merge_dicts(self, base_dict: dict[str, Any], update_dict: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
Prevents this:
```
Traceback (most recent call last):
  File "/Users/ahuang/repos/lumen/lumen/ai/report.py", line 309, in _run_task
    out = await task.respond(messages, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 977, in async_wrapper
    return await instrumented_func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/site-packages/logfire/_internal/instrument.py", line 93, in wrapper
    result = await func(*func_args, **func_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/agents.py", line 1875, in respond
    doc_examples = await self._get_doc_examples(user_query)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/agents.py", line 1826, in _get_doc_examples
    vector_store = self._get_vector_store()
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/agents.py", line 1550, in _get_vector_store
    self._vector_store = DuckDBVectorStore(uri=str(uri))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/vector_store.py", line 1067, in __init__
    connection.execute(f"ATTACH DATABASE '{self.uri}' AS embedded;")
duckdb.duckdb.IOException: IO Error: Could not set lock on file "/Users/ahuang/Library/Caches/lumen/vega_lite_examples_openai.db": Conflicting lock is held in /Users/ahuang/miniconda3/envs/lumen/bin/python3.12 (PID 97973) by user ahuang. See also https://duckdb.org/docs/stable/connect/concurrency
```

Tested by running simultaneous Lumen serves calling VegaLite.