### PR TITLE
Pin zensical to fix docs build

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -97,7 +97,7 @@ toolz = "*"
 # =============================================
 [feature.doc.dependencies]
 # Replaced mkdocs with zensical
-zensical = "*"
+zensical = "<0.0.17"
 mkdocstrings = "*"
 mkdocstrings-python = "*"
 mkdocs-gen-files = "*"
@@ -105,7 +105,7 @@ mkdocs-literate-nav = "*"
 
 [feature.doc.tasks]
 # Updated tasks to use zensical instead of mkdocs
-docs-build = { cmd = 'zensical build', depends-on = ['install'] }
+docs-build = { cmd = 'zensical build --clean', depends-on = ['install'] }
 docs-serve = { cmd = 'zensical serve', depends-on = ['install'] }
 docs-clean = { cmd = 'rm -rf builtdocs', depends-on = ['install'] }
 


### PR DESCRIPTION
Zensical 0.0.17 seems to have completely broken docs builds (see https://github.com/zensical/zensical/issues/294 for reference).