### PR TITLE
Refactor UI for getting started

### DIFF
--- a/docs/getting_started/using_lumen_ai.md
+++ b/docs/getting_started/using_lumen_ai.md
@@ -47,6 +47,8 @@ If results aren't what you expected, you have several options:
 
 **Continue the conversation** — Send a new message to refine or adjust the results. For example: "Can you make that chart show only the top 5 items?" or "Add a trend line to the visualization."
 
+**Add annotations** — For visualizations, click the annotation button (💬 icon) to add highlights, callouts, or labels. For example: "Highlight the peak values" or "Mark outliers in red."
+
 **Manually edit** — Directly edit the SQL query or visualization specification in the editor panel. This works if you're comfortable with SQL or need precise control over the output.
 
 Use manual editing for small tweaks (like changing chart colors or sort order), and send a new message for bigger changes to the underlying query or analysis approach.

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -244,7 +244,7 @@ class BaseSourceControls(Viewer):
         files_to_process = self._upload_cards.param["objects"].rx.len() > 0
         self._add_button = Button.from_param(
             self.param.add,
-            name="Add file(s)",
+            name="Confirm file(s)",
             icon="add",
             visible=files_to_process,
             button_type="success"
@@ -854,7 +854,7 @@ class DownloadControls(BaseSourceControls):
 
         success_count = len(downloaded_files)
         if success_count > 0:
-            self._message_placeholder.object = f"Successfully downloaded {success_count} file(s). Click 'Add file(s)' to process."
+            self._message_placeholder.object = f"Successfully downloaded {success_count} file(s). Click 'Confirm file(s)' to process."
         else:
             self._message_placeholder.visible = False
 
@@ -1133,13 +1133,14 @@ class SourceCatalog(Viewer):
         self._sources_tree.on_action("Delete", self._on_delete_source)
 
         # === Global Documents Tree ===
-        self._docs_title = Markdown("**Apply to All Tables**", margin=(10, 10, 0, 10))
+        self._docs_title = Markdown("**Apply to All Tables**", margin=(10, 10, 0, 10), visible=False)
         self._docs_tree = Tree(
             items=[],
             checkboxes=True,
             color="secondary",
             sizing_mode="stretch_width",
             margin=(0, 10),
+            visible=False,
         )
         self._docs_tree.param.watch(self._on_docs_active_change, "active")
 
@@ -1631,11 +1632,11 @@ class SourceCatalog(Viewer):
     def _sync_docs_tree(self):
         """Sync the global docs tree with available metadata."""
         if not self._available_metadata:
-            self._docs_title.object = "**Apply to All Tables** *(no documents available)*"
-            self._docs_tree.items = []
+            self._docs_title.visible = False
             self._docs_tree.visible = False
             return
 
+        self._docs_title.visible = True
         self._docs_title.object = "**Apply to All Tables**"
         self._docs_tree.visible = True
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -371,20 +371,16 @@ class LlamaCpp(Llm, LlamaCppMixin):
 
     model_kwargs = param.Dict(default={
         "default": {
-            "repo_id": "unsloth/Qwen3-8B-GGUF",
-            "filename": "Qwen3-8B-Q5_K_M.gguf",
+            "repo_id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
+            "filename": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
             "chat_format": "qwen",
         },
     })
 
     select_models = param.List(default=[
-        "unsloth/Qwen3-8B-GGUF",
-        "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-        "unsloth/DeepSeek-V3.1-GGUF",
-        "unsloth/gpt-oss-20b-GGUF",
-        "unsloth/GLM-4.6-GGUF",
-        "microsoft/Phi-4-GGUF",
-        "meta-llama/Llama-3.3-70B-Instruct-GGUF"
+        "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
+        "unsloth/Qwen2.5-7B-Instruct-GGUF",
+        "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF"
     ], constant=True, doc="Available models for selection dropdowns")
 
     temperature = param.Number(default=0.4, bounds=(0, None), constant=True)
@@ -475,12 +471,12 @@ class OpenAI(Llm, OpenAIMixin):
     })
 
     select_models = param.List(default=[
-        "gpt-4.1-mini",
-        "gpt-4.1-nano",
+        "gpt-5.2",
         "gpt-5-mini",
-        "gpt-4-turbo",
-        "gpt-4o",
-        "gpt-4o-mini"
+        "gpt-5-nano",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano"
     ], constant=True, doc="Available models for selection dropdowns")
 
     temperature = param.Number(default=0.25, bounds=(0, None), constant=True)
@@ -748,13 +744,8 @@ class Anthropic(Llm):
 
     select_models = param.List(default=[
         "claude-sonnet-4-5",
-        "claude-sonnet-4-0",
-        "claude-3-7-sonnet-latest",
-        "claude-opus-4-1",
-        "claude-opus-4-0",
         "claude-haiku-4-5",
-        "claude-3-5-haiku-latest",
-        "claude-3-haiku-20240307"
+        "claude-opus-4-5"
     ], constant=True, doc="Available models for selection dropdowns")
 
     temperature = param.Number(default=0.7, bounds=(0, 1), constant=True)

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -371,16 +371,20 @@ class LlamaCpp(Llm, LlamaCppMixin):
 
     model_kwargs = param.Dict(default={
         "default": {
-            "repo_id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
-            "filename": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
+            "repo_id": "unsloth/Qwen3-8B-GGUF",
+            "filename": "Qwen3-8B-Q5_K_M.gguf",
             "chat_format": "qwen",
         },
     })
 
     select_models = param.List(default=[
-        "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
-        "unsloth/Qwen2.5-7B-Instruct-GGUF",
-        "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF"
+        "unsloth/Qwen3-8B-GGUF",
+        "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+        "unsloth/DeepSeek-V3.1-GGUF",
+        "unsloth/gpt-oss-20b-GGUF",
+        "unsloth/GLM-4.6-GGUF",
+        "microsoft/Phi-4-GGUF",
+        "meta-llama/Llama-3.3-70B-Instruct-GGUF"
     ], constant=True, doc="Available models for selection dropdowns")
 
     temperature = param.Number(default=0.4, bounds=(0, None), constant=True)

--- a/lumen/ai/llm_dialog.py
+++ b/lumen/ai/llm_dialog.py
@@ -12,12 +12,29 @@ from panel.layout import Column, HSpacer, Row
 from panel.pane import Markdown
 from panel.viewable import Viewer
 from panel_material_ui import (
-    Button, Dialog, Divider, FloatSlider, Select,
+    Button, Dialog, Divider, FloatSlider, Select, Typography,
 )
 
 from .agents import Agent
 from .llm import Llm
 from .utils import class_name_to_llm_spec_key
+
+LLM_CONFIG_HELP = """
+**AI Model Configuration**
+
+Configure the language models used for different tasks.
+
+**Provider:** Choose between OpenAI, Anthropic, etc.
+**Temperature:** Lower (0.1-0.3) for focused answers, higher (0.7-1.0) for creative tasks
+
+**Model roles:**
+- **Default Model** — Used for most queries
+- **Edit Model** — Used when revising outputs with the sparkle button
+- **UI Model** — Used for lightweight interface interactions
+"""
+
+# Export for use in ui.py
+AI_CONFIGURATION_HELP = LLM_CONFIG_HELP
 
 
 class LLMModelCard(Viewer):
@@ -136,9 +153,6 @@ class LLMConfigDialog(Viewer):
         if not self.provider_choices:
             self.provider_choices = self._get_available_providers()
 
-        # Title
-        self._subtitle = Markdown("Configure your language model provider, settings and select models for different tasks.", margin=(0, 0, 8, 0))
-
         # Provider selection
         current_provider_class = type(self.llm)
         self._provider_select = Select(
@@ -173,9 +187,17 @@ class LLMConfigDialog(Viewer):
 
         self._buttons = Row(self._reset_button, HSpacer(), self._cancel_button, self._apply_button, sizing_mode="stretch_width")
 
-        # Create the dialog content
+        # Create the dialog content with help caption
+        help_caption = Typography(
+            "Configure your language model provider, settings and select models for different tasks.",
+            variant="body2",
+            color="text.secondary",
+            margin=(0, 0, 10, 0),
+            sizing_mode="stretch_width"
+        )
+
         self._content = Column(
-            self._subtitle,
+            help_caption,
             Divider(sizing_mode="stretch_width"),
             Markdown("### Provider Selection", margin=0),
             Markdown(
@@ -199,7 +221,6 @@ class LLMConfigDialog(Viewer):
             self._model_cards,
             self._buttons,
             sizing_mode="stretch_width",
-            margin=(0, 24, 8, 24),
         )
 
         # Create dialog wrapper

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -251,10 +251,6 @@ Toolbar actions for this exploration:
 Drag the divider between editor and view to resize.
 """
 
-EXPLORATIONS_INTRO_HELP = "Select a table below to start a new exploration, or ask a question in the chat."
-
-EXPLORATION_VIEW_HELP = "Use < > to expand/collapse panels. Edit the spec (top) and the view (bottom) syncs. Click ✨ to ask LLM to revise."
-
 REPORT_HELP = """
 **Report Mode: View All Your Work**
 
@@ -306,15 +302,6 @@ DATA_SOURCES_HELP = """
 - Data connections persist for your session
 """
 
-DATA_SOURCES_UPLOAD_HELP = (
-    "Add data to explore with Lumen AI. Supports CSV, Parquet, JSON, Excel, and databases. "
-    "Select between data / metadata and set an alias."
-)
-
-DATA_SOURCES_CATALOG_HELP = (
-    "Check on the box to make the source visible to the LLM. Associate metadata with datasets"
-)
-
 PREFERENCES_HELP = """
 **Control how Lumen AI analyzes your questions.**
 
@@ -338,6 +325,10 @@ PREFERENCES_HELP = """
 
 **Configure AI Models** — Choose which LLM provider and models to use for different tasks
 """
+
+EXPLORATIONS_INTRO_HELP = "Select a table below to start a new exploration, or ask a question in the chat."
+
+EXPLORATION_VIEW_HELP = "Use < > to expand/collapse panels. Edit the spec (top) and the view (bottom) syncs. Click ✨ to ask LLM to revise."
 
 
 class UI(Viewer):
@@ -435,8 +426,6 @@ class UI(Viewer):
         interface: ChatInterface | None = None,
         **params
     ):
-        self._page = None
-        self._explorer = None
         params["log_level"] = params.get("log_level", self.param["log_level"].default).upper()
         super().__init__(**params)
         self._configure_context(data)
@@ -764,11 +753,16 @@ class UI(Viewer):
                 self._source_content[:] = [self._upload_controls]
             else:
                 self._source_content[:] = [self._download_controls]
-            self._sources_help_caption.object = DATA_SOURCES_UPLOAD_HELP
+            self._sources_help_caption.object = (
+                "Add data to explore with Lumen AI. Supports CSV, Parquet, JSON, Excel, and databases. "
+                "Select between data / metadata and set an alias."
+            )
         elif len(active) == 2:
             # Upload > Source Catalog (0, 0) or Download > Source Catalog (1, 0)
             self._source_content[:] = [self._source_catalog]
-            self._sources_help_caption.object = DATA_SOURCES_CATALOG_HELP
+            self._sources_help_caption.object = (
+                "Check on the box to make the source visible to the LLM. Associate metadata with datasets"
+            )
 
     def _configure_coordinator(self):
         # Set up table upload callbacks on all control classes
@@ -799,7 +793,121 @@ class UI(Viewer):
             **self.coordinator_params
         )
 
-    def _create_sources_dialog(self):
+    def _render_header(self) -> list[Viewable]:
+        return []
+
+    def _render_main(self) -> list[Viewable]:
+        num_sources = len(self.context.get("sources", []))
+        if num_sources == 0:
+            prefix_text = "Drag & drop your dataset here to begin, then"
+        else:
+            prefix_text = f"{num_sources} source{'s' if num_sources > 1 else ''} connected;"
+
+        self._cta = Typography(
+            f"{prefix_text} ask any question, or select a quick action below. {SPLASH_HELP_HINT}"
+        )
+
+        self._splash = MuiColumn(
+            Paper(
+                Typography(
+                    "Ask questions, get insights",
+                    disable_anchors=True,
+                    variant="h1"
+                ),
+                self._cta,
+                self.interface._widget,
+                max_width=850,
+                styles={'margin': 'auto'},
+                sx={'p': '0 20px 20px 20px'}
+            ),
+            margin=(0, 5, 0, 0),
+            sx={'display': 'flex', 'align-items': 'center'},
+            height_policy='max'
+        )
+
+        self._main = Column(self._splash, sizing_mode='stretch_both', align="center")
+
+        if self.suggestions:
+            self._add_suggestions_to_footer(
+                self.suggestions,
+                num_objects=1,
+                inplace=True,
+                analysis=False,
+                append_demo=True,
+                hide_after_use=False
+            )
+
+        # Create info dialog with breadcrumb navigation
+        self._help_content = MuiColumn(sizing_mode="stretch_width")
+
+        help_items = [
+            {"label": "Quickstart", "icon": "rocket_launch"},
+            {"label": "Interface", "icon": "dashboard"},
+            {"label": "Explorations", "icon": "layers"},
+            {"label": "Editor", "icon": "code"},
+            {"label": "Results", "icon": "analytics"},
+            {"label": "Export", "icon": "ios_share"},
+            {"label": "Tips", "icon": "lightbulb"},
+        ]
+
+        self._help_breadcrumbs = Breadcrumbs(
+            items=help_items,
+            value=help_items[0],
+            margin=(0, 0, 10, 0),
+        )
+
+        self._next_help_button = Button(
+            name="Next",
+            variant="outlined",
+            sizing_mode="stretch_width",
+            align="end",
+        )
+
+        def next_section(event):
+            current_item = self._help_breadcrumbs.value
+            current_index = help_items.index(current_item)
+            if current_index < len(help_items) - 1:
+                self._help_breadcrumbs.value = help_items[current_index + 1]
+
+        self._next_help_button.on_click(next_section)
+
+        def update_help_content(event):
+            selected_item = event.new
+            section_index = help_items.index(selected_item)
+            help_texts = [
+                HELP_GETTING_STARTED, HELP_INTERFACE, HELP_EXPLORATIONS,
+                HELP_EDITOR, HELP_RESULTS, HELP_EXPORT, HELP_TIPS
+            ]
+            text = help_texts[section_index]
+            if section_index == 0:
+                text = self._current_help_text
+            self._help_content[:] = [Markdown(text, sizing_mode="stretch_width")]
+
+            if section_index == len(help_items) - 1:
+                self._next_help_button.visible = False
+            else:
+                self._next_help_button.visible = True
+
+        self._help_breadcrumbs.param.watch(update_help_content, 'value')
+
+        # Initialize with first section (will be updated based on data source availability)
+        # Use a deferred initialization to avoid race condition
+        self._help_content[:] = [Markdown("", sizing_mode="stretch_width")]
+
+        self._info_dialog = Dialog(
+            MuiColumn(
+                self._help_breadcrumbs,
+                self._help_content,
+                self._next_help_button,
+                sizing_mode="stretch_width"
+            ),
+            close_on_click=True,
+            show_close_button=True,
+            sizing_mode='stretch_width',
+            width_option='md',
+            title="Help Guides"
+        )
+
         # Set up actions for the ChatAreaInput speed dial
         # Use document_vector_store if available, otherwise fall back to main vector_store
         doc_store = self.document_vector_store or self._coordinator.vector_store
@@ -848,7 +956,8 @@ class UI(Viewer):
         self._source_breadcrumbs.param.watch(self._update_source_content, 'active')
 
         self._sources_help_caption = Typography(
-            DATA_SOURCES_UPLOAD_HELP,
+            "Add data to explore with Lumen AI. Supports CSV, Parquet, JSON, Excel, and databases. "
+            "Select between data / metadata and set an alias.",
             variant="body2",
             color="text.secondary",
             sizing_mode="stretch_width"
@@ -867,120 +976,6 @@ class UI(Viewer):
         )
         # Watch for dialog close to handle pending query if user closes without adding files
         self._sources_dialog_content.param.watch(self._on_sources_dialog_close, 'open')
-
-    def _create_info_dialog(self):
-        # Create info dialog with breadcrumb navigation
-        self._help_content = MuiColumn(sizing_mode="stretch_width")
-
-        help_items = [
-            {"label": "Getting Started", "icon": "rocket_launch"},
-            {"label": "Interface", "icon": "dashboard"},
-            {"label": "Explorations", "icon": "layers"},
-            {"label": "Editor", "icon": "code"},
-            {"label": "Results", "icon": "analytics"},
-            {"label": "Export", "icon": "ios_share"},
-            {"label": "Tips", "icon": "lightbulb"},
-        ]
-
-        self._help_breadcrumbs = Breadcrumbs(
-            items=help_items,
-            value=help_items[0],
-            margin=(0, 0, 10, 0),
-        )
-
-        self._next_help_button = Button(
-            name="Next",
-            variant="outlined",
-            sizing_mode="stretch_width",
-            align="end",
-        )
-
-        def next_section(event):
-            current_item = self._help_breadcrumbs.value
-            current_index = help_items.index(current_item)
-            if current_index < len(help_items) - 1:
-                self._help_breadcrumbs.value = help_items[current_index + 1]
-
-        self._next_help_button.on_click(next_section)
-
-        def update_help_content(event):
-            selected_item = event.new
-            section_index = help_items.index(selected_item)
-            help_texts = [
-                HELP_GETTING_STARTED, HELP_INTERFACE, HELP_EXPLORATIONS,
-                HELP_EDITOR, HELP_RESULTS, HELP_EXPORT, HELP_TIPS
-            ]
-            text = help_texts[section_index]
-            if section_index == 0:
-                text = self._current_help_text
-            elif section_index == 2:
-                text = self._current_explorations_help
-            self._help_content[:] = [Markdown(text, sizing_mode="stretch_width")]
-
-            if section_index == len(help_items) - 1:
-                self._next_help_button.visible = False
-            else:
-                self._next_help_button.visible = True
-
-        self._help_breadcrumbs.param.watch(update_help_content, 'value')
-
-        # Initialize with first section (will be updated based on data source availability)
-        # Use a deferred initialization to avoid race condition
-        self._help_content[:] = [Markdown("", sizing_mode="stretch_width")]
-
-        self._info_dialog = Dialog(
-            MuiColumn(
-                self._help_breadcrumbs,
-                self._help_content,
-                self._next_help_button,
-                sizing_mode="stretch_width"
-            ),
-            close_on_click=True,
-            show_close_button=True,
-            sizing_mode='stretch_width',
-            width_option='md',
-            title="Help Guides"
-        )
-
-    def _render_header(self) -> list[Viewable]:
-        return []
-
-    def _render_main(self) -> list[Viewable]:
-        self._cta = Typography()
-        self._update_cta()
-
-        self._splash = MuiColumn(
-            Paper(
-                Typography(
-                    "Ask questions, get insights",
-                    disable_anchors=True,
-                    variant="h1"
-                ),
-                self._cta,
-                self.interface._widget,
-                max_width=850,
-                styles={'margin': 'auto'},
-                sx={'p': '0 20px 20px 20px'}
-            ),
-            margin=(0, 5, 0, 0),
-            sx={'display': 'flex', 'align-items': 'center'},
-            height_policy='max'
-        )
-
-        self._main = Column(self._splash, sizing_mode='stretch_both', align="center")
-
-        if self.suggestions:
-            self._add_suggestions_to_footer(
-                self.suggestions,
-                num_objects=1,
-                inplace=True,
-                analysis=False,
-                append_demo=True,
-                hide_after_use=False
-            )
-
-        self._create_info_dialog()
-        self._create_sources_dialog()
 
         self._notebook_export = FileDownload(
             callback=self._export_notebook,
@@ -1004,6 +999,7 @@ class UI(Viewer):
         self._explorations.param.watch(self._sync_active, 'value')
         self._explorations.on_action('remove', self._delete_exploration)
 
+        # Create LLM configuration dialog
         self._llm_dialog = LLMConfigDialog(
             llm=self.llm,
             llm_choices=self.llm_choices,
@@ -1033,16 +1029,6 @@ class UI(Viewer):
             sx={"&.mui-light .sidebar": {"bgcolor": "var(--mui-palette-grey-50)"}}
         )
 
-    def _update_cta(self):
-        num_sources = len(self.context.get("sources", []))
-        if num_sources == 0:
-            prefix_text = "Drag & drop your dataset here to begin, then"
-        else:
-            prefix_text = f"{num_sources} source{'s' if num_sources > 1 else ''} connected;"
-        cta_text = f"{prefix_text} ask any question, or select a quick action below. {SPLASH_HELP_HINT}"
-        self._cta.object = cta_text
-        return cta_text
-
     def _update_help_getting_started(self):
         """Update the Getting Started help text based on whether data sources are connected."""
         num_sources = len(self.context.get("sources", []))
@@ -1050,17 +1036,39 @@ class UI(Viewer):
             self._current_help_text = HELP_NO_SOURCES
         else:
             self._current_help_text = HELP_GETTING_STARTED
-        self._current_explorations_help = HELP_EXPLORATIONS
 
-    def _get_table_slugs(self, sources: list[Source]) -> set[str]:
-        slugs = set()
-        for source in sources:
-            tables = source.get_tables()
-            for table in tables:
-                slugs.add(f'{source.name}{SOURCE_TABLE_SEPARATOR}{table}')
-        return slugs
+    @param.depends('context', on_init=True, watch=True)
+    async def _sync_sources(self, event=None):
+        context = event.new if event else self.context
+        if 'sources' in context:
+            old_sources = self.context.get("sources", [self.context["source"]] if "source" in self.context else [])
+            new_sources = [src for src in context["sources"] if src not in old_sources]
+            self.context["sources"] = old_sources + new_sources
 
-    def _sync_context_source(self, context: dict[str, Any]):
+            # Compute table slugs for old, new, and all sources
+            old_slugs = set()
+            for source in old_sources:
+                tables = source.get_tables()
+                for table in tables:
+                    table_slug = f'{source.name}{SOURCE_TABLE_SEPARATOR}{table}'
+                    old_slugs.add(table_slug)
+
+            all_slugs = set()
+            for source in self.context["sources"]:
+                tables = source.get_tables()
+                for table in tables:
+                    table_slug = f'{source.name}{SOURCE_TABLE_SEPARATOR}{table}'
+                    all_slugs.add(table_slug)
+
+            new_slugs = all_slugs - old_slugs
+
+            # Update visible_slugs: preserve old table visibility, auto-check new tables
+            current_visible = self.context.get("visible_slugs")
+            if current_visible is not None:  # Check for None, not truthiness (empty set is valid!)
+                self.context["visible_slugs"] = current_visible.intersection(old_slugs) | new_slugs
+            else:
+                self.context["visible_slugs"] = all_slugs
+
         if "source" in context:
             if "source" in self.context:
                 old_source = self.context["source"]
@@ -1072,49 +1080,29 @@ class UI(Viewer):
         if "table" in context:
             self.context["table"] = context["table"]
 
-    @param.depends('context', on_init=True, watch=True)
-    async def _sync_sources(self, event=None):
-        context = event.new if event else self.context
-        if 'sources' in context:
-            old_sources = self.context.get("sources", [self.context["source"]] if "source" in self.context else [])
-            new_sources = [src for src in context["sources"] if src not in old_sources]
-            self.context["sources"] = old_sources + new_sources
-
-            # Compute table slugs for old, new, and all sources
-            old_slugs = self._get_table_slugs(old_sources)
-            all_slugs = self._get_table_slugs(self.context["sources"])
-            new_slugs = all_slugs - old_slugs
-
-            # Update visible_slugs: preserve old table visibility, auto-check new tables
-            current_visible = self.context.get("visible_slugs")
-            if current_visible is not None:  # Check for None, not truthiness (empty set is valid!)
-                self.context["visible_slugs"] = current_visible.intersection(old_slugs) | new_slugs
-            else:
-                self.context["visible_slugs"] = all_slugs
-
-        self._sync_context_source(context)
-
         # Guard against early calls during init when components don't exist yet
-        if not self._page:
-            return
-
-        if self.context.get("sources"):
-            await self._coordinator.sync(self.context)
-
-        if self._explorer:
+        if hasattr(self, '_explorer'):
             await self._explorer.sync()
-        self._source_catalog.sync(self.context)
+        # Only sync coordinator if we have sources and coordinator exists
+        if hasattr(self, '_coordinator') and self.context.get("sources"):
+            await self._coordinator.sync(self.context)
+        if hasattr(self, '_source_catalog'):
+            self._source_catalog.sync(self.context)
 
-        self._update_cta()
+        num_sources = len(self.context.get("sources", []))
+        if num_sources == 0:
+            prefix_text = "Drag & drop your dataset here to begin, then"
+        else:
+            prefix_text = f"{num_sources} source{'s' if num_sources > 1 else ''} connected;"
+        if hasattr(self, '_cta'):
+            self._cta.object = f"{prefix_text} ask any question, or select a quick action below. {SPLASH_HELP_HINT}"
 
         # Update help dialog content when sources change
-        self._update_help_getting_started()
-        # Only update if we're currently showing the Getting Started or Explorations section
-        label = self._help_breadcrumbs.value['label']
-        if label == 'Getting Started':
-            self._help_content[:] = [Markdown(self._current_help_text, sizing_mode="stretch_width")]
-        elif label == 'Explorations':
-            self._help_content[:] = [Markdown(self._current_explorations_help, sizing_mode="stretch_width")]
+        if hasattr(self, '_help_content'):
+            self._update_help_getting_started()
+            # Only update if we're currently showing the Getting Started section
+            if hasattr(self, '_help_breadcrumbs') and self._help_breadcrumbs.value['label'] == 'Getting Started':
+                self._help_content[:] = [Markdown(self._current_help_text, sizing_mode="stretch_width")]
 
     def _open_llm_dialog(self, event=None):
         """Open the LLM configuration dialog when the LLM chip is clicked."""
@@ -1155,7 +1143,8 @@ class UI(Viewer):
 
     async def _on_visibility_changed(self, event):
         """Handle visibility changes from SourceCatalog by re-syncing the coordinator."""
-        await self._coordinator.sync(self.context)
+        if hasattr(self, '_coordinator'):
+            await self._coordinator.sync(self.context)
 
     def _add_suggestions_to_footer(
         self,
@@ -1390,12 +1379,6 @@ class ExplorerUI(UI):
 
     _exploration = param.Dict()
 
-    def _update_help_getting_started(self):
-        super()._update_help_getting_started()
-        is_home = self._exploration.get("view") is self._home
-        if not is_home:
-            self._current_explorations_help = EXPLORATION_TOOLBAR_HELP
-
     def _export_notebook(self):
         nb = export_notebook(self._exploration['view'].plan.views, preamble=self.notebook_preamble)
         return StringIO(nb)
@@ -1421,21 +1404,13 @@ class ExplorerUI(UI):
 
     @param.depends("_exploration", watch=True)
     def _update_home(self):
-        if not self._page:
-            return
         is_home = self._exploration["view"] is self._home
+        if not hasattr(self, '_page'):
+            return
         if not is_home:
             self._transition_to_chat()
         exploration, report = self._sidebar_menu.items[:2]
         self._sidebar_menu.update_item(exploration, active=True, icon="timeline" if report["active"] else "insights")
-
-        self._explorations_title.object = "Explorations" if is_home else self._exploration['label']
-        self._explorations_help_caption.object = EXPLORATIONS_INTRO_HELP if is_home else EXPLORATION_VIEW_HELP
-
-        # Update help dialog content when exploration changes
-        self._update_help_getting_started()
-        if self._help_breadcrumbs.value['label'] == 'Explorations':
-            self._help_content[:] = [Markdown(self._current_explorations_help, sizing_mode="stretch_width")]
 
     def _render_sidebar(self) -> list[Viewable]:
         switches = []
@@ -1544,7 +1519,7 @@ class ExplorerUI(UI):
         )
         self._explorer = TableExplorer(context=self.context)
         self._explorer.param.watch(self._add_exploration_from_explorer, "add_exploration")
-        self._home.view = MuiColumn(self._explorer)
+        self._home.view = MuiColumn(self._explorations_intro, self._explorer)
 
         # Menus
         self._breadcrumbs = NestedBreadcrumbs(
@@ -1557,11 +1532,7 @@ class ExplorerUI(UI):
         # Main Area
         self._notebook_export.disabled = self.param._exploration.rx()['view'].rx.is_(self._home)
         self._output = Paper(
-            MuiColumn(
-                Row(self._breadcrumbs, self._notebook_export, sizing_mode="stretch_width"),
-                self._explorations_intro,
-                sizing_mode="stretch_width"
-            ),
+            Row(self._breadcrumbs, self._notebook_export, sizing_mode="stretch_width"),
             self._home,
             elevation=2,
             margin=(5, 10, 5, 5),
@@ -1594,7 +1565,7 @@ class ExplorerUI(UI):
 
         with hold():
             self._transition_to_chat()
-            self.interface.stream(f"Added exploration for the `{table}` table", user="Assistant")
+            self.interface.send(f"Add exploration for the `{table}` table", respond=False)
             out_context = await sql_out.render_context()
             watcher = plan.param.watch(partial(self._add_views, exploration), "views")
             try:

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -28,7 +28,6 @@ from panel_material_ui import (
 
 from ..base import Component
 from ..config import dump_yaml, load_yaml
-from ..downloads import Download
 from ..pipeline import Pipeline
 from ..transforms.sql import SQLLimit
 from ..views.base import Panel, Table, View
@@ -193,14 +192,7 @@ class LumenOutput(Viewer):
             """
             ]
         )
-        download = Download(
-            view=table, hide=False, filename=f'{pipeline.table}',
-            format='csv'
-        )
-        download_pane = download.__panel__()
-        download_pane.sizing_mode = 'fixed'
         controls = Row(
-            download_pane,
             styles={'position': 'absolute', 'right': '40px', 'top': '-35px'}
         )
         for sql_limit in pipeline.sql_transforms:


### PR DESCRIPTION
Follow up on:
https://github.com/holoviz/lumen/pull/1540

- Clean up one more download button

- Update icons to use outlined version (less distracting)

- Migrated configuring AI models under preferences and added descriptions to switches
<img width="340" height="269" alt="image" src="https://github.com/user-attachments/assets/721acc00-1ad6-47c0-9226-a50542a8139a" />

- Broke Help Guides into breadcrumbs
<img width="1737" height="923" alt="image" src="https://github.com/user-attachments/assets/16a51fd3-4d1d-4a34-b331-1c959c1d826c" />

- More instructions littered everywhere
<img width="612" height="268" alt="image" src="https://github.com/user-attachments/assets/65cfac79-cb47-4e6b-8264-5e193b5df1e6" />
<img width="956" height="424" alt="image" src="https://github.com/user-attachments/assets/a298c451-996d-4d27-994f-b885862df7b8" />
<img width="966" height="444" alt="image" src="https://github.com/user-attachments/assets/c099e358-86f1-4e63-a19d-6f28f3209eda" />

- Create a empty reports screen
<img width="831" height="322" alt="image" src="https://github.com/user-attachments/assets/3fb4c643-f828-476a-97ad-8f4fd99f9403" />

- Reduce breadcrumb depth for sources
<img width="526" height="141" alt="image" src="https://github.com/user-attachments/assets/76190897-08de-4cb4-bbc7-c2adc94c9671" />

- Add cdn to show table list icons
<img width="914" height="566" alt="image" src="https://github.com/user-attachments/assets/251450cb-365c-4685-bda9-aad676242aec" />
