### PR TITLE
Fix report background color in dark mode

### DIFF
--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -963,7 +963,11 @@ class Report(TaskGroup):
             height_policy="max",
             stylesheets=[":host > div { overflow-y: auto; }"],
             min_height=600,
-            sx={"minWidth": "320px", "background-color": "var(--mui-palette-grey-100)"}
+            sx={
+                "minWidth": "320px",
+                ".mui-light &": { "background-color": "var(--mui-palette-grey-100)"},
+                ".mui-dark &": { "background-color": "var(--mui-palette-grey-900)"}
+            }
         )
 
 


### PR DESCRIPTION
Background was always set to grey-100 which looked bad in dark mode.