### PR TITLE
Rest duckdb source

### DIFF
--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -366,11 +366,14 @@ class DuckDBSource(BaseSQLSource):
 
         # Only preserve existing tables if reusing the connection
         # If uri or initializers changed, start fresh with only new tables
+        all_tables = tables
         if 'uri' not in kwargs and 'initializers' not in kwargs:
             # Reuse connection - start with ALL existing tables (upsert behavior)
-            all_tables = dict(self.tables) if isinstance(self.tables, dict) else {}
-            # Update with new tables (overwrites if exists, adds if new)
-            all_tables.update(tables)
+            # Only applies when self.tables is a dict (list-based tables don't have SQL expressions)
+            if isinstance(self.tables, dict):
+                all_tables = dict(self.tables)
+                # Update with new tables (overwrites if exists, adds if new)
+                all_tables.update(tables)
         else:
             # New connection - only use the new tables, but include file-based dependencies
             all_tables = dict(tables)

--- a/lumen/sources/rest_duckdb.py
+++ b/lumen/sources/rest_duckdb.py
@@ -1,0 +1,168 @@
+"""
+RESTDuckDBSource - DuckDB source with URL parameterization support.
+
+Enables dynamic URL query parameter updates for REST API endpoints,
+making it compatible with LLM-based agents like SQLAgent.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from urllib.parse import urlencode, urlparse, urlunparse
+
+import param
+import sqlglot
+
+from duckdb import InvalidInputException
+
+from .duckdb import DuckDBSource
+
+
+class RESTDuckDBSource(DuckDBSource):
+    """
+    DuckDBSource subclass that supports parameterized REST API URLs.
+
+    This source allows defining URL templates with dynamic query parameters
+    that can be updated at runtime, enabling LLM agents to modify API calls
+    on the fly.
+
+    Parameters
+    ----------
+    materialize : bool, default True
+        Whether to materialize REST tables as temp tables on initialization.
+        When True, REST tables are immediately fetched and stored as temp tables,
+        allowing them to be referenced in SQL expressions.
+    cache : bool, default False
+        Whether to cache HTTP responses using DuckDB's cache_httpfs extension.
+        When True, repeated requests to the same URL return cached results.
+
+    REST table configurations are specified as dictionaries with:
+    - 'url': Base URL of the REST endpoint
+    - 'url_params': Dict of query parameters (including 'format' if the API supports it)
+    - 'required_params': Optional list of parameter names that must be provided
+    - 'read_fn': Optional override for the DuckDB read function ('json', 'csv', 'parquet').
+                 If not specified, auto-detects from url_params['format'] or URL extension.
+    - 'read_options': Optional dict of DuckDB read_* function options
+    """
+
+    cache_httpfs = param.Boolean(
+        default=True,
+        doc="""
+        Whether to cache HTTP responses using DuckDB's cache_httpfs extension.
+        When True, repeated requests to the same URL return cached results.
+        """,
+    )
+
+    data_format = param.String(
+        default="json",
+        doc="""
+        Default data format for REST tables if not specified in url_params.
+        Used to determine the appropriate DuckDB read function.
+        """,
+    )
+
+    source_type: ClassVar[str] = 'rest_duckdb'
+
+    # Map format to DuckDB read function (using auto variants where available)
+    _format_to_reader: ClassVar[dict[str, str]] = {
+        'json': 'read_json_auto',
+        'csv': 'read_csv_auto',
+        'parquet': 'read_parquet',
+        'ndjson': 'read_ndjson_auto',
+    }
+
+    _created_views = param.Dict(default={}, doc="Internal dict of created views for REST tables.")
+
+    def _is_rest_table(self, table: str) -> bool:
+        if table not in self.tables:
+            raise ValueError(f"Table '{table}' not found in source tables.")
+        return isinstance(self.tables[table], dict) and 'url' in self.tables[table]
+
+    def get_sql_expr(self, table: str) -> str:
+        if self._is_rest_table(table):
+            read_fn = self._format_to_reader[self.data_format]
+            return f"SELECT * FROM {read_fn}(?)"
+        return super().get_sql_expr(table)
+
+    def get(self, table: str, url_params: dict[str, Any] | None = None, **query):
+        if not self._is_rest_table(table):
+            return super().get(table, **query)
+
+        table_params = self.tables[table]
+        url_params = {**table_params.get("url_params", {}), **(url_params or {})}
+
+        last_exc = None
+        url = self.render_table_url(table, url_params=url_params)
+        data_format = url_params.get("format", self.data_format)
+        for try_data_format in (data_format, 'csv'):
+            with self.param.update(table_params={table: [url]}, data_format=try_data_format):
+                try:
+                    return super().get(table, **query)
+                except InvalidInputException as exc:
+                    last_exc = exc
+                    continue
+
+        if last_exc is not None:
+            raise last_exc
+
+    def render_table_url(self, table: str, url_params: dict[str, Any] | None = None) -> str:
+        """
+        Get the current full URL for a REST table.
+
+        Can be called with either table OR config (for internal use).
+
+        Parameters
+        ----------
+        table : str
+            Name of the REST table
+        url_params : dict[str, Any] | None
+            Optional URL parameters to override or add to the table's url params
+
+        Returns
+        -------
+        str
+            Full URL with current query parameters
+
+        Raises
+        ------
+        ValueError
+            If table is not a REST table or if neither table nor config is provided
+        """
+        if not self._is_rest_table(table):
+            raise ValueError(f"Table '{table}' is not a REST table.")
+
+        table_params = self.tables[table]
+        url = table_params["url"]
+        if url_params is None:
+            url_params = table_params["url_params"]
+        parsed = urlparse(url)
+        return urlunparse((
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            parsed.params,
+            urlencode(url_params),
+            parsed.fragment,
+        ))
+
+    def execute(self, sql_query: str, params: list | dict | None = None, url_params: dict[str, Any] | None = None, *args, **kwargs):
+        # First ensure all REST tables in the query are materialized
+        table_objs = sqlglot.parse_one(sql_query).find_all(sqlglot.exp.Table)
+        rest_tables = {table_obj.name for table_obj in table_objs if self._is_rest_table(table_obj.name)}
+        for table in rest_tables:
+            # if the table params have changed, recreate the view
+            if self._created_views.get(table) != self.tables[table]:
+                self._connection.from_df(self.get(table, url_params=url_params)).to_view(table)
+                self._created_views[table] = {**self.tables[table], **(url_params or {})}
+        return super().execute(sql_query, *args, params=params, **kwargs)
+
+    def to_spec(self) -> dict[str, Any]:
+        spec = super().to_spec()
+        spec.pop("_created_views", None)
+        return spec
+
+    def create_sql_expr_source(self, tables, materialize = True, params = None, url_params: dict[str, Any] | None = None, **kwargs) -> RESTDuckDBSource:
+        source = super().create_sql_expr_source(tables, materialize, params, **kwargs)
+        # TODO: investigate whether we should ALWAYS copy every tables, not just REST tables
+        # keep references of the original rest tables so views can be recreated
+        source.tables.update(**{table: self.tables[table] for table in self.tables if self._is_rest_table(table)})
+        return source

--- a/lumen/sources/rest_duckdb.py
+++ b/lumen/sources/rest_duckdb.py
@@ -138,11 +138,6 @@ class RESTDuckDBSource(DuckDBSource):
         -------
         str
             Full URL with current query parameters
-
-        Raises
-        ------
-        ValueError
-            If table is not a REST table or if neither table nor config is provided
         """
         if not self._is_rest_table(table):
             raise ValueError(f"Table '{table}' is not a REST table.")

--- a/lumen/sources/rest_duckdb.py
+++ b/lumen/sources/rest_duckdb.py
@@ -127,8 +127,6 @@ class RESTDuckDBSource(DuckDBSource):
         """
         Get the current full URL for a REST table.
 
-        Can be called with either table OR config (for internal use).
-
         Parameters
         ----------
         table : str

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -743,10 +743,8 @@ def test_detour_roundtrip(sample_csv_files):
         assert len(limited_df) == 1
         assert limited_df.iloc[[0]].equals(df.iloc[[0]])
 
-        # Serialize and deserialize - need to use absolute paths
+        # Serialize and deserialize
         spec = new_source.to_spec()
-        spec['tables']['customers'] = files['customers']
-        spec['tables']['orders'] = files['orders']
         
         read_source = DuckDBSource.from_spec(spec)
         read_df = read_source.get("limited_customers")

--- a/lumen/tests/sources/test_rest_duckdb.py
+++ b/lumen/tests/sources/test_rest_duckdb.py
@@ -9,43 +9,90 @@ except ImportError:
     pytestmark = pytest.mark.skip(reason="DuckDB is not installed")
 
 
-@pytest.fixture
-def rest_duckdb_config():
-    """Fixture providing test configuration for RESTDuckDBSource."""
-    return {
+# Table configurations as constants
+DAILY_TABLE_CONFIG = {
+    'url': 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py',
+    'url_params': {
+        'stations': 'ABR',
+        'sts': '2025-12-08',
+        'ets': '2025-12-09',
+        'network': 'SD_ASOS',
+        'format': 'csv'
+    },
+}
+
+RAOB_TABLE_CONFIG = {
+    'url': 'https://mesonet.agron.iastate.edu/cgi-bin/request/raob.py',
+    'url_params': {
+        'station': 'KABR',
+        'sts': '2025-12-08T15:49',
+        'ets': '2025-12-09T15:49',
+        'format': 'csv'
+    },
+}
+
+PENGUINS_CSV_URL = 'https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv'
+
+
+@pytest.fixture(scope="session")
+def single_table_source():
+    """Fixture providing a RESTDuckDBSource with one REST table."""
+    config = {
         'uri': ':memory:',
         'tables': {
-            'daily': {
-                'url': 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py',
-                'url_params': {
-                    'stations': 'ABR',
-                    'sts': '2025-12-08',
-                    'ets': '2025-12-09',
-                    'network': 'SD_ASOS',
-                    'format': 'csv'
-                },
-            },
-            'raob': {
-                'url': 'https://mesonet.agron.iastate.edu/cgi-bin/request/raob.py',
-                'url_params': {
-                    'station': 'KABR',
-                    'sts': '2025-12-08T15:49',
-                    'ets': '2025-12-09T15:49',
-                    'format': 'csv'
-                },
-            },
+            'daily': DAILY_TABLE_CONFIG,
         }
     }
+    source = RESTDuckDBSource(**config)
+    # Pre-materialize to avoid repeated API calls
+    daily_df = source.get('daily')
+    source._connection.from_df(daily_df).to_view('daily')
+    source._cached_rest_tables["daily"] = DAILY_TABLE_CONFIG
+    return source
 
 
-@pytest.fixture
-def rest_duckdb_source(rest_duckdb_config):
-    """Fixture providing a RESTDuckDBSource instance."""
-    return RESTDuckDBSource(**rest_duckdb_config)
+@pytest.fixture(scope="session")
+def multi_table_source():
+    """Fixture providing a RESTDuckDBSource with two REST tables."""
+    config = {
+        'uri': ':memory:',
+        'tables': {
+            'daily': DAILY_TABLE_CONFIG,
+            'raob': RAOB_TABLE_CONFIG,
+        }
+    }
+    source = RESTDuckDBSource(**config)
+    # Pre-materialize both tables
+    daily_df = source.get('daily')
+    raob_df = source.get('raob')
+    source._connection.from_df(daily_df).to_view('daily')
+    source._connection.from_df(raob_df).to_view('raob')
+    source._cached_rest_tables["daily"] = DAILY_TABLE_CONFIG
+    source._cached_rest_tables["raob"] = RAOB_TABLE_CONFIG
+    return source
 
 
-class TestRESTDuckDBSource:
-    """Tests for RESTDuckDBSource class."""
+@pytest.fixture(scope="session")
+def mixed_table_source():
+    """Fixture providing a RESTDuckDBSource with REST table and CSV file."""
+    config = {
+        'uri': ':memory:',
+        'tables': {
+            'daily': DAILY_TABLE_CONFIG,
+            'penguins': PENGUINS_CSV_URL,
+        }
+    }
+    source = RESTDuckDBSource(**config)
+    # Pre-materialize REST table
+    daily_df = source.get('daily')
+    source._connection.from_df(daily_df).to_view('daily')
+    source._cached_rest_tables["daily"] = DAILY_TABLE_CONFIG
+    # CSV table doesn't need pre-materialization
+    return source
+
+
+class TestRESTDuckDBSourceBasics:
+    """Test basic functionality and initialization."""
 
     def test_source_type(self):
         """Test that source_type is correctly set."""
@@ -55,120 +102,109 @@ class TestRESTDuckDBSource:
         """Test that the source can be resolved by module path."""
         assert RESTDuckDBSource._get_type('lumen.sources.rest_duckdb.RESTDuckDBSource') is RESTDuckDBSource
 
-    def test_initialization(self, rest_duckdb_config):
+    def test_initialization(self, single_table_source):
         """Test that RESTDuckDBSource initializes correctly."""
-        source = RESTDuckDBSource(**rest_duckdb_config)
-        assert source.uri == ':memory:'
-        assert 'daily' in source.tables
-        assert 'raob' in source.tables
+        assert single_table_source.uri == ':memory:'
+        assert 'daily' in single_table_source.tables
+        assert isinstance(single_table_source.tables['daily'], dict)
+        assert 'url' in single_table_source.tables['daily']
 
-    def test_render_table_url(self, rest_duckdb_source):
+
+class TestRESTTableOperations:
+    """Test REST-specific table operations."""
+
+    def test_render_table_url(self, single_table_source):
         """Test that render_table_url constructs correct URLs."""
-        daily_url = rest_duckdb_source.render_table_url('daily')
-        assert 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py' in daily_url
-        assert 'stations=ABR' in daily_url
-        assert 'sts=2025-12-08' in daily_url
-        assert 'ets=2025-12-09' in daily_url
-        assert 'network=SD_ASOS' in daily_url
-        assert 'format=csv' in daily_url
+        url = single_table_source.render_table_url('daily')
+        assert 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py' in url
+        assert 'stations=ABR' in url
+        assert 'sts=2025-12-08' in url
+        assert 'format=csv' in url
 
-        raob_url = rest_duckdb_source.render_table_url('raob')
-        assert 'https://mesonet.agron.iastate.edu/cgi-bin/request/raob.py' in raob_url
-        assert 'station=KABR' in raob_url
-
-    def test_get_table(self, rest_duckdb_source):
+    def test_get_table(self, single_table_source):
         """Test that get() retrieves data correctly."""
-        df = rest_duckdb_source.get('daily')
+        df = single_table_source.get('daily')
         
         assert isinstance(df, pd.DataFrame)
         assert not df.empty
         assert 'station' in df.columns
         assert 'day' in df.columns
         assert 'max_temp_f' in df.columns
-        assert 'min_temp_f' in df.columns
-        
-        # Check that we have the expected rows
-        assert len(df) == 2  # Based on the sample data showing 2 rows
+        assert len(df) == 2
         assert all(df['station'] == 'ABR')
 
-    def test_get_multiple_tables(self, rest_duckdb_source):
+    def test_get_multiple_tables(self, multi_table_source):
         """Test that both tables can be retrieved."""
-        daily_df = rest_duckdb_source.get('daily')
-        raob_df = rest_duckdb_source.get('raob')
+        daily_df = multi_table_source.get('daily')
+        raob_df = multi_table_source.get('raob')
         
         assert isinstance(daily_df, pd.DataFrame)
         assert isinstance(raob_df, pd.DataFrame)
         assert not daily_df.empty
-        # raob_df might be empty depending on data availability
 
-    def test_tables_property(self, rest_duckdb_source):
-        """Test that tables property returns correct table information."""
-        tables = rest_duckdb_source.tables
-        
-        assert isinstance(tables, dict)
-        assert 'daily' in tables
-        assert 'raob' in tables
-        
-        # Check that table configs are preserved
-        daily_config = tables['daily']
-        assert 'url' in daily_config
-        assert daily_config['url'] == 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py'
+    def test_invalid_table_name(self, single_table_source):
+        """Test that accessing non-existent table raises appropriate error."""
+        with pytest.raises(Exception):
+            single_table_source.get('nonexistent_table')
 
-    def test_execute_sql(self, rest_duckdb_source):
-        """Test that execute() runs SQL queries correctly."""
-        result = rest_duckdb_source.execute("SELECT * FROM daily LIMIT 5")
+
+class TestSQLExecution:
+    """Test SQL query execution."""
+
+    def test_execute_simple_query(self, single_table_source):
+        """Test basic SQL execution."""
+        result = single_table_source.execute("SELECT * FROM daily LIMIT 5")
         
         assert isinstance(result, pd.DataFrame)
         assert len(result) <= 5
         assert 'station' in result.columns
-        assert 'day' in result.columns
 
-    def test_execute_sql_with_filter(self, rest_duckdb_source):
-        """Test SQL execution with WHERE clause."""
-        result = rest_duckdb_source.execute("SELECT * FROM daily WHERE max_temp_f > 20")
+    def test_execute_with_filter(self, single_table_source):
+        """Test SQL with WHERE clause."""
+        result = single_table_source.execute("SELECT * FROM daily WHERE max_temp_f > 20")
         
         assert isinstance(result, pd.DataFrame)
         if not result.empty:
             assert all(result['max_temp_f'] > 20)
 
-    def test_execute_sql_count(self, rest_duckdb_source):
-        """Test SQL COUNT query."""
-        result = rest_duckdb_source.execute("SELECT COUNT(*) as count FROM daily")
+    def test_execute_aggregate(self, single_table_source):
+        """Test SQL aggregation functions."""
+        result = single_table_source.execute("SELECT COUNT(*) as count FROM daily")
         
         assert isinstance(result, pd.DataFrame)
         assert 'count' in result.columns
         assert result['count'].iloc[0] > 0
 
-    def test_create_sql_expr_source(self, rest_duckdb_source):
-        """Test creating a derived source with SQL expressions."""
-        new_source = rest_duckdb_source.create_sql_expr_source({
+    def test_execute_materializes_rest_tables(self, single_table_source):
+        """Test that execute() automatically materializes REST tables."""
+        result = single_table_source.execute("SELECT COUNT(*) as cnt FROM daily")
+        
+        assert isinstance(result, pd.DataFrame)
+        assert 'daily' in single_table_source._cached_rest_tables
+
+    def test_invalid_sql_query(self, single_table_source):
+        """Test that invalid SQL raises appropriate error."""
+        with pytest.raises(Exception):
+            single_table_source.execute("SELECT * FROM nonexistent_table")
+
+
+class TestSQLExpressionSource:
+    """Test create_sql_expr_source functionality."""
+
+    def test_create_simple_expression(self, single_table_source):
+        """Test creating a source with a simple SQL expression."""
+        new_source = single_table_source.create_sql_expr_source({
             'daily_1': "SELECT * FROM daily LIMIT 1"
         })
         
-        # Check that new source exists and has the derived table
-        assert hasattr(new_source, 'tables')
         assert 'daily_1' in new_source.tables
-        
-        # Check that the derived table can be queried
         df = new_source.get('daily_1')
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 1
-        assert 'station' in df.columns
 
-    def test_create_sql_expr_source_preserves_original_tables(self, rest_duckdb_source):
-        """Test that creating SQL expr source preserves original tables."""
-        new_source = rest_duckdb_source.create_sql_expr_source({
-            'daily_1': "SELECT * FROM daily LIMIT 1"
-        })
-        
-        # Original tables should still be accessible
-        daily_df = new_source.get('daily')
-        assert isinstance(daily_df, pd.DataFrame)
-        assert len(daily_df) > 1  # Original table has more rows
-
-    def test_create_sql_expr_source_multiple_expressions(self, rest_duckdb_source):
+    def test_create_multiple_expressions(self, single_table_source):
         """Test creating multiple SQL expressions at once."""
-        new_source = rest_duckdb_source.create_sql_expr_source({
+        new_source = single_table_source.create_sql_expr_source({
             'daily_1': "SELECT * FROM daily LIMIT 1",
             'daily_high_temp': "SELECT * FROM daily WHERE max_temp_f > 30"
         })
@@ -182,72 +218,201 @@ class TestRESTDuckDBSource:
         assert len(df1) == 1
         assert isinstance(df_high, pd.DataFrame)
 
-    def test_to_spec(self, rest_duckdb_source):
+    def test_preserves_original_tables(self, single_table_source):
+        """Test that creating SQL expr source preserves original tables."""
+        new_source = single_table_source.create_sql_expr_source({
+            'daily_1': "SELECT * FROM daily LIMIT 1"
+        })
+        
+        # Original table should still be accessible
+        daily_df = new_source.get('daily')
+        assert isinstance(daily_df, pd.DataFrame)
+        assert len(daily_df) > 1
+
+    def test_rest_table_dependency_materialization(self, single_table_source):
+        """Test that REST tables in SQL expressions are materialized."""
+        new_source = single_table_source.create_sql_expr_source({
+            'daily_filtered': "SELECT * FROM daily WHERE max_temp_f > 20"
+        })
+        
+        # REST table should be accessible and materialized
+        assert 'daily' in new_source.tables
+        daily_df = new_source.get('daily')
+        filtered_df = new_source.get('daily_filtered')
+        
+        assert len(filtered_df) <= len(daily_df)
+        if not filtered_df.empty:
+            assert all(filtered_df['max_temp_f'] > 20)
+
+    def test_upsert_behavior(self, single_table_source):
+        """Test that new tables with same name override existing ones."""
+        source1 = single_table_source.create_sql_expr_source({
+            'summary': "SELECT COUNT(*) as total_days FROM daily"
+        })
+        result1 = source1.get('summary')
+        assert 'total_days' in result1.columns
+        
+        source2 = source1.create_sql_expr_source({
+            'summary': "SELECT AVG(max_temp_f) as avg_temp FROM daily"
+        })
+        result2 = source2.get('summary')
+        assert 'avg_temp' in result2.columns
+        assert 'total_days' not in result2.columns
+
+    def test_multiple_rest_dependencies(self, multi_table_source):
+        """Test SQL expression that references multiple REST tables."""
+        new_source = multi_table_source.create_sql_expr_source({
+            'combined': """
+                SELECT station, day, max_temp_f FROM daily
+                UNION ALL
+                SELECT station, validUTC as day, tmpc as max_temp_f FROM raob
+                LIMIT 10
+            """
+        })
+        
+        # Both REST tables should be materialized
+        assert 'daily' in new_source.tables
+        assert 'raob' in new_source.tables
+        assert 'combined' in new_source.tables
+        
+        result = new_source.get('combined')
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) <= 10
+
+    def test_preserves_rest_configs(self, single_table_source):
+        """Test that REST table configs are preserved in derived sources."""
+        new_source = single_table_source.create_sql_expr_source({
+            'daily_subset': "SELECT * FROM daily LIMIT 5"
+        })
+        
+        # REST config should be preserved
+        assert isinstance(new_source.tables['daily'], dict)
+        assert 'url' in new_source.tables['daily']
+        url = new_source.render_table_url('daily')
+        assert 'https://mesonet.agron.iastate.edu' in url
+
+
+class TestSerialization:
+    """Test source serialization."""
+
+    def test_to_spec_basic(self, single_table_source):
         """Test that to_spec() returns correct specification."""
-        spec = rest_duckdb_source.to_spec()
+        spec = single_table_source.to_spec()
         
         assert isinstance(spec, dict)
-        assert 'uri' in spec
         assert spec['uri'] == ':memory:'
         assert 'tables' in spec
-        assert 'type' in spec
         assert spec['type'] == 'rest_duckdb'
+        assert '_cached_rest_tables' not in spec
 
-    def test_to_spec_with_sql_expressions(self, rest_duckdb_source):
+    def test_to_spec_with_sql_expressions(self, single_table_source):
         """Test to_spec() on derived source with SQL expressions."""
-        new_source = rest_duckdb_source.create_sql_expr_source({
+        new_source = single_table_source.create_sql_expr_source({
             'daily_1': "SELECT * FROM daily LIMIT 1"
         })
         
         spec = new_source.to_spec()
-        
-        assert isinstance(spec, dict)
-        assert 'tables' in spec
         assert 'daily_1' in spec['tables']
-        # Check that SQL expression is preserved in spec
         assert spec['tables']['daily_1'] == "SELECT * FROM daily LIMIT 1"
 
-    def test_invalid_table_name(self, rest_duckdb_source):
-        """Test that accessing non-existent table raises appropriate error."""
-        with pytest.raises(Exception):
-            rest_duckdb_source.get('nonexistent_table')
 
-    def test_invalid_sql_query(self, rest_duckdb_source):
-        """Test that invalid SQL raises appropriate error."""
-        with pytest.raises(Exception):
-            rest_duckdb_source.execute("SELECT * FROM nonexistent_table")
+class TestDataValidation:
+    """Test data type and content validation."""
 
-    def test_column_access(self, rest_duckdb_source):
-        """Test accessing specific columns from the data."""
-        df = rest_duckdb_source.get('daily')
+    def test_column_presence(self, single_table_source):
+        """Test that expected columns are present."""
+        df = single_table_source.get('daily')
         
-        # Test expected columns exist
         expected_columns = ['station', 'day', 'max_temp_f', 'min_temp_f', 
                           'max_dewpoint_f', 'min_dewpoint_f', 'precip_in']
         for col in expected_columns:
             assert col in df.columns
 
-    def test_data_types(self, rest_duckdb_source):
+    def test_data_types(self, single_table_source):
         """Test that data types are correctly inferred."""
-        df = rest_duckdb_source.get('daily')
+        df = single_table_source.get('daily')
         
-        # Numeric columns should be numeric types
         assert pd.api.types.is_numeric_dtype(df['max_temp_f'])
         assert pd.api.types.is_numeric_dtype(df['min_temp_f'])
         assert pd.api.types.is_numeric_dtype(df['precip_in'])
 
-    def test_sql_join_across_tables(self, rest_duckdb_source):
-        """Test SQL JOIN operations across multiple tables."""
-        # Note: This test assumes both tables might have related data
-        # In practice, adjust the JOIN condition based on actual schema
-        query = """
-        SELECT d.station, d.day, d.max_temp_f 
-        FROM daily d
-        LIMIT 5
-        """
-        result = rest_duckdb_source.execute(query)
+
+class TestMixedTableTypes:
+    """Test mixing REST tables with regular CSV tables."""
+
+    def test_mixed_source_has_both_table_types(self, mixed_table_source):
+        """Test that mixed source contains both REST and CSV tables."""
+        assert 'daily' in mixed_table_source.tables
+        assert 'penguins' in mixed_table_source.tables
+        
+        # daily is REST table (dict config)
+        assert isinstance(mixed_table_source.tables['daily'], dict)
+        assert 'url' in mixed_table_source.tables['daily']
+        
+        # penguins is CSV table (string URL)
+        assert isinstance(mixed_table_source.tables['penguins'], str)
+
+    def test_get_csv_table(self, mixed_table_source):
+        """Test retrieving CSV table from mixed source."""
+        df = mixed_table_source.get('penguins')
+        
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert 'species' in df.columns
+        assert 'island' in df.columns
+        assert 'bill_length_mm' in df.columns
+
+    def test_get_rest_table_from_mixed(self, mixed_table_source):
+        """Test retrieving REST table from mixed source."""
+        df = mixed_table_source.get('daily')
+        
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert 'station' in df.columns
+
+    def test_sql_join_rest_and_csv(self, mixed_table_source):
+        """Test SQL query joining REST and CSV tables."""
+        result = mixed_table_source.execute("""
+            SELECT d.station, p.species, COUNT(*) as count
+            FROM daily d
+            CROSS JOIN penguins p
+            WHERE p.species = 'Adelie'
+            GROUP BY d.station, p.species
+            LIMIT 5
+        """)
         
         assert isinstance(result, pd.DataFrame)
+        assert not result.empty
         assert 'station' in result.columns
-        assert 'day' in result.columns
-        assert 'max_temp_f' in result.columns
+        assert 'species' in result.columns
+        assert all(result['species'] == 'Adelie')
+
+    def test_create_sql_expr_with_mixed_tables(self, mixed_table_source):
+        """Test creating SQL expressions that reference both table types."""
+        new_source = mixed_table_source.create_sql_expr_source({
+            'rest_summary': "SELECT station, AVG(max_temp_f) as avg_temp FROM daily GROUP BY station",
+            'csv_summary': "SELECT species, COUNT(*) as count FROM penguins GROUP BY species",
+            'combined': """
+                SELECT 'weather' as source_type, station as name FROM daily
+                UNION ALL
+                SELECT 'penguin' as source_type, species as name FROM penguins
+                LIMIT 10
+            """
+        })
+        
+        # All tables should exist
+        assert 'rest_summary' in new_source.tables
+        assert 'csv_summary' in new_source.tables
+        assert 'combined' in new_source.tables
+        
+        # Verify they work
+        rest_df = new_source.get('rest_summary')
+        csv_df = new_source.get('csv_summary')
+        combined_df = new_source.get('combined')
+        
+        assert isinstance(rest_df, pd.DataFrame)
+        assert isinstance(csv_df, pd.DataFrame)
+        assert isinstance(combined_df, pd.DataFrame)
+        assert 'avg_temp' in rest_df.columns
+        assert 'species' in csv_df.columns
+        assert 'source_type' in combined_df.columns

--- a/lumen/tests/sources/test_rest_duckdb.py
+++ b/lumen/tests/sources/test_rest_duckdb.py
@@ -1,0 +1,253 @@
+"""Tests for RESTDuckDBSource."""
+import pandas as pd
+import pytest
+
+try:
+    from lumen.sources.rest_duckdb import RESTDuckDBSource
+    pytestmark = pytest.mark.xdist_group("duckdb")
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="DuckDB is not installed")
+
+
+@pytest.fixture
+def rest_duckdb_config():
+    """Fixture providing test configuration for RESTDuckDBSource."""
+    return {
+        'uri': ':memory:',
+        'tables': {
+            'daily': {
+                'url': 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py',
+                'url_params': {
+                    'stations': 'ABR',
+                    'sts': '2025-12-08',
+                    'ets': '2025-12-09',
+                    'network': 'SD_ASOS',
+                    'format': 'csv'
+                },
+            },
+            'raob': {
+                'url': 'https://mesonet.agron.iastate.edu/cgi-bin/request/raob.py',
+                'url_params': {
+                    'station': 'KABR',
+                    'sts': '2025-12-08T15:49',
+                    'ets': '2025-12-09T15:49',
+                    'format': 'csv'
+                },
+            },
+        }
+    }
+
+
+@pytest.fixture
+def rest_duckdb_source(rest_duckdb_config):
+    """Fixture providing a RESTDuckDBSource instance."""
+    return RESTDuckDBSource(**rest_duckdb_config)
+
+
+class TestRESTDuckDBSource:
+    """Tests for RESTDuckDBSource class."""
+
+    def test_source_type(self):
+        """Test that source_type is correctly set."""
+        assert RESTDuckDBSource.source_type == 'rest_duckdb'
+
+    def test_resolve_module_type(self):
+        """Test that the source can be resolved by module path."""
+        assert RESTDuckDBSource._get_type('lumen.sources.rest_duckdb.RESTDuckDBSource') is RESTDuckDBSource
+
+    def test_initialization(self, rest_duckdb_config):
+        """Test that RESTDuckDBSource initializes correctly."""
+        source = RESTDuckDBSource(**rest_duckdb_config)
+        assert source.uri == ':memory:'
+        assert 'daily' in source.tables
+        assert 'raob' in source.tables
+
+    def test_render_table_url(self, rest_duckdb_source):
+        """Test that render_table_url constructs correct URLs."""
+        daily_url = rest_duckdb_source.render_table_url('daily')
+        assert 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py' in daily_url
+        assert 'stations=ABR' in daily_url
+        assert 'sts=2025-12-08' in daily_url
+        assert 'ets=2025-12-09' in daily_url
+        assert 'network=SD_ASOS' in daily_url
+        assert 'format=csv' in daily_url
+
+        raob_url = rest_duckdb_source.render_table_url('raob')
+        assert 'https://mesonet.agron.iastate.edu/cgi-bin/request/raob.py' in raob_url
+        assert 'station=KABR' in raob_url
+
+    def test_get_table(self, rest_duckdb_source):
+        """Test that get() retrieves data correctly."""
+        df = rest_duckdb_source.get('daily')
+        
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert 'station' in df.columns
+        assert 'day' in df.columns
+        assert 'max_temp_f' in df.columns
+        assert 'min_temp_f' in df.columns
+        
+        # Check that we have the expected rows
+        assert len(df) == 2  # Based on the sample data showing 2 rows
+        assert all(df['station'] == 'ABR')
+
+    def test_get_multiple_tables(self, rest_duckdb_source):
+        """Test that both tables can be retrieved."""
+        daily_df = rest_duckdb_source.get('daily')
+        raob_df = rest_duckdb_source.get('raob')
+        
+        assert isinstance(daily_df, pd.DataFrame)
+        assert isinstance(raob_df, pd.DataFrame)
+        assert not daily_df.empty
+        # raob_df might be empty depending on data availability
+
+    def test_tables_property(self, rest_duckdb_source):
+        """Test that tables property returns correct table information."""
+        tables = rest_duckdb_source.tables
+        
+        assert isinstance(tables, dict)
+        assert 'daily' in tables
+        assert 'raob' in tables
+        
+        # Check that table configs are preserved
+        daily_config = tables['daily']
+        assert 'url' in daily_config
+        assert daily_config['url'] == 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py'
+
+    def test_execute_sql(self, rest_duckdb_source):
+        """Test that execute() runs SQL queries correctly."""
+        result = rest_duckdb_source.execute("SELECT * FROM daily LIMIT 5")
+        
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) <= 5
+        assert 'station' in result.columns
+        assert 'day' in result.columns
+
+    def test_execute_sql_with_filter(self, rest_duckdb_source):
+        """Test SQL execution with WHERE clause."""
+        result = rest_duckdb_source.execute("SELECT * FROM daily WHERE max_temp_f > 20")
+        
+        assert isinstance(result, pd.DataFrame)
+        if not result.empty:
+            assert all(result['max_temp_f'] > 20)
+
+    def test_execute_sql_count(self, rest_duckdb_source):
+        """Test SQL COUNT query."""
+        result = rest_duckdb_source.execute("SELECT COUNT(*) as count FROM daily")
+        
+        assert isinstance(result, pd.DataFrame)
+        assert 'count' in result.columns
+        assert result['count'].iloc[0] > 0
+
+    def test_create_sql_expr_source(self, rest_duckdb_source):
+        """Test creating a derived source with SQL expressions."""
+        new_source = rest_duckdb_source.create_sql_expr_source({
+            'daily_1': "SELECT * FROM daily LIMIT 1"
+        })
+        
+        # Check that new source exists and has the derived table
+        assert hasattr(new_source, 'tables')
+        assert 'daily_1' in new_source.tables
+        
+        # Check that the derived table can be queried
+        df = new_source.get('daily_1')
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 1
+        assert 'station' in df.columns
+
+    def test_create_sql_expr_source_preserves_original_tables(self, rest_duckdb_source):
+        """Test that creating SQL expr source preserves original tables."""
+        new_source = rest_duckdb_source.create_sql_expr_source({
+            'daily_1': "SELECT * FROM daily LIMIT 1"
+        })
+        
+        # Original tables should still be accessible
+        daily_df = new_source.get('daily')
+        assert isinstance(daily_df, pd.DataFrame)
+        assert len(daily_df) > 1  # Original table has more rows
+
+    def test_create_sql_expr_source_multiple_expressions(self, rest_duckdb_source):
+        """Test creating multiple SQL expressions at once."""
+        new_source = rest_duckdb_source.create_sql_expr_source({
+            'daily_1': "SELECT * FROM daily LIMIT 1",
+            'daily_high_temp': "SELECT * FROM daily WHERE max_temp_f > 30"
+        })
+        
+        assert 'daily_1' in new_source.tables
+        assert 'daily_high_temp' in new_source.tables
+        
+        df1 = new_source.get('daily_1')
+        df_high = new_source.get('daily_high_temp')
+        
+        assert len(df1) == 1
+        assert isinstance(df_high, pd.DataFrame)
+
+    def test_to_spec(self, rest_duckdb_source):
+        """Test that to_spec() returns correct specification."""
+        spec = rest_duckdb_source.to_spec()
+        
+        assert isinstance(spec, dict)
+        assert 'uri' in spec
+        assert spec['uri'] == ':memory:'
+        assert 'tables' in spec
+        assert 'type' in spec
+        assert spec['type'] == 'rest_duckdb'
+
+    def test_to_spec_with_sql_expressions(self, rest_duckdb_source):
+        """Test to_spec() on derived source with SQL expressions."""
+        new_source = rest_duckdb_source.create_sql_expr_source({
+            'daily_1': "SELECT * FROM daily LIMIT 1"
+        })
+        
+        spec = new_source.to_spec()
+        
+        assert isinstance(spec, dict)
+        assert 'tables' in spec
+        assert 'daily_1' in spec['tables']
+        # Check that SQL expression is preserved in spec
+        assert spec['tables']['daily_1'] == "SELECT * FROM daily LIMIT 1"
+
+    def test_invalid_table_name(self, rest_duckdb_source):
+        """Test that accessing non-existent table raises appropriate error."""
+        with pytest.raises(Exception):
+            rest_duckdb_source.get('nonexistent_table')
+
+    def test_invalid_sql_query(self, rest_duckdb_source):
+        """Test that invalid SQL raises appropriate error."""
+        with pytest.raises(Exception):
+            rest_duckdb_source.execute("SELECT * FROM nonexistent_table")
+
+    def test_column_access(self, rest_duckdb_source):
+        """Test accessing specific columns from the data."""
+        df = rest_duckdb_source.get('daily')
+        
+        # Test expected columns exist
+        expected_columns = ['station', 'day', 'max_temp_f', 'min_temp_f', 
+                          'max_dewpoint_f', 'min_dewpoint_f', 'precip_in']
+        for col in expected_columns:
+            assert col in df.columns
+
+    def test_data_types(self, rest_duckdb_source):
+        """Test that data types are correctly inferred."""
+        df = rest_duckdb_source.get('daily')
+        
+        # Numeric columns should be numeric types
+        assert pd.api.types.is_numeric_dtype(df['max_temp_f'])
+        assert pd.api.types.is_numeric_dtype(df['min_temp_f'])
+        assert pd.api.types.is_numeric_dtype(df['precip_in'])
+
+    def test_sql_join_across_tables(self, rest_duckdb_source):
+        """Test SQL JOIN operations across multiple tables."""
+        # Note: This test assumes both tables might have related data
+        # In practice, adjust the JOIN condition based on actual schema
+        query = """
+        SELECT d.station, d.day, d.max_temp_f 
+        FROM daily d
+        LIMIT 5
+        """
+        result = rest_duckdb_source.execute(query)
+        
+        assert isinstance(result, pd.DataFrame)
+        assert 'station' in result.columns
+        assert 'day' in result.columns
+        assert 'max_temp_f' in result.columns


### PR DESCRIPTION
Builds upon https://github.com/holoviz/lumen/pull/1518

```python
from lumen.sources.rest_duckdb import RESTDuckDBSource

# Create a source with multiple REST tables
source = RESTDuckDBSource(
    uri=':memory:',
    tables={
        # https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py?stations=AMW&sts=2019-01-01&ets=2019-01-31&format=csv
        'daily': {
            'url': 'https://mesonet.agron.iastate.edu/cgi-bin/request/daily.py',
            'url_params': {'stations': 'ABR', 'sts': '2025-12-08', 'ets': '2025-12-09', 'network': 'SD_ASOS', 'format': 'csv'},
        },
        # https://mesonet.agron.iastate.edu/cgi-bin/request/raob.py?station=KABR&sts=2025-12-08T15%3A49&ets=2025-12-09T15%3A49
        'raob': {
            'url': 'https://mesonet.agron.iastate.edu/cgi-bin/request/raob.py',
            'url_params': {'station': 'KABR', 'sts': '2025-12-08T15:49', 'ets': '2025-12-09T15:49', 'format': 'csv'},
        },
    }
)

source.get("daily", url_params={'stations': 'CMI', 'sts': '2025-12-08', 'ets': '2025-12-09', 'network': 'IL_ASOS', 'format': 'csv'})
print(source.render_table_url('daily', url_params={'stations': 'CMI', 'sts': '2025-12-08', 'ets': '2025-12-09', 'network': 'IL_ASOS', 'format': 'csv'}))
print(source.create_sql_expr_source(tables={"daily2": "SELECT * FROM daily LIMIT 5 OFFSET 1"}).get("daily2"))

```
