### PR TITLE
Fix download controls using stale URL text after cancel

### DIFF
--- a/lumen/ai/controls/download.py
+++ b/lumen/ai/controls/download.py
@@ -261,7 +261,7 @@ class DownloadControls(BaseSourceControls):
 
     def _handle_urls(self, event):
         """Handle URL input and trigger downloads"""
-        url_text = self._url_input.value
+        url_text = self._url_input.value_input or self._url_input.value
         if not url_text:
             return
 


### PR DESCRIPTION
## Description
When a user starts a download, cancels it mid-way, changes the URL in the text field, and hits Shift+Enter, the download controls re-download the **old** URL instead of the new one.

### Root cause

`_handle_urls` reads `self._url_input.value`, which is the param-synced value that only updates on blur or enter commit. When `enter_pressed` fires, the `value` param still holds the old text because the new keystrokes haven't been committed yet.

### Fix

Read `self._url_input.value_input` instead, which reflects every keystroke from the browser in real time. Falls back to `self._url_input.value` for the initial state when `value_input` is empty.

```python
# Before
url_text = self._url_input.value

# After
url_text = self._url_input.value_input or self._url_input.value
```
After fix :

https://github.com/user-attachments/assets/75876ad0-242c-4951-aaa1-e3381479526c


### How I found this

While testing PR #1736 (download done_callback fix), I noticed that after cancelling a download and changing the URL, Shift+Enter would re-download the old URL.

## How Has This Been Tested?

Manually verified in Lumen AI UI:
1. Enter a URL, Shift+Enter to start download
2. Cancel mid-download
3. Change URL text to a different URL
4. Shift+Enter again -- now correctly downloads the new URL

## Checklist

- [ ] Tests added and passing
- [ ] Added documentation

## AI Disclosure

I identified this bug while manually testing PR #1736. AI assisted with tracing the param sync behaviour to find the root cause, fixed it by myself, tested manuallly 