### PR TITLE
DuckDB set read only on file uris

### DIFF
--- a/lumen/ai/agents/table_list.py
+++ b/lumen/ai/agents/table_list.py
@@ -26,6 +26,7 @@ class TableListAgent(BaseListAgent):
     conditions = param.List(default=[
         "Use when user explicitly asks to 'list data', 'show available data', or 'what data do you have'",
         "NOT for showing actual data contents, querying, or analyzing data",
+        "NOT for describing data sources or telling what the data is about",
     ])
 
     not_with = param.List(default=["DbtslAgent", "SQLAgent"])

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -65,6 +65,9 @@ class DuckDBSource(BaseSQLSource):
         Whether the data is ephemeral, i.e. manually inserted into the
         DuckDB table or derived from real data.""")
 
+    read_only = param.Boolean(default=True, doc="""
+        Whether to open the DuckDB database in read-only mode.""")
+
     tables = param.ClassSelector(class_=(list, dict), doc="""
         List or dictionary of tables.""")
 
@@ -84,7 +87,7 @@ class DuckDBSource(BaseSQLSource):
         if connection:
             self._connection = connection
         else:
-            self._connection = duckdb.connect(self.uri)
+            self._connection = duckdb.connect(self.uri, read_only=self.read_only)
             for init in self.initializers:
                 with self._connection.cursor() as cursor:
                     cursor.execute(init)

--- a/lumen/tests/ai/conftest.py
+++ b/lumen/tests/ai/conftest.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError:
 from pydantic import BaseModel
 
 from lumen.ai.llm import Llm, Message
+from lumen.sources.duckdb import DuckDBSource
 
 
 def pytest_collection_modifyitems(config, items):
@@ -61,8 +62,6 @@ def llm():
 
 @pytest.fixture
 def tiny_source():
-    from lumen.sources.duckdb import DuckDBSource
-
     return DuckDBSource(tables={
     'tiny': """
         SELECT * FROM (

--- a/lumen/tests/ai/conftest.py
+++ b/lumen/tests/ai/conftest.py
@@ -11,7 +11,6 @@ except ModuleNotFoundError:
 from pydantic import BaseModel
 
 from lumen.ai.llm import Llm, Message
-from lumen.sources.duckdb import DuckDBSource
 
 
 def pytest_collection_modifyitems(config, items):
@@ -62,6 +61,8 @@ def llm():
 
 @pytest.fixture
 def tiny_source():
+    from lumen.sources.duckdb import DuckDBSource
+
     return DuckDBSource(tables={
     'tiny': """
         SELECT * FROM (

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -1,5 +1,6 @@
 import asyncio
 import sqlite3
+import sys
 import tempfile
 
 from pathlib import Path
@@ -962,7 +963,6 @@ class TestResolveData:
 
     def test_resolve_data_mixed_local_and_remote(self):
         """Test resolving a mix of local and remote files."""
-        import sys
         if sys.platform == 'win32':
             # Skip on Windows due to httpfs extension file locking issues in CI
             pytest.skip("httpfs extension has file locking issues on Windows CI")

--- a/lumen/tests/conftest.py
+++ b/lumen/tests/conftest.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import os
 import tempfile
 

--- a/lumen/tests/sources/conftest.py
+++ b/lumen/tests/sources/conftest.py
@@ -7,8 +7,6 @@ import pytest
 
 from hvplot.tests.util import makeMixedDataFrame
 
-from lumen.sources.duckdb import DuckDBSource
-
 
 @pytest.fixture
 def source_tables():

--- a/lumen/tests/sources/conftest.py
+++ b/lumen/tests/sources/conftest.py
@@ -2,7 +2,6 @@ import tempfile
 
 from pathlib import Path
 
-import duckdb
 import pandas as pd
 import pytest
 
@@ -26,25 +25,3 @@ def source_tables():
     }
     yield tables
     pd.set_option('mode.string_storage', string)
-
-
-@pytest.fixture
-def duckdb_file_source():
-    """
-    Create a temporary DuckDB database file with a test table.
-
-    Yields the DuckDBSource and cleans up after the test.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / 'test.duckdb'
-        conn = duckdb.connect(str(db_path))
-        conn.execute('CREATE TABLE test (id INTEGER, name VARCHAR)')
-        conn.execute("INSERT INTO test VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')")
-        conn.close()
-
-        source = DuckDBSource(
-            uri=str(db_path),
-            tables=['test'],
-        )
-        yield source
-        source.close()


### PR DESCRIPTION
I noticed it was writing views to the original URI. With read_only, it still works

Teeny tiny tweak to prompt.