### PR TITLE
Use material-ui loading spinner

### DIFF
--- a/lumen/ai/views.py
+++ b/lumen/ai/views.py
@@ -86,7 +86,6 @@ class LumenOutput(Viewer):
             on_keyup=False,
             indent=2,
             margin=(0, 10),
-            loading=self.param.loading,
             disabled=self.param.spec.rx.is_(None),
             styles={"border": "1px solid var(--border-color)"}
         )
@@ -98,6 +97,7 @@ class LumenOutput(Viewer):
         return Column(
             self._editor,
             self._icons,
+            loading=self.param.loading,
             sizing_mode="stretch_both"
         )
 


### PR DESCRIPTION
Using the panel loading spinner is a bit ugly and inconsistent so we instead set the loading spinner on the panel-material-ui column.