### PR TITLE
Exclude API key

### DIFF
--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -1125,6 +1125,8 @@ class DuckDBVectorStore(VectorStore):
             "params": {}
         }
         for param_name in self.embeddings.param:
+            if param_name == "api_key":
+                continue
             if param_name not in ['name']:
                 value = getattr(self.embeddings, param_name)
                 if isinstance(value, (str, int, float, bool, list, dict)) or value is None:


### PR DESCRIPTION
Without this, API key is stored in the metadata as plain text