### PR TITLE
Add define_tool helper and fix tool instantiation

### DIFF
--- a/lumen/ai/tools/__init__.py
+++ b/lumen/ai/tools/__init__.py
@@ -1,4 +1,6 @@
-from .base import FunctionTool, Tool, ToolUser
+from .base import (
+    FunctionTool, Tool, ToolUser, define_tool,
+)
 from .dbtsl_lookup import DbtslLookup
 from .metadata_lookup import MetadataLookup
 from .vector_lookup import VectorLookupTool, VectorLookupToolUser
@@ -7,6 +9,7 @@ __all__ = [
     "Tool",
     "FunctionTool",
     "ToolUser",
+    "define_tool",
     "VectorLookupTool",
     "VectorLookupToolUser",
     "MetadataLookup",

--- a/lumen/ai/tools/vector_lookup.py
+++ b/lumen/ai/tools/vector_lookup.py
@@ -362,12 +362,10 @@ class VectorLookupToolUser(ToolUser):
         # Get base kwargs from parent
         kwargs = super()._get_tool_kwargs(tool, prompt_tools, **params)
 
-        # If the tool is already instantiated and has a vector_store, use it
-        if (
-            (isinstance(tool, type) and not issubclass(tool, VectorLookupTool)) or
-            not isinstance(tool, VectorLookupTool) or
-            (isinstance(tool, VectorLookupTool) and tool.vector_store is not None)
-        ):
+        # If the tool is not a VectorLookupTool or is already instantiated and has a vector_store skip
+        is_class = isinstance(tool, type) and issubclass(tool, VectorLookupTool)
+        is_instance = isinstance(tool, VectorLookupTool)
+        if not (is_class or is_instance) or (is_instance and tool.vector_store is not None):
             return kwargs
 
         # Always pass document_vector_store if available

--- a/lumen/ai/tools/vector_lookup.py
+++ b/lumen/ai/tools/vector_lookup.py
@@ -364,7 +364,8 @@ class VectorLookupToolUser(ToolUser):
 
         # If the tool is already instantiated and has a vector_store, use it
         if (
-            ((isinstance(tool, type) and not issubclass(tool, VectorLookupTool)) and not isinstance(tool, VectorLookupTool)) or
+            (isinstance(tool, type) and not issubclass(tool, VectorLookupTool)) or
+            not isinstance(tool, VectorLookupTool) or
             (isinstance(tool, VectorLookupTool) and tool.vector_store is not None)
         ):
             return kwargs
@@ -376,7 +377,7 @@ class VectorLookupToolUser(ToolUser):
         # First, try to inherit vector_store from another tool with the same _item_type_name
         # This takes precedence over self.vector_store to allow tools to share stores
         inherited_vector_store = None
-        tool_item_type = tool._item_type_name
+        tool_item_type = getattr(tool, "_item_type_name", None)
         for t in prompt_tools:
             if not isinstance(t, VectorLookupTool) or t.vector_store is None:
                 continue


### PR DESCRIPTION
Explicitly instantiating `FunctionTool` is annoying so we add a little helper called `define_tool` that annotates a function so that when we internally instantiate it we can look up the annotations and construct a `FunctionTool` with the provided parameters. We also fix some issues instantiating functions provided as tools and add tests and docs.