### PR TITLE
Tweak error handling

### DIFF
--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -20,7 +20,7 @@ from ...transforms.sql import SQLLimit
 from ..config import PROMPTS_DIR, SOURCE_TABLE_SEPARATOR
 from ..context import ContextModel, TContext
 from ..llm import Message
-from ..models import PartialBaseModel, RetrySpec
+from ..models import EscapeBaseModel, PartialBaseModel, RetrySpec
 from ..schemas import Metaset
 from ..utils import (
     clean_sql, describe_data, get_data, get_pipeline, parse_table_slug,
@@ -192,7 +192,7 @@ def make_discovery_model(sources: list[tuple[str, str]]):
             description="Choose 2-4 discovery queries. Use SampleQuery/DistinctQuery for known tables, TableQuery for wildcard searches."
         )
 
-    class DiscoverySufficiency(PartialBaseModel):
+    class DiscoverySufficiency(EscapeBaseModel):
         """Evaluate if discovery results provide enough context to fix the original error."""
 
         reasoning: str = Field(description="Analyze discovery results - do they reveal the cause of the error?")

--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -155,9 +155,7 @@ class Plan(Section):
                 error_msg = str(root_exception)
                 step.failed_title = f"{task.title!r} failed: {error_msg}"
                 step.stream(f"\n\n❌ **{error_msg}**")
-                # Set error status and store the error message
                 task.status = "error"
-                # Store the error in context so it can be accessed later
                 task.out_context["__error__"] = error_msg
                 return [], {"__error__": error_msg}  # Return with error message in context
         elif isinstance(e, asyncio.CancelledError):

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -2002,7 +2002,7 @@ class ExplorerUI(UI):
             ), "role": "user"}],
             response_model=ErrorDescription
         )
-        explanation = f"⚠️ **Unable to complete your request**\n\n{response.explanation}"
+        explanation = f"❌ **Unable to complete your request**\n\n{response.explanation}"
         tabs = exploration.view[0]
         if exploration.initialized:
             tabs.append(("Error", Markdown(explanation, margin=(5, 20))))

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -2002,7 +2002,7 @@ class ExplorerUI(UI):
             ), "role": "user"}],
             response_model=ErrorDescription
         )
-        explanation = f"⚠️ **Unable to complete your request:**\n\n{response.explanation}"
+        explanation = f"⚠️ **Unable to complete your request**\n\n{response.explanation}"
         tabs = exploration.view[0]
         if exploration.initialized:
             tabs.append(("Error", Markdown(explanation, margin=(5, 20))))

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -111,7 +111,7 @@ async def test_exploration_ui_error(explorer_ui_with_error):
     # Ensure error output is correct
     tabs = exploration.view[0]
     assert len(tabs) == 3
-    assert tabs[-1].object == "⚠️ **Unable to complete your request:**\n\nbar"
+    assert tabs[-1].object == "⚠️ **Unable to complete your request**\n\nbar"
 
     # Check Interface contents
     assert len(ui.interface) == 2

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -111,7 +111,7 @@ async def test_exploration_ui_error(explorer_ui_with_error):
     # Ensure error output is correct
     tabs = exploration.view[0]
     assert len(tabs) == 3
-    assert tabs[-1].object == "⚠️ **Unable to complete your request**\n\nbar"
+    assert tabs[-1].object == "❌ **Unable to complete your request**\n\nbar"
 
     # Check Interface contents
     assert len(ui.interface) == 2


### PR DESCRIPTION
1. Tweak look on exploration error message to use consistent emoji x
2. Ensure the error bubbles up properly so it's not generic `failed to provide declared context values` internal error
3. Allow SQLAgent to escape (i.e. if I only uploaded olympic hosts without medal data, it should tell me that!)

<img width="1737" height="928" alt="image" src="https://github.com/user-attachments/assets/1cbb625d-5e63-46f2-9575-4e6bbc0112a4" />


<img width="1680" height="523" alt="image" src="https://github.com/user-attachments/assets/fa9fda15-f877-4b23-b82f-a9896a9a66bf" />
