### PR TITLE
Refactor UI navigation logic and add tests

### DIFF
--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -18,8 +18,6 @@ from lumen.ai.coordinator.planner import Reasoning, make_plan_model
 from lumen.ai.models import ReplaceLine, RetrySpec
 from lumen.ai.report import ActorTask
 from lumen.ai.schemas import get_metaset
-from lumen.ai.tools import MetadataLookup
-from lumen.ai.vector_store import NumpyVectorStore
 from lumen.ai.views import SQLOutput
 from lumen.config import SOURCE_TABLE_SEPARATOR
 

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -10,14 +10,14 @@ except ModuleNotFoundError:
 
 from panel.layout import Column, Row
 from panel.tests.util import async_wait_until
-from panel_material_ui import Column as MuiColumn, Container
+from panel_material_ui import Container
 from panel_splitjs import VSplit
 
 from lumen.ai.agents.analyst import AnalystAgent
 from lumen.ai.agents.sql import SQLAgent, make_sql_model
 from lumen.ai.coordinator import Plan
-from lumen.ai.models import ErrorDescription, YesNo
-from lumen.ai.report import ActorTask, Report
+from lumen.ai.models import ErrorDescription
+from lumen.ai.report import ActorTask
 from lumen.ai.schemas import get_metaset
 from lumen.ai.ui import Exploration, ExplorerUI
 from lumen.ai.views import SQLOutput
@@ -523,7 +523,7 @@ async def test_delete_exploration_switches_to_parent(explorer_ui):
         is_followup=True
     )
 
-    child_exploration = await explorer_ui._add_exploration(child_plan, parent_exploration)
+    await explorer_ui._add_exploration(child_plan, parent_exploration)
 
     await asyncio.sleep(0.1)
 

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -10,14 +10,14 @@ except ModuleNotFoundError:
 
 from panel.layout import Column, Row
 from panel.tests.util import async_wait_until
-from panel_material_ui import Column as MuiColumn
+from panel_material_ui import Column as MuiColumn, Container
 from panel_splitjs import VSplit
 
 from lumen.ai.agents.analyst import AnalystAgent
 from lumen.ai.agents.sql import SQLAgent, make_sql_model
 from lumen.ai.coordinator import Plan
 from lumen.ai.models import ErrorDescription, YesNo
-from lumen.ai.report import ActorTask
+from lumen.ai.report import ActorTask, Report
 from lumen.ai.schemas import get_metaset
 from lumen.ai.ui import Exploration, ExplorerUI
 from lumen.ai.views import SQLOutput
@@ -409,3 +409,239 @@ async def test_exploration_parent_relationship(explorer_ui):
     # Check that parent is home
     assert exploration.parent is explorer_ui._home
     assert exploration.parent.title == 'Home'
+
+
+# Tests for view transition states
+
+async def test_initial_state_shows_splash(explorer_ui):
+    """Test 1: On start the user sees just the self._splash in main."""
+    # Initially, _main should contain only _splash
+    assert len(explorer_ui._main) == 1
+    assert explorer_ui._main[0] is explorer_ui._splash
+
+    # Should be on home
+    assert explorer_ui._explorations.value['view'] is explorer_ui._home
+    assert len(explorer_ui._explorations.items) == 1  # Only home
+
+
+async def test_exploration_launch_transitions_to_split(explorer_ui):
+    """Test 2: When an exploration is launched we switch from splash to split view."""
+    # Initially showing splash
+    assert explorer_ui._main[0] is explorer_ui._splash
+
+    # Create an exploration
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+
+    # Wait for exploration to be created
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+
+    # After exploration is created, should transition to split view
+    # The view should update when views are added (which happens in _add_exploration_from_explorer)
+    await async_wait_until(lambda: explorer_ui._split in explorer_ui._main or explorer_ui._navigation in explorer_ui._main)
+
+    # Should now show split view (with navigation if there are explorations)
+    if explorer_ui._should_show_navigation():
+        assert len(explorer_ui._main) == 2
+        assert explorer_ui._main[0] is explorer_ui._navigation
+        assert explorer_ui._main[1] is explorer_ui._split
+    else:
+        assert len(explorer_ui._main) == 1
+        assert explorer_ui._main[0] is explorer_ui._split
+
+    # Should not be showing splash anymore
+    assert explorer_ui._splash not in explorer_ui._main
+
+
+async def test_exploration_with_pipeline_data_shows_split(explorer_ui):
+    """Test 2b: When plan produces data, should show split view with navigation."""
+    # Create an exploration with pipeline data
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+    exploration = explorer_ui._explorations.items[1]['view']
+
+    # Wait for views to be added (pipeline data)
+    await async_wait_until(lambda: len(exploration.plan.views) > 0, timeout=5.0)
+
+    # Should show split view with navigation (since we have explorations)
+    assert explorer_ui._should_show_navigation()
+    assert len(explorer_ui._main) == 2
+    assert explorer_ui._main[0] is explorer_ui._navigation
+    assert explorer_ui._main[1] is explorer_ui._split
+
+    # Output should contain the exploration
+    assert len(explorer_ui._output) > 1
+    assert explorer_ui._output[1] is exploration.view
+
+
+async def test_delete_exploration_switches_to_home(explorer_ui):
+    """Test 3: When deleting an exploration, switch to home if no parent exploration."""
+    # Create an exploration
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+    exploration_item = explorer_ui._explorations.items[1]
+
+    # Delete the exploration
+    await explorer_ui._delete_exploration(exploration_item)
+    await asyncio.sleep(0.1)
+
+    # Should switch back to home (splash view)
+    assert len(explorer_ui._explorations.items) == 1
+    assert explorer_ui._explorations.value['view'] is explorer_ui._home
+    assert explorer_ui._main[0] is explorer_ui._splash
+
+
+async def test_delete_exploration_switches_to_parent(explorer_ui):
+    """Test 3b: When deleting a child exploration, switch to parent if available."""
+    # Create first exploration
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+    parent_item = explorer_ui._explorations.items[1]
+    parent_exploration = parent_item['view']
+
+    sql_agent = SQLAgent(llm=explorer_ui.llm)
+    test_source = explorer_ui.context["source"]
+    SQLQueryWithTables = make_sql_model([(test_source.name, "test_table")])
+    explorer_ui.llm.set_responses([
+        SQLQueryWithTables(
+            query="SELECT * FROM test_table LIMIT 5",
+            table_slug="test_limit",
+            tables=["test_table"]
+        )
+    ])
+
+    child_plan = Plan(
+        ActorTask(sql_agent),
+        history=[{"content": "Show first 5 rows", "role": "user"}],
+        title="First 5 rows",
+        context=explorer_ui._explorations.value["view"].context,
+        is_followup=True
+    )
+
+    child_exploration = await explorer_ui._add_exploration(child_plan, parent_exploration)
+
+    await asyncio.sleep(0.1)
+
+    # Verify we're currently on the child
+    child_item = explorer_ui._explorations.items[1]['items'][0]  # First child of first exploration
+    assert explorer_ui._explorations.value is child_item
+
+    # Delete the child exploration
+    await explorer_ui._delete_exploration(child_item)
+
+    # Should switch back to parent exploration
+    assert explorer_ui._explorations.value is explorer_ui._explorations.items[1]
+    assert explorer_ui._explorations.value['view'] is parent_exploration
+
+
+async def test_switch_to_report_mode_with_no_explorations(explorer_ui):
+    """Test 4: When switching to report mode with no explorations, show placeholder."""
+    # Initially no explorations (only home)
+    assert len(explorer_ui._explorations.items) == 1
+
+    # Switch to report mode
+    explorer_ui._toggle_report_mode(True)
+
+    # Should show placeholder message
+    assert len(explorer_ui._main) == 1
+    main_content = explorer_ui._main[0]
+    assert isinstance(main_content, Column)
+    # Should contain the "No Explorations Yet" message
+    assert len(main_content) >= 1
+
+    # Navigation should show "Report"
+    assert explorer_ui._navigation_title.object == "Report"
+
+
+async def test_switch_to_report_mode_with_explorations(explorer_ui):
+    """Test 4b: When switching to report mode with explorations, show Report."""
+    # Create an exploration
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+
+    # Wait for views to be added
+    exploration = explorer_ui._explorations.items[1]['view']
+    await async_wait_until(lambda: len(exploration.plan.views) > 0, timeout=5.0)
+
+    # Switch to report mode
+    explorer_ui._handle_sidebar_event(explorer_ui._sidebar_menu.items[1])
+
+    # Should show Report component with navigation
+    assert explorer_ui._should_show_navigation()
+    assert len(explorer_ui._main) == 2
+    assert explorer_ui._main[0] is explorer_ui._navigation
+
+    # Main content should be a Report instance
+    assert isinstance(explorer_ui._main[1], Column)
+    assert len(explorer_ui._main[1]) == 2
+    assert isinstance(explorer_ui._main[1][1], Container)
+
+    # Navigation should show "Report"
+    assert explorer_ui._navigation_title.object == "Report"
+
+
+async def test_switch_back_from_report_to_exploration(explorer_ui):
+    """Test 5: When switching back from report to exploration, show selected exploration."""
+    # Create an exploration
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+
+    exploration_item = explorer_ui._explorations.items[1]
+    exploration = exploration_item['view']
+
+    # Wait for views to be added
+    await async_wait_until(lambda: len(exploration.plan.views) > 0, timeout=5.0)
+
+    # Switch to report mode
+    explorer_ui._handle_sidebar_event(explorer_ui._sidebar_menu.items[1])
+    assert isinstance(explorer_ui._main[1][1], Container)
+
+    # Switch back to exploration mode
+    explorer_ui._handle_sidebar_event(explorer_ui._sidebar_menu.items[0])
+
+    # Should show split view with the selected exploration
+    assert len(explorer_ui._main) == 2
+    assert explorer_ui._main[0] is explorer_ui._navigation
+    assert explorer_ui._main[1] is explorer_ui._split
+
+    # Output should contain the exploration
+    assert explorer_ui._output[1] is exploration.view
+
+    # Navigation should show "Exploration"
+    assert explorer_ui._navigation_title.object == "Exploration"
+
+
+async def test_navigation_visibility_with_explorations(explorer_ui):
+    """Test that navigation pane is shown/hidden correctly based on explorations."""
+    # Initially no explorations (only home) - no navigation
+    assert not explorer_ui._should_show_navigation()
+    assert len(explorer_ui._main) == 1
+    assert explorer_ui._navigation not in explorer_ui._main
+
+    # Create an exploration
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+
+    # Now should show navigation
+    assert explorer_ui._should_show_navigation()
+    # View should update to include navigation
+    explorer_ui._update_main_view()
+    assert len(explorer_ui._main) == 2
+    assert explorer_ui._main[0] is explorer_ui._navigation
+
+    # Delete exploration
+    exploration_item = explorer_ui._explorations.items[1]
+    await explorer_ui._delete_exploration(exploration_item)
+
+    # Navigation should be hidden again
+    assert not explorer_ui._should_show_navigation()
+    assert len(explorer_ui._main) == 1
+    assert explorer_ui._navigation not in explorer_ui._main


### PR DESCRIPTION
I hated how the logic to navigate between explorations, the splash screen, the interface and the report view was split into a bunch of different methods. In this PR we unify this logic a little bit with various useful helpers to determine the current UI state and also add a bunch of tests.