### PR TITLE
fix: Re-selecting the same file after chip removal in ChatAreaInput

### DIFF
--- a/lumen/ai/__init__.py
+++ b/lumen/ai/__init__.py
@@ -14,3 +14,28 @@ pn.chat.message.DEFAULT_AVATARS.update({
     "sql": "🗄️",
     "router": "🚦",
 })
+
+
+def _patch_chat_area_input_file_reset():
+    try:
+        from panel_material_ui.base import BASE_PATH
+        bundle_path = BASE_PATH / "dist" / "panel-material-ui.bundle.js"
+        if not bundle_path.exists():
+            return
+        content = bundle_path.read_text(encoding="utf-8")
+        if 'R.current&&(R.current.value="")' in content:
+            return
+        content = content.replace(
+            "ee.splice(W,1),v(ee),_.current=ee}",
+            'ee.splice(W,1),v(ee),_.current=ee,R.current&&(R.current.value="")}',
+        )
+        content = content.replace(
+            "v(ue),_.current=ue}}",
+            'v(ue),_.current=ue,W.target.value=""}}',
+        )
+        bundle_path.write_text(content, encoding="utf-8")
+    except Exception:
+        pass
+
+
+_patch_chat_area_input_file_reset()


### PR DESCRIPTION
## Description

After removing a file chip (×) in the Chat with Data input, the hidden `<input type="file">` element still holds the previous filename internally. Browsers do not fire `onChange` when the same file is selected again because the value hasn't changed, causing the chip to never reappear. Drag-and-drop bypasses the file input entirely, which is why it works.

**Before:**

https://github.com/user-attachments/assets/8da2142c-9908-4f71-9290-edaa5e78929e

**After:**

https://github.com/user-attachments/assets/7b577c80-8bad-456f-8f3b-f3fa57448b6c

**How it's fixed:** 
When a chip is removed or a file is selected, we now reset the hidden `<input type="file">` value to `""` immediately after. This is done by patching the `panel_material_ui` bundle on import in `lumen/ai/__init__.py`:

```python
# Reset hidden file input when a chip is removed (× button)
content = content.replace(
    "ee.splice(W,1),v(ee),_.current=ee}",
    'ee.splice(W,1),v(ee),_.current=ee,R.current&&(R.current.value="")}',
)
# Reset hidden file input after files are selected via the picker
content = content.replace(
    "v(ue),_.current=ue}}",
    'v(ue),_.current=ue,W.target.value=""}}',
)
```

This tricks the browser into treating the next selection as a fresh one, so `onChange` fires correctly even when the same file is picked again.


Fixes #1757

## How Has This Been Tested?

1. Start the lumen AI server
2. Open Chat with Data
3. Click **+** and select any file (e.g. `penguins_raw.csv`)
4. Click **×** on the chip to remove it
5. Click **+** and select the **same file** again
6. Verify the chip reappears and the file is staged for upload

Confirmed that drag-and-drop and selecting a different file still work as expected.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

Tools and Models: Claude Code + Sonnet 4.6

## Checklist

- [ ] Tests added and are passing
- [ ] Added documentation