### PR TITLE
feat: add JSON and Markdown export formats to SQLEditor

### DIFF
--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -21,29 +21,31 @@ ChatMessage.default_avatars.update({
 })
 
 FORMAT_ICONS = {
-    "csv":   "table_chart",
-    "html":  "html",
-    "jpeg":  "photo_camera_back",
-    "json":  "data_object",
-    "pdf":   "picture_as_pdf",
-    "png":   "image",
-    "sql":   "code",
-    "svg":   "polyline",
-    "xlsx":  "grid_on",
-    "yaml":  "segment",
+    "csv":      "table_chart",
+    "html":     "html",
+    "jpeg":     "photo_camera_back",
+    "json":     "data_object",
+    "markdown": "format_list_bulleted",
+    "pdf":      "picture_as_pdf",
+    "png":      "image",
+    "sql":      "code",
+    "svg":      "polyline",
+    "xlsx":     "grid_on",
+    "yaml":     "segment",
 }
 
 FORMAT_LABELS = {
-    "csv": "CSV",
-    "html": "HTML",
-    "jpeg": "JPEG",
-    "json": "JSON",
-    "pdf": "PDF",
-    "png": "PNG",
-    "sql": "SQL",
-    "svg": "SVG",
-    "xlsx": "Excel",
-    "yaml": "YAML",
+    "csv":      "CSV",
+    "html":     "HTML",
+    "jpeg":     "JPEG",
+    "json":     "JSON",
+    "markdown": "Markdown",
+    "pdf":      "PDF",
+    "png":      "PNG",
+    "sql":      "SQL",
+    "svg":      "SVG",
+    "xlsx":     "Excel",
+    "yaml":     "YAML",
 }
 
 class UserCancelledError(Exception):

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -600,23 +600,11 @@ class SQLEditor(LumenEditor):
         data = self.component.data
         if fmt == 'sql':
             return StringIO(self.spec)
-        elif fmt == 'csv':
+        elif fmt in ('csv', 'xlsx'):
             sio = StringIO()
-            data.to_csv(sio, index=False)
+            data.to_csv(sio)
             sio.seek(0)
             return sio
-        elif fmt == 'xlsx':
-            try:
-                import openpyxl  # noqa: F401
-            except ImportError:
-                raise ImportError(
-                    "Excel export requires openpyxl. "
-                    "Install it with: pip install openpyxl"
-                )
-            bio = BytesIO()
-            data.to_excel(bio, index=False)
-            bio.seek(0)
-            return bio
         elif fmt == 'json':
             sio = StringIO()
             data.to_json(sio, orient='records', indent=2)

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -600,21 +600,15 @@ class SQLEditor(LumenEditor):
         data = self.component.data
         if fmt == 'sql':
             return StringIO(self.spec)
-        elif fmt in ('csv', 'xlsx'):
-            sio = StringIO()
+        sio = StringIO()
+        if fmt in ('csv', 'xlsx'):
             data.to_csv(sio)
-            sio.seek(0)
-            return sio
         elif fmt == 'json':
-            sio = StringIO()
             data.to_json(sio, orient='records', indent=2)
-            sio.seek(0)
-            return sio
         elif fmt == 'markdown':
-            sio = StringIO()
             sio.write(data.to_markdown(index=False))
-            sio.seek(0)
-            return sio
+        sio.seek(0)
+        return sio
 
     def render_explorer(self):
         return GraphicWalker(

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -592,17 +592,41 @@ class SQLEditor(LumenEditor):
 
     language = "sql"
 
-    export_formats = ("sql", "csv", "xlsx")
+    export_formats = ("sql", "csv", "xlsx", "json", "markdown")
     _label = "Table"
 
-    def export(self, fmt: str) -> str | bytes:
+    def export(self, fmt: str) -> StringIO | BytesIO:
         super().export(fmt)
+        data = self.component.data
         if fmt == 'sql':
             return StringIO(self.spec)
-        sio = StringIO()
-        self.component.data.to_csv(sio)
-        sio.seek(0)
-        return sio
+        elif fmt == 'csv':
+            sio = StringIO()
+            data.to_csv(sio, index=False)
+            sio.seek(0)
+            return sio
+        elif fmt == 'xlsx':
+            try:
+                import openpyxl  # noqa: F401
+            except ImportError:
+                raise ImportError(
+                    "Excel export requires openpyxl. "
+                    "Install it with: pip install openpyxl"
+                )
+            bio = BytesIO()
+            data.to_excel(bio, index=False)
+            bio.seek(0)
+            return bio
+        elif fmt == 'json':
+            sio = StringIO()
+            data.to_json(sio, orient='records', indent=2)
+            sio.seek(0)
+            return sio
+        elif fmt == 'markdown':
+            sio = StringIO()
+            sio.write(data.to_markdown(index=False))
+            sio.seek(0)
+            return sio
 
     def render_explorer(self):
         return GraphicWalker(

--- a/lumen/tests/ai/test_editors.py
+++ b/lumen/tests/ai/test_editors.py
@@ -1,5 +1,62 @@
 """Tests for lumen.ai.editors module."""
-from lumen.ai.editors import LumenEditor
+import json
+
+import pandas as pd
+import param
+import pytest
+
+import lumen.ai.editors as editors_module
+
+from lumen.ai.editors import LumenEditor, SQLEditor
+from lumen.base import Component
+
+
+class MockComponent(Component):
+    """Minimal component for testing editor exports."""
+
+    data = param.Parameter()
+
+    table = param.String(default="test")
+
+
+@pytest.fixture
+def sql_editor(monkeypatch):
+    """Return a SQLEditor with a minimal valid component and spec."""
+    df = pd.DataFrame({'name': ['Alice', 'Bob'], 'age': [30, 25]})
+    component = MockComponent(data=df)
+    monkeypatch.setattr(editors_module, 'ParamMethod', lambda *args, **kwargs: None)
+    return SQLEditor(component=component, spec="SELECT * FROM test")
+
+
+def test_sqleditor_export_sql(sql_editor):
+    result = sql_editor.export('sql')
+    assert 'SELECT' in result.getvalue()
+
+
+def test_sqleditor_export_csv(sql_editor):
+    result = sql_editor.export('csv')
+    content = result.getvalue()
+    assert 'name' in content
+    assert 'Alice' in content
+
+
+def test_sqleditor_export_json(sql_editor):
+    result = sql_editor.export('json')
+    data = json.loads(result.getvalue())
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]['name'] == 'Alice'
+
+
+def test_sqleditor_export_markdown(sql_editor):
+    result = sql_editor.export('markdown')
+    content = result.getvalue()
+    assert '|' in content  # markdown tables use pipes
+    assert 'name' in content
+    assert 'Alice' in content
+
+
+
 
 
 def test_class_name_to_filename():


### PR DESCRIPTION
### Description

This PR adds two new export formats to the SQL editor's table export functionality: **JSON** and **Markdown**, enabling users to export query results in more flexible formats for documentation, web APIs, and modern data workflows.

### Before: 

<img width="336" height="245" alt="image" src="https://github.com/user-attachments/assets/0bb20ba9-8bf8-450f-bace-b83480d00bcf" />

**Took inspiration from a VScode database extension:**
<img width="1174" height="400" alt="image" src="https://github.com/user-attachments/assets/c97ea756-eabf-4884-b01b-7024d81a641e" />

**The implementation:**

- Adds `json` and `markdown` to `SQLEditor.export_formats`
- Implements proper serialization for each format in the `export()` method
- Adds corresponding icons and labels to `FORMAT_ICONS` and `FORMAT_LABELS` in config for UI consistency
- Uses existing pandas methods (`to_json()` with `orient='records'` and `to_markdown()`) — no new dependencies required

### After the fix:
Checked every formats one by one (including existing) to ensure it doesn't break anything.

https://github.com/user-attachments/assets/1051a2a9-84af-4282-a9a8-7dfa55217022

**Formats now supported:**

- SQL
- CSV
- Excel
- **JSON** — new, exports as JSON array with indentation for readability
- **Markdown** — new, exports as GitHub-style markdown table

Fixes #1742

### How Has This Been Tested?

Tested in the Lumen AI UI by:

1. Running `pixi run lumen-ai serve --provider google`
2. Creating a query and running it
3. Clicking "Export Table as" menu
4. Verifying each format downloads correctly:
   - JSON: Valid JSON array with records
   - Markdown: Properly formatted markdown table
   - CSV & Excel: Existing formats still work as before
   - SQL: Query export unchanged

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.
    - Tools: GitHub Copilot (Claude Haiku 4.5)
### Checklist

- [x] No new dependencies added
- [x] Existing formats (SQL, CSV, Excel) remain unchanged
- [x] UI icons and labels added for new formats
- [x] Code follows existing patterns in the export system
- [x] Tested in Lumen AI UI with live query results