### PR TITLE
Fix download done_callback: or -> and prevents crash and wrong message

### DIFF
--- a/lumen/ai/controls/download.py
+++ b/lumen/ai/controls/download.py
@@ -70,31 +70,39 @@ class DownloadControls(BaseSourceControls):
         )
 
     def _handle_cancel(self, event):
-        """Handle cancel button click by cancelling active download task"""
+        """Handle cancel button click by cancelling active download task.
+
+        Actual cleanup and messaging is handled by ``_on_download_done``
+        when the cancelled task's done callback fires.
+        """
         if self._active_download_task and not self._active_download_task.done():
             self._active_download_task.cancel()
-            self.progress.clear()
-            self._message_placeholder.param.update(
-                object="Download cancelled by user.",
-                visible=True
-            )
-        # Clear the active task so Cancel button hides
-        self._active_download_task = None
 
     def _on_download_done(self, task):
-        """Handle download task completion, cancellation, or failure."""
+        """Handle download task completion, cancellation, or failure.
+
+        Only acts on the currently active download task to avoid stale
+        callbacks from interfering with a newer download.  The success
+        path is intentionally a no-op because ``_download_and_process_urls``
+        already sets a more informative message with a call-to-action.
+        """
+        if task is not self._active_download_task:
+            return
+
         if task.cancelled():
             self._message_placeholder.param.update(
                 object="Download cancelled.",
                 visible=True
             )
         elif task.exception() is not None:
-            return
-        else:
             self._message_placeholder.param.update(
-                object="Download complete.",
+                object=f"Download failed: {task.exception()}",
                 visible=True
             )
+
+        # Clean up so the Cancel button hides for finished tasks
+        self.progress.clear()
+        self._active_download_task = None
 
     def _is_valid_url(self, url):
         """Basic URL validation"""
@@ -338,9 +346,6 @@ class DownloadControls(BaseSourceControls):
             self._message_placeholder.object = f"Successfully downloaded {success_count} file(s). Click 'Confirm file(s)' to process."
         else:
             self._message_placeholder.visible = False
-
-        # Clear the active task so Cancel button hides
-        self._active_download_task = None
 
     @param.depends("add", watch=True)
     def _on_add(self):

--- a/lumen/ai/controls/download.py
+++ b/lumen/ai/controls/download.py
@@ -285,7 +285,7 @@ class DownloadControls(BaseSourceControls):
             lambda t: self._message_placeholder.param.update(
                 object="Download complete." if not t.cancelled() else "Download cancelled.",
                 visible=True
-            ) if not t.cancelled() or t.exception() is None else None
+            ) if not t.cancelled() and t.exception() is None else None
         )
 
     async def _download_and_process_urls(self, urls):

--- a/lumen/ai/controls/download.py
+++ b/lumen/ai/controls/download.py
@@ -81,6 +81,21 @@ class DownloadControls(BaseSourceControls):
         # Clear the active task so Cancel button hides
         self._active_download_task = None
 
+    def _on_download_done(self, task):
+        """Handle download task completion, cancellation, or failure."""
+        if task.cancelled():
+            self._message_placeholder.param.update(
+                object="Download cancelled.",
+                visible=True
+            )
+        elif task.exception() is not None:
+            return
+        else:
+            self._message_placeholder.param.update(
+                object="Download complete.",
+                visible=True
+            )
+
     def _is_valid_url(self, url):
         """Basic URL validation"""
         try:
@@ -281,12 +296,7 @@ class DownloadControls(BaseSourceControls):
             self._active_download_task.cancel()
 
         self._active_download_task = asyncio.create_task(self._download_and_process_urls(valid_urls))
-        self._active_download_task.add_done_callback(
-            lambda t: self._message_placeholder.param.update(
-                object="Download complete." if not t.cancelled() else "Download cancelled.",
-                visible=True
-            ) if not t.cancelled() and t.exception() is None else None
-        )
+        self._active_download_task.add_done_callback(self._on_download_done)
 
     async def _download_and_process_urls(self, urls):
         """Download URLs and generate file cards for processing"""

--- a/lumen/tests/ai/test_controls/test_download.py
+++ b/lumen/tests/ai/test_controls/test_download.py
@@ -244,59 +244,51 @@ class TestDownloadControlsUnsupportedFiles:
         assert "binary.exe" in error_text
 
 
-class TestDownloadCallbackLogic:
-    """Tests for the done_callback logic on download tasks."""
+class TestDownloadDoneCallback:
+    """Tests for DownloadControls._on_download_done callback behavior."""
 
-    def _make_callback(self, results):
-        """Create a callback matching the pattern in DownloadControls._process_urls."""
-        def callback(t):
-            if not t.cancelled() and t.exception() is None:
-                results.append("complete")
-            # With the old bug (or instead of and), this would:
-            # 1. Crash with CancelledError when task is cancelled
-            # 2. Show "complete" when task fails with an exception
-        return callback
+    @pytest.fixture
+    def _setup(self, download_controls):
+        """Run _on_download_done via add_done_callback on a real asyncio.Task."""
+        self.controls = download_controls
 
-    async def test_callback_on_successful_task(self):
-        """Callback should fire on a successful task."""
-        results = []
-
+    async def test_successful_task_shows_complete(self, _setup):
+        """On success, message should show 'Download complete.'"""
         async def success():
             return "ok"
 
-        t = asyncio.create_task(success())
-        t.add_done_callback(self._make_callback(results))
-        await t
-        assert results == ["complete"]
+        task = asyncio.create_task(success())
+        task.add_done_callback(self.controls._on_download_done)
+        await task
 
-    async def test_callback_on_cancelled_task(self):
-        """Callback should NOT fire (or crash) on a cancelled task."""
-        results = []
+        assert self.controls._message_placeholder.object == "Download complete."
+        assert self.controls._message_placeholder.visible is True
 
+    async def test_cancelled_task_shows_cancelled(self, _setup):
+        """On cancellation, message should show 'Download cancelled.' without crashing."""
         async def slow():
             await asyncio.sleep(10)
 
-        t = asyncio.create_task(slow())
-        t.add_done_callback(self._make_callback(results))
+        task = asyncio.create_task(slow())
+        task.add_done_callback(self.controls._on_download_done)
         await asyncio.sleep(0.01)
-        t.cancel()
-        try:
-            await t
-        except asyncio.CancelledError:
-            pass
-        assert results == []
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
 
-    async def test_callback_on_failed_task(self):
-        """Callback should NOT fire on a task that raised an exception."""
-        results = []
+        assert self.controls._message_placeholder.object == "Download cancelled."
+        assert self.controls._message_placeholder.visible is True
+
+    async def test_failed_task_does_not_show_complete(self, _setup):
+        """On exception, message should NOT be updated to 'Download complete.'"""
+        initial_message = self.controls._message_placeholder.object
 
         async def fail():
-            raise ValueError("download failed")
+            raise ValueError("network error")
 
-        t = asyncio.create_task(fail())
-        t.add_done_callback(self._make_callback(results))
-        try:
-            await t
-        except ValueError:
-            pass
-        assert results == []
+        task = asyncio.create_task(fail())
+        task.add_done_callback(self.controls._on_download_done)
+        with pytest.raises(ValueError):
+            await task
+
+        assert self.controls._message_placeholder.object == initial_message

--- a/lumen/tests/ai/test_controls/test_download.py
+++ b/lumen/tests/ai/test_controls/test_download.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 
 import pytest
@@ -241,3 +242,61 @@ class TestDownloadControlsUnsupportedFiles:
         error_text = download_controls._error_placeholder.object
         assert "script.py" in error_text
         assert "binary.exe" in error_text
+
+
+class TestDownloadCallbackLogic:
+    """Tests for the done_callback logic on download tasks."""
+
+    def _make_callback(self, results):
+        """Create a callback matching the pattern in DownloadControls._process_urls."""
+        def callback(t):
+            if not t.cancelled() and t.exception() is None:
+                results.append("complete")
+            # With the old bug (or instead of and), this would:
+            # 1. Crash with CancelledError when task is cancelled
+            # 2. Show "complete" when task fails with an exception
+        return callback
+
+    async def test_callback_on_successful_task(self):
+        """Callback should fire on a successful task."""
+        results = []
+
+        async def success():
+            return "ok"
+
+        t = asyncio.create_task(success())
+        t.add_done_callback(self._make_callback(results))
+        await t
+        assert results == ["complete"]
+
+    async def test_callback_on_cancelled_task(self):
+        """Callback should NOT fire (or crash) on a cancelled task."""
+        results = []
+
+        async def slow():
+            await asyncio.sleep(10)
+
+        t = asyncio.create_task(slow())
+        t.add_done_callback(self._make_callback(results))
+        await asyncio.sleep(0.01)
+        t.cancel()
+        try:
+            await t
+        except asyncio.CancelledError:
+            pass
+        assert results == []
+
+    async def test_callback_on_failed_task(self):
+        """Callback should NOT fire on a task that raised an exception."""
+        results = []
+
+        async def fail():
+            raise ValueError("download failed")
+
+        t = asyncio.create_task(fail())
+        t.add_done_callback(self._make_callback(results))
+        try:
+            await t
+        except ValueError:
+            pass
+        assert results == []

--- a/lumen/tests/ai/test_controls/test_download.py
+++ b/lumen/tests/ai/test_controls/test_download.py
@@ -249,20 +249,27 @@ class TestDownloadDoneCallback:
 
     @pytest.fixture
     def _setup(self, download_controls):
-        """Run _on_download_done via add_done_callback on a real asyncio.Task."""
+        """Set up controls with an active download task reference."""
         self.controls = download_controls
 
-    async def test_successful_task_shows_complete(self, _setup):
-        """On success, message should show 'Download complete.'"""
+    async def test_successful_task_preserves_coroutine_message(self, _setup):
+        """On success, _on_download_done should NOT overwrite the message.
+
+        The coroutine (_download_and_process_urls) sets a more informative
+        message with a call-to-action; the callback must not clobber it.
+        """
+        self.controls._message_placeholder.object = "Successfully downloaded 1 file(s). Click 'Confirm file(s)' to process."
+
         async def success():
             return "ok"
 
         task = asyncio.create_task(success())
+        self.controls._active_download_task = task
         task.add_done_callback(self.controls._on_download_done)
         await task
 
-        assert self.controls._message_placeholder.object == "Download complete."
-        assert self.controls._message_placeholder.visible is True
+        assert self.controls._message_placeholder.object == "Successfully downloaded 1 file(s). Click 'Confirm file(s)' to process."
+        assert self.controls._active_download_task is None
 
     async def test_cancelled_task_shows_cancelled(self, _setup):
         """On cancellation, message should show 'Download cancelled.' without crashing."""
@@ -270,6 +277,7 @@ class TestDownloadDoneCallback:
             await asyncio.sleep(10)
 
         task = asyncio.create_task(slow())
+        self.controls._active_download_task = task
         task.add_done_callback(self.controls._on_download_done)
         await asyncio.sleep(0.01)
         task.cancel()
@@ -278,17 +286,35 @@ class TestDownloadDoneCallback:
 
         assert self.controls._message_placeholder.object == "Download cancelled."
         assert self.controls._message_placeholder.visible is True
+        assert self.controls._active_download_task is None
 
-    async def test_failed_task_does_not_show_complete(self, _setup):
-        """On exception, message should NOT be updated to 'Download complete.'"""
-        initial_message = self.controls._message_placeholder.object
-
+    async def test_failed_task_shows_error(self, _setup):
+        """On exception, message should show the error, not 'Download complete.'"""
         async def fail():
             raise ValueError("network error")
 
         task = asyncio.create_task(fail())
+        self.controls._active_download_task = task
         task.add_done_callback(self.controls._on_download_done)
         with pytest.raises(ValueError):
             await task
 
-        assert self.controls._message_placeholder.object == initial_message
+        assert "network error" in self.controls._message_placeholder.object
+        assert self.controls._active_download_task is None
+
+    async def test_stale_task_is_ignored(self, _setup):
+        """A done callback from a stale (replaced) task should be a no-op."""
+        self.controls._message_placeholder.object = "Preparing..."
+
+        async def success():
+            return "ok"
+
+        old_task = asyncio.create_task(success())
+        old_task.add_done_callback(self.controls._on_download_done)
+        # Simulate a new download replacing the old one
+        self.controls._active_download_task = asyncio.create_task(success())
+        await old_task
+
+        # Stale callback should not touch anything
+        assert self.controls._message_placeholder.object == "Preparing..."
+        assert self.controls._active_download_task is not None


### PR DESCRIPTION
## Description

The done_callback in `DownloadControls._handle_urls` had two bugs caused by incorrect boolean logic (`or` instead of `and`), plus structural issues with duplicated cleanup logic scattered across multiple methods.

### Bug 1: CancelledError crash

When a download task is cancelled, `not t.cancelled()` evaluates to `False`. With `or`, Python evaluates the right side `t.exception()`. But calling `.exception()` on a cancelled task raises `asyncio.CancelledError`, crashing the callback.

### Bug 2: "Download complete." shown on failure

When a download fails with an exception, `not t.cancelled()` is `True`. With `or`, `True or ...` short-circuits to `True`, so the callback shows "Download complete." even though the download failed.

### What this PR does

1. **Extracts the inline lambda into a proper `_on_download_done` method** with explicit `if/elif` handling all three task states:
   - **Cancelled**: shows "Download cancelled."
   - **Failed**: shows "Download failed: {error}" (previously silent or showed "complete")
   - **Success**: no-op, preserves the more informative message set by `_download_and_process_urls` ("Successfully downloaded X file(s). Click 'Confirm file(s)' to process.")

2. **Adds a stale task guard** (`if task is not self._active_download_task: return`) so callbacks from replaced downloads don't interfere with newer ones.

3. **Consolidates cleanup into `_on_download_done` as single source of truth**, removes redundant `_active_download_task = None` and `progress.clear()` from `_handle_cancel` and `_download_and_process_urls`, eliminating race conditions between duplicate cleanup paths.

### Truth table

| Task state | `not t.cancelled()` | `t.exception() is None` | Old `or` (bug) | New behavior |
|---|---|---|---|---|
| Success | True | True | True (correct) | No-op, preserves coroutine message |
| Cancelled | False | *CancelledError* | **CRASH** | Shows "Download cancelled." |
| Failed | True | False | **True (wrong)** | Shows "Download failed: ..." |

### Before / After proof
The issue :

https://github.com/user-attachments/assets/9b133946-2c55-4d4a-8055-d03a3fda3e55

After  :

https://github.com/user-attachments/assets/04b25f37-9e72-4b06-8edd-2fc20c25e5ad


```
=== BEFORE (inline lambda with or) - BUGGY ===

Bug 1: Cancelled task
  Code: not t.cancelled() or t.exception() is None
  CRASH: asyncio.CancelledError raised!
  (calling t.exception() on cancelled task crashes)

Bug 2: Failed task (download error)
  Code: not t.cancelled() or t.exception() is None
  Result: True
  User sees: "Download complete." (WRONG - download failed!)

=== AFTER (_on_download_done method) - FIXED ===

Fix 1: Cancelled task
  -> Shows: "Download cancelled." (correct, no crash)

Fix 2: Failed task (download error)
  -> Shows: "Download failed: network timeout" (correct)

Fix 3: Successful task
  -> No-op, preserves: "Successfully downloaded 1 file(s). Click Confirm..." (correct)
```

### How I found this

I was reviewing the async callback patterns in the codebase and noticed the boolean logic was incorrect. I verified by tracing all task state transitions and confirmed both bugs.

## How Has This Been Tested?

Added 4 async unit tests in `test_download.py` that exercise the actual `_on_download_done` method via the `download_controls` fixture:
- `test_successful_task_preserves_coroutine_message` - callback doesn't overwrite the call-to-action message
- `test_cancelled_task_shows_cancelled` - shows cancel message without crashing
- `test_failed_task_shows_error` - shows error message, not "Download complete."
- `test_stale_task_is_ignored` - replaced task's callback is a no-op

All 26 download tests pass (22 existing + 4 new).

## Checklist

- [x] Tests added and passing
- [ ] Added documentation

## AI Disclosure

I planned, identified, and tested this fix myself. AI was used to assist with code review and verification.