### PR TITLE
Fix splash margins and make data sources a bit prettier

### DIFF
--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -19,7 +19,7 @@ from panel.pane.markup import HTML, Markdown
 from panel.viewable import Viewer
 from panel.widgets import FileDropper
 from panel_material_ui import (
-    AutocompleteInput, Button, Card, Column as MuiColumn, IconButton,
+    AutocompleteInput, Button, Card, Column as MuiColumn, Divider, IconButton,
     LinearProgress, Popup, RadioButtonGroup, Select, Tabs, TextAreaInput,
     TextInput, ToggleIcon, Tree, Typography,
 )
@@ -250,7 +250,8 @@ class BaseSourceControls(Viewer):
             name="Confirm file(s)",
             icon="add",
             visible=files_to_process,
-            button_type="success"
+            sizing_mode="stretch_width",
+            height=42,
         )
 
         self._error_placeholder = HTML("", visible=False, margin=(0, 10, 5, 10))
@@ -552,6 +553,7 @@ class UploadControls(BaseSourceControls):
 
         self._layout = MuiColumn(
             self._file_input,
+            Divider(),
             self._upload_cards,
             self._add_button,
             self._error_placeholder,
@@ -633,6 +635,7 @@ class DownloadControls(BaseSourceControls):
 
         self._layout = MuiColumn(
             self._url_input,
+            Divider(),
             self._upload_cards,
             Row(self._add_button, self._cancel_button),
             self._error_placeholder,
@@ -1563,17 +1566,17 @@ class SourceCatalog(Viewer):
     def _sync_sources_tree(self, sources: list):
         """Sync the sources tree with current sources."""
         if not sources:
-            self._sources_title.object = "**Data Sources** *(no sources available)*"
+            self._sources_title.object = "**Available Sources** *(no sources available)*"
             self._sources_tree.items = []
             return
 
         items = self._build_sources_items(sources)
         if not items:
-            self._sources_title.object = "**Data Sources** *(no tables found)*"
+            self._sources_title.object = "**Available Sources** *(no tables found)*"
             self._sources_tree.items = []
             return
 
-        self._sources_title.object = "**Data Sources**"
+        self._sources_title.object = "**Available Sources**"
         self._auto_associate_unassociated_metadata(sources)
         self._update_sources_tree_state(items, sources)
 

--- a/lumen/ai/controls.py
+++ b/lumen/ai/controls.py
@@ -616,7 +616,7 @@ class DownloadControls(BaseSourceControls):
         self._url_input = TextAreaInput.from_param(
             self.param.download_url,
             placeholder=self.param.input_placeholder,
-            rows=4,
+            rows=2,
             margin=10,
             sizing_mode="stretch_width",
             disabled=self.param.disabled,

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -869,13 +869,13 @@ class UI(Viewer):
         return []
 
     def _render_main(self) -> list[Viewable]:
-        self._cta = Typography(self._get_status_text(), margin=(10, 0, 0, 10))
+        self._cta = Typography(self._get_status_text(), margin=(0, 0, 10, 0))
         self._chat_splash = Column(self._cta, self.interface._widget, margin=(0, 0, 0, -10))
         self._error_alert = Alert(
             object="",
             severity="error",
             sizing_mode="stretch_width",
-            margin=(5, 10),
+            margin=(10, 0, 5, 0),
             visible=False
         )
 
@@ -884,17 +884,16 @@ class UI(Viewer):
                 Typography(
                     "Ask questions, get insights",
                     disable_anchors=True,
-                    variant="h1"
+                    variant="h1",
+                    margin=(10, 0, 5, 0),
                 ),
-                self._chat_splash,
                 self._cta,
+                self._chat_splash,
                 self._error_alert,
-                self.interface._widget,
                 max_width=850,
                 styles={'margin': 'auto'},
                 sx={'p': '0 20px 20px 20px'}
             ),
-            margin=(0, 5, 0, 0),
             sx={'display': 'flex', 'align-items': 'center'},
             height_policy='max'
         )
@@ -1305,7 +1304,7 @@ class UI(Viewer):
                 footer_objects = message.footer_objects or []
                 message.footer_objects = footer_objects + [suggestion_buttons]
         else:
-            self._splash[0][1].append(suggestion_buttons)
+            self._splash[0][2].append(suggestion_buttons)
 
         self.interface.param.watch(hide_suggestions, "objects")
 
@@ -1575,7 +1574,7 @@ class ExplorerUI(UI):
         )
 
         # Update chat_splash to use tabs instead of interface widget
-        self._chat_splash[:] = [self._cta, self._input_tabs]
+        self._chat_splash[:] = [self._input_tabs]
 
         # Add suggestions to chat_splash (after tabs)
         if self.suggestions:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -805,6 +805,7 @@ class UI(Viewer):
         self._transition_to_chat()
         msg = Column(user_prompt, source_view) if source_view else user_prompt
         self.interface.send(msg, respond=True)
+        self.interface.active_widget.value_input = ""
 
     def _on_sources_dialog_close(self, event):
         """Handle sources dialog close - restore pending query to input if user closed without adding files."""
@@ -1230,7 +1231,6 @@ class UI(Viewer):
                     suggestion_buttons.visible = False
                     if event.new > 1:  # prevent double clicks
                         return
-
                 self._transition_to_chat()
 
                 if not analysis:


### PR DESCRIPTION
Builds on https://github.com/holoviz/lumen/pull/1577

Tweak UI
<img width="1561" height="921" alt="image" src="https://github.com/user-attachments/assets/0cddaed2-b2ae-416e-8da0-20bc36ee3c2c" />

Unsure if this is prettier, but make confirm button more prominent
(ideally the green filedropper success background is more muted)

<img width="1556" height="921" alt="image" src="https://github.com/user-attachments/assets/07cd73af-3e64-4f1e-a6f5-11d5fce023ba" />

Align height
<img width="1142" height="391" alt="image" src="https://github.com/user-attachments/assets/5a2c094f-d79a-4098-8725-971543baaf94" />
<img width="1183" height="333" alt="image" src="https://github.com/user-attachments/assets/66e171df-f10b-4b70-9358-e7c585f2a13b" />
