### PR TITLE
Allow hiding the nav bar

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -23,7 +23,7 @@ from panel.viewable import (
 from panel_material_ui import (
     Alert, Breadcrumbs, Button, ChatFeed, ChatInterface, ChatMessage,
     Column as MuiColumn, Dialog, FileDownload, IconButton, MenuList, Page,
-    Paper, Popup, Row, Select, Switch, Tabs, ToggleIcon, Typography,
+    Paper, Popup, Row, Select, Switch, Tabs, Typography,
 )
 from panel_splitjs import HSplit, MultiSplit, VSplit
 
@@ -757,11 +757,10 @@ class UI(Viewer):
             self._navigation_caption.object = EXPLORATION_CAPTION
 
         show_nav = self._should_show_navigation()
-        if not self._nav_toggle.visible and show_nav:
-            self._nav_toggle.value = True
+        if not self._sidebar_menu.items[6]["active"] and show_nav:
+            self._toggle_navigation(True)
         if not show_nav:
-            self._nav_toggle.value = False
-        self._nav_toggle.visible = show_nav
+            self._toggle_navigation(False)
         self._main[:] = [self._navigation, main_content]
 
     def _configure_interface(self, interface):
@@ -1614,6 +1613,12 @@ class ExplorerUI(UI):
             self._settings_popup.open = True
         elif item["id"] == "help":
             self._open_info_dialog()
+        elif item["id"] == "nav":
+            self._toggle_navigation(not item["active"])
+
+    def _toggle_navigation(self, active: bool):
+        self._navigation.visible = active
+        self._sidebar_menu.update_item(self._sidebar_menu.items[6], active=active, icon="view_list" if active else "view_list_outlined")
 
     @param.depends("_exploration", watch=True)
     def _update_home(self):
@@ -1713,6 +1718,8 @@ class ExplorerUI(UI):
                 {"label": "Sources", "icon": "create_new_folder_outlined", "id": "data"},
                 {"label": "Settings", "icon": "tune_outlined", "id": "preferences"},
                 None,
+                {"label": "Navigate", "icon": "view_list_outlined", "id": "nav", "active": False},
+                None,
                 {"label": "Help", "icon": "help_outline", "id": "help"}
             ],
             active=0,
@@ -1742,17 +1749,7 @@ class ExplorerUI(UI):
             },
             sizing_mode="stretch_width",
         )
-
-        self._nav_toggle = ToggleIcon(
-            active_icon="chevron_left",
-            icon="chevron_right",
-            styles={"margin-left": "auto", "margin-top": "auto"},
-            value=False,
-            visible=False
-        )
-        self._navigation.visible = self._nav_toggle
-
-        return [menu, self._nav_toggle]
+        return [menu]
 
     def _render_page(self):
         super()._render_page()

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -759,6 +759,8 @@ class UI(Viewer):
         show_nav = self._should_show_navigation()
         if not self._nav_toggle.visible and show_nav:
             self._nav_toggle.value = True
+        if not show_nav:
+            self._nav_toggle.value = False
         self._nav_toggle.visible = show_nav
         self._main[:] = [self._navigation, main_content]
 

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -23,7 +23,7 @@ from panel.viewable import (
 from panel_material_ui import (
     Alert, Breadcrumbs, Button, ChatFeed, ChatInterface, ChatMessage,
     Column as MuiColumn, Dialog, FileDownload, IconButton, MenuList, Page,
-    Paper, Popup, Row, Select, Switch, Tabs, Typography,
+    Paper, Popup, Row, Select, Switch, Tabs, ToggleIcon, Typography,
 )
 from panel_splitjs import HSplit, MultiSplit, VSplit
 
@@ -756,10 +756,11 @@ class UI(Viewer):
             self._navigation_title.object = "Exploration"
             self._navigation_caption.object = EXPLORATION_CAPTION
 
-        if self._should_show_navigation():
-            self._main[:] = [self._navigation, main_content]
-        else:
-            self._main[:] = [main_content]
+        show_nav = self._should_show_navigation()
+        if not self._nav_toggle.visible and show_nav:
+            self._nav_toggle.value = True
+        self._nav_toggle.visible = show_nav
+        self._main[:] = [self._navigation, main_content]
 
     def _configure_interface(self, interface):
         def on_undo(instance, _):
@@ -1193,7 +1194,7 @@ class UI(Viewer):
             sx={
                 # Hover
                 ".sidebar": {"transition": "width 0.2s ease-in-out"},
-                ".sidebar:hover": {"width": "140px"},
+                ".sidebar:hover": {"width": "140px", "transitionDelay": "0.5s"},
                 "&.mui-light .sidebar": {"bgcolor": "var(--mui-palette-grey-50)"},
             }
         )
@@ -1740,7 +1741,16 @@ class ExplorerUI(UI):
             sizing_mode="stretch_width",
         )
 
-        return [menu]
+        self._nav_toggle = ToggleIcon(
+            active_icon="chevron_left",
+            icon="chevron_right",
+            styles={"margin-left": "auto", "margin-top": "auto"},
+            value=False,
+            visible=False
+        )
+        self._navigation.visible = self._nav_toggle
+
+        return [menu, self._nav_toggle]
 
     def _render_page(self):
         super()._render_page()
@@ -1811,12 +1821,13 @@ class ExplorerUI(UI):
             self._navigation_title,
             self._navigation_caption,
             self._explorations,
-            sizing_mode="stretch_height",
+            height_policy="max",
             sx={"borderRadius": 0},
             theme_config={"light": {"palette": {"background": {"paper": "var(--mui-palette-grey-100)"}}}, "dark": {}},
-            width=275,
+            visible=False,
+            width=250
         )
-        self._main[:] = [self._splash]
+        self._main[:] = [self._navigation, self._splash]
 
         # Create code execution warning dialog if code execution is not hidden
         if self.code_execution != "hidden":
@@ -1898,7 +1909,7 @@ class ExplorerUI(UI):
             title='Home',
             conversation=self.interface.objects
         )
-        self._exploration = {'label': 'Home', 'icon': None, 'view': self._home, 'items': []}
+        self._exploration = {'label': 'New Exploration', 'icon': "add_circle_outline", 'view': self._home, 'items': []}
         super()._configure_session()
         self._idle = asyncio.Event()
         self._idle.set()

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1600,12 +1600,12 @@ class ExplorerUI(UI):
     def _handle_sidebar_event(self, item):
         if item["id"] == "exploration":
             self._toggle_report_mode(False)
-            self._sidebar_menu.update_item(item, active=True, icon="insights")
+            self._sidebar_menu.update_item(item, active=True, icon="insert_chart")
             self._sidebar_menu.update_item(self._sidebar_menu.items[1], active=False, icon="description_outlined")
             self._update_home()
         elif item["id"] == "report":
             self._toggle_report_mode(True)
-            self._sidebar_menu.update_item(self._sidebar_menu.items[0], active=False, icon="timeline")
+            self._sidebar_menu.update_item(self._sidebar_menu.items[0], active=False, icon="insert_chart_outlined")
             self._sidebar_menu.update_item(item, active=True, icon="description")
         elif item["id"] == "data":
             self._open_sources_dialog()
@@ -1618,14 +1618,14 @@ class ExplorerUI(UI):
 
     def _toggle_navigation(self, active: bool):
         self._navigation.visible = active
-        self._sidebar_menu.update_item(self._sidebar_menu.items[6], active=active, icon="view_list" if active else "view_list_outlined")
+        self._sidebar_menu.update_item(self._sidebar_menu.items[6], active=active, icon="layers" if active else "layers_outlined")
 
     @param.depends("_exploration", watch=True)
     def _update_home(self):
         if not hasattr(self, '_page'):
             return
         exploration, report = self._sidebar_menu.items[:2]
-        self._sidebar_menu.update_item(exploration, active=True, icon="timeline" if report["active"] else "insights")
+        self._sidebar_menu.update_item(exploration, active=True, icon="timeline" if report["active"] else "insert_chart")
         self._update_main_view()
 
     def _render_sidebar(self) -> list[Viewable]:
@@ -1712,13 +1712,13 @@ class ExplorerUI(UI):
         )
         self._sidebar_menu = menu = MenuList(
             items=[
-                {"label": "Explore", "icon": "insights", "id": "exploration", "active": True},
+                {"label": "Explore", "icon": "insert_chart", "id": "exploration", "active": True},
                 {"label": "Report", "icon": "description_outlined", "id": "report", "active": False},
                 None,
                 {"label": "Sources", "icon": "create_new_folder_outlined", "id": "data"},
                 {"label": "Settings", "icon": "tune_outlined", "id": "preferences"},
                 None,
-                {"label": "Navigate", "icon": "view_list_outlined", "id": "nav", "active": False},
+                {"label": "Navigate", "icon": "layers_outlined", "id": "nav", "active": False},
                 None,
                 {"label": "Help", "icon": "help_outline", "id": "help"}
             ],
@@ -1816,10 +1816,18 @@ class ExplorerUI(UI):
             margin=(10, 10, 5, 10),
             sizing_mode="stretch_width"
         )
+        self._navigation_footer = Typography(
+            'Toggle <span class="material-icons" style="vertical-align: middle;">layers</span>**Navigate** to close',
+            variant="body2",
+            color="text.secondary",
+            margin=20,
+            styles={"margin": "auto auto 20px auto"}
+        )
         self._navigation = Paper(
             self._navigation_title,
             self._navigation_caption,
             self._explorations,
+            self._navigation_footer,
             height_policy="max",
             sx={"borderRadius": 0},
             theme_config={"light": {"palette": {"background": {"paper": "var(--mui-palette-grey-100)"}}}, "dark": {}},


### PR DESCRIPTION
The nav bar was quite wide by default and took up a lot of space, especially for smaller screen sizes (and lower resolutions). With these changes the nav bar is now always added but it's visibility is toggled by a `ToggleIcon` in the sidebar.

<img width="317" height="992" alt="Screenshot 2026-01-26 at 16 13 37" src="https://github.com/user-attachments/assets/a2ca3f97-7ebe-4f21-b369-77ab001af1b6" />
