### PR TITLE
Fix literal \n in revision and annotation markdown output

### DIFF
--- a/lumen/ai/controls/revision.py
+++ b/lumen/ai/controls/revision.py
@@ -118,11 +118,11 @@ class RetryControls(RevisionControls):
                     self.instruction, messages, self.task.out_context, self.view
                 )
         except Exception as e:
-            self._report_status(f"```\\n{e}\\n```", title="❌ Failed to generate revisions")
+            self._report_status(f"```\n{e}\n```", title="❌ Failed to generate revisions")
             raise
 
         diff = generate_diff(old_spec, new_spec, filename=self.view.language or "spec")
-        diff_md = f'```diff\\n{diff}\\n```'
+        diff_md = f'```diff\n{diff}\n```'
         try:
             self.view.spec = new_spec
         except Exception:
@@ -156,11 +156,11 @@ class AnnotationControls(RevisionControls):
                     self.instruction, list(self.task.history), self.task.out_context, {"spec": load_yaml(self.view.spec)}
                 )
         except Exception as e:
-            self._report_status(f"```\\n{e}\\n```", title="❌ Failed to generate annotations")
+            self._report_status(f"```\n{e}\n```", title="❌ Failed to generate annotations")
             raise
 
         diff = generate_diff(old_spec, new_spec, filename=self.view.language or "spec")
-        diff_md = f'```diff\\n{diff}\\n```'
+        diff_md = f'```diff\n{diff}\n```'
         try:
             self.view.spec = new_spec
         except Exception:

--- a/lumen/tests/ai/test_controls/test_revision.py
+++ b/lumen/tests/ai/test_controls/test_revision.py
@@ -383,28 +383,99 @@ class TestRetryControls:
         interface = MockInterface()
         view = MockView(spec="original")
         task = MockTask()
-        
+
         # Mock revise to raise exception
         task.actor.revise = AsyncMock(side_effect=Exception("LLM Error"))
         task.history = []
         task.out_context = {}
-        
+
         controls = RetryControls(
             interface=interface,
             view=view,
             task=task
         )
-        
+
         # Trigger revision and expect exception
         controls.instruction = "Fix this"
         with pytest.raises(Exception, match="LLM Error"):
             await controls._revise()
-            
+
         # Verify error was reported (check that a Card was created with correct title)
         assert len(interface.messages) == 1
         card = interface.messages[0]["content"]
         assert hasattr(card, 'title')
         assert "Failed to generate revisions" in card.title
+
+    @pytest.mark.asyncio
+    async def test_revise_error_markdown_uses_real_newlines(self):
+        """Test that error markdown uses actual newlines, not literal backslash-n.
+
+        Regression test: f-strings previously used escaped newlines (\\\\n)
+        which rendered as literal \\n text in the chat instead of proper
+        markdown code blocks.
+        """
+        interface = MockInterface()
+        view = MockView(spec="original")
+        task = MockTask()
+
+        task.actor.revise = AsyncMock(side_effect=Exception("Some error"))
+        task.history = []
+        task.out_context = {}
+
+        controls = RetryControls(
+            interface=interface,
+            view=view,
+            task=task
+        )
+
+        controls.instruction = "Fix this"
+        with pytest.raises(Exception):
+            await controls._revise()
+
+        # The Card wraps a Markdown object; extract its content
+        card = interface.messages[0]["content"]
+        md_object = card.objects[0]
+        md_text = md_object.object
+
+        # Must contain real newlines for proper markdown code block rendering
+        assert "\\n" not in md_text, (
+            "Error markdown contains literal backslash-n instead of real newlines"
+        )
+        assert md_text.startswith("```\n")
+        assert md_text.endswith("\n```")
+
+    @pytest.mark.asyncio
+    async def test_revise_diff_markdown_uses_real_newlines(self):
+        """Test that diff markdown uses actual newlines after successful revision."""
+        interface = MockInterface()
+        old_spec = "type: bar"
+        new_spec = "type: line"
+        view = MockView(spec=old_spec)
+        task = MockTask()
+
+        task.actor.revise = AsyncMock(return_value=new_spec)
+        task.history = []
+        task.out_context = {}
+
+        controls = RetryControls(
+            interface=interface,
+            view=view,
+            task=task
+        )
+
+        with patch('lumen.ai.controls.revision.generate_diff', return_value="- type: bar\n+ type: line"):
+            controls.instruction = "Change to line chart"
+            await controls._revise()
+
+        card = interface.messages[0]["content"]
+        md_object = card.objects[0]
+        md_text = md_object.object
+
+        assert "\\n" not in md_text, (
+            "Diff markdown contains literal backslash-n instead of real newlines"
+        )
+        assert md_text.startswith("```diff\n")
+        assert md_text.endswith("\n```")
         
     @pytest.mark.asyncio
     async def test_revise_spec_application_failure(self):
@@ -565,29 +636,64 @@ class TestAnnotationControls:
         interface = MockInterface()
         view = MockView(spec="original")
         task = MockTask()
-        
+
         # Mock annotate to raise exception
         task.actor.annotate = AsyncMock(side_effect=Exception("Annotation failed"))
         task.history = []
         task.out_context = {}
-        
+
         controls = AnnotationControls(
             interface=interface,
             view=view,
             task=task
         )
-        
+
         with patch('lumen.ai.controls.revision.load_yaml', return_value={}):
             controls.instruction = "Add labels"
-            
+
             with pytest.raises(Exception, match="Annotation failed"):
                 await controls._annotate()
-                
+
             # Verify error was reported with correct title
             assert len(interface.messages) == 1
             card = interface.messages[0]["content"]
             assert hasattr(card, 'title')
             assert "Failed to generate annotations" in card.title
+
+    @pytest.mark.asyncio
+    async def test_annotate_error_markdown_uses_real_newlines(self):
+        """Test that annotation error markdown uses actual newlines.
+
+        Regression test: same escaped newline bug as in RetryControls.
+        """
+        interface = MockInterface()
+        view = MockView(spec="original")
+        task = MockTask()
+
+        task.actor.annotate = AsyncMock(side_effect=Exception("Annotation error"))
+        task.history = []
+        task.out_context = {}
+
+        controls = AnnotationControls(
+            interface=interface,
+            view=view,
+            task=task
+        )
+
+        with patch('lumen.ai.controls.revision.load_yaml', return_value={}):
+            controls.instruction = "Annotate peaks"
+            with pytest.raises(Exception):
+                await controls._annotate()
+
+        card = interface.messages[0]["content"]
+        md_object = card.objects[0]
+        md_text = md_object.object
+
+        assert "\\n" not in md_text, (
+            "Error markdown contains literal backslash-n instead of real newlines"
+        )
+        assert md_text.startswith("```\n")
+        assert md_text.endswith("\n```")
             
     @pytest.mark.asyncio
     async def test_annotate_spec_application_failure(self):

--- a/lumen/tests/ai/test_controls/test_revision.py
+++ b/lumen/tests/ai/test_controls/test_revision.py
@@ -694,7 +694,41 @@ class TestAnnotationControls:
         )
         assert md_text.startswith("```\n")
         assert md_text.endswith("\n```")
-            
+
+    @pytest.mark.asyncio
+    async def test_annotate_diff_markdown_uses_real_newlines(self):
+        """Test that diff markdown uses actual newlines after successful annotation."""
+        interface = MockInterface()
+        old_spec = "type: bar"
+        new_spec = "type: bar\nannotations:\n  - mark: peak"
+        view = MockView(spec=old_spec)
+        task = MockTask()
+
+        task.actor.annotate = AsyncMock(return_value=new_spec)
+        task.history = []
+        task.out_context = {}
+
+        controls = AnnotationControls(
+            interface=interface,
+            view=view,
+            task=task
+        )
+
+        with patch('lumen.ai.controls.revision.generate_diff', return_value="- type: bar\n+ type: bar\n+ annotations:\n+   - mark: peak"):
+            with patch('lumen.ai.controls.revision.load_yaml', return_value={}):
+                controls.instruction = "Highlight peak values"
+                await controls._annotate()
+
+        card = interface.messages[0]["content"]
+        md_object = card.objects[0]
+        md_text = md_object.object
+
+        assert "\\n" not in md_text, (
+            "Diff markdown contains literal backslash-n instead of real newlines"
+        )
+        assert md_text.startswith("```diff\n")
+        assert md_text.endswith("\n```")
+
     @pytest.mark.asyncio
     async def test_annotate_spec_application_failure(self):
         """Test _annotate handles spec application failures."""


### PR DESCRIPTION
## Description

While testing Lumen AI's "Ask AI to make changes" feature, I noticed that error messages and diff output in the chat display literal `\n` characters instead of actual newlines. This breaks the markdown code block rendering, making error messages hard to read.
**Root cause:** The f-strings in `RetryControls._revise()` and `AnnotationControls._annotate()` use double-escaped newlines (`\\n`) which produce literal backslash-n text instead of real newline characters. This affects:
- Error messages when revision/annotation fails (lines 121, 159)
- Diff markdown output after successful revision/annotation (lines 125, 163)
**Fix:** Replace `\\n` with `\n` in all 4 f-strings so markdown code blocks render correctly.

### Before (literal `\n` shown in error message)
<img width="1217" height="764" alt="before-revision-fix" src="https://github.com/user-attachments/assets/cc5ee17a-2101-4e6b-8915-49298b8e3f54" />


### After (proper code block rendering)

<img width="1217" height="764" alt="after-revision-fix" src="https://github.com/user-attachments/assets/ec315f6a-6801-4bac-85e9-2e87fcf08d80" />


## Steps to Reproduce

1. Start Lumen AI: `lumen ai serve --provider google`
2. Upload a CSV and ask a question (e.g., "Show me total revenue by product")
3. Once a chart is generated, click the "Ask AI to make changes" toggle
4. Enter any modification request (e.g., "Make bars green")
5. If the revision fails (e.g., due to retries), the error message shows literal `\n` instead of a properly formatted code block

## How Has This Been Tested?

- Tested manually by reproducing the bug with Google Gemini provider
- Triggered the "Ask AI to make changes" feature, observed the error rendering before and after the fix
- Added 3 regression tests verifying markdown output uses actual newlines (not literal `\n`) for both `RetryControls` and `AnnotationControls`
- All 25 tests in `test_revision.py` pass

## Checklist

- [x] Tests added and is passing
- [ ] Added documentation

## AI Disclosure

I discovered this bug while actively testing Lumen AI's chart revision feature. I planned the investigation and fix. AI assisted with scaffolding the code changes and test structure.