### PR TITLE
Fix broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ Once installed you will be able to start a Lumen Explorer server by running (rep
 
     lumen-ai serve data.csv
 
-Check out the [docs](https://lumen.holoviz.org/lumen_ai/getting_started/using_lumen_ai.html) for more details!
+Check out the [docs](https://lumen.holoviz.org/getting_started/using_lumen_ai/) for more details!


### PR DESCRIPTION
## Summary
Fixes a broken link in the README.md file that was pointing to an incorrect documentation URL.

## Changes
- Updated the documentation link from `https://lumen.holoviz.org/lumen_ai/getting_started/using_lumen_ai.html` to `https://lumen.holoviz.org/getting_started/using_lumen_ai/`

## Impact
This ensures users can successfully access the "Using Lumen AI" documentation page from the README.