### PR TITLE
Make chunk size default to None

### DIFF
--- a/lumen/ai/tools.py
+++ b/lumen/ai/tools.py
@@ -1320,7 +1320,7 @@ class DbtslLookup(VectorLookupTool, DbtslMixin):
                 "metric_type": str(metric.type.value) if metric.type else "UNKNOWN",
             }
 
-            items_to_upsert.append({"text": enriched_text, "metadata": vector_metadata})
+            items_to_upsert.append({"text": enriched_text, "metadata": vector_metadata, "chunk_size": None})
 
         # Make a single upsert call with all metrics
         if items_to_upsert:

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -59,7 +59,7 @@ class VectorStore(LLMUser):
     )
 
     chunk_size = param.Integer(
-        default=None, doc="Maximum size of text chunks to split documents into."
+        default=1024, doc="Maximum size of text chunks to split documents into."
     )
 
     chunk_tokenizer = param.String(


### PR DESCRIPTION
Based on https://github.com/holoviz/lumen/pull/1501

Setting chunk_size to None so that:
`semchunk.chunkerify`

chunk_size (int, optional): The maximum number of tokens a chunk may contain. Defaults to `None` in which case it will be set to the same value as the tokenizer's `model_max_length` attribute (deducted by the number of tokens returned by attempting to tokenize an empty string) if possible otherwise a `ValueError` will be raised.


```
        if self.chunk_func is None:
            self.chunk_func = semchunk.chunkerify(
                self.chunk_tokenizer, chunk_size=self.chunk_size
            )
```


Edit: Okay it seems that setting the default chunk_size=None doesn't work; but it does work on upsert