### PR TITLE
json to yaml views

### DIFF
--- a/lumen/ai/prompts/BaseViewAgent/main.jinja2
+++ b/lumen/ai/prompts/BaseViewAgent/main.jinja2
@@ -11,8 +11,8 @@ Here is the current dataset to use:
 
 {%- if "view" in memory %}
 The previous view specification was:
-```
-{{ memory["view"] }}
+```yaml
+{{ memory["view"] | json_to_yaml }}
 ```
 {%- endif %}
 

--- a/lumen/ai/prompts/ValidationAgent/main.jinja2
+++ b/lumen/ai/prompts/ValidationAgent/main.jinja2
@@ -51,6 +51,8 @@ Data Overview:
 {%- endif -%}
 {% if memory.get('view') %}
 Generated View:
-{{ memory["view"] }}
+```yaml
+{{ memory["view"] | json_to_yaml }}
+```
 {%- endif -%}
 {%- endblock -%}

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -148,6 +148,28 @@ def get_template_loader(
     return FileSystemLoader(search_paths), template_name
 
 
+def json_to_yaml(data):
+    """
+    Convert JSON string or Python dict/list to YAML format.
+
+    Parameters
+    ----------
+    data : str | dict | list
+        JSON string or Python data structure to convert to YAML
+
+    Returns
+    -------
+    str
+        YAML formatted string, or original data if conversion fails
+    """
+    try:
+        if isinstance(data, str):
+            data = json.loads(data)
+        return yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return data
+
+
 def render_template(template_path: Path | str, overrides: dict | None = None, relative_to: Path = PROMPTS_DIR, **context):
     fs_loader, template_name = get_template_loader(template_path, relative_to)
     if overrides:
@@ -171,6 +193,7 @@ def render_template(template_path: Path | str, overrides: dict | None = None, re
         env = Environment(loader=fs_loader, undefined=StrictUndefined)
 
     env.globals["dedent"] = lambda text: textwrap.dedent(text).strip()
+    env.filters["json_to_yaml"] = json_to_yaml
     template = env.get_template(template_name)
     return template.render(**context)
 


### PR DESCRIPTION
Before (improperly labeled as yaml and consumed more tokens):
```yaml
{'spec': {'title': {'text': 'Yearly Sea Surface Temperature (sst_c) from 1950 to 2024', 'subtitle': 'Trend of sea surface temperature over time', 'anchor': 'start', 'fontSize': 20, 'subtitleFontSize': 14, 'subtitleColor': '#666666'}, 'data': {'name': 'year_sst_c_from_data_oni_csv'}, 'layer': [{'mark': {'type': 'line', 'point': True}, 'encoding': {'x': {'field': 'year', 'type': 'quantitative', 'axis': {'title': 'Year'}}, 'y': {'field': 'sst_c', 'type': 'quantitative', 'axis': {'title': 'Sea Surface Temperature (°C)'}}, 'tooltip': [{'field': 'year', 'type': 'quantitative', 'title': 'Year'}, {'field': 'sst_c', 'type': 'quantitative', 'title': 'Sea Surface Temperature (°C)'}]}}], '$schema': 'https://vega.github.io/schema/vega-lite/v5.json', 'width': 'container', 'height': 'container'}, 'sizing_mode': 'stretch_both', 'min_height': 300, 'type': 'vegalite'}
```

Now:

```
The previous view specification was:
```yaml
spec:
  title:
    anchor: start
    fontSize: 20
    subtitle: Average power capacity steadily increased from 1982 to 2022 with some
      fluctuations
    subtitleColor: '#666666'
    subtitleFontSize: 16
    text: Average Power Capacity Over Years
  data:
    name: average_pcap_per_year_from_windturbines
  layer:
  - mark:
      type: line
      point: true
    encoding:
      x:
        field: p_year
        type: quantitative
        title: Year
      y:
        field: average_pcap
        type: quantitative
        title: Average Power Capacity
  - mark:
      type: text
      align: left
      dx: 5
      dy: -5
      color: black
    encoding:
      x:
        field: p_year
        type: quantitative
      y:
        field: average_pcap
        type: quantitative
      text:
        field: average_pcap
        type: quantitative
    transform:
    - window:
      - op: min
        field: p_year
        as: minYear
      - op: max
        field: p_year
        as: maxYear
      frame:
      - null
      - null
    - filter: datum.p_year === datum.minYear || datum.p_year === datum.maxYear
  $schema: https://vega.github.io/schema/vega-lite/v5.json
  width: container
  height: container
sizing_mode: stretch_both
min_height: 300
type: vegalite
```