### PR TITLE
Add FillNA transform as counterpart to DropNA

### DIFF
--- a/lumen/tests/transforms/test_base.py
+++ b/lumen/tests/transforms/test_base.py
@@ -5,7 +5,7 @@ import pandas as pd
 import param  # type: ignore
 
 from lumen.transforms.base import (
-    Count, DropNA, Eval, Sum, Transform, project_lnglat,
+    Count, DropNA, Eval, FillNA, Sum, Transform, project_lnglat,
 )
 
 
@@ -80,6 +80,25 @@ def test_dropna_transform(mixed_df):
     assert len(DropNA.apply_to(mixed_df, how='all')) == 5
     assert len(DropNA.apply_to(mixed_df, axis=1).columns) == 3
     assert len(DropNA.apply_to(mixed_df, axis=1, how='all').columns) == 4
+
+
+def test_fillna_transform_value(mixed_df):
+    mixed_df.loc[1, 'A'] = float('NaN')
+    result = FillNA.apply_to(mixed_df, value=0)
+    assert result.loc[1, 'A'] == 0
+    assert not result['A'].isna().any()
+
+
+def test_fillna_transform_ffill(mixed_df):
+    mixed_df.loc[1, 'A'] = float('NaN')
+    result = FillNA.apply_to(mixed_df, method='ffill')
+    assert result.loc[1, 'A'] == mixed_df.loc[0, 'A']
+
+
+def test_fillna_transform_bfill(mixed_df):
+    mixed_df.loc[1, 'A'] = float('NaN')
+    result = FillNA.apply_to(mixed_df, method='bfill')
+    assert result.loc[1, 'A'] == mixed_df.loc[2, 'A']
 
 
 def test_project_lnglat_default_params():

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -884,6 +884,45 @@ class DropNA(Transform):
         return table.dropna(**kwargs)
 
 
+class FillNA(Transform):
+    """
+    `FillNA` fills missing values.
+
+    `df.fillna(value=<value>)` or `df.ffill()` / `df.bfill()`
+    """
+
+    value = param.Parameter(default=None, doc="""
+        Value to use to fill holes (e.g. 0). Can also be a dict/Series
+        for per-column fill values. Cannot be used together with method.""")
+
+    method = param.Selector(default=None, objects=[None, 'bfill', 'ffill'], doc="""
+        Method to use for filling holes.
+        ffill: propagate last valid observation forward.
+        bfill: use next valid observation to fill gap.""")
+
+    limit = param.Integer(default=None, doc="""
+        Maximum number of consecutive NaN values to forward/backward fill.
+        Only used when method is specified.""")
+
+    axis = param.ClassSelector(default=None, class_=(int, str), doc="""
+        Axis along which to fill missing values.
+        0 or 'index', 1 or 'columns'.""")
+
+    transform_type: ClassVar[str] = 'fillna'
+
+    def apply(self, table: DataFrame) -> DataFrame:
+        if self.method == 'ffill':
+            return table.ffill(limit=self.limit, axis=self.axis)
+        elif self.method == 'bfill':
+            return table.bfill(limit=self.limit, axis=self.axis)
+        kwargs = {}
+        if self.value is not None:
+            kwargs['value'] = self.value
+        if self.axis is not None:
+            kwargs['axis'] = self.axis
+        return table.fillna(**kwargs)
+
+
 class Corr(Transform):
     """
     ``Corr`` computes pairwise correlation of columns, excluding NA/null values.


### PR DESCRIPTION
## Summary

`DropNA` exists for removing rows with missing values, but there is no way to *fill* missing values instead of dropping them. This adds `FillNA` as the natural counterpart.


## What this adds

**`FillNA` transform** with three fill strategies:
- **Constant value**: `FillNA(value=0)` fills NaN with a fixed value
- **Forward fill**: `FillNA(method='ffill')` propagates last valid observation forward
- **Backward fill**: `FillNA(method='bfill')` uses next valid observation to fill gaps

Also supports `limit` (max consecutive fills) and `axis` parameters.

### Example usage in YAML pipeline:
```yaml
transforms:
  - type: fillna
    method: ffill
```

### Example usage in Python:
```python
FillNA.apply_to(df, method='ffill')
FillNA.apply_to(df, value=0)
FillNA.apply_to(df, method='bfill', limit=3)
```

## Implementation notes

- Uses `df.ffill()` / `df.bfill()` instead of the deprecated `fillna(method=...)` for pandas 2.x compatibility
- Follows the exact same pattern as `DropNA` (same param types, same conditional kwargs approach)
- Auto-registered via the existing `__all__` mechanism, no other files need changes

## Tests

3 new tests covering value fill, forward fill, and backward fill. All existing tests continue to pass.

## Question for maintainers

Would `Rolling` (rolling window operations like 3-day moving average) and `DatetimeParts` (extract year/month/day/weekday from datetime columns) also be useful additions? Happy to open separate PRs for those if there is interest.

## AI Disclosure

I planned the approach and identified this gap from my own usage. Used AI to help scaffold the implementation and tests, but reviewed every line against the existing DropNA pattern to make sure it matches codebase conventions.