### PR TITLE
Fix DerivedSource.get mutating self.transforms in mirror mode

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -1620,7 +1620,7 @@ class DerivedSource(Source):
         if self.tables:
             transforms = self.tables[table].get('transforms', []) + self.transforms
         else:
-            transforms = self.transforms
+            transforms = list(self.transforms)
         transforms.append(FilterTransform(conditions=list(query.items())))
         for transform in transforms:
             df = transform.apply(df)

--- a/lumen/tests/sources/test_derived.py
+++ b/lumen/tests/sources/test_derived.py
@@ -119,3 +119,18 @@ def test_derived_clear_cache(original, mirror_mode_spec):
     assert cache_key in derived._cache
     derived.clear_cache()
     assert len(derived._cache) == 0
+
+
+def test_derived_mirror_get_does_not_mutate_transforms(original, mirror_mode_spec):
+    """Regression test: DerivedSource.get() in mirror mode mutated self.transforms."""
+    derived = Source.from_spec(mirror_mode_spec)
+    n_transforms = len(derived.transforms)
+
+    derived.clear_cache()
+    derived.get('test')
+    derived.clear_cache()
+    derived.get('test')
+
+    assert len(derived.transforms) == n_transforms, (
+        "DerivedSource.get() should not permanently append to self.transforms"
+    )


### PR DESCRIPTION
## Description

In mirror mode (when `self.tables` is empty), `DerivedSource.get()` assigns `transforms = self.transforms` which is a direct reference to the instance's list. The subsequent `transforms.append(FilterTransform(...))` permanently mutates `self.transforms`, causing:

- The transforms list to grow by one `FilterTransform` on every `.get()` call
- Stale filters from previous queries to accumulate and affect future results

The `tables` branch (line 1621) is safe because `+` creates a new list, but the mirror-mode `else` branch was missing a copy.

### Change

```diff
  else:
-     transforms = self.transforms
+     transforms = list(self.transforms)
```

## How Has This Been Tested?

Added regression test `test_derived_mirror_get_does_not_mutate_transforms` that calls `.get()` twice and verifies `self.transforms` length is unchanged.

```
$ pixi run -e test-core pytest lumen/tests/sources/test_derived.py -v
8 passed in 10.24s
```

## Checklist

- [x] Tests added and passing

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.
    Tools: Claude — used to audit source code for mutation bugs. Bug identification, fix, and test verified by me.