### PR TITLE
Fix duckdb BindException

### DIFF
--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -89,7 +89,6 @@ class DuckDBSource(BaseSQLSource):
                     cursor.execute(init)
 
         # Process tables to handle automatic file detection
-        # Skip view creation if connection was passed in (views already exist)
         if isinstance(self.tables, dict):
             processed_tables = {}
             self._file_based_tables = {}


### PR DESCRIPTION
Not sure why, but it suddenly broke on me today, when launching from CLI `lumen-ai serve data/file.csv`

<img width="617" height="394" alt="image" src="https://github.com/user-attachments/assets/a54d2dda-84cf-490c-aebc-d197c76e14e2" />

```
duckdb.duckdb.BinderException: Binder Error: infinite recursion detected: attempting to recursively bind view "data_gpt_41_mini_csv"
```

The issue seems to stem from:

Initially properly set up DuckDBSource:
```
{'data_gpt_41_mini_csv': 'data/gpt-41-mini.csv'} FILE BASED TABLES...
{} SQL BASED TABLES...
```

Somehow, when create_sql_expr_source() is called:
```
{} FILE BASED TABLES...
{'data_gpt_41_mini_csv': 'SELECT * FROM "data_gpt_41_mini_csv"',   <-- here


'full_data_from_data_gpt_41_mini_csv': 'SELECT * FROM "data_gpt_41_mini_csv"'} SQL BASED TABLES...
```

This PR manually sorts it out
