### PR TITLE
feat: Add WebP, TIFF and EPS export formats to VegaLiteEditor

### DIFF
--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -22,6 +22,7 @@ ChatMessage.default_avatars.update({
 
 FORMAT_ICONS = {
     "csv":      "table_chart",
+    "eps":      "brush",
     "html":     "html",
     "jpeg":     "photo_camera_back",
     "json":     "data_object",
@@ -30,12 +31,15 @@ FORMAT_ICONS = {
     "png":      "image",
     "sql":      "code",
     "svg":      "polyline",
+    "tiff":     "photo_library",
+    "webp":     "filter",
     "xlsx":     "grid_on",
     "yaml":     "segment",
 }
 
 FORMAT_LABELS = {
     "csv":      "CSV",
+    "eps":      "EPS",
     "html":     "HTML",
     "jpeg":     "JPEG",
     "json":     "JSON",
@@ -44,6 +48,8 @@ FORMAT_LABELS = {
     "png":      "PNG",
     "sql":      "SQL",
     "svg":      "SVG",
+    "tiff":     "TIFF",
+    "webp":     "WebP",
     "xlsx":     "Excel",
     "yaml":     "YAML",
 }

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -285,7 +285,9 @@ class LumenEditor(Viewer):
 
 class VegaLiteEditor(LumenEditor):
 
-    export_formats = ("yaml", "png", "jpeg", "pdf", "svg", "html")
+    export_formats = ("yaml", "png", "jpeg", "pdf", "svg", "html", "webp", "tiff", "eps")
+
+    _PILLOW_FORMATS = ("webp", "tiff", "eps")
 
     _controls = [RetryControls, AnnotationControls, CopyControls]
     _label = "Plot"
@@ -294,20 +296,28 @@ class VegaLiteEditor(LumenEditor):
         ret = super().export(fmt)
         if ret is not None:
             return ret
-        kwargs = {"scale": 2} if fmt in ("png", "jpeg", "pdf") else {}
-        # Replace 'container' with actual dimensions for image and HTML exports
-        if fmt in ("png", "jpeg", "pdf", "svg", "html"):
-            spec = load_yaml(self.spec)
-            # Replace 'container' with actual pixel values or use defaults
-            if spec.get("width") == "container" or "width" not in spec:
-                spec["width"] = 800
-            if spec.get("height") == "container" or "height" not in spec:
-                spec["height"] = 400
-            # Temporarily update spec for export
-            with self.param.update(spec=dump_yaml(spec)):
-                out = self.component.get_panel().export(fmt, **kwargs)
-            return BytesIO(out) if isinstance(out, bytes) else StringIO(out)
-        out = self.component.get_panel().export(fmt, **kwargs)
+
+        render_fmt = "png" if fmt in self._PILLOW_FORMATS else fmt
+        kwargs = {"scale": 2} if render_fmt in ("png", "jpeg", "pdf") else {}
+
+        spec = load_yaml(self.spec)
+        if spec.get("width") == "container" or "width" not in spec:
+            spec["width"] = 800
+        if spec.get("height") == "container" or "height" not in spec:
+            spec["height"] = 400
+        with self.param.update(spec=dump_yaml(spec)):
+            out = self.component.get_panel().export(render_fmt, **kwargs)
+
+        if fmt in self._PILLOW_FORMATS:
+            from PIL import Image
+            img = Image.open(BytesIO(out))
+            if fmt == "eps":
+                img = img.convert("RGB")
+            buf = BytesIO()
+            img.save(buf, format=fmt.upper())
+            buf.seek(0)
+            return buf
+
         return BytesIO(out) if isinstance(out, bytes) else StringIO(out)
 
     @cache

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -14,7 +14,6 @@ import param
 import requests
 
 from jsonschema import Draft7Validator, ValidationError
-from PIL import Image
 from panel.config import config
 from panel.io import cache
 from panel.layout import Column, Row
@@ -29,6 +28,7 @@ from panel_material_ui import (
     Alert, Button, Checkbox, CircularProgress, FileDownload, FlexBox,
     FloatInput, MenuButton, Tabs,
 )
+from PIL import Image
 
 from ..base import Component
 from ..config import dump_yaml, load_yaml

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -14,6 +14,7 @@ import param
 import requests
 
 from jsonschema import Draft7Validator, ValidationError
+from PIL import Image
 from panel.config import config
 from panel.io import cache
 from panel.layout import Column, Row
@@ -287,7 +288,7 @@ class VegaLiteEditor(LumenEditor):
 
     export_formats = ("yaml", "png", "jpeg", "pdf", "svg", "html", "webp", "tiff", "eps")
 
-    _PILLOW_FORMATS = ("webp", "tiff", "eps")
+    _pillow_formats = ("webp", "tiff", "eps")
 
     _controls = [RetryControls, AnnotationControls, CopyControls]
     _label = "Plot"
@@ -297,7 +298,8 @@ class VegaLiteEditor(LumenEditor):
         if ret is not None:
             return ret
 
-        render_fmt = "png" if fmt in self._PILLOW_FORMATS else fmt
+        # vl-convert doesn't support webp/tiff/eps; render as png first, then convert with Pillow
+        render_fmt = "png" if fmt in self._pillow_formats else fmt
         kwargs = {"scale": 2} if render_fmt in ("png", "jpeg", "pdf") else {}
 
         spec = load_yaml(self.spec)
@@ -308,8 +310,7 @@ class VegaLiteEditor(LumenEditor):
         with self.param.update(spec=dump_yaml(spec)):
             out = self.component.get_panel().export(render_fmt, **kwargs)
 
-        if fmt in self._PILLOW_FORMATS:
-            from PIL import Image
+        if fmt in self._pillow_formats:
             img = Image.open(BytesIO(out))
             if fmt == "eps":
                 img = img.convert("RGB")

--- a/lumen/tests/ai/test_editors.py
+++ b/lumen/tests/ai/test_editors.py
@@ -1,10 +1,12 @@
 """Tests for lumen.ai.editors module."""
 import json
+
 from io import BytesIO
 
 import pandas as pd
 import param
 import pytest
+
 from PIL import Image
 
 import lumen.ai.editors as editors_module

--- a/lumen/tests/ai/test_editors.py
+++ b/lumen/tests/ai/test_editors.py
@@ -1,13 +1,15 @@
 """Tests for lumen.ai.editors module."""
 import json
+from io import BytesIO
 
 import pandas as pd
 import param
 import pytest
+from PIL import Image
 
 import lumen.ai.editors as editors_module
 
-from lumen.ai.editors import LumenEditor, SQLEditor
+from lumen.ai.editors import LumenEditor, SQLEditor, VegaLiteEditor
 from lumen.base import Component
 
 
@@ -17,6 +19,57 @@ class MockComponent(Component):
     data = param.Parameter()
 
     table = param.String(default="test")
+
+
+class MockVegaComponent(Component):
+    _mock_panel = param.Parameter()
+
+    def get_panel(self):
+        return self._mock_panel
+
+
+def _make_png_bytes(mode="RGBA"):
+    img = Image.new(mode, (10, 10), color=(255, 0, 0, 128) if mode == "RGBA" else (255, 0, 0))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+_MINIMAL_VEGALITE_SPEC = """\
+$schema: https://vega.github.io/schema/vega-lite/v5.json
+mark: bar
+encoding:
+  x:
+    field: A
+    type: quantitative
+  y:
+    field: B
+    type: quantitative
+data:
+  values:
+    - {A: 1, B: 2}
+"""
+
+
+@pytest.fixture
+def mock_panel():
+    class FakePanel:
+        def __init__(self):
+            self.calls = []
+
+        def export(self, fmt, **kwargs):
+            self.calls.append((fmt, kwargs))
+            return _make_png_bytes()
+
+    return FakePanel()
+
+
+@pytest.fixture
+def vegalite_editor(monkeypatch, mock_panel):
+    monkeypatch.setattr(editors_module, 'ParamMethod', lambda *args, **kwargs: None)
+    monkeypatch.setattr(VegaLiteEditor, '_update_component', lambda self, *a, **kw: None)
+    component = MockVegaComponent(_mock_panel=mock_panel)
+    return VegaLiteEditor(component=component, spec=_MINIMAL_VEGALITE_SPEC)
 
 
 @pytest.fixture
@@ -57,6 +110,20 @@ def test_sqleditor_export_markdown(sql_editor):
 
 
 
+def test_vegalite_export_formats_includes_pillow_formats():
+    assert {"webp", "tiff", "eps"} <= set(VegaLiteEditor.export_formats)
+
+
+@pytest.mark.parametrize("fmt,validate", [
+    ("webp", lambda r: Image.open(r).format == "WEBP"),
+    ("tiff", lambda r: Image.open(r).format == "TIFF"),
+    ("eps",  lambda r: r.read().startswith(b"%!PS")),
+])
+def test_vegalite_pillow_export(vegalite_editor, mock_panel, fmt, validate):
+    result = vegalite_editor.export(fmt)
+    assert isinstance(result, BytesIO)
+    assert validate(result)
+    assert mock_panel.calls[-1] == ("png", {"scale": 2})
 
 
 def test_class_name_to_filename():


### PR DESCRIPTION
## Description

The VegaLite editor's `Export Plot as` menu was missing **WebP**, **TIFF**, and **EPS**, formats needed for web dashboards, print/GIS workflows, and LaTeX documents respectively.

Since `vl-convert-python` doesn't support these natively, the export renders PNG via vl-convert first, then converts with Pillow to the target format. No new dependencies required.

### After the fix:

https://github.com/user-attachments/assets/56d2befb-4659-42e3-8d2c-11446f0100e9

Fixes #1752

## How Has This Been Tested?

Added parametrized pytest tests in `lumen/tests/ai/test_editors.py` covering all three new formats, verifying output type, format correctness, and that `scale=2` is passed through to the underlying PNG render.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

Tools and Models: Claude Code + Sonnet 4.6

## Checklist

- [x] Tests added and are passing
- [x] Added documentation
