### PR TITLE
Refactor to use streamlined method

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -177,7 +177,8 @@ class LLMUser(param.Parameterized):
         response_model: type[BaseModel] | None = None,
         model_spec: str | None = None,
         model_index: int | None = None,
-        **kwargs
+        model_kwargs: dict | None = None,
+        **prompt_kwargs
     ) -> Any:
         """
         Render a prompt and invoke the LLM.
@@ -203,10 +204,10 @@ class LLMUser(param.Parameterized):
         -------
         The structured response from the LLM
         """
-        system = await self._render_prompt(prompt_name, messages, context, **kwargs)
+        system = await self._render_prompt(prompt_name, messages, context, **prompt_kwargs)
         if response_model is None:
             try:
-                response_model = self._get_model(prompt_name, **kwargs)
+                response_model = self._get_model(prompt_name, **model_kwargs)
             except (KeyError, AttributeError):
                 pass
 

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -176,6 +176,7 @@ class LLMUser(param.Parameterized):
         context: TContext,
         response_model: type[BaseModel] | None = None,
         model_spec: str | None = None,
+        model_index: int | None = None,
         **kwargs
     ) -> Any:
         """
@@ -193,6 +194,8 @@ class LLMUser(param.Parameterized):
             Pydantic model to structure the response
         model_spec : str, optional
             Specification for which LLM to use
+        model_index : int, optional
+            The index of the model to subset if the model spec returns a list of models
         **kwargs : dict
             Additional context variables for the prompt template
 
@@ -212,6 +215,9 @@ class LLMUser(param.Parameterized):
                 model_spec = self._lookup_prompt_key(prompt_name, "llm_spec")
             except KeyError:
                 model_spec = self.llm_spec_key
+
+        if model_index is not None:
+            model_spec = model_spec[model_index]
 
         result = await self.llm.invoke(
             messages=messages,

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -195,6 +195,8 @@ class LLMUser(param.Parameterized):
             Pydantic model to structure the response
         model_spec : str, optional
             Specification for which LLM to use
+        model_kwargs : dict, optional
+            Additional context variables for determining the model_spec or response_model
         model_index : int, optional
             The index of the model to subset if the model spec returns a list of models
         **kwargs : dict
@@ -235,6 +237,8 @@ class LLMUser(param.Parameterized):
         context: TContext,
         response_model: type[BaseModel] | None = None,
         model_spec: str | None = None,
+        model_kwargs: dict | None = None,
+        model_index: int | None = None,
         field: str | None = None,
         **kwargs
     ):
@@ -253,6 +257,10 @@ class LLMUser(param.Parameterized):
             Pydantic model to structure the response
         model_spec : str, optional
             Specification for which LLM to use
+        model_kwargs : dict, optional
+            Additional context variables for determining the model_spec or response_model
+        model_index : int, optional
+            The index of the model to subset if the model spec returns a list of models
         field : str, optional
             Specific field to extract from the response model
         **kwargs : dict
@@ -268,7 +276,7 @@ class LLMUser(param.Parameterized):
         # Determine the response model
         if response_model is None:
             try:
-                response_model = self._get_model(prompt_name, **kwargs)
+                response_model = self._get_model(prompt_name, **model_kwargs)
             except (KeyError, AttributeError):
                 pass
 
@@ -278,6 +286,9 @@ class LLMUser(param.Parameterized):
                 model_spec = self._lookup_prompt_key(prompt_name, "llm_spec")
             except KeyError:
                 model_spec = self.llm_spec_key
+
+        if model_index is not None:
+            model_spec = model_spec[model_index]
 
         # Stream from the LLM
         async for chunk in self.llm.stream(

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -209,7 +209,7 @@ class LLMUser(param.Parameterized):
         system = await self._render_prompt(prompt_name, messages, context, **prompt_kwargs)
         if response_model is None:
             try:
-                response_model = self._get_model(prompt_name, **model_kwargs)
+                response_model = self._get_model(prompt_name, **(model_kwargs or {}))
             except (KeyError, AttributeError):
                 pass
 
@@ -276,7 +276,7 @@ class LLMUser(param.Parameterized):
         # Determine the response model
         if response_model is None:
             try:
-                response_model = self._get_model(prompt_name, **model_kwargs)
+                response_model = self._get_model(prompt_name, **(model_kwargs or {}))
             except (KeyError, AttributeError):
                 pass
 

--- a/lumen/ai/agents/analysis.py
+++ b/lumen/ai/agents/analysis.py
@@ -93,12 +93,17 @@ class AnalysisAgent(BaseLumenAgent):
 
         if len(analyses) > 1:
             with self._add_step(title="Choosing the most relevant analysis...", steps_layout=self._steps_layout) as step:
-                analysis_name = await self.invoke_prompt(
-                    "main",
-                    messages,
-                    analyses=list(analyses),
-                    context=context,
-                    data=context.get("data"),
+                analysis_name = (
+                    await self._invoke_prompt(
+                        "main",
+                        messages,
+                        model_kwargs=dict(
+                            analyses=list(analyses)
+                        ),
+                        analyses=analyses,
+                        context=context,
+                        data=context.get("data"),
+                    )
                 ).analysis
                 step.stream(f"Selected {analysis_name}")
                 step.success_title = f"Selected {analysis_name}"

--- a/lumen/ai/agents/analysis.py
+++ b/lumen/ai/agents/analysis.py
@@ -93,23 +93,12 @@ class AnalysisAgent(BaseLumenAgent):
 
         if len(analyses) > 1:
             with self._add_step(title="Choosing the most relevant analysis...", steps_layout=self._steps_layout) as step:
-                analysis_model = self._get_model("main", analyses=list(analyses))
-                system_prompt = await self._render_prompt(
+                analysis_name = await self.invoke_prompt(
                     "main",
                     messages,
-                    analyses=analyses,
+                    analyses=list(analyses),
                     context=context,
                     data=context.get("data"),
-                )
-                model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-                analysis_name = (
-                    await self.llm.invoke(
-                        messages,
-                        system=system_prompt,
-                        model_spec=model_spec,
-                        response_model=analysis_model,
-                        allow_partial=False,
-                    )
                 ).analysis
                 step.stream(f"Selected {analysis_name}")
                 step.success_title = f"Selected {analysis_name}"

--- a/lumen/ai/agents/base.py
+++ b/lumen/ai/agents/base.py
@@ -84,9 +84,9 @@ class Agent(Viewer, ToolUser, ContextProvider):
     def __panel__(self):
         return self.interface
 
-    async def _stream(self, messages: list[Message], context: TContext) -> Any:
+    async def _stream(self, messages: list[Message], context: TContext, **kwargs) -> Any:
         message = None
-        output = self._stream_prompt("main", messages, context, field="output")
+        output = self._stream_prompt("main", messages, context, field="output", **kwargs)
         try:
             async for output_chunk in output:
                 if self.interface is None:

--- a/lumen/ai/agents/base.py
+++ b/lumen/ai/agents/base.py
@@ -84,10 +84,9 @@ class Agent(Viewer, ToolUser, ContextProvider):
     def __panel__(self):
         return self.interface
 
-    async def _stream(self, messages: list[Message], system_prompt: str) -> Any:
+    async def _stream(self, messages: list[Message], context: TContext) -> Any:
         message = None
-        model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-        output = self.llm.stream(messages, system=system_prompt, model_spec=model_spec, field="output")
+        output = self._stream_prompt("main", messages, context, field="output")
         try:
             async for output_chunk in output:
                 if self.interface is None:
@@ -139,5 +138,4 @@ class Agent(Viewer, ToolUser, ContextProvider):
             If the Agent response is part of a longer query this describes
             the step currently being processed.
         """
-        system_prompt = await self._render_prompt("main", messages, context)
-        return [await self._stream(messages, system_prompt)], context
+        return [await self._stream(messages, context)], context

--- a/lumen/ai/agents/base_lumen.py
+++ b/lumen/ai/agents/base_lumen.py
@@ -45,22 +45,16 @@ class BaseLumenAgent(Agent):
             raise ValueError("Must provide previous spec to revise.")
         lines = spec.splitlines()
         numbered_text = "\n".join(f"{i:2d}: {line}" for i, line in enumerate(lines, 1))
-        system = await self._render_prompt(
+        result = await self._invoke_prompt(
             "revise_output",
             messages,
             context,
+            model_spec="edit",
             numbered_text=numbered_text,
             language=language,
             feedback=instruction,
             errors=errors,
             **kwargs
-        )
-        retry_model = self._lookup_prompt_key("revise_output", "response_model")
-        result = await self.llm.invoke(
-            messages,
-            system=system,
-            response_model=retry_model,
-            model_spec="edit"
         )
         new_spec_raw = apply_changes(lines, result.edits)
         spec = load_yaml(new_spec_raw)

--- a/lumen/ai/agents/base_view.py
+++ b/lumen/ai/agents/base_view.py
@@ -88,21 +88,14 @@ class BaseViewAgent(BaseLumenAgent):
     ) -> dict[str, Any]:
         errors_context = self._build_errors_context(pipeline, context, errors)
         doc = self.view_type.__doc__.split("\n\n")[0] if self.view_type.__doc__ else self.view_type.__name__
-        system = await self._render_prompt(
+        response = await self._stream_prompt(
             "main",
             messages,
             context,
             table=pipeline.table,
             doc=doc,
+            schema=schema,
             **errors_context,
-        )
-
-        model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-        response = self.llm.stream(
-            messages,
-            system=system,
-            model_spec=model_spec,
-            response_model=self._get_model("main", schema=schema),
         )
 
         e = None

--- a/lumen/ai/agents/base_view.py
+++ b/lumen/ai/agents/base_view.py
@@ -94,7 +94,7 @@ class BaseViewAgent(BaseLumenAgent):
             context,
             table=pipeline.table,
             doc=doc,
-            schema=schema,
+            model_kwargs=dict(schema=schema),
             **errors_context,
         )
 

--- a/lumen/ai/agents/chat.py
+++ b/lumen/ai/agents/chat.py
@@ -56,5 +56,4 @@ class ChatAgent(Agent):
         if len(context.get("data", [])) == 0 and context.get("sql"):
             context["sql"] = f"{context['sql']}\n-- No data was returned from the query."
 
-        system_prompt = await self._render_prompt("main", messages, context, **prompt_context)
-        return [await self._stream(messages, system_prompt)], {}
+        return [await self._stream(messages, context, **prompt_context)], {}

--- a/lumen/ai/agents/dbtsl.py
+++ b/lumen/ai/agents/dbtsl.py
@@ -129,20 +129,12 @@ class DbtslAgent(BaseLumenAgent, DbtslMixin):
         """
         Create a valid dbt Semantic Layer query based on user messages.
         """
-        system_prompt = await self._render_prompt(
-            "main",
-            messages,
-            errors=errors,
-        )
-
         out_context = {}
         with self._add_step(title=title or "dbt Semantic Layer query", steps_layout=self._steps_layout) as step:
-            model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-            response = self.llm.stream(
+            response = self._stream_prompt(
+                "main",
                 messages,
-                system=system_prompt,
-                model_spec=model_spec,
-                response_model=DbtslQueryParams,
+                errors=errors,
             )
 
             query_params = None

--- a/lumen/ai/agents/deck_gl.py
+++ b/lumen/ai/agents/deck_gl.py
@@ -154,7 +154,7 @@ class DeckGLAgent(BaseCodeAgent):
         errors_context = self._build_errors_context(pipeline, context, errors)
 
         with self._add_step(title="Generating DeckGL specification", steps_layout=self._steps_layout) as step:
-            system_prompt = await self._render_prompt(
+            response = self._stream_prompt(
                 "main",
                 messages,
                 context,
@@ -162,15 +162,6 @@ class DeckGLAgent(BaseCodeAgent):
                 doc=doc,
                 **errors_context,
             )
-
-            model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-            response = self.llm.stream(
-                messages,
-                system=system_prompt,
-                model_spec=model_spec,
-                response_model=DeckGLSpec,
-            )
-
             async for output in response:
                 step.stream(output.chain_of_thought, replace=True)
 
@@ -193,21 +184,13 @@ class DeckGLAgent(BaseCodeAgent):
         errors_context = self._build_errors_context(pipeline, context, errors)
 
         with self._add_step(title="Generating PyDeck code", steps_layout=self._steps_layout) as step:
-            system_prompt = await self._render_prompt(
+            response = self._stream_prompt(
                 "main_pydeck",
                 messages,
                 context,
                 table=pipeline.table,
                 doc=doc,
                 **errors_context,
-            )
-
-            model_spec = self.prompts["main_pydeck"].get("llm_spec", self.llm_spec_key)
-            response = self.llm.stream(
-                messages,
-                system=system_prompt,
-                model_spec=model_spec,
-                response_model=PyDeckSpec,
             )
 
             async for output in response:

--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -519,7 +519,7 @@ class SQLAgent(BaseLumenAgent):
         if len(all_tables) <= 3:
             return all_tables
 
-        selection = self._stream_prompt("select_tables", messages, context, available_tables=all_tables)
+        selection = self._stream_prompt("select_tables", messages, context, model_kwargs=dict(available_tables=all_tables))
         selected = selection.tables if selection else metaset.get_top_tables(n=3)
         step.stream(f"Selected: {selected}")
         return selected
@@ -572,6 +572,7 @@ class SQLAgent(BaseLumenAgent):
                 "main",
                 messages,
                 context,
+                model_kwargs=dict(sources=list(sources)),
                 dialect=dialect,
                 step_number=1,
                 is_final_step=True,
@@ -581,7 +582,6 @@ class SQLAgent(BaseLumenAgent):
                 sql_plan_context=None,
                 errors=errors,
                 discovery_context=discovery_context,
-                sources=list(sources)
             )
 
             if not output:
@@ -639,9 +639,9 @@ class SQLAgent(BaseLumenAgent):
             "select_discoveries",
             messages,
             context,
+            model_kwargs=dict(sources=list(sources)),
             model_index=0,
             error_context=error_context,
-            sources=list(sources)
         )
         return selection
 
@@ -668,10 +668,10 @@ class SQLAgent(BaseLumenAgent):
             "check_sufficiency",
             messages,
             context,
+            model_kwargs=dict(sources=sources_list),
             model_index=1,
             error_context=error_context,
             discovery_results=discovery_results,
-            sources=sources_list,
         )
         return sufficiency
 

--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -95,15 +95,7 @@ class ValidationAgent(Agent):
                 f"{step[0].__class__.__name__}: {step.instruction}" for step in context["plan"]
             ]
 
-        system_prompt = await self._render_prompt("main", messages, context, executed_steps=executed_steps)
-        model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-
-        result = await self.llm.invoke(
-            messages=messages,
-            system=system_prompt,
-            model_spec=model_spec,
-            response_model=QueryCompletionValidation,
-        )
+        result = await self._invoke_prompt("main", messages, context, executed_steps=executed_steps)
         response_parts = []
         if result.correct:
             return [result], {"validation_result": result}

--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -331,6 +331,7 @@ class Planner(Coordinator):
                 messages,
                 context,
                 model_spec=model_spec,
+                model_kwargs=dict(agents=agents, tools=tools),
                 agents=agents,
                 tools=tools,
                 unmet_dependencies=unmet_dependencies,

--- a/lumen/ai/tools/base.py
+++ b/lumen/ai/tools/base.py
@@ -138,18 +138,9 @@ class FunctionTool(Tool):
     async def respond(
         self, messages: list[Message], context: TContext, **kwargs: dict[str, Any]
     ) -> tuple[list[Any], ContextModel]:
-        prompt = await self._render_prompt("main", messages, context)
         model_kwargs = {}
         if any(field not in self.requires and field not in kwargs for field in self._model.model_fields):
-            model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-            model_kwargs = await self.llm.invoke(
-                messages,
-                system=prompt,
-                model_spec=model_spec,
-                response_model=self._model,
-                allow_partial=False,
-                max_retries=3,
-            )
+            model_kwargs = await self._invoke_prompt("main", messages, context, response_model=self._model, max_retries=3)
         arguments = dict(model_kwargs, **{k: context[k] for k in self.requires}, **kwargs)
         if param.parameterized.iscoroutinefunction(self.function):
             result = await self.function(**arguments)

--- a/lumen/ai/tools/mcp.py
+++ b/lumen/ai/tools/mcp.py
@@ -249,18 +249,9 @@ class MCPTool(Tool):
         context: TContext,
         **kwargs: dict[str, Any],
     ) -> tuple[list[Any], ContextModel]:
-        prompt = await self._render_prompt("main", messages, context)
         model_kwargs = {}
         if any(field not in self.requires for field in self._model.model_fields):
-            model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-            kwargs = await self.llm.invoke(
-                messages,
-                system=prompt,
-                model_spec=model_spec,
-                response_model=self._model,
-                allow_partial=False,
-                max_retries=3,
-            )
+            kwargs = await self._invoke_prompt("main", messages, context, response_model=self._model, max_retries=3)
         arguments = dict(model_kwargs, **{k: context[k] for k in self.requires}, **kwargs)
 
         output = await self.execute(**arguments)

--- a/lumen/ai/tools/vector_lookup.py
+++ b/lumen/ai/tools/vector_lookup.py
@@ -170,25 +170,16 @@ class VectorLookupTool(Tool):
         messages = [{"role": "user", "content": original_query}]
 
         try:
-            refined_query_model = self._get_model("refine_query", item_type_name=self._item_type_name)
-            system_prompt = await self._render_prompt(
+            output = await self._invoke_prompt(
                 "refine_query",
                 messages,
                 context,
+                item_type_name=self._item_type_name,
                 results=results,
                 results_description=results_description,
                 original_query=original_query,
                 item_type=self._item_type_name
             )
-
-            model_spec = self.prompts["refine_query"].get("llm_spec", self.llm_spec_key)
-            output = await self.llm.invoke(
-                messages=messages,
-                system=system_prompt,
-                model_spec=model_spec,
-                response_model=refined_query_model
-            )
-
             return output.refined_search_query
         except Exception as e:
             with self._add_step(title="Query refinement error") as step:

--- a/lumen/ai/tools/vector_lookup.py
+++ b/lumen/ai/tools/vector_lookup.py
@@ -174,7 +174,7 @@ class VectorLookupTool(Tool):
                 "refine_query",
                 messages,
                 context,
-                item_type_name=self._item_type_name,
+                model_kwargs=dict(item_type_name=self._item_type_name),
                 results=results,
                 results_description=results_description,
                 original_query=original_query,


### PR DESCRIPTION
Compresses the code with the already-implemented `_invoke_prompt` and `stream_prompt`

Previously, we were also hardcoding response models in some areas, e.g.
```
            response = self.llm.stream(
                messages,
                system=system_prompt,
                model_spec=model_spec,
                response_model=AltairSpec,
            )
```

We need to look up `AltairSpec` instead with `response_model = self._get_model(prompt_name, **kwargs)` in case the dev changes it.