### PR TITLE
Fix refactoring regression

### DIFF
--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -334,7 +334,7 @@ class Planner(Coordinator):
                 messages,
                 context,
                 model_spec=model_spec,
-                model_kwargs=dict(agents=agents, tools=tools),
+                response_model=Reasoning,
                 agents=agents,
                 tools=tools,
                 unmet_dependencies=unmet_dependencies,


### PR DESCRIPTION
Encountering:
```python
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/copy.py", line 151, in deepcopy
    rv = reductor(4)
         ^^^^^^^^^^^
TypeError: cannot pickle '_thread.RLock' object
```

This is because while refactoring to use streamlined methods in https://github.com/holoviz/lumen/pull/1699, specifically
https://github.com/holoviz/lumen/commit/e6cbedc4a3a7e504ab35f6a2b568445923f64869#diff-6d7c1940d0ec733200d5290f940de75d303eab6481a4f52f5dde8c66a1e5b276L345-L350

<img width="1381" height="527" alt="image" src="https://github.com/user-attachments/assets/99de3129-a683-4178-88da-b3092fae290b" />


I saw `response_model=Reasoning` and since the streamlined method automatically pull model spec, I assumed it was using the correct `main` model, but on second look, it's not the original `Reasoning` response model:
```
            "main": {
                "template": PROMPTS_DIR / "Planner" / "main.jinja2",
                "response_model": make_plan_model,
            },
```
We actually call `main` prompt twice, once with reasoning and then the actual make plan model. This PR corrects this by specifying `Reasoning`
