### PR TITLE
Fix annotation feature failing with Google Gemini provider

### DIFF
--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -741,7 +741,7 @@ class VegaLiteAgent(BaseCodeAgent):
         str
             Updated specification with annotations
         """
-        messages = self._prepare_vision_messages(messages, view, f"Revise this chart: {instruction!r}")
+        messages = self._prepare_vision_messages(messages, view, f"Annotate this chart: {instruction!r}")
 
         vega_spec = dump_yaml(spec["spec"], default_flow_style=False)
         result = await self._invoke_prompt(
@@ -749,6 +749,7 @@ class VegaLiteAgent(BaseCodeAgent):
             messages,
             context,
             vega_spec=vega_spec,
+            instruction=instruction,
         )
         update_dict = load_yaml(result.yaml_update)
 

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -297,16 +297,14 @@ class VegaLiteAgent(BaseCodeAgent):
             return None
 
     def _prepare_vision_messages(
-        self, messages: list[Message], out: LumenEditor | None, content: str,
-        text_fallback: bool = False
+        self, messages: list[Message], out: LumenEditor | None, content: str
     ) -> list[Message]:
         """Add plot image to messages for LLM vision analysis.
 
-        When *text_fallback* is True the content string is always
-        appended as a plain-text user message if vision is unavailable
-        or image export fails, so the instruction is never lost.
+        If vision is unavailable or image export fails we append the
+        content as a plain-text message.
         """
-        fallback = messages + [{"role": "user", "content": content}] if text_fallback else messages
+        fallback = messages + [{"role": "user", "content": content}]
         if not self.llm._supports_vision:
             return fallback
         if out is None or not isinstance(out, VegaLiteEditor):
@@ -748,7 +746,7 @@ class VegaLiteAgent(BaseCodeAgent):
         str
             Updated specification with annotations
         """
-        messages = self._prepare_vision_messages(messages, view, f"Annotate this chart: {instruction!r}", text_fallback=True)
+        messages = self._prepare_vision_messages(messages, view, f"Annotate this chart: {instruction!r}")
 
         vega_spec = dump_yaml(spec["spec"], default_flow_style=False)
         result = await self._invoke_prompt(

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -297,17 +297,24 @@ class VegaLiteAgent(BaseCodeAgent):
             return None
 
     def _prepare_vision_messages(
-        self, messages: list[Message], out: LumenEditor | None, content: str
+        self, messages: list[Message], out: LumenEditor | None, content: str,
+        text_fallback: bool = False
     ) -> list[Message]:
-        """Add plot image to messages for LLM vision analysis."""
+        """Add plot image to messages for LLM vision analysis.
+
+        When *text_fallback* is True the content string is always
+        appended as a plain-text user message if vision is unavailable
+        or image export fails, so the instruction is never lost.
+        """
+        fallback = messages + [{"role": "user", "content": content}] if text_fallback else messages
         if not self.llm._supports_vision:
-            return messages
+            return fallback
         if out is None or not isinstance(out, VegaLiteEditor):
-            return messages
+            return fallback
 
         image_bytes = self._export_plot_image(out)
         if image_bytes is None:
-            return messages
+            return fallback
 
         base64_str = base64.b64encode(image_bytes).decode('utf-8')
         plot_image = Image.from_raw_base64(base64_str)
@@ -741,7 +748,7 @@ class VegaLiteAgent(BaseCodeAgent):
         str
             Updated specification with annotations
         """
-        messages = self._prepare_vision_messages(messages, view, f"Annotate this chart: {instruction!r}")
+        messages = self._prepare_vision_messages(messages, view, f"Annotate this chart: {instruction!r}", text_fallback=True)
 
         vega_spec = dump_yaml(spec["spec"], default_flow_style=False)
         result = await self._invoke_prompt(
@@ -749,7 +756,6 @@ class VegaLiteAgent(BaseCodeAgent):
             messages,
             context,
             vega_spec=vega_spec,
-            instruction=instruction,
         )
         update_dict = load_yaml(result.yaml_update)
 

--- a/lumen/ai/controls/revision.py
+++ b/lumen/ai/controls/revision.py
@@ -153,7 +153,7 @@ class AnnotationControls(RevisionControls):
         try:
             with self.task.actor.param.update(interface=self.interface), self.view.editor.param.update(loading=True):
                 new_spec = await self.task.actor.annotate(
-                    self.instruction, list(self.task.history), self.task.out_context, {"spec": load_yaml(self.view.spec)}
+                    self.instruction, list(self.task.history), self.task.out_context, {"spec": load_yaml(self.view.spec)}, self.view
                 )
         except Exception as e:
             self._report_status(f"```\n{e}\n```", title="❌ Failed to generate annotations")

--- a/lumen/ai/prompts/VegaLiteAgent/annotate_plot.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/annotate_plot.jinja2
@@ -43,6 +43,8 @@ Point: `type, color, size, filled, shape`
 {% endblock %}
 
 {% block context %}
+User's annotation request: {{ instruction }}
+
 Build off the following Vega-Lite yaml:
 ```yaml
 {{ vega_spec | safe }}

--- a/lumen/ai/prompts/VegaLiteAgent/annotate_plot.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/annotate_plot.jinja2
@@ -43,8 +43,6 @@ Point: `type, color, size, filled, shape`
 {% endblock %}
 
 {% block context %}
-User's annotation request: {{ instruction }}
-
 Build off the following Vega-Lite yaml:
 ```yaml
 {{ vega_spec | safe }}

--- a/lumen/tests/ai/test_controls/test_revision.py
+++ b/lumen/tests/ai/test_controls/test_revision.py
@@ -775,6 +775,38 @@ class TestAnnotationControls:
                 assert "Failed to apply annotations" in card.title
                 
     @pytest.mark.asyncio
+    async def test_annotate_passes_view_to_actor(self):
+        """Test _annotate passes view to actor.annotate for vision analysis.
+
+        Without passing view, the LLM may receive no user messages
+        (only a system prompt), causing providers like Google Gemini
+        to reject the request.
+        """
+        interface = MockInterface()
+        view = MockView(spec="type: bar")
+        task = MockTask()
+
+        task.actor.annotate = AsyncMock(return_value="annotated spec")
+        task.history = []
+        task.out_context = {}
+
+        controls = AnnotationControls(
+            interface=interface,
+            view=view,
+            task=task
+        )
+
+        with patch('lumen.ai.controls.revision.load_yaml', return_value={"type": "bar"}):
+            with patch('lumen.ai.controls.revision.generate_diff', return_value=""):
+                controls.instruction = "Highlight peaks"
+                await controls._annotate()
+
+                # Verify view was passed as the 5th argument
+                call_args = task.actor.annotate.call_args[0]
+                assert len(call_args) == 5
+                assert call_args[4] is view
+
+    @pytest.mark.asyncio
     async def test_annotate_uses_load_yaml(self):
         """Test _annotate properly loads and passes spec to annotate method."""
         interface = MockInterface()

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -302,18 +302,11 @@ class TestPrepareVisionMessages:
             agent.llm = llm
         return agent
 
-    def test_no_vision_no_fallback(self, agent):
-        """Without text_fallback, returns messages unchanged when vision unsupported."""
-        agent.llm._supports_vision = False
-        msgs = [{"role": "user", "content": "hello"}]
-        result = agent._prepare_vision_messages(msgs, None, "Annotate this")
-        assert result is msgs
-
     def test_no_vision_with_fallback(self, agent):
         """With text_fallback, appends text-only message when vision unsupported."""
         agent.llm._supports_vision = False
         msgs = [{"role": "user", "content": "hello"}]
-        result = agent._prepare_vision_messages(msgs, None, "Annotate this", text_fallback=True)
+        result = agent._prepare_vision_messages(msgs, None, "Annotate this")
         assert len(result) == 2
         assert result[1] == {"role": "user", "content": "Annotate this"}
 
@@ -328,20 +321,9 @@ class TestPrepareVisionMessages:
         """With text_fallback, appends text-only message when editor is None."""
         agent.llm._supports_vision = True
         msgs = [{"role": "user", "content": "hello"}]
-        result = agent._prepare_vision_messages(msgs, None, "Annotate this", text_fallback=True)
+        result = agent._prepare_vision_messages(msgs, None, "Annotate this")
         assert len(result) == 2
         assert result[1] == {"role": "user", "content": "Annotate this"}
-
-    def test_image_export_fails_no_fallback(self, agent):
-        """Without text_fallback, returns messages unchanged when image export fails."""
-        agent.llm._supports_vision = True
-        mock_editor = MagicMock()
-        mock_editor.__class__ = type("VegaLiteEditor", (), {})
-        msgs = [{"role": "user", "content": "hello"}]
-        with patch.object(agent, '_export_plot_image', return_value=None):
-            with patch('lumen.ai.agents.vega_lite.VegaLiteEditor', mock_editor.__class__):
-                result = agent._prepare_vision_messages(msgs, mock_editor, "Annotate this")
-        assert result is msgs
 
     def test_image_export_fails_with_fallback(self, agent):
         """With text_fallback, appends text-only message when image export fails."""
@@ -351,7 +333,7 @@ class TestPrepareVisionMessages:
         msgs = [{"role": "user", "content": "hello"}]
         with patch.object(agent, '_export_plot_image', return_value=None):
             with patch('lumen.ai.agents.vega_lite.VegaLiteEditor', mock_editor.__class__):
-                result = agent._prepare_vision_messages(msgs, mock_editor, "Annotate this", text_fallback=True)
+                result = agent._prepare_vision_messages(msgs, mock_editor, "Annotate this")
         assert len(result) == 2
         assert result[1] == {"role": "user", "content": "Annotate this"}
 
@@ -369,7 +351,7 @@ class TestPrepareVisionMessages:
         msgs = [{"role": "user", "content": "hello"}]
         with patch.object(agent, '_export_plot_image', return_value=fake_png):
             with patch('lumen.ai.agents.vega_lite.VegaLiteEditor', mock_editor.__class__):
-                result = agent._prepare_vision_messages(msgs, mock_editor, "Annotate this", text_fallback=True)
+                result = agent._prepare_vision_messages(msgs, mock_editor, "Annotate this")
         assert len(result) == 2
         content = result[1]["content"]
         assert isinstance(content, list)

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -310,13 +310,6 @@ class TestPrepareVisionMessages:
         assert len(result) == 2
         assert result[1] == {"role": "user", "content": "Annotate this"}
 
-    def test_no_editor_no_fallback(self, agent):
-        """Without text_fallback, returns messages unchanged when editor is None."""
-        agent.llm._supports_vision = True
-        msgs = [{"role": "user", "content": "hello"}]
-        result = agent._prepare_vision_messages(msgs, None, "Annotate this")
-        assert result is msgs
-
     def test_no_editor_with_fallback(self, agent):
         """With text_fallback, appends text-only message when editor is None."""
         agent.llm._supports_vision = True

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -294,8 +294,12 @@ class TestPrepareVisionMessages:
 
     @pytest.fixture
     def agent(self, llm):
+        import warnings
         agent = VegaLiteAgent.__new__(VegaLiteAgent)
-        agent.llm = llm
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            warnings.simplefilter("ignore", PendingDeprecationWarning)
+            agent.llm = llm
         return agent
 
     def test_no_vision_no_fallback(self, agent):

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -3,11 +3,14 @@
 import base64
 import os
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 try:
     import lumen.ai as lmai
 
+    from lumen.ai.agents.vega_lite import VegaLiteAgent
     from lumen.ai.llm import (
         Anthropic, AzureOpenAI, Google, Groq, Message, MistralAI, OpenAI,
     )
@@ -280,3 +283,92 @@ class TestCheckForImage:
         assert content[0] == "Compare:"
         assert isinstance(content[1], Image)
         assert isinstance(content[2], Image)
+
+
+# ---------------------------------------------------------------------------
+# _prepare_vision_messages tests
+# ---------------------------------------------------------------------------
+
+class TestPrepareVisionMessages:
+    """Tests for VegaLiteAgent._prepare_vision_messages fallback behavior."""
+
+    @pytest.fixture
+    def agent(self, llm):
+        agent = VegaLiteAgent.__new__(VegaLiteAgent)
+        agent.llm = llm
+        return agent
+
+    def test_no_vision_no_fallback(self, agent):
+        """Without text_fallback, returns messages unchanged when vision unsupported."""
+        agent.llm._supports_vision = False
+        msgs = [{"role": "user", "content": "hello"}]
+        result = agent._prepare_vision_messages(msgs, None, "Annotate this")
+        assert result is msgs
+
+    def test_no_vision_with_fallback(self, agent):
+        """With text_fallback, appends text-only message when vision unsupported."""
+        agent.llm._supports_vision = False
+        msgs = [{"role": "user", "content": "hello"}]
+        result = agent._prepare_vision_messages(msgs, None, "Annotate this", text_fallback=True)
+        assert len(result) == 2
+        assert result[1] == {"role": "user", "content": "Annotate this"}
+
+    def test_no_editor_no_fallback(self, agent):
+        """Without text_fallback, returns messages unchanged when editor is None."""
+        agent.llm._supports_vision = True
+        msgs = [{"role": "user", "content": "hello"}]
+        result = agent._prepare_vision_messages(msgs, None, "Annotate this")
+        assert result is msgs
+
+    def test_no_editor_with_fallback(self, agent):
+        """With text_fallback, appends text-only message when editor is None."""
+        agent.llm._supports_vision = True
+        msgs = [{"role": "user", "content": "hello"}]
+        result = agent._prepare_vision_messages(msgs, None, "Annotate this", text_fallback=True)
+        assert len(result) == 2
+        assert result[1] == {"role": "user", "content": "Annotate this"}
+
+    def test_image_export_fails_no_fallback(self, agent):
+        """Without text_fallback, returns messages unchanged when image export fails."""
+        agent.llm._supports_vision = True
+        mock_editor = MagicMock()
+        mock_editor.__class__ = type("VegaLiteEditor", (), {})
+        msgs = [{"role": "user", "content": "hello"}]
+        with patch.object(agent, '_export_plot_image', return_value=None):
+            with patch('lumen.ai.agents.vega_lite.VegaLiteEditor', mock_editor.__class__):
+                result = agent._prepare_vision_messages(msgs, mock_editor, "Annotate this")
+        assert result is msgs
+
+    def test_image_export_fails_with_fallback(self, agent):
+        """With text_fallback, appends text-only message when image export fails."""
+        agent.llm._supports_vision = True
+        mock_editor = MagicMock()
+        mock_editor.__class__ = type("VegaLiteEditor", (), {})
+        msgs = [{"role": "user", "content": "hello"}]
+        with patch.object(agent, '_export_plot_image', return_value=None):
+            with patch('lumen.ai.agents.vega_lite.VegaLiteEditor', mock_editor.__class__):
+                result = agent._prepare_vision_messages(msgs, mock_editor, "Annotate this", text_fallback=True)
+        assert len(result) == 2
+        assert result[1] == {"role": "user", "content": "Annotate this"}
+
+    def test_vision_success_returns_image_message(self, agent):
+        """When vision succeeds, appends message with [content, Image]."""
+        agent.llm._supports_vision = True
+        mock_editor = MagicMock()
+        mock_editor.__class__ = type("VegaLiteEditor", (), {})
+        fake_png = (
+            b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01'
+            b'\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00'
+            b'\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00'
+            b'\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82'
+        )
+        msgs = [{"role": "user", "content": "hello"}]
+        with patch.object(agent, '_export_plot_image', return_value=fake_png):
+            with patch('lumen.ai.agents.vega_lite.VegaLiteEditor', mock_editor.__class__):
+                result = agent._prepare_vision_messages(msgs, mock_editor, "Annotate this", text_fallback=True)
+        assert len(result) == 2
+        content = result[1]["content"]
+        assert isinstance(content, list)
+        assert len(content) == 2
+        assert content[0] == "Annotate this"
+        assert isinstance(content[1], Image)


### PR DESCRIPTION
## Description

I discovered while testing Lumen AI with Google Gemini that clicking the "Add annotations" button on a Vega-Lite chart always fails. I traced three issues in the annotation pipeline:

1. **`AnnotationControls._annotate()` did not pass `self.view` to `actor.annotate()`**, so `_prepare_vision_messages()` received `None` and skipped adding the chart image. This left the LLM with no user messages, causing Google Gemini to reject the request with *"At least one user message must be included"*.

2. **`_check_for_image()` in `llm.py` destroyed list content** when serializing images. A message with content `[text, Image]` was replaced with just the serialized `Image`, losing the text instruction entirely.


3. **`Google.run_client()` let instructor auto-detect image content** and apply `HARM_CATEGORY_IMAGE_*` safety settings that are not supported by the Google GenAI v1beta API, causing a `400 INVALID_ARGUMENT` error.

### Before (error when clicking annotate)
<img width="1217" height="764" alt="before-annotation-bug-2" src="https://github.com/user-attachments/assets/e76563a3-d1c5-427c-9383-fc0326ea46d1" />

### After (annotation applied successfully)
<img width="1217" height="764" alt="after-annotation-working" src="https://github.com/user-attachments/assets/c29948e2-d0bb-45a4-91c4-6f2d89f5b55f" />

<img width="1469" height="836" alt="Screenshot 2026-03-11 at 1 44 42 PM" src="https://github.com/user-attachments/assets/d4d68580-fc45-4fa1-b5f7-dea97274fa3b" />


## Fixes

- Pass `self.view` as 5th argument to `annotate()` in `revision.py`
- Add a text-only user message in `vega_lite.py` `annotate()` before `_prepare_vision_messages()` so the instruction text survives serialization
- Preserve all list items in `_check_for_image()` instead of overwriting the list with a single serialized image
- Pass `safety_settings=[]` in `Google.run_client()` to bypass instructor unsupported image safety categories

## How Has This Been Tested?

- Added regression test `test_annotate_passes_view_to_actor` verifying the view is passed as the 5th argument
- All 317 AI tests pass
- Manually tested end-to-end: uploaded CSV, created bar chart, clicked "Add annotations", typed "Highlight the highest revenue product" -- annotation was successfully applied with "Top Seller ($45.1k)" label

## Checklist

- [x] Tests added and passing
- [ ] Added documentation

## AI Disclosure

I identified the bug through hands-on testing of Lumen AI with Google Gemini, traced the root cause through the code, and designed the fix. AI tools assisted with scaffolding the implementation.