### PR TITLE
Make Planner aware of LLM tools

### DIFF
--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -328,8 +328,9 @@ class Planner(Coordinator):
             # the unmet dependencies
             agent_candidates = [agent for agent in agents if not unmet_dependencies or set(agent.output_schema.__annotations__) & unmet_dependencies]
             tool_candidates = [tool for tool in tools if not unmet_dependencies or set(tool.output_schema.__annotations__) & unmet_dependencies]
+            llm_tools, _, _ = self.llm._normalize_tools(self.llm.tools)
             model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-            async for reasoning in self._stream_prompt(
+            system = await self._render_prompt(
                 "main",
                 messages,
                 context,
@@ -342,6 +343,14 @@ class Planner(Coordinator):
                 previous_actors=previous_actors,
                 previous_plans=previous_plans,
                 is_follow_up=is_follow_up,
+                llm_tools=llm_tools
+            )
+            async for reasoning in self.llm.stream(
+                messages=messages,
+                system=system,
+                model_spec=model_spec,
+                response_model=Reasoning,
+                max_retries=3,
             ):
                 if reasoning.chain_of_thought:  # do not replace with empty string
                     context["reasoning"] = reasoning.chain_of_thought

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -82,12 +82,23 @@ Conditions:
 Should never be used together with: `{{ agent.not_with | join('`, `') }}`{%- endif %}
 {% endfor %}
 
-## LLM Tools Specs
+{%- if llm_tools %}
+## LLM Tools
 
-The LLM can also directly invoke tools. This can aid it in getting additional context, so if such a tool is referenced do not duplicate its functionality simply call the agent you think can make use of the context.
+The LLM is capable of invoking tools directly.
+
+If a required capability is covered by one of these tools:
+- Do NOT attempt to replicate the tool’s functionality in the plan
+- Do NOT construct or infer the tool’s output yourself
+- Instead, delegate to an agent that can leverage the tool, or allow the LLM to call the tool directly
+
+The planner’s role is to coordinate agents, not to replace tool usage.
+
+Available tools:
 {% for tool in llm_tools %}
 - {{ tool }}
 {% endfor %}
+{% endif -%}
 
 ## Current Data Context
 

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -81,6 +81,14 @@ Conditions:
 {% if agent.not_with %}
 Should never be used together with: `{{ agent.not_with | join('`, `') }}`{%- endif %}
 {% endfor %}
+
+## LLM Tools Specs
+
+The LLM can also directly invoke tools. This can aid it in getting additional context, so if such a tool is referenced do not duplicate its functionality simply call the agent you think can make use of the context.
+{% for tool in llm_tools %}
+- {{ tool }}
+{% endfor %}
+
 ## Current Data Context
 
 {%- if memory.get('metaset') %}


### PR DESCRIPTION
## Description

It is now possible to provide the LLM with direct access to call tools. However since the LLM is not aware of the `llm_tools` it will make plans that are not considering that the LLM might make use of that additional context.

## How Has This Been Tested?

Manual testing.

## AI Disclosure

- [ ] This PR contains AI-generated content.
  - [ ] I have tested all AI-generated content in my PR.
  - [ ] I take responsibility for all AI-generated content in my PR.
