### PR TITLE
Missing gemini req

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ ai-mistralai = ['lumen[ai]', 'mistralai']
 ai-anthropic = ['lumen[ai]', 'anthropic']
 ai-transformers = ['lumen[ai-local]', 'sentence_transformers>=2.7.0', 'transformers>=4.51.0']  # for embeddings
 ai-llama = ['lumen[ai-local]', 'llama-cpp-python >=0.3.15']
-ai-google = ['lumen[ai]', 'google-genai']
+ai-google = ['lumen[ai]', 'google-genai', 'jsonref']
 ai-litellm = ['lumen[ai]', 'litellm']
 ai-ollama = ['lumen[ai]', 'ollama']
 bigquery = ['google-cloud-bigquery', 'sqlalchemy-bigquery']


### PR DESCRIPTION
Using instructor with gemini
```
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/instructor/providers/gemini/utils.py", line 142, in map_to_gemini_function_schema
    import jsonref
ModuleNotFoundError: No module named 'jsonref'
```

