### PR TITLE
Fix Table view horizontal overflow with long string columns

### DIFF
--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -10,7 +10,7 @@ from lumen.sources.base import FileSource
 from lumen.state import state
 from lumen.variables.base import Variables
 from lumen.views.base import (
-    Panel, VegaLiteView, View, hvOverlayView, hvPlotView,
+    Panel, Table, VegaLiteView, View, hvOverlayView, hvPlotView,
 )
 
 
@@ -220,6 +220,29 @@ def test_hvplot_view_to_spec(set_root):
         'y': 'B',
         'alpha': 0.3
     }
+
+def test_table_layout_defaults(set_root):
+    set_root(str(Path(__file__).parent.parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    view = View.from_spec({'type': 'table', 'table': 'test'}, source, [])
+    panel = view.get_panel()
+    assert panel.sizing_mode == 'stretch_width'
+    assert panel.layout == 'fit_data_stretch'
+    assert panel._configuration.get('columnDefaults', {}).get('maxInitialWidth') == 300
+
+
+def test_table_user_configuration_merges(set_root):
+    set_root(str(Path(__file__).parent.parent))
+    source = FileSource(tables={'test': 'sources/test.csv'})
+    table = Table(
+        pipeline=Pipeline(source=source, table='test'),
+        configuration={'columnDefaults': {'maxInitialWidth': 500, 'headerSort': False}},
+    )
+    panel = table.get_panel()
+    config = panel._configuration
+    assert config['columnDefaults']['maxInitialWidth'] == 500
+    assert config['columnDefaults']['headerSort'] is False
+
 
 @pytest.mark.parametrize("view_type", ("table", "hvplot"))
 def test_view_title(set_root, view_type):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1163,11 +1163,24 @@ class Table(View):
     _panel_type = pn.widgets.tables.Tabulator
 
     def get_panel(self):
-        return self._panel_type(**self._normalize_params(self._get_params()))
+        params = self._normalize_params(self._get_params())
+        config = {'columnDefaults': {'maxInitialWidth': 300}}
+        if 'configuration' in self.kwargs:
+            config.update(self.kwargs['configuration'])
+        params['configuration'] = config
+        return self._panel_type(**params)
 
     def _get_params(self):
-        return dict(value=self.get_data(), disabled=True, page_size=self.page_size,
-                    **self.kwargs)
+        kwargs = {k: v for k, v in self.kwargs.items() if k != 'configuration'}
+        params = dict(
+            value=self.get_data(),
+            disabled=True,
+            page_size=self.page_size,
+            sizing_mode='stretch_width',
+            layout='fit_data_stretch',
+        )
+        params.update(kwargs)
+        return params
 
 
 class DownloadView(View):


### PR DESCRIPTION
## Description

I was exploring an Amazon product reviews dataset using Lumen AI and noticed that when the Table view renders columns containing long text (like review bodies or metadata strings), the Tabulator scrolls endlessly to the right. The table becomes unusable because columns stretch to fit the full text content, pushing the layout way beyond the viewport.

I fixed this by setting sensible defaults on the `Table` view:

- `layout='fit_data_stretch'` - columns fit their content but stretch to fill available width
- `sizing_mode='stretch_width'` - table respects the container width
- `maxInitialWidth: 300` via Tabulator's `columnDefaults` config - caps the initial column width so long strings don't blow out the layout

Columns are still resizable by dragging, so users can widen any column to see full content. If a user passes their own `configuration` kwarg, it merges on top of the defaults so nothing is lost.

### Before

https://github.com/user-attachments/assets/bd0d5b6b-b52f-48c9-bb5d-bb0084c62bd6

### After

https://github.com/user-attachments/assets/99922015-11a3-42df-a744-766beb983582

## How Has This Been Tested?

- Tested with a 999-row Amazon reviews dataset containing review text up to 11K characters
- Verified on both Lumen YAML dashboards and Lumen AI
- Added 2 unit tests: one for default layout params, one for user configuration merging
- All 25 existing view tests pass

## Checklist

- [x] Tests added and is passing
- [ ] Added documentation