### PR TITLE
Fix _set_schema_cache checking wrong parameter

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -422,7 +422,7 @@ class Source(MultiTypeComponent):
             )
 
     def _set_schema_cache(self, schema):
-        if not self.cache_metadata:
+        if not self.cache_schema:
             return
         self._schema_cache = schema
         if not self.cache_dir:

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -331,3 +331,29 @@ async def test_base_sql_source_get_async():
     result_async_filtered = await mock_source.get_async('test_table', category='A')
     # The base implementation should build and execute a filtered query
     assert len(result_async_filtered) <= len(expected)  # Should be filtered
+
+
+def test_set_schema_cache_respects_cache_schema_flag(make_filesource):
+    """Test that _set_schema_cache checks cache_schema, not cache_metadata.
+
+    Regression test: _set_schema_cache previously checked self.cache_metadata
+    instead of self.cache_schema, so setting cache_schema=False had no effect
+    and setting cache_schema=True with cache_metadata=False would skip caching.
+    """
+    root = os.path.dirname(__file__)
+
+    schema = {'test': {'A': {'type': 'integer'}}}
+
+    # cache_schema=False should NOT cache schema
+    src = make_filesource(root, cache_schema=False, cache_metadata=True)
+    src._set_schema_cache(schema)
+    assert src._schema_cache == {}, (
+        "_set_schema_cache should not cache when cache_schema=False"
+    )
+
+    # cache_schema=True should cache schema
+    src2 = make_filesource(root, cache_schema=True, cache_metadata=False)
+    src2._set_schema_cache(schema)
+    assert src2._schema_cache == schema, (
+        "_set_schema_cache should cache when cache_schema=True"
+    )


### PR DESCRIPTION
## Description

Fixes #1723

`_set_schema_cache()` checks `self.cache_metadata` instead of `self.cache_schema`, making the `cache_schema` parameter completely non-functional. This is a copy-paste bug from the sibling method `_set_metadata_cache()`.

**Before (bug):**
| Setting | Expected | Actual |
|---------|----------|--------|
| `cache_schema=False, cache_metadata=True` | Schema NOT cached | Schema IS cached |
| `cache_schema=True, cache_metadata=False` | Schema IS cached | Schema NOT cached |

**After (fix):**
Both scenarios behave correctly -- `cache_schema` controls schema caching as intended.

### Changes

- `lumen/sources/base.py` line 425: `self.cache_metadata` -> `self.cache_schema` (one-line fix)

## How Has This Been Tested?

I added a regression test `test_set_schema_cache_respects_cache_schema_flag` that verifies both directions:
1. `cache_schema=False` prevents caching even when `cache_metadata=True`
2. `cache_schema=True` enables caching even when `cache_metadata=False`

All 75 existing tests pass:
```
$ pixi run -e test-core pytest lumen/tests/sources/test_base.py -v
75 passed, 1 skipped in 2.68s
```

## Checklist

- [x] Tests added and is passing

## AI Disclosure

I used Claude Code to help trace through the caching methods and identify the parameter mismatch between `_set_metadata_cache` and `_set_schema_cache`. I verified the bug and fix myself locally by running the reproducer and full test suite.