### PR TITLE
MenuList Stretch-width

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1143,7 +1143,8 @@ class ExplorerUI(UI):
                     "color": "var(--mui-palette-primary-dark)",
                     "fontSize": "28px"
                 }
-            }
+            },
+            sizing_mode="stretch_width",
         )
 
         return [menu, collapse]


### PR DESCRIPTION
I noticed the MenuList did not stretch width across the entire sidebar width. This PR fixes the issue.

You see it when hovering over the items.

## Before

https://github.com/user-attachments/assets/5b36d891-b77f-45ab-a8b6-769b34e1d15f

## After

https://github.com/user-attachments/assets/d1cde816-003d-411d-beb5-4fef8356369d