### PR TITLE
No longer set widget to None before calling super

### DIFF
--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -247,7 +247,6 @@ class BaseWidgetFilter(Filter):
     __abstract = True
 
     def __init__(self, **params):
-        self.widget = None
         super().__init__(**params)
 
     def _setup_sync(self):


### PR DESCRIPTION
I ran the `test-unit` task locally with a local version of Param from its main branch and got this warning:

```
param._utils.ParamPendingDeprecationWarning: Setting the Parameter 'widget' to None before the Parameterized class 'WidgetFilter' is fully instantiated is deprecated and will raise an error in a future version. Ensure the value is set after calling `super().__init_
```