### PR TITLE
Add chevron for expanding explorer output

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -821,13 +821,11 @@ class ExplorerUI(UI):
     def _toggle_explorer_panel(self, event):
         """Toggle the explorer output panel visibility."""
         if event.new:
-            # Collapse the panel (hide it)
             self._split.param.update(
                 collapsed=True,
                 sizes=(100, 0),
             )
         else:
-            # Expand the panel (show it)
             self._split.param.update(
                 collapsed=False,
                 sizes=self._split.expanded_sizes,


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/1473

I think it can be confusing without a dedicated icon for the exploration output.

However, I think panel-material-ui has a bug with ThemeToggle; initially makes the whole screen blue?

https://github.com/user-attachments/assets/ace752b5-82c3-48fc-90fb-0811519d9a13

