### PR TITLE
fix(translate): Add param.Range support in param_to_pydantic

### DIFF
--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -32,6 +32,7 @@ PARAM_TYPE_MAPPING: dict[param.Parameter, type] = {
     param.Event: bool,
     param.Tuple: tuple,
     param.NumericTuple: tuple,
+    param.Range: tuple[float, float],
     param.Date: DATE_TYPE,
     param.DateRange: tuple[DATE_TYPE],
     param.CalendarDate: DATE_TYPE,

--- a/lumen/tests/ai/test_translate.py
+++ b/lumen/tests/ai/test_translate.py
@@ -543,3 +543,33 @@ def test_round_trip_with_default_values():
     # Verify param behavior is preserved
     with pytest.raises(ValueError):
         round_trip_settings.max_connections = 5  # Below minimum
+
+
+def test_param_range_conversion():
+    """
+    Test that param.Range parameters are correctly converted to Pydantic fields.
+
+    Regression test for https://github.com/holoviz/lumen/issues/1730
+    """
+
+    class PlotConfig(param.Parameterized):
+        xlim = param.Range(default=None, doc="X-axis limits")
+        ylim = param.Range(default=(0.0, 10.0), doc="Y-axis limits")
+
+    created_models = param_to_pydantic(PlotConfig)
+    PydanticPlotConfig = created_models["PlotConfig"]
+
+    # Check schema has correct types
+    schema = PydanticPlotConfig.model_json_schema()
+    assert "xlim" in schema["properties"]
+    assert "ylim" in schema["properties"]
+
+    # Test with default values
+    instance = PydanticPlotConfig()
+    assert instance.xlim is None
+    assert instance.ylim == (0.0, 10.0)
+
+    # Test with custom values
+    instance = PydanticPlotConfig(xlim=(1.0, 5.0), ylim=(-1.0, 1.0))
+    assert instance.xlim == (1.0, 5.0)
+    assert instance.ylim == (-1.0, 1.0)


### PR DESCRIPTION
## Description

Fixes #1730

`param_to_pydantic()` in `lumen/ai/translate.py` raises `NotImplementedError` when it encounters a `param.Range` parameter because `param.Range` is not in the `PARAM_TYPE_MAPPING` dict.

```
NotImplementedError: Parameter 'xlim' of 'Range' not supported
```

`param.Range` is a subclass of `param.NumericTuple`, but Python dict lookup uses exact class match, so the existing `param.NumericTuple: tuple` entry does not cover `param.Range`.

### Before

```python
from lumen.ai.translate import param_to_pydantic
import param

class PlotConfig(param.Parameterized):
    xlim = param.Range(default=None, doc="X-axis limits")

param_to_pydantic(PlotConfig)
# NotImplementedError: Parameter 'xlim' of 'Range' not supported
```

### After

```python
param_to_pydantic(PlotConfig)
# {'PlotConfig': <class 'PlotConfig'>}  -- works, xlim maps to Optional[tuple[float, float]]
```

### Changes

- Added `param.Range: tuple[float, float]` to `PARAM_TYPE_MAPPING` in `lumen/ai/translate.py`
- Added `test_param_range_conversion` regression test in `lumen/tests/ai/test_translate.py`

## How Has This Been Tested?

1. Verified the reproducer from #1730 now works instead of raising `NotImplementedError`
2. Tested `param.Range` with `default=None` (maps to `Optional[tuple[float, float]]`) and with a tuple default like `(0.0, 10.0)`
3. New test `test_param_range_conversion` validates schema generation, default values, and custom values
4. Full test suite passes (824 passed, 27 skipped)

## Checklist

- [x] Tests added and is passing
- [ ] Added documentation

## AI Disclosure

I planned, implemented, and tested this fix myself. AI was used to assist with code review and verification.