### PR TITLE
Fix SQL transform for unselected data

### DIFF
--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -8,12 +8,16 @@ import sqlglot
 
 import lumen as lm
 
-from lumen.sources.duckdb import DuckDBSource
 from lumen.transforms.sql import (
     SQLColumns, SQLCount, SQLDistinct, SQLFilter, SQLFormat, SQLGroupBy,
     SQLLimit, SQLMinMax, SQLOverride, SQLPreFilter, SQLRemoveSourceSeparator,
     SQLSample, SQLSelectFrom, SQLTransform,
 )
+
+try:
+    from lumen.sources.duckdb import DuckDBSource
+except ImportError:
+    DuckDBSource = None
 
 
 def test_dialect_alias_postgresql():
@@ -1115,6 +1119,9 @@ def test_sql_filter_empty_list_conditions():
     multi-select widget with all options deselected). An empty list should produce
     no filter condition, leaving data unfiltered.
     """
+    if DuckDBSource is None:
+        pytest.skip("DuckDBSource not available, skipping test")
+
     df = pd.DataFrame({
         "region":   ["North", "South", "North", "East", "South", "East"],
         "product":  ["A", "B", "A", "C", "C", "B"],

--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -2,9 +2,13 @@ import datetime as dt
 
 from textwrap import dedent
 
+import pandas as pd
 import pytest
 import sqlglot
 
+import lumen as lm
+
+from lumen.sources.duckdb import DuckDBSource
 from lumen.transforms.sql import (
     SQLColumns, SQLCount, SQLDistinct, SQLFilter, SQLFormat, SQLGroupBy,
     SQLLimit, SQLMinMax, SQLOverride, SQLPreFilter, SQLRemoveSourceSeparator,
@@ -1102,3 +1106,33 @@ class TestSQLFilterBase:
         csv_matches = result.count('csv')
         assert parquet_matches == 1, f"Expected 1 'parquet', found {parquet_matches}"
         assert csv_matches == 1, f"Expected 1 'csv', found {csv_matches}"
+
+
+def test_sql_filter_empty_list_conditions():
+    """
+    SQLFilter._build_filter_conditions called or_() unconditionally on range_filters,
+    which crashes with a ValueError from sqlglot when the list is empty (e.g. a
+    multi-select widget with all options deselected). An empty list should produce
+    no filter condition, leaving data unfiltered.
+    """
+    df = pd.DataFrame({
+        "region":   ["North", "South", "North", "East", "South", "East"],
+        "product":  ["A", "B", "A", "C", "C", "B"],
+        "revenue":  [120, 85, 200, 150, 95, 175],
+        "quantity": [10, 7, 18, 12, 9, 14],
+    })
+    source = DuckDBSource.from_df({"sales": df})
+    pipeline = lm.Pipeline.from_spec({
+        "source": source,
+        "table":  "sales",
+        "filters": [
+            {"type": "widget", "field": "revenue"},
+            {"type": "widget", "field": "product"},
+        ],
+    })
+
+    product_filter = next(f for f in pipeline.filters if f.field == "product")
+    product_filter.value = []
+
+    result = pipeline.data
+    assert len(result) == len(df)

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -567,7 +567,8 @@ class SQLFilterBase(SQLTransform):
                             v2_str = str(v2)
 
                         range_filters.append(column_expr.between(SQLLiteral.string(v1_str), SQLLiteral.string(v2_str)))
-                    filters.append(or_(*range_filters))
+                    if range_filters:
+                        filters.append(or_(*range_filters))
                 else:
                     # Handle None values separately in lists
                     non_none_values = [v for v in val if v is not None]


### PR DESCRIPTION
To reproduce:
```python
import pandas as pd
import lumen as lm
import panel as pn
from lumen.sources.duckdb import DuckDBSource

pn.extension()

df = pd.DataFrame(
    {
        "region": ["North", "South", "North", "East", "South", "East"],
        "product": ["A", "B", "A", "C", "C", "B"],
        "revenue": [120, 85, 200, 150, 95, 175],
        "quantity": [10, 7, 18, 12, 9, 14],
    }
)
source = DuckDBSource.from_df({"sales": df})
pipeline = lm.Pipeline.from_spec(
    {
        "source": source,
        "table": "sales",
        "filters": [
            # {"type": "constant", "field": "region", "value": "North"},
            {"type": "widget", "field": "revenue"},
            {"type": "widget", "field": "product"},
        ],
    }
)

pipeline.data
```

Before fix:
```python
File ~/repos/lumen/lumen/transforms/sql.py:570, in SQLFilterBase._build_filter_conditions(self, conditions)
    567             v2_str = str(v2)
    569         range_filters.append(column_expr.between(SQLLiteral.string(v1_str), SQLLiteral.string(v2_str)))
--> [570](https://file+.vscode-resource.vscode-cdn.net/Users/ahuang/repos/anaconda-lumen/~/repos/lumen/lumen/transforms/sql.py:570)     filters.append(or_(*range_filters))
    571 else:
    572     # Handle None values separately in lists
    573     non_none_values = [v for v in val if v is not None]

File ~/miniconda3/envs/lumen/lib/python3.12/site-packages/sqlglot/expressions.py:8538, in or_(dialect, copy, wrap, *expressions, **opts)
   8511 def or_(
   8512     *expressions: t.Optional[ExpOrStr],
   8513     dialect: DialectType = None,
   (...)
   8516     **opts,
   8517 ) -> Condition:
   8518     """
   8519     Combine multiple conditions with an OR logical operator.
   8520 
   (...)
   8536         The new condition
   8537     """
-> [8538](https://file+.vscode-resource.vscode-cdn.net/Users/ahuang/repos/anaconda-lumen/~/miniconda3/envs/lumen/lib/python3.12/site-packages/sqlglot/expressions.py:8538)     return t.cast(Condition, _combine(expressions, Or, dialect, copy=copy, wrap=wrap, **opts))

File ~/miniconda3/envs/lumen/lib/python3.12/site-packages/sqlglot/expressions.py:8082, in _combine(expressions, operator, dialect, copy, wrap, **opts)
   8068 def _combine(
   8069     expressions: t.Sequence[t.Optional[ExpOrStr]],
   8070     operator: t.Type[Connector],
   (...)
   8074     **opts,
   8075 ) -> Expression:
   8076     conditions = [
   8077         condition(expression, dialect=dialect, copy=copy, **opts)
   8078         for expression in expressions
   8079         if expression is not None
   8080     ]
-> [8082](https://file+.vscode-resource.vscode-cdn.net/Users/ahuang/repos/anaconda-lumen/~/miniconda3/envs/lumen/lib/python3.12/site-packages/sqlglot/expressions.py:8082)     this, *rest = conditions
   8083     if rest and wrap:
   8084         this = _wrap(this, Connector)

ValueError: not enough values to unpack (expected at least 1, got 0)
```

Used Claude to help me transfer the test over