### PR TITLE
Fix typo "Sucessfully" in plan completion message

### DIFF
--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -243,7 +243,7 @@ class Plan(Section):
             steps_title, todo_list = self.steps_layout.header
             todo_list.object = todos
             if self.status == "success":
-                steps_title.object = f"✅ Sucessfully completed {self.title!r}"
+                steps_title.object = f"✅ Successfully completed {self.title!r}"
             else:
                 steps_title.object = f"❌ Failed to execute {self.title!r}"
             self.steps_layout.collapsed = True


### PR DESCRIPTION
## Description

While using Lumen AI to explore a sales dataset, I noticed a typo in the Planner's completion message. Every time a plan completes successfully, the message reads:

> ✅ Sucessfully completed 'Revenue by Product'

The word "Sucessfully" is missing a "c". It should be "Successfully".

This typo appears on every single successful exploration, making it highly visible to users.

**Fix:** One-character change in `lumen/ai/coordinator/base.py` line 246.

### Before (typo visible in completion message)

<img width="1217" height="764" alt="before-typo-fix" src="https://github.com/user-attachments/assets/b332a1c5-9170-4542-b047-9a3174fdcbcb" />

## How Has This Been Tested?

- I was testing Lumen AI with Google Gemini provider, uploaded a CSV dataset, and ran several queries (scatter plot, line chart, heatmap)
- The typo appeared consistently in every successful plan completion
- Verified the fix corrects the spelling in the source code

## Checklist

- [ ] Tests added and is passing
- [ ] Added documentation

## AI Disclosure

No AI was used for this fix. I discovered the typo while actively testing Lumen AI and planned the fix myself.