### PR TITLE
Remove set page_size to unlimit num rows on big vertical screen

### DIFF
--- a/lumen/ai/agents.py
+++ b/lumen/ai/agents.py
@@ -385,7 +385,6 @@ class ListAgent(Agent):
                 min_width=350,
                 widths={self._column_name: "90%"},
                 disabled=True,
-                page_size=10,
                 pagination="remote",
                 header_filters=header_filters,
                 sizing_mode="stretch_width",

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1127,8 +1127,10 @@ class Table(View):
     See https://panel.holoviz.org/reference/widgets/Tabulator.html
     """
 
-    page_size = param.Integer(default=20, bounds=(1, None), doc="""
-        Number of rows to render per page, if pagination is enabled.""")
+    page_size = param.Integer(default=None, bounds=(1, None), doc="""
+        Number of rows to render per page, if pagination is enabled.
+        If None all rows are rendered. If None the initial amount of data
+        is determined by the initial_page_size""")
 
     view_type = 'table'
 


### PR DESCRIPTION
Rather than set the page_size arbitrarily, let it be determined by the initial page size