### PR TITLE
Add metadata to prompt and list agents

### DIFF
--- a/lumen/ai/agents/base_list.py
+++ b/lumen/ai/agents/base_list.py
@@ -65,6 +65,12 @@ class BaseListAgent(Agent):
                 header_filters = {self._column_name: column_filter}
 
             df = pd.DataFrame({self._column_name: source_items})
+
+            # Check if subclass provides row_content method
+            row_content = None
+            if hasattr(self, '_create_row_content'):
+                row_content = self._create_row_content(context, source_name)
+
             item_list = pn.widgets.Tabulator(
                 df,
                 buttons={"show": '<i class="fa fa-eye"></i>'},
@@ -77,7 +83,8 @@ class BaseListAgent(Agent):
                 pagination="remote",
                 header_filters=header_filters,
                 sizing_mode="stretch_width",
-                name=source_name
+                name=source_name,
+                row_content=row_content
             )
             item_list.on_click(partial(self._use_item, interface=self.interface))
             tabs.append(item_list)

--- a/lumen/ai/agents/base_list.py
+++ b/lumen/ai/agents/base_list.py
@@ -45,6 +45,10 @@ class BaseListAgent(Agent):
         message = self._message_format.format(item=repr(item))
         interface.send(message)
 
+    def _create_row_content(self, context: TContext, source_name: str):
+        """Create row content function that displays more info collapsed under each row."""
+        return
+
     async def respond(
         self,
         messages: list[Message],
@@ -66,10 +70,9 @@ class BaseListAgent(Agent):
 
             df = pd.DataFrame({self._column_name: source_items})
 
-            # Check if subclass provides row_content method
-            row_content = None
-            if hasattr(self, '_create_row_content'):
-                row_content = self._create_row_content(context, source_name)
+            row_content = self._create_row_content(context, source_name)
+            if row_content == "":
+                row_content = None
 
             item_list = pn.widgets.Tabulator(
                 df,

--- a/lumen/ai/agents/document_list.py
+++ b/lumen/ai/agents/document_list.py
@@ -1,5 +1,7 @@
 import param
 
+from panel_material_ui import Markdown
+
 from ..context import ContextModel, TContext
 from ..schemas import Metaset
 from .base_list import BaseListAgent
@@ -30,6 +32,38 @@ class DocumentListAgent(BaseListAgent):
     _column_name = "Documents"
 
     _message_format = "Tell me about: {item}"
+
+    def _create_row_content(self, context: TContext, source_name: str):
+        """Create row content function that displays document preview."""
+        metaset = context.get('metaset')
+
+        def row_content(row):
+            filename = row[self._column_name]
+
+            if not metaset or not metaset.has_docs:
+                return Markdown("*No preview available*")
+
+            # Find all chunks for this document
+            doc_chunks = [doc for doc in metaset.docs if doc.filename == filename]
+
+            if not doc_chunks:
+                return Markdown("*No preview available*")
+
+            # Show preview from first chunk
+            first_chunk = doc_chunks[0]
+            preview_text = first_chunk.text[:500]  # First 500 chars
+            if len(first_chunk.text) > 500:
+                preview_text += "..."
+
+            content = f"**Preview:**\n\n{preview_text}"
+
+            # Show chunk count if multiple
+            if len(doc_chunks) > 1:
+                content += f"\n\n*({len(doc_chunks)} chunks available)*"
+
+            return Markdown(content, sizing_mode='stretch_width')
+
+        return row_content
 
     @classmethod
     async def applies(cls, context: TContext) -> bool:

--- a/lumen/ai/agents/table_list.py
+++ b/lumen/ai/agents/table_list.py
@@ -1,5 +1,6 @@
 from typing import NotRequired
 
+import panel as pn
 import param
 
 from ...sources.base import Source
@@ -39,6 +40,54 @@ class TableListAgent(BaseListAgent):
     _message_format = "Show the data: {item}"
 
     input_schema = TableListInputs
+
+    def _create_row_content(self, context: TContext, source_name: str):
+        """Create row content function that displays metadata for a table."""
+        metaset = context.get('metaset')
+
+        def row_content(row):
+            table_name = row[self._column_name]
+            table_slug = f"{source_name}{SOURCE_TABLE_SEPARATOR}{table_name}"
+
+            if not metaset or table_slug not in metaset.catalog:
+                return pn.pane.Markdown("*No metadata available*")
+
+            entry = metaset.catalog[table_slug]
+
+            # Build metadata display
+            content_parts = []
+
+            # Show description if available
+            if entry.description:
+                content_parts.append(f"**Description:** {entry.description}")
+
+            # Show metadata
+            if entry.metadata:
+                metadata_lines = ["**Metadata:**"]
+                # Fields to exclude from display
+                exclude_keys = {'description', 'columns', 'data_type', 'source_name', 'rows', 'updated_at', 'created_at'}
+                for key, value in entry.metadata.items():
+                    if key in exclude_keys or value is None or value == '':
+                        continue
+                    metadata_lines.append(f"- **{key}:** {value}")
+                if len(metadata_lines) > 1:
+                    content_parts.append("\n".join(metadata_lines))
+
+            # Show row and column count at the bottom
+            counts = []
+            if entry.metadata and 'rows' in entry.metadata:
+                counts.append(f"{entry.metadata['rows']} rows")
+            if entry.columns:
+                counts.append(f"{len(entry.columns)} columns")
+            if counts:
+                content_parts.append(" | ".join(counts))
+
+            if not content_parts:
+                return pn.pane.Markdown("*No metadata available*")
+
+            return pn.pane.Markdown("\n\n".join(content_parts), sizing_mode='stretch_width')
+
+        return row_content
 
     @classmethod
     async def applies(cls, context: TContext) -> bool:

--- a/lumen/ai/agents/table_list.py
+++ b/lumen/ai/agents/table_list.py
@@ -54,14 +54,10 @@ class TableListAgent(BaseListAgent):
 
             entry = metaset.catalog[table_slug]
 
-            # Build metadata display
             content_parts = []
-
-            # Show description if available
             if entry.description:
                 content_parts.append(f"**Description:** {entry.description}")
 
-            # Show metadata
             if entry.metadata:
                 metadata_lines = ["**Metadata:**"]
                 # Fields to exclude from display
@@ -73,7 +69,6 @@ class TableListAgent(BaseListAgent):
                 if len(metadata_lines) > 1:
                     content_parts.append("\n".join(metadata_lines))
 
-            # Show row and column count at the bottom
             counts = []
             if entry.metadata and 'rows' in entry.metadata:
                 counts.append(f"{entry.metadata['rows']} rows")

--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -163,6 +163,15 @@ def tuple_presenter(dumper, data):
 def path_representer(dumper, data):
     return dumper.represent_scalar('tag:yaml.org,2002:str', str(data.resolve()))
 
+
+def numpy_representer(dumper, data):
+    """Convert numpy types to native Python types for YAML serialization."""
+    if hasattr(data, 'item'):  # Scalar types (integers, floats, bools)
+        return dumper.represent_data(data.item())
+    elif hasattr(data, 'tolist'):  # Arrays
+        return dumper.represent_list(data.tolist())
+    return dumper.represent_data(data)
+
 pn.chat.ChatStep.min_width = 375
 pn.chat.ChatStep.collapsed_on_success = False
 
@@ -171,3 +180,13 @@ yaml.add_representer(str, str_presenter)
 yaml.add_representer(tuple, tuple_presenter)
 yaml.add_representer(PosixPath, path_representer)
 yaml.add_representer(Path, path_representer)
+
+# Add numpy representer if numpy is available
+try:
+    import numpy as np
+
+    # Use multi_representer to handle all numpy types with a single function
+    yaml.add_multi_representer(np.ndarray, numpy_representer)
+    yaml.add_multi_representer(np.generic, numpy_representer)
+except ImportError:
+    pass

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -129,6 +129,7 @@ class Metaset:
         include_schema: bool,
         truncate: bool,
         include_sql: bool = True,
+        include_metadata: bool = True,
     ) -> dict:
         data = {}
 
@@ -144,11 +145,8 @@ class Metaset:
                 desc = truncate_string(desc, max_length=100)
             data['info'] = desc
 
-        # Include table metadata if available
-        if catalog_entry.metadata:
-            # Filter out null values and serialize numpy types
+        if include_metadata and catalog_entry.metadata:
             clean_metadata = {}
-            # Fields to exclude from metadata output
             exclude_keys = {'columns', 'data_type', 'source_name', 'rows', 'description'}
             for key, value in catalog_entry.metadata.items():
                 if key in exclude_keys or value is None or value == '':
@@ -229,6 +227,7 @@ class Metaset:
         include_schema: bool = True,
         truncate: bool = False,
         include_sql: bool = True,
+        include_metadata: bool = True,
         include_docs: bool = True,
         n: int | None = None,
         offset: int = 0,
@@ -264,7 +263,7 @@ class Metaset:
             if single_source and not show_source and SOURCE_TABLE_SEPARATOR in table_slug:
                 display_slug = table_slug.split(SOURCE_TABLE_SEPARATOR, 1)[1]
             tables_data[display_slug] = self._build_table_data(
-                table_slug, entry, include_columns, include_schema, truncate, include_sql
+                table_slug, entry, include_columns, include_schema, truncate, include_sql, include_metadata
             )
 
         # Build result
@@ -326,46 +325,50 @@ class Metaset:
             sorted_slugs = sorted_slugs[:n]
         return sorted_slugs
 
-    def table_list(self, n: int | None = None, offset: int = 0, show_source: bool | None = None, n_others: int = 0, **override_kwargs) -> str:
+    def table_list(self, n: int | None = None, offset: int = 0, show_source: bool | None = None, n_others: int = 0, include_metadata: bool = False, **override_kwargs) -> str:
         """Generate minimal table listing for planning - just table names and columns without schema details."""
         generate_kwargs = {
             "include_columns": False,
             "include_schema": False,
             "truncate": False,
             "include_sql": False,
+            "include_metadata": include_metadata,
             "include_docs": True,
         }
         generate_kwargs.update(override_kwargs)
         return self._generate_context(**generate_kwargs, n=n, offset=offset, show_source=show_source, n_others=n_others)
 
-    def table_context(self, n: int | None = None, offset: int = 0, show_source: bool | None = None, n_others: int = 0, **override_kwargs) -> str:
+    def table_context(self, n: int | None = None, offset: int = 0, show_source: bool | None = None, n_others: int = 0, include_metadata: bool = True, **override_kwargs) -> str:
         generate_kwargs = {
             "include_columns": True,
             "include_schema": False,
             "truncate": False,
             "include_sql": False,
+            "include_metadata": include_metadata,
             "include_docs": True,
         }
         generate_kwargs.update(override_kwargs)
         return self._generate_context(**generate_kwargs, n=n, offset=offset, show_source=show_source, n_others=n_others)
 
-    def full_context(self, n: int | None = None, offset: int = 0, show_source: bool | None = None, n_others: int = 0, **override_kwargs) -> str:
+    def full_context(self, n: int | None = None, offset: int = 0, show_source: bool | None = None, n_others: int = 0, include_metadata: bool = True, **override_kwargs) -> str:
         generate_kwargs = {
             "include_columns": True,
             "include_schema": True,
             "truncate": False,
             "include_sql": False,
+            "include_metadata": include_metadata,
             "include_docs": True,
         }
         generate_kwargs.update(override_kwargs)
         return self._generate_context(**generate_kwargs, n=n, offset=offset, show_source=show_source, n_others=n_others)
 
-    def compact_context(self, n: int | None = None, offset: int = 0, show_source: bool | None = None, n_others: int = 0, **override_kwargs) -> str:
+    def compact_context(self, n: int | None = None, offset: int = 0, show_source: bool | None = None, n_others: int = 0, include_metadata: bool = True, **override_kwargs) -> str:
         generate_kwargs = {
             "include_columns": True,
             "include_schema": True,
             "truncate": True,
             "include_sql": False,
+            "include_metadata": include_metadata,
             "include_docs": True,
         }
         generate_kwargs.update(override_kwargs)

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -144,6 +144,26 @@ class Metaset:
                 desc = truncate_string(desc, max_length=100)
             data['info'] = desc
 
+        # Include table metadata if available
+        if catalog_entry.metadata:
+            # Filter out null values and serialize numpy types
+            clean_metadata = {}
+            # Fields to exclude from metadata output
+            exclude_keys = {'columns', 'data_type', 'source_name', 'rows', 'description'}
+            for key, value in catalog_entry.metadata.items():
+                if key in exclude_keys:
+                    continue
+                if value is None:
+                    continue
+                # Convert numpy types to native Python types
+                if hasattr(value, 'item'):
+                    value = value.item()
+                if value == '':
+                    continue
+                clean_metadata[key] = value
+            if clean_metadata:
+                data['metadata'] = clean_metadata
+
         if include_schema and self.has_schemas:
             schema = self.schemas.get(table_slug)
             if schema and schema.get("__len__"):

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -151,9 +151,7 @@ class Metaset:
             # Fields to exclude from metadata output
             exclude_keys = {'columns', 'data_type', 'source_name', 'rows', 'description'}
             for key, value in catalog_entry.metadata.items():
-                if key in exclude_keys:
-                    continue
-                if value is None or value == '':
+                if key in exclude_keys or value is None or value == '':
                     continue
                 clean_metadata[key] = value
             if clean_metadata:

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -153,12 +153,7 @@ class Metaset:
             for key, value in catalog_entry.metadata.items():
                 if key in exclude_keys:
                     continue
-                if value is None:
-                    continue
-                # Convert numpy types to native Python types
-                if hasattr(value, 'item'):
-                    value = value.item()
-                if value == '':
+                if value is None or value == '':
                     continue
                 clean_metadata[key] = value
             if clean_metadata:


### PR DESCRIPTION
I noticed that metadata was inserted to the tables in upload controls

<img width="723" height="628" alt="image" src="https://github.com/user-attachments/assets/8e0a74c3-5197-4ea6-aa85-56a3e8ac5c02" />

However we were not using it.

```
DuckDBSource00454 ⦙ census_data:
  metadata:
    dataset: acs/acs5
    vintage: 2023
    group: B01003
    geography: state
DuckDBSource00464 ⦙ census_data:
  metadata:
    dataset: acs/acs5
    vintage: 2022
    group: B01003
    geography: state
```

(slightly outdated; moved rows next to columns and cleaned up nones)
<img width="1568" height="556" alt="image" src="https://github.com/user-attachments/assets/986650fe-2ebb-4cca-b025-e08d30738996" />

(updated)
<img width="1192" height="708" alt="image" src="https://github.com/user-attachments/assets/7dd7c54a-7ecd-443f-b59e-50ee7847bed9" />


