### PR TITLE
Stabilize AI source-control output contracts and add regression coverage

### DIFF
--- a/docs/configuration/controls.md
+++ b/docs/configuration/controls.md
@@ -31,6 +31,8 @@ Common use cases include:
 | `UploadControls` | Uploading local files (CSV, Excel, etc.) |
 | `DownloadControls` | Fetching data from URLs |
 
+`UploadControls` stages selected files before processing. After selecting files, click `Confirm file(s)` to process them, or `Clear selected` to reset the staged selection.
+
 ### Creating custom controls
 
 Custom controls inherit from `BaseSourceControls` and override two hooks:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -123,6 +123,13 @@ pixi run -e docs docs-build
 - Ensure all tests pass
 - Aim for >80% coverage
 
+### AI source controls contract
+When contributing to `lumen.ai.controls` source loaders, keep these output invariants true:
+
+- `outputs["sources"]` must not contain duplicate source objects
+- `outputs["source"]` must always reference an item present in `outputs["sources"]`
+- `outputs["table"]` should reflect the most recently active table when applicable
+
 ### Documentation
 - Update docs for new features
 - Add docstrings

--- a/lumen/ai/controls/base.py
+++ b/lumen/ai/controls/base.py
@@ -431,10 +431,7 @@ class BaseSourceControls(Viewer):
             return
 
         for source in result.sources:
-            self.outputs["source"] = source
-            if "sources" not in self.outputs:
-                self.outputs["sources"] = []
-            self.outputs["sources"].append(source)
+            self._register_source_output(source)
 
         if result.table:
             self.outputs["table"] = result.table
@@ -451,6 +448,15 @@ class BaseSourceControls(Viewer):
         target = self._error_placeholder if error else self._message_placeholder
         target.object = message
         target.visible = True
+
+    def _register_source_output(self, source: DuckDBSource):
+        """
+        Record the active source while keeping ``outputs["sources"]`` deduplicated.
+        """
+        self.outputs["source"] = source
+        sources = self.outputs.setdefault("sources", [])
+        if not any(existing is source for existing in sources):
+            sources.append(source)
 
     def _create_file_object(self, file_data: bytes | io.BytesIO | io.StringIO, suffix: str):
         if isinstance(file_data, (io.BytesIO, io.StringIO)):
@@ -560,11 +566,7 @@ class BaseSourceControls(Viewer):
         else:
             df_rel.to_view(table)
         duckdb_source.tables[table] = sql_expr
-        self.outputs["source"] = duckdb_source
-        if "sources" not in self.outputs:
-            self.outputs["sources"] = [duckdb_source]
-        else:
-            self.outputs["sources"].append(duckdb_source)
+        self._register_source_output(duckdb_source)
         self.outputs["table"] = table
         self.param.trigger('outputs')
         self._last_table = table
@@ -736,11 +738,7 @@ class BaseSourceControls(Viewer):
                 )
                 if source is not None:
                     n_tables += len(source.get_tables())
-                    self.outputs["source"] = source
-                    if "sources" not in self.outputs:
-                        self.outputs["sources"] = [source]
-                    else:
-                        self.outputs["sources"].append(source)
+                    self._register_source_output(source)
                     self.param.trigger("outputs")
             elif card.extension.endswith(TABLE_EXTENSIONS):
                 if source is None:

--- a/lumen/ai/controls/base.py
+++ b/lumen/ai/controls/base.py
@@ -766,6 +766,7 @@ class BaseSourceControls(Viewer):
         self._upload_cards.clear()
         self._file_cards.clear()
         self._add_button.visible = False
+        self._upload_cards.visible = False
 
     def __panel__(self):
         return self._layout

--- a/lumen/ai/controls/upload.py
+++ b/lumen/ai/controls/upload.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import param
 
 from panel.widgets import FileDropper
-from panel_material_ui import Column as MuiColumn
+from panel_material_ui import Button, Column as MuiColumn, Row
 
 from .base import BaseSourceControls
 
@@ -34,11 +34,20 @@ class UploadControls(BaseSourceControls):
 
         self._file_input = FileDropper(**file_dropper_params)
         self._file_input.param.watch(self._on_file_upload, "value")
+        self._clear_button = Button(
+            name="Clear selected",
+            icon="delete",
+            on_click=self._on_clear_selection,
+            visible=self._upload_cards.param.visible,
+            height=42,
+            sizing_mode="stretch_width",
+            description="",
+        )
 
         return MuiColumn(
             self._file_input,
             self._upload_cards,
-            self._add_button,
+            Row(self._add_button, self._clear_button),
             self._error_placeholder,
             self._message_placeholder,
             self.progress.bar,
@@ -48,7 +57,23 @@ class UploadControls(BaseSourceControls):
 
     def _on_file_upload(self, event):
         """Handle file upload from FileDropper."""
-        self._generate_file_cards(self._file_input.value or {})
+        files = event.new if event is not None else self._file_input.value
+        files = files or {}
+        self._generate_file_cards(files)
+        if files:
+            self._message_placeholder.param.update(
+                object=f"{len(files)} file(s) selected. Click 'Confirm file(s)' to process or 'Clear selected' to reset.",
+                visible=True
+            )
+
+    def _on_clear_selection(self, event):
+        """Clear staged files before processing."""
+        self._clear_uploads()
+        self._file_input.value = {}
+        self._message_placeholder.param.update(
+            object="Selection cleared.",
+            visible=True
+        )
 
     @param.depends("add", watch=True)
     def _on_add(self):

--- a/lumen/tests/ai/test_controls/test_upload.py
+++ b/lumen/tests/ai/test_controls/test_upload.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from lumen.ai.controls import UploadedFileRow
+from lumen.ai.controls import SourceResult, UploadedFileRow
+from lumen.sources.duckdb import DuckDBSource
 
 
 @pytest.mark.asyncio
@@ -304,3 +305,35 @@ class TestUploadControlsSelectionUX:
         assert upload_controls._file_input.value == {}
         assert upload_controls._message_placeholder.visible is True
         assert upload_controls._message_placeholder.object == "Selection cleared."
+
+
+class TestUploadControlsOutputContract:
+    """Regression tests for source output invariants."""
+
+    def test_multi_table_upload_deduplicates_outputs_sources(self, upload_controls):
+        upload_controls._generate_file_cards(
+            {
+                "first.csv": b"a,b\n1,2\n",
+                "second.csv": b"a,b\n3,4\n",
+            }
+        )
+
+        n_tables, n_docs, n_metadata = upload_controls._process_files()
+
+        assert n_tables == 2
+        assert n_docs == 0
+        assert n_metadata == 0
+        assert "sources" in upload_controls.outputs
+        assert len(upload_controls.outputs["sources"]) == 1
+        assert upload_controls.outputs["source"] in upload_controls.outputs["sources"]
+
+    def test_handle_success_deduplicates_duplicate_source_entries(self, upload_controls):
+        source = DuckDBSource(uri=":memory:", ephemeral=True, name="dedup_test", tables={})
+        result = SourceResult(sources=[source, source], table="my_table")
+
+        upload_controls._handle_success(result)
+
+        assert "sources" in upload_controls.outputs
+        assert len(upload_controls.outputs["sources"]) == 1
+        assert upload_controls.outputs["source"] is upload_controls.outputs["sources"][0]
+        assert upload_controls.outputs["table"] == "my_table"

--- a/lumen/tests/ai/test_controls/test_upload.py
+++ b/lumen/tests/ai/test_controls/test_upload.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -276,3 +277,30 @@ class TestUploadControlsUnsupportedFiles:
         assert upload_controls._error_placeholder.visible is True
         assert "script.py" in upload_controls._error_placeholder.object
         assert "unsupported format" in upload_controls._error_placeholder.object
+
+
+class TestUploadControlsSelectionUX:
+    """Tests for staged file selection UX in UploadControls."""
+
+    def test_file_selection_shows_guidance_message(self, upload_controls):
+        upload_controls._on_file_upload(
+            SimpleNamespace(new={"a.csv": b"x,y\n1,2\n", "b.csv": b"x,y\n3,4\n"})
+        )
+        assert upload_controls._message_placeholder.visible is True
+        assert "2 file(s) selected" in upload_controls._message_placeholder.object
+        assert "Clear selected" in upload_controls._message_placeholder.object
+
+    def test_clear_selection_resets_staged_files(self, upload_controls):
+        upload_controls._on_file_upload(
+            SimpleNamespace(new={"a.csv": b"x,y\n1,2\n"})
+        )
+        assert len(upload_controls._file_cards) == 1
+        assert upload_controls._upload_cards.visible is True
+
+        upload_controls._on_clear_selection(None)
+
+        assert len(upload_controls._file_cards) == 0
+        assert upload_controls._upload_cards.visible is False
+        assert upload_controls._file_input.value == {}
+        assert upload_controls._message_placeholder.visible is True
+        assert upload_controls._message_placeholder.object == "Selection cleared."


### PR DESCRIPTION
## Summary

This PR hardens source-control output handling in `lumen.ai.controls` by enforcing a consistent contract for `outputs["source"]` and `outputs["sources"]`, and adds regression tests for duplicate-source scenarios.

## Changes

- Centralized source output registration in `BaseSourceControls` via a helper that:
  - sets `outputs["source"]` to the active source
  - deduplicates `outputs["sources"]` by object identity
- Replaced ad-hoc output writes in:
  - `_handle_success`
  - `_add_table`
  - `_process_files` (custom upload-handler path)
- Added regression tests in `test_upload.py` for:
  - multi-table upload not duplicating the same source in `outputs["sources"]`
  - duplicate entries in `SourceResult.sources` being deduplicated
- Documented source-control output invariants in `docs/contributing.md`.

## Contract/Invariants

- `outputs["sources"]` must not contain duplicate source instances.
- `outputs["source"]` must always reference an item present in `outputs["sources"]`.
- `outputs["table"]` remains the latest active table when applicable.

## Validation

Ran:
- `.\\.venv\\Scripts\\python.exe -m pytest -q lumen/tests/ai/test_controls/test_upload.py lumen/tests/ai/test_controls/test_download.py`

Result:
- `33 passed`
