### PR TITLE
Improve output rendering

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1859,7 +1859,7 @@ class ExplorerUI(UI):
         self._last_synced = exploration
         return exploration
 
-    def _render_pop_out(self, exploration: Exploration, view: VSplit, title: str):
+    def _render_pop_out(self, exploration: Exploration, view: Column, title: str):
         title_view = Typography(
             title.upper(),
             color="primary",
@@ -1902,28 +1902,29 @@ class ExplorerUI(UI):
 
         task = next(task for task in exploration.plan if view in task.views)
         controls = view.render_controls(task, self.interface)
-        editor = Column(controls, view.editor)
         vsplit = VSplit(
-            editor, view,
+            Column(view.editor, width_policy="max", scroll="y-auto"),
+            view,
             expanded_sizes=(20, 80),
             sizes=(20, 80),
             sizing_mode="stretch_both",
             styles={"overflow": "auto"},
             stylesheets=SPLITJS_STYLESHEETS
         )
-        controls.append(self._render_pop_out(exploration, vsplit, title))
-        return (title, vsplit)
+        view = Column(controls, vsplit)
+        controls.append(self._render_pop_out(exploration, view, title))
+        return (title, view)
 
     def _find_view_in_tabs(self, exploration: Exploration, out: LumenOutput):
         tabs = exploration.view[0]
-        for i, tab in enumerate(tabs):
-            content = tab[1] if isinstance(tab, tuple) and len(tab) > 1 else tab
+        for i, tab in enumerate(tabs[1:], start=1):
+            content = tab[1][1] if isinstance(tab, tuple) and len(tab) > 1 else tab[1]
             if isinstance(content, VSplit) and out.view in content:
                 return i
         return None
 
     def _find_view_in_popped_out(self, exploration: Exploration, out: LumenOutput):
-        for i, standalone in enumerate(exploration.view[1:], start=1):
+        for i, standalone in enumerate(exploration.view):
             if isinstance(standalone, Column) and len(standalone) > 1:
                 vsplit = standalone[1]
                 if isinstance(vsplit, VSplit) and out.view in vsplit:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1915,20 +1915,18 @@ class ExplorerUI(UI):
         controls.append(self._render_pop_out(exploration, view, title))
         return (title, view)
 
-    def _find_view_in_tabs(self, exploration: Exploration, out: LumenOutput):
+    def _find_view_in_tabs(self, exploration: Exploration, out: Column):
         tabs = exploration.view[0]
         for i, tab in enumerate(tabs[1:], start=1):
-            content = tab[1][1] if isinstance(tab, tuple) and len(tab) > 1 else tab[1]
-            if isinstance(content, VSplit) and out.view in content:
+            content = tab[1] if isinstance(tab, tuple) and len(tab) > 1 else tab
+            if out is content:
                 return i
         return None
 
-    def _find_view_in_popped_out(self, exploration: Exploration, out: LumenOutput):
-        for i, standalone in enumerate(exploration.view):
-            if isinstance(standalone, Column) and len(standalone) > 1:
-                vsplit = standalone[1]
-                if isinstance(vsplit, VSplit) and out.view in vsplit:
-                    return i
+    def _find_view_in_popped_out(self, exploration: Exploration, out: Column):
+        for i, standalone in enumerate(exploration.view[1:], start=1):
+            if isinstance(standalone, Column) and len(standalone) > 1 and out is standalone[1]:
+                return i
         return None
 
     def _add_views(self, exploration: Exploration, event: param.parameterized.Event | None = None, items: list | None = None):

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -13,9 +13,10 @@ import tqdm  # type: ignore
 
 from panel.io.document import unlocked
 from panel.io.state import state as pn_state
+from panel.layout import Column, Row
 from panel.param import Param
 from panel.viewable import Viewer
-from panel.widgets import Widget
+from panel.widgets import Tabulator, Widget
 
 from .base import Component
 from .filters.base import Filter, ParamFilter, WidgetFilter
@@ -194,8 +195,12 @@ class Pipeline(Viewer, Component):
     def _update_refs(self, *events: param.parameterized.Event):
         self._update_data()
 
-    def __panel__(self) -> pn.Row:
-        return pn.Row(self.control_panel, pn.widgets.Tabulator(self.param.data, pagination='remote'))
+    def __panel__(self) -> Row:
+        controls = self.control_panel
+        table = Tabulator(self.param.data, pagination='remote', sizing_mode="stretch_both", min_height=300)
+        if controls:
+            return Row(self.control_panel, table)
+        return table
 
     def to_spec(self, context: dict[str, Any] | None = None) -> dict[str, Any]:
         """
@@ -709,8 +714,8 @@ class Pipeline(Viewer, Component):
         return objects
 
     @property
-    def control_panel(self) -> pn.Column:
-        col = pn.Column()
+    def control_panel(self) -> Column:
+        col = Column()
         filters = [filt.panel for filt in self.traverse('filters')]
         if any(filters):
             col.append('<div style="font-size: 1.5em; font-weight: bold;">Filters</div>')


### PR DESCRIPTION
- Pipeline output looked bad when no controls were added
- Editor output could overflow the VSplit window, so we add scroll and move the controls outside the VSplit
- Views displayed duplicate loading spinners