### PR TITLE
Unify navigation

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -1666,7 +1666,7 @@ class TableExplorer(Viewer):
     interrogate the data via a chat interface.
     """
 
-    add_exploration = param.Event(label='Explore table(s)')
+    add_exploration = param.Event(label="Explore table")
 
     table_slug = param.Selector(label="Select table(s) to preview")
 
@@ -1677,16 +1677,17 @@ class TableExplorer(Viewer):
         super().__init__(**params)
         self._table_select = Select.from_param(
             self.param.table_slug,
-            max_height=200,
+            height=80,
             margin=0,
             label="",
-            sizing_mode='stretch_width'
+            sizing_mode='stretch_width',
+            sx={"height": "80px"}
         )
         self._explore_button = Button.from_param(
             self.param.add_exploration,
             icon='add_chart', color='primary', icon_size="2em",
             disabled=self._table_select.param.value.rx().rx.not_(),
-            margin=(0, 0, 0, 10), width=200, align='end'
+            margin=(0, 0, 0, 10), width=180, height=80
         )
         self._input_row = Row(
             self._table_select, self._explore_button
@@ -1724,8 +1725,7 @@ class TableExplorer(Viewer):
         self.source_map.clear()
         self.source_map.update(new)
         selected = selected[-1] if len(selected) == 1 else None
-        self.param.table_slug.objects = self.source_map
-        self.table_slug = selected
+        self._table_select.param.update(options=list(self.source_map), value=selected)
         self._input_row.visible = bool(self.source_map)
         self._initialized = True
 

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -1677,7 +1677,7 @@ class TableExplorer(Viewer):
         super().__init__(**params)
         self._table_select = Select.from_param(
             self.param.table_slug,
-            height=80,
+            height=60,
             margin=0,
             label="",
             sizing_mode='stretch_width',
@@ -1687,7 +1687,7 @@ class TableExplorer(Viewer):
             self.param.add_exploration,
             icon='add_chart', color='primary', icon_size="2em",
             disabled=self._table_select.param.value.rx().rx.not_(),
-            margin=(0, 0, 0, 10), width=180, height=80
+            margin=(0, 0, 0, 10), width=180, height=60
         )
         self._input_row = Row(
             self._table_select, self._explore_button

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -1268,7 +1268,7 @@ class SourceCatalog(Viewer):
         - Sources: If ALL their tables are in visible_slugs
         """
         active = []
-        visible_slugs = self.context.get("visible_slugs")
+        visible_slugs = self.context.get("visible_slugs", [])
         available_metadata = self._available_metadata
         meta_filenames = [m["filename"] for m in available_metadata]
 

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -1676,8 +1676,11 @@ class TableExplorer(Viewer):
         self._initialized = False
         super().__init__(**params)
         self._table_select = Select.from_param(
-            self.param.table_slug, sizing_mode='stretch_width',
-            max_height=200, margin=0
+            self.param.table_slug,
+            max_height=200,
+            margin=0,
+            label="",
+            sizing_mode='stretch_width'
         )
         self._explore_button = Button.from_param(
             self.param.add_exploration,
@@ -1685,7 +1688,9 @@ class TableExplorer(Viewer):
             disabled=self._table_select.param.value.rx().rx.not_(),
             margin=(0, 0, 0, 10), width=200, align='end'
         )
-        self._input_row = Row(self._table_select, self._explore_button, margin=(0, 10, 0, 10))
+        self._input_row = Row(
+            self._table_select, self._explore_button
+        )
         self.source_map = {}
         self._layout = self._input_row
 
@@ -1719,7 +1724,8 @@ class TableExplorer(Viewer):
         self.source_map.clear()
         self.source_map.update(new)
         selected = selected[-1] if len(selected) == 1 else None
-        self._table_select.param.update(options=list(self.source_map), value=selected)
+        self.param.table_slug.objects = self.source_map
+        self.table_slug = selected
         self._input_row.visible = bool(self.source_map)
         self._initialized = True
 

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -19,9 +19,9 @@ from panel.pane.markup import HTML, Markdown
 from panel.viewable import Viewer
 from panel.widgets import FileDropper
 from panel_material_ui import (
-    Button, Card, ChatAreaInput, Column as MuiColumn, IconButton,
-    LinearProgress, Popup, RadioButtonGroup, Select, Tabs, TextInput,
-    ToggleIcon, Tree, Typography,
+    Button, Card, Column as MuiColumn, IconButton, LinearProgress, Popup,
+    RadioButtonGroup, Select, Tabs, TextAreaInput, TextInput, ToggleIcon, Tree,
+    Typography,
 )
 
 from ..config import load_yaml
@@ -538,9 +538,10 @@ class UploadControls(BaseSourceControls):
         self._file_input = FileDropper(
             layout="compact",
             multiple=self.param.multiple,
-            margin=0,
+            margin=1,
             sizing_mode="stretch_width",
             disabled=self.param.disabled,
+            stylesheets=[".bk-input.filepond--root { box-shadow: unset; cursor: grab; } .bk-input.filepond--root:not([disabled]):hover { box-shadow: unset; }"]
         )
         self._file_input.param.watch(self._on_file_upload, "value")
 
@@ -594,23 +595,22 @@ class DownloadControls(BaseSourceControls):
     Controls for downloading files from URLs.
     """
 
-    download_url = param.String(default="", doc="URL input for downloading files")
+    download_url = param.String(default="", doc="Enter one or more URLs, one per line, and press <Shift+Enter> to download", label="Download URL(s)")
 
-    input_placeholder = param.String(default="Enter URLs, one per line, and press <Enter> to download")
+    input_placeholder = param.String(default="Enter URLs, one per line, and press <Shift+Enter> to download")
 
     _active_download_task = param.ClassSelector(class_=asyncio.Task)
 
     def __init__(self, **params):
         super().__init__(**params)
 
-        self._url_input = ChatAreaInput.from_param(
+        self._url_input = TextAreaInput.from_param(
             self.param.download_url,
             placeholder=self.param.input_placeholder,
             rows=4,
             margin=10,
             sizing_mode="stretch_width",
             disabled=self.param.disabled,
-            enable_upload=False
         )
         self._url_input.param.watch(self._handle_urls, "enter_pressed")
 
@@ -1150,7 +1150,8 @@ class SourceCatalog(Viewer):
             self._docs_tree,
             self._sources_title,
             self._sources_tree,
-            sizing_mode="stretch_width"
+            sizing_mode="stretch_width",
+            margin=(0, 0, 10, 0)
         )
 
         # Track the mapping from tree paths to source/table/metadata

--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -55,6 +55,8 @@ class Plan(Section):
 
     interface = param.ClassSelector(class_=ChatFeed)
 
+    is_followup = param.Boolean(default=False)
+
     _tasks = param.List(item_type=ActorTask)
 
     def render_task_history(self, i: int | None = None, failed: bool = False) -> tuple[list[Message], str]:
@@ -325,7 +327,7 @@ class Coordinator(Viewer, VectorLookupToolUser):
                 agent = agent()
             if isinstance(agent, AnalysisAgent):
                 analyses = indent("\n".join(
-                    f"- `{analysis.__name__}`:\n{indent(dedent(analysis.__doc__ or '').strip(), " " * 4)} (required cols: {', '.join(analysis.columns)})"
+                    f"- `{analysis.__name__}`:\n{indent(dedent(analysis.__doc__ or '').strip(), ' ' * 4)} (required cols: {', '.join(analysis.columns)})"
                     for analysis in agent.analyses if analysis._callable_by_llm
                 ), " " * 4)
                 agent.conditions.append(

--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -72,14 +72,12 @@ class Plan(Section):
             instruction = task.instruction
             if failed and idx == i:
                 status = "❌"
+            elif i == idx:
+                status = "🟡"
+            elif idx < i:
+                status = "🟢"
             else:
-                if i == idx:
-                    instruction = f"<u>{instruction}</u>"
-                if idx < i:
-                    status = "x"
-                else:
-                    status = " "
-                status = f"[{status}]"
+                status = "⚪"
             todos_list.append(f"- {status} {instruction}")
         todos = "\n".join(todos_list)
 

--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -81,7 +81,7 @@ class Plan(Section):
             todos_list.append(f"- {status} {instruction}")
         todos = "\n".join(todos_list)
 
-        formatted_content = f"User Request: {user_query['content']!r}\n\nComplete the underlined todo:\n{todos}"
+        formatted_content = (f"User Request: {user_query['content']!r}\n\n" if user_query else "") + f"Complete the current todo:\n{todos}"
         rendered_history = []
         for msg in self.history:
             if msg is user_query:

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -422,7 +422,7 @@ class TaskGroup(Task):
                         break
                 views += new
             finally:
-                self._current = i + 1
+                self._current = i + (0 if task.status == "error" else 1)
         if self.status != "error":
             self.status = "success"
         contexts = [self.context] if self.context else []

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -243,6 +243,8 @@ class Task(Viewer):
 
 class TaskGroup(Task):
 
+    _current = param.Integer(default=0)
+
     _tasks = param.List(item_type=Task)
 
     level = 3
@@ -256,7 +258,8 @@ class TaskGroup(Task):
             tasks = list(tasks)
         self._task_watchers = {}
         _tasks = []
-        for task in tasks:
+        current = 0
+        for i, task in enumerate(tasks):
             if isinstance(task, FunctionType):
                 task = FunctionTool(task)
             if isinstance(task, Actor) and not issubclass(Actor, self.param._tasks.item_type):
@@ -266,9 +269,12 @@ class TaskGroup(Task):
                 self._task_watchers[task] = task.param.watch(
                     self._sync_context, 'out_context'
                 )
+            if current == i and task.status == "success":
+                current = i+1
             _tasks.append(task)
-        super().__init__(_tasks=_tasks, **params)
-        self._current = 0
+        if "status" not in params and current == len(tasks):
+            params["status"] = "success"
+        super().__init__(_tasks=_tasks, _current=current, **params)
         self._watchers = {}
         self._init_view()
         self._init_views()
@@ -416,10 +422,9 @@ class TaskGroup(Task):
                         break
                 views += new
             finally:
-                self._current = i
+                self._current = i + 1
         if self.status != "error":
             self.status = "success"
-            self._current += 1
         contexts = [self.context] if self.context else []
         contexts += [task.out_context for task in self]
         return views, merge_contexts(LWW, contexts)
@@ -446,7 +451,7 @@ class TaskGroup(Task):
             self._tasks.remove(t)
         self._populate_view()
         self._init_views()
-        self._current = min(self._current, len(self)-1)
+        self._current = min(self._current, len(self))
 
     def cleanup(self):
         for task, watcher in self._task_watchers.items():
@@ -815,6 +820,11 @@ class Report(TaskGroup):
             margin=(0, 0, 0, 5),
             sizing_mode="stretch_both"
         )
+        self._update_run_state()
+
+    @param.depends('_current', '_tasks', watch=True)
+    def _update_run_state(self):
+        self._run.disabled = self._current == len(self)
 
     async def _execute_event(self, event):
         await self.execute()
@@ -970,7 +980,11 @@ class ActorTask(ExecutableTask):
     level = 3
 
     def __init__(self, actor: Actor, **params):
+        views = params.get("views", None)
+        out_context = params.get("out_context", None)
         super().__init__(actor=actor, **params)
+        if views and out_context:
+            self._add_outputs(views, out_context)
 
     @property
     def input_schema(self):

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1639,8 +1639,11 @@ class ExplorerUI(UI):
     async def _update_conversation(self, event=None, replan: bool = False):
         exploration = self._explorations.value['view']
         if exploration is self._home:
-            self._split[0] = self._splash
-        self._output[1:] = [exploration]
+            self._main[:] = [self._navigation, self._splash]
+        else:
+            if self._splash in self._main:
+                self._main[:] = [self._navigation, self._split]
+            self._output[1:] = [exploration]
 
         if event is not None:
             # When user switches explorations and coordinator is running

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1668,7 +1668,14 @@ class ExplorerUI(UI):
             self._main[:] = [self._navigation, main] if len(self._explorations.items) > 1 else [main]
 
     def _delete_exploration(self, item):
-        self._explorations.items = [it for it in self._explorations.items if it is not item]
+        with hold():
+            if item in self._explorations.items:
+                self._explorations.items = [it for it in self._explorations.items if it is not item]
+                self._explorations.value = self._home
+            else:
+                parent = item["parent"]
+                self._explorations.update_item(parent, items=[it for it in parent["items"] if it is not item])
+                self._explorations.value = parent
 
     def _destroy(self, session_context):
         """
@@ -1761,6 +1768,7 @@ class ExplorerUI(UI):
             'view': exploration,
             'icon': "insights",
             'actions': [{'action': 'remove', 'label': 'Remove', 'icon': 'delete'}],
+            'parent': parent_item if plan.is_followup else self._home,
             'items': []
         }
         with hold():

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -326,7 +326,7 @@ PREFERENCES_HELP = """
 **Configure AI Models** — Choose which LLM provider and models to use for different tasks
 """
 
-EXPLORATIONS_INTRO_HELP = "Select a table below to start a new exploration:"
+EXPLORATIONS_INTRO_HELP = "Select a table below to start a new exploration."
 
 EXPLORATION_VIEW_HELP = "Use < > to expand/collapse panels. Edit the spec (top) and the view (bottom) syncs. Click ✨ to ask LLM to revise."
 

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1595,7 +1595,7 @@ class ExplorerUI(UI):
             sizing_mode="stretch_height",
             sx={"borderRadius": 0},
             theme_config={"light": {"palette": {"background": {"paper": "var(--mui-palette-grey-100)"}}}, "dark": {}},
-            width=300,
+            width=275,
         )
         self._main[:] = [self._split]
         return main
@@ -1631,7 +1631,7 @@ class ExplorerUI(UI):
             title='Home',
             conversation=self.interface.objects
         )
-        self._exploration = {'label': 'Home', 'icon': 'home', 'view': self._home, 'items': []}
+        self._exploration = {'label': 'Home', 'icon': None, 'view': self._home, 'items': []}
         super()._configure_session()
         self._idle = asyncio.Event()
         self._idle.set()
@@ -1767,13 +1767,15 @@ class ExplorerUI(UI):
         view_item = {
             'label': plan.title,
             'view': exploration,
-            'icon': "insights",
+            'icon': None,
             'actions': [{'action': 'remove', 'label': 'Remove', 'icon': 'delete'}],
             'parent': parent_item if plan.is_followup else self._explorations.items[0],
             'items': []
         }
         with hold():
             self.interface.objects = conversation
+            # Collapse sidebar if we are launching first exploration
+            self._sidebar_collapse.value = len(self._main) == 1
             # Temporarily un-idle to allow exploration to be rendered
             self._idle.set()
             if is_home or not plan.is_followup:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -335,7 +335,7 @@ EXPLORATION_VIEW_HELP = "Use < > to expand/collapse panels. Edit the spec (top) 
 EXPLORATION_CAPTION = """
 Launch new explorations by chatting or selecting a table.
 
-Ask follow up question by navigating to an existing exploration.
+Ask follow-up questions by navigating to an existing exploration.
 """
 
 REPORT_CAPTION = "Use ▶ to execute all, × to clear outputs, ∨∧ to collapse/expand sections. Click exploration names to jump to them."  # noqa: RUF001
@@ -1671,7 +1671,7 @@ class ExplorerUI(UI):
         with hold():
             if item in self._explorations.items:
                 self._explorations.items = [it for it in self._explorations.items if it is not item]
-                self._explorations.value = self._home
+                self._explorations.value = self._explorations.items[0]
             else:
                 parent = item["parent"]
                 self._explorations.update_item(parent, items=[it for it in parent["items"] if it is not item])
@@ -1768,7 +1768,7 @@ class ExplorerUI(UI):
             'view': exploration,
             'icon': "insights",
             'actions': [{'action': 'remove', 'label': 'Remove', 'icon': 'delete'}],
-            'parent': parent_item if plan.is_followup else self._home,
+            'parent': parent_item if plan.is_followup else self._explorations.items[0],
             'items': []
         }
         with hold():

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -658,7 +658,7 @@ class UI(Viewer):
                 chat_input.value_uploaded = {}
 
                 # Store the pending query to execute after files are added
-                self._pending_query = user_prompt
+                self._pending_query = user_prompt or None
                 self._pending_sources_snapshot = list(self.context.get("sources", []))
 
                 # Clear the input
@@ -721,11 +721,7 @@ class UI(Viewer):
 
     def _handle_upload_successful(self, event):
         """Handle successful file upload by switching to Source Catalog and executing pending query."""
-
-        # Maybe expand
-
-        # Execute pending query if one exists
-        if self._pending_query is not None or self._pending_sources_snapshot is not None:
+        if self._pending_query is not None:
             self._execute_pending_query()
 
     def _execute_pending_query(self):
@@ -736,8 +732,6 @@ class UI(Viewer):
         # Clear pending state first (before any dialog operations)
         self._pending_query = None
         self._pending_sources_snapshot = None
-
-        # Note: Dialog stays open so user can review the Source Catalog
 
         # Build message with new sources info
         new_sources = [
@@ -1087,6 +1081,10 @@ class UI(Viewer):
 
         if hasattr(self, '_cta'):
             self._cta.object = self._get_status_text()
+
+        if hasattr(self, '_splash_tabs'):
+            num_sources = len(self.context.get("sources", []))
+            self._splash_tabs.disabled = [] if num_sources else [1]
 
         # Update help dialog content when sources change
         if hasattr(self, '_help_content'):
@@ -1503,11 +1501,14 @@ class ExplorerUI(UI):
             self._explorations_help_caption,
             self._explorer
         )
-        self._splash[0][1] = Tabs(
+        num_sources = len(self.context.get("sources", []))
+        self._splash_tabs = Tabs(
             ("Chat with Data", self._chat_splash),
             ("Browse Data", self._explorer_splash),
+            disabled=[] if num_sources else [1],
             margin=(0, 10)
         )
+        self._splash[0][1] = self._splash_tabs
 
         # Initialize home as empty
         self._home.view = MuiColumn()

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1565,10 +1565,10 @@ class ExplorerUI(UI):
         sql_agent = next(agent for agent in self._coordinator.agents if isinstance(agent, SQLAgent))
         sql_task = ActorTask(sql_agent, title=f"Load {table}")
         plan = Plan(sql_task, title=f"Explore {table}")
-        exploration = await self._add_exploration(plan, self._home)
 
         with hold():
             self._transition_to_chat()
+            exploration = await self._add_exploration(plan, self._home)
             self.interface.send(f"Add exploration for the `{table}` table", respond=False)
             out_context = await sql_out.render_context()
             watcher = plan.param.watch(partial(self._add_views, exploration), "views")

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1504,9 +1504,10 @@ class ExplorerUI(UI):
         num_sources = len(self.context.get("sources", []))
         self._splash_tabs = Tabs(
             ("Chat with Data", self._chat_splash),
-            ("Browse Data", self._explorer_splash),
+            ("Select Data to Explore", self._explorer_splash),
             disabled=[] if num_sources else [1],
-            margin=(0, 10)
+            margin=(0, 10),
+            stylesheets=[".MuiTabsPanel > .MuiBox-root { overflow: visible}"]
         )
         self._splash[0][1] = self._splash_tabs
 

--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -59,6 +59,7 @@ class LumenOutput(Viewer):
     language = "yaml"
 
     _controls = [CopyControls, RetryControls]
+    _label = "Result"
 
     def __init__(self, **params):
         try:
@@ -108,7 +109,7 @@ class LumenOutput(Viewer):
 
     def render_controls(self, task: Task, interface: ChatFeed):
         export_menu = MenuButton(
-            label="Export Output", variant='text', icon="file_download", margin=0,
+            label=f"Export {self._label} as", variant='text', icon="file_download", margin=0,
             items=[
                 {
                     "label": FORMAT_LABELS.get(fmt, f"{fmt.upper()}"),
@@ -268,6 +269,7 @@ class VegaLiteOutput(LumenOutput):
     export_formats = ("yaml", "png", "jpeg", "pdf", "svg", "html")
 
     _controls = [CopyControls, RetryControls, AnnotationControls]
+    _label = "Plot"
 
     def export(self, fmt: str) -> StringIO | BytesIO:
         ret = super().export(fmt)
@@ -480,6 +482,7 @@ class SQLOutput(LumenOutput):
     language = "sql"
 
     export_formats = ("sql", "csv", "xlsx")
+    _label = "Table"
 
     def export(self, fmt: str) -> str | bytes:
         super().export(fmt)

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -83,7 +83,7 @@ async def test_planner_simple_plan(llm):
     assert reasoning_step[0].object == "Just use ChatAgent"
     title, todos = steps_layout.header
     assert title.object == "🧾 Checklist ready..."
-    assert todos.object == "- [ ] Say Hello!"
+    assert todos.object == "- ⚪ Say Hello!"
 
     assert isinstance(plan, Plan)
     assert plan.title == "Hello!"


### PR DESCRIPTION
Based on feedback in various PRs we have already removed the Home indicator, however the navigation between different explorations was still confusing since we had a sidebar menu in the reports but used the nested breadcrumbs in the explorations view. This PR unifies the two by reusing the same `MenuList` to navigate between different explorations in both views. 

Additionally this cleans up the handling of nested explorations, i.e. if you had one exploration and then asked an unrelated question internally we would still treat one as the child of the previous exploration. Since we already asked the LLM determine if we were asking a followup questions we now reuse that flag to determine whether an exploration is a followup or completely standalone.

<img width="2202" height="1755" alt="Screenshot 2026-01-06 at 15 12 47" src="https://github.com/user-attachments/assets/4e6c967c-7993-4377-994b-929782a797b8" />

## Other fixes

- Ensure that deleting explorations works
- Change task status indicators to ⚪ 🟡 🟢 ❌ (instead of underlining the active task)

## Todo

- Ensure that report unpacks all (even nested) items
- Ensure that the menu expands when a nested item is added
- Update and add tests