### PR TITLE
Fix metadata lookup

### DIFF
--- a/lumen/ai/tools/metadata_lookup.py
+++ b/lumen/ai/tools/metadata_lookup.py
@@ -385,7 +385,7 @@ class MetadataLookup(VectorLookupTool):
 
         # Get all document filenames from vector store
         all_doc_results = await doc_store.query(text="", top_k=1000, filters=filters)
-        all_filenames = {r["metadata"]["filename"] for r in all_doc_results}
+        all_filenames = {r["metadata"]["filename"] for r in all_doc_results if "filename" in r["metadata"]}
 
         # Get visible docs (if specified, only include these; otherwise include all)
         visible_docs = context.get("visible_docs")


### PR DESCRIPTION
We'd error out if a piece of metadata did not include a filename.