### PR TITLE
fix: flatten nested JSON objects using json_normalize to prevent [object Object] in table view

### DIFF
--- a/lumen/ai/controls/base.py
+++ b/lumen/ai/controls/base.py
@@ -591,7 +591,7 @@ class BaseSourceControls(Viewer):
             if len(data) == 0:
                 raise ValueError("JSON array is empty")
             if all(isinstance(item, dict) for item in data):
-                return pd.DataFrame(data)
+                return pd.json_normalize(data)
             else:
                 return pd.DataFrame({"value": data})
         elif isinstance(data, dict):
@@ -599,7 +599,7 @@ class BaseSourceControls(Viewer):
             for key in data_keys:
                 if key in data and isinstance(data[key], list):
                     if len(data[key]) > 0 and all(isinstance(item, dict) for item in data[key]):
-                        return pd.DataFrame(data[key])
+                        return pd.json_normalize(data[key])
             if all(isinstance(v, list) for v in data.values()):
                 lengths = [len(v) for v in data.values()]
                 if len(set(lengths)) == 1:

--- a/lumen/tests/ai/test_controls/test_base.py
+++ b/lumen/tests/ai/test_controls/test_base.py
@@ -3,7 +3,6 @@ import json
 
 import pytest
 
-
 try:
     import lumen.ai  # noqa
 except ModuleNotFoundError:

--- a/lumen/tests/ai/test_controls/test_base.py
+++ b/lumen/tests/ai/test_controls/test_base.py
@@ -1,0 +1,62 @@
+import io
+import json
+
+import pytest
+
+
+try:
+    import lumen.ai  # noqa
+except ModuleNotFoundError:
+    pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
+
+
+@pytest.fixture
+def make_json_file():
+    def _make(data):
+        return io.BytesIO(json.dumps(data).encode())
+    return _make
+
+
+class TestReadJsonFile:
+    """Tests for _read_json_file nested object flattening."""
+
+    def test_flat_json_array_loads_correctly(self, upload_controls, make_json_file):
+        data = [{"id": 1, "name": "foo"}, {"id": 2, "name": "bar"}]
+        df = upload_controls._read_json_file(make_json_file(data), "test.json")
+        assert list(df.columns) == ["id", "name"]
+        assert len(df) == 2
+
+    def test_nested_object_is_flattened(self, upload_controls, make_json_file):
+        data = [
+            {"id": 1, "meta": {"rate": 3.9, "count": 120}},
+            {"id": 2, "meta": {"rate": 4.1, "count": 259}},
+        ]
+        df = upload_controls._read_json_file(make_json_file(data), "test.json")
+        assert "meta" not in df.columns
+        assert "meta.rate" in df.columns
+        assert "meta.count" in df.columns
+        assert df["meta.rate"].tolist() == [3.9, 4.1]
+        assert df["meta.count"].tolist() == [120, 259]
+
+    def test_deeply_nested_object_is_flattened(self, upload_controls, make_json_file):
+        data = [{"id": 1, "address": {"city": "NYC", "geo": {"lat": 40.7, "lng": -74.0}}}]
+        df = upload_controls._read_json_file(make_json_file(data), "test.json")
+        assert "address.city" in df.columns
+        assert "address.geo.lat" in df.columns
+        assert "address.geo.lng" in df.columns
+
+    def test_nested_object_under_wrapper_key_is_flattened(self, upload_controls, make_json_file):
+        data = {"results": [
+            {"id": 1, "score": {"value": 99, "grade": "A"}},
+            {"id": 2, "score": {"value": 75, "grade": "B"}},
+        ]}
+        df = upload_controls._read_json_file(make_json_file(data), "test.json")
+        assert "score" not in df.columns
+        assert "score.value" in df.columns
+        assert "score.grade" in df.columns
+
+    def test_no_nested_objects_no_regression(self, upload_controls, make_json_file):
+        data = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+        df = upload_controls._read_json_file(make_json_file(data), "test.json")
+        assert list(df.columns) == ["a", "b"]
+        assert df["a"].tolist() == [1, 2]


### PR DESCRIPTION
## Description

**Problem:** 
When loading JSON data that contains nested objects, the table view was displaying `[object Object]` instead of actual values. This happened because `pd.DataFrame(data)` preserves nested dicts as Python objects in the DataFrame column. When these get serialized to JavaScript for the Tabulator widget, the browser renders them as `[object Object]` since it can't stringify a plain JS object automatically.

**Solution:** 
The fix replaces `pd.DataFrame(data)` with `pd.json_normalize(data)` in the `_read_json_file()` method inside `lumen/ai/controls/base.py`. This automatically flattens nested objects into separate dot-notated columns, making them readable and queryable.

**Before:**

| column | nestedField |
|--------|-------------|
| value1 | [object Object] |
| value2 | [object Object] |


https://github.com/user-attachments/assets/a065b603-6f05-4f87-a745-d49de2114602

**After:**

| column | nestedField.subFieldA | nestedField.subFieldB |
|--------|-----------------------|-----------------------|
| value1 | value | 123 |
| value2 | value | 456 |

https://github.com/user-attachments/assets/ecdd6a85-008f-4203-b3bd-1471b84c0806


## How Has This Been Tested?

Loaded JSON datasets with the following structures via **Fetch Remote Data** and verified the table view:

- JSON with single-level nested objects — nested fields correctly flattened into dot-notated columns
- JSON with deeply nested objects (multiple levels) — all levels fully flattened
- JSON with flat structure — data loads correctly with no regression

Fixes #1754

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

Tools and Models: Github copilot

## Checklist

- [x] Tests added and are passing
- [ ] Added documentation
