### PR TITLE
Add note about large data in VegaLiteAgent prompt

### DIFF
--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -12,6 +12,9 @@ Every visualization must:
 - Include narrative titles that tell a story about the data (what happened, not just what's shown)
 - Do not overcrowd the plot with too many data points, especially for bars
 - Do not use scientific notation in axis ticks
+- When row counts exceed 10k:
+  - Use aggregation and/or binning either in the encoding fields or as distinct transforms
+  - OR enable canvas rendering using `{config: {render: {renderer: "canvas"}}}` (up to 50k rows)
 
 # MARK vs ENCODING
 


### PR DESCRIPTION
Generating VL charts with more than 10k rows can make the UI unusable. We therefore instruct the LLM to use aggregation/binning techniques or at minimum enable canvas rendering.