### PR TITLE
Tweaks and fixes for VegaLiteAgent large data handling

### DIFF
--- a/lumen/ai/prompts/VegaLiteAgent/annotate_plot.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/annotate_plot.jinja2
@@ -45,7 +45,7 @@ Point: `type, color, size, filled, shape`
 {% block context %}
 Build off the following Vega-Lite yaml:
 ```yaml
-{{ vega_spec }}
+{{ vega_spec | safe }}
 ```
 {% endblock %}
 

--- a/lumen/ai/prompts/VegaLiteAgent/improvement_step.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/improvement_step.jinja2
@@ -3,7 +3,7 @@
 {% block context %}
 Build off the following Vega-Lite yaml:
 ```yaml
-{{ vega_spec }}
+{{ vega_spec | safe }}
 ```
 
 Data context:

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -12,7 +12,7 @@ Every visualization must:
 - Include narrative titles that tell a story about the data (what happened, not just what's shown)
 - Do not overcrowd the plot with too many data points, especially for bars
 - Do not use scientific notation in axis ticks
-- When row counts exceed 10k:
+- When n_rows > 10000:
   - Use aggregation and/or binning either in the encoding fields or as distinct transforms
   - OR enable canvas rendering using `{config: {render: {renderer: "canvas"}}}` (up to 50k rows)
 

--- a/lumen/ai/prompts/VegaLiteAgent/main_altair.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main_altair.jinja2
@@ -11,6 +11,11 @@ Generate Altair code. Data is `df`, assign to `chart`, end with `.interactive()`
 - **Transforms**: `.transform_filter()` | `.transform_window(rank='rank()')` | `.transform_aggregate()`
 - **Layouts**: `alt.hconcat()` | `alt.vconcat()` | `.facet()` | `.repeat()` (omit width on sub-charts)
 - **Geo**: `longitude='lon:Q', latitude='lat:Q'` with `.project(type='mercator')`
+
+# Rules
+- When the n_rows > 5000:
+  - You **MUST** include `alt.data_transformers.disable_max_rows()` and `alt.renderers.set_embed_options(renderer="canvas")`
+  - Prefer aggregated and binned plots
 {% endblock %}
 
 {% block examples %}

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -147,7 +147,7 @@ class Metaset:
         if include_schema and self.has_schemas:
             schema = self.schemas.get(table_slug)
             if schema and schema.get("__len__"):
-                data['row_count'] = len(schema)
+                data['n_rows'] = len(schema)
 
         if include_columns:
             if catalog_entry.columns:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -644,7 +644,8 @@ async def describe_data(df: pd.DataFrame, enum_limit: int = 3, reduce_enums: boo
         result = {
             "summary": {
                 "n_cells": size,
-                "shape": shape,
+                "n_rows": shape[0],
+                "n_cols": shape[1],
                 "sampled_cols": sampled_columns,
                 "is_sampled": is_sampled,
             },


### PR DESCRIPTION
- Makes `n_rows` the consistent name in schema and data description for length of data
- Fixes serialization of vega spec in polishing prompt (previously was treating string as yaml, resulting in double escaping)
- Tweaks instructions for code and spec paths to ensure larger datasets are handled more gracefully
- Ensures that the code execution path still handles geographic plots correctly 