### PR TITLE
Fix per-table lock reuse in cached() decorator

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -84,7 +84,7 @@ def cached(method, locks=None):
             main_lock = threading.RLock()
             locks[self] = {'main': main_lock}
         with main_lock:
-            if table in locks:
+            if table in locks[self]:
                 lock = locks[self][table]
             else:
                 locks[self][table] = lock = threading.RLock()

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -1,6 +1,8 @@
 import asyncio
 import datetime as dt
 import os
+import threading
+import weakref
 
 from pathlib import Path
 
@@ -9,7 +11,7 @@ import pytest
 
 from hvplot.tests.util import makeMixedDataFrame
 
-from lumen.sources.base import Source
+from lumen.sources.base import Source, cached
 from lumen.state import state
 from lumen.transforms.sql import SQLLimit
 
@@ -199,11 +201,6 @@ def test_cached_reuses_per_table_lock(source):
     Since a string key can never exist in a WeakKeyDictionary, this caused
     a new RLock to be created on every call, defeating per-table locking.
     """
-    import threading
-    import weakref
-
-    from lumen.sources.base import cached
-
     locks = weakref.WeakKeyDictionary()
 
     def mock_get(self, table, **query):
@@ -218,7 +215,7 @@ def test_cached_reuses_per_table_lock(source):
     assert source in locks
     assert 'test' in locks[source]
     lock_first = locks[source]['test']
-    assert 'RLock' in type(lock_first).__name__
+    assert isinstance(lock_first, type(threading.RLock()))
 
     # Second call — should reuse the same lock, not create a new one
     source.clear_cache()

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -190,6 +190,46 @@ def test_extension_of_comlicated_url(source):
     assert source._named_files["test"][1] is None
 
 
+def test_cached_reuses_per_table_lock(source):
+    """Test that the cached decorator reuses the same per-table lock.
+
+    Regression test: the per-table lock lookup in cached() previously
+    checked `if table in locks` (the WeakKeyDictionary keyed by Source
+    instances) instead of `if table in locks[self]` (the per-source dict).
+    Since a string key can never exist in a WeakKeyDictionary, this caused
+    a new RLock to be created on every call, defeating per-table locking.
+    """
+    import threading
+    import weakref
+
+    from lumen.sources.base import cached
+
+    locks = weakref.WeakKeyDictionary()
+
+    def mock_get(self, table, **query):
+        return pd.DataFrame({'A': [1]})
+
+    wrapped = cached(mock_get, locks=locks)
+
+    # First call — creates the per-source dict and per-table lock
+    source.clear_cache()
+    wrapped(source, 'test')
+
+    assert source in locks
+    assert 'test' in locks[source]
+    lock_first = locks[source]['test']
+    assert 'RLock' in type(lock_first).__name__
+
+    # Second call — should reuse the same lock, not create a new one
+    source.clear_cache()
+    wrapped(source, 'test')
+
+    lock_second = locks[source]['test']
+    assert lock_first is lock_second, (
+        "Per-table lock was not reused; a new lock was created on each call"
+    )
+
+
 # Async tests for base source methods
 @pytest.mark.asyncio
 async def test_source_get_async_default_implementation(source):


### PR DESCRIPTION
## Summary

- Fixed a bug in the `cached()` decorator where the per-table lock lookup checked `if table in locks` instead of `if table in locks[self]`
- Since `locks` is a `WeakKeyDictionary` keyed by Source instances, a string `table` key can never match, so the condition was always `False`
- This caused a new `RLock` to be created on every `Source.get()` call, defeating per-table serialization for concurrent access
- The sibling function `cached_schema()` already does this correctly (line 130)

## Bug Demonstration

```python
>>> import weakref
>>> locks = weakref.WeakKeyDictionary()
>>> locks[source] = {"main": RLock(), "test_table": RLock()}
>>> "test_table" in locks       # Bug: always False (strings cannot be WKD keys)
False
>>> "test_table" in locks[source]  # Fix: correctly checks per-source dict
True
```

## Change

```diff
- if table in locks:
+ if table in locks[self]:
      lock = locks[self][table]
```

## Test plan

- [x] Added regression test `test_cached_reuses_per_table_lock` that verifies lock identity across calls
- [x] All 74 existing source tests pass
- [x] Verified independently that string keys always return `False` from `WeakKeyDictionary.__contains__`

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.
    Tools: Claude — used for planning the debugging approach. The bug identification, fix, and test were written and verified by me.