### PR TITLE
Fix project_lnglat latitude default pointing to 'longitude'

### DIFF
--- a/lumen/tests/transforms/test_base.py
+++ b/lumen/tests/transforms/test_base.py
@@ -5,7 +5,7 @@ import pandas as pd
 import param  # type: ignore
 
 from lumen.transforms.base import (
-    Count, DropNA, Eval, Sum, Transform,
+    Count, DropNA, Eval, Sum, Transform, project_lnglat,
 )
 
 
@@ -80,3 +80,10 @@ def test_dropna_transform(mixed_df):
     assert len(DropNA.apply_to(mixed_df, how='all')) == 5
     assert len(DropNA.apply_to(mixed_df, axis=1).columns) == 3
     assert len(DropNA.apply_to(mixed_df, axis=1, how='all').columns) == 4
+
+
+def test_project_lnglat_default_params():
+    """Regression test: latitude default was 'longitude' (copy-paste bug)."""
+    transform = project_lnglat()
+    assert transform.longitude == 'longitude'
+    assert transform.latitude == 'latitude'

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -919,7 +919,7 @@ class project_lnglat(Transform):
     """
 
     longitude = param.String(default='longitude', doc="Longitude column")
-    latitude = param.String(default='longitude', doc="Latitude column")
+    latitude = param.String(default='latitude', doc="Latitude column")
 
     transform_type: ClassVar[str] = 'project_lnglat'
 


### PR DESCRIPTION
## Description

The `latitude` parameter in `project_lnglat` defaults to `'longitude'` instead of `'latitude'` — a copy-paste bug from the line above. This causes both axes to silently read from the same column, producing incorrect Web Mercator projections.

```python
longitude = param.String(default='longitude', doc="Longitude column")
latitude = param.String(default='longitude', doc="Latitude column")  # bug: should be 'latitude'
```

### Change

```diff
- latitude = param.String(default='longitude', doc="Latitude column")
+ latitude = param.String(default='latitude', doc="Latitude column")
```

## How Has This Been Tested?

Added regression test `test_project_lnglat_default_params` that verifies both defaults are correct.

```
$ pixi run -e test-core pytest lumen/tests/transforms/test_base.py -v
9 passed in 0.12s
```

## Checklist

- [x] Tests added and passing

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.
    Tools: Claude — used to audit transform parameter definitions. Bug identification, fix, and test verified by me.