### PR TITLE
Provide up-to-date metadata vector store per exploration

### DIFF
--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -655,9 +655,6 @@ class SQLAgent(BaseLumenAgent):
         # Get sources from context for the discovery models
         metaset = context["metaset"]
         selected_slugs = list(metaset.catalog)
-        visible_slugs = context.get('visible_slugs', [])
-        if visible_slugs:
-            selected_slugs = [slug for slug in selected_slugs if slug in visible_slugs]
         sources_list = [
             tuple(table_slug.split(SOURCE_TABLE_SEPARATOR))
             for table_slug in selected_slugs
@@ -832,13 +829,6 @@ class SQLAgent(BaseLumenAgent):
         sources = context["sources"]
         metaset = context["metaset"]
         selected_slugs = list(metaset.catalog)
-        visible_slugs = context.get('visible_slugs', [])
-        if selected_slugs and visible_slugs:
-            # hide de-selected slugs
-            selected_slugs = [slug for slug in selected_slugs if slug in visible_slugs]
-        elif not selected_slugs and visible_slugs:
-            # if no closest matches, use visible slugs
-            selected_slugs = list(visible_slugs)
 
         # Select relevant tables if there are many
         if len(selected_slugs) > 3:

--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -264,14 +264,7 @@ class Planner(Coordinator):
         tools: dict[str, Tool],
     ) -> tuple[dict[str, Agent], dict[str, Tool], dict[str, Any]]:
         is_follow_up = await self._check_follow_up_question(messages, context)
-        if not is_follow_up:
-            await self._execute_planner_tools(messages, context)
-        else:
-            log_debug("\033[92mDetected follow-up question, using existing context\033[0m")
-            with self._add_step(title="Using existing data context...", user="Assistant", steps_layout=self.steps_layout) as step:
-                step.stream("Detected that this is a follow-up question related to the previous dataset.")
-                step.stream("\n\nUsing the existing data in memory to answer without re-executing data retrieval.")
-                step.success_title = "Using existing data for follow-up question"
+        await self._execute_planner_tools(messages, context)
         agents, tools, pre_plan_output = await super()._pre_plan(messages, context, agents, tools)
         pre_plan_output["is_follow_up"] = is_follow_up
         return agents, tools, pre_plan_output

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -137,6 +137,11 @@ The previously used visualization type was `{{ view_type }}`, please consider us
 👉 Existing metadata found: Evaluate if current data is sufficient before requesting more
 {%- endif %}
 
+{%- if 'prev_plan' in memory and (is_follow_up or 'data' not in memory) %}
+The previous plan that was executed:
+{{ memory['prev_plan'].render_task_history()[-1] }}
+{% endif %}
+
 {# Break the terrible loop of it not planning properly #}
 {% if previous_plans and not (previous_plans | length) % 2 == 0 and unmet_dependencies %}
 # ❌ Previous Planning Failure

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -103,7 +103,7 @@ Available tools:
 ## Current Data Context
 
 {%- if memory.get('metaset') %}
-{%- set table_list = memory['metaset'].table_list(n=3, n_others=17) %}
+{%- set table_list = memory['metaset'].table_list(n=3, n_others=17, show_source=True) %}
 Data sources:
 {{ table_list }}
 {%- endif %}

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -581,6 +581,8 @@ class TaskGroup(Task):
             other.parent = self
             self._tasks.append(task)
         self._view[:] = list(self._view) + list(other._view)
+        self.context = merge_contexts(LWW, [self.context, other.context])
+        self.out_context = merge_contexts(LWW, [self.context, self.out_context])
         self.history += [h for h in other.history if h not in self.history]
         self._init_views()
         return self

--- a/lumen/ai/tools/metadata_lookup.py
+++ b/lumen/ai/tools/metadata_lookup.py
@@ -127,6 +127,7 @@ class MetadataLookup(VectorLookupTool):
         super().__init__(**params)
         self._raw_metadata = {}
         self._semaphore = asyncio.Semaphore(self.max_concurrent)
+        self._initialized = False
         self._ready_event = asyncio.Event()
         self._ready_event.set()  # Initially ready (no pending sync)
         self.param.watch(self._sync_ready_event, "_ready")
@@ -212,7 +213,12 @@ class MetadataLookup(VectorLookupTool):
                 column = Column(name=col_name, description=col_desc, metadata=col_info.copy() if isinstance(col_info, dict) else {})
                 columns.append(column)
 
-        vector_metadata = {"source": source.name, "table_name": table_name, "type": self._item_type_name}
+        vector_metadata = {
+            "source": source.name,
+            "table_name": table_name,
+            "type": self._item_type_name,
+            "provenance_chain": self._get_provenance_chain(context),
+        }
         # the following is for the embeddings/vector store use only (i.e. filter from 1000s of tables)
         enriched_text = f"Table: {table_name}"
         if description := vector_info.pop("description", ""):
@@ -242,9 +248,11 @@ class MetadataLookup(VectorLookupTool):
         elif sources is None or len(sources) == 0:
             return
         self._ready = False
-        await asyncio.sleep(0.5)  # allow main thread time to load UI first
+        if not self._initialized:
+            await asyncio.sleep(0.5)
         tasks = []
         processed_sources = []
+        provenance_chain = tuple(self._get_provenance_chain(context))
 
         # Use class variable to track which sources are currently being processed
         vector_store_id = id(self.vector_store)
@@ -259,14 +267,17 @@ class MetadataLookup(VectorLookupTool):
             async with self._progress_lock:
                 # Skip this source if already processed with the same (or more) tables
                 current_table_count = len(source.get_tables())
-                known_count = self._sources_in_progress[vector_store_id].get(source.name, 0)
+                source_key = (source.name, provenance_chain)
+                known_count = self._sources_in_progress[vector_store_id].get(source_key, 0)
                 if known_count >= current_table_count:
-                    log_debug(f"[MetadataLookup] Skipping source {source.name} - already processed {known_count} tables")
+                    log_debug(
+                        f"[MetadataLookup] Skipping source {source.name} for provenance {provenance_chain} - already processed {known_count} tables"
+                    )
                     continue
 
                 # Mark this source as in progress with current table count
-                self._sources_in_progress[vector_store_id][source.name] = current_table_count
-                processed_sources.append(source.name)
+                self._sources_in_progress[vector_store_id][source_key] = current_table_count
+                processed_sources.append(source_key)
                 log_debug(f"[MetadataLookup] Processing source {source.name}")
 
             if self.include_metadata and self._raw_metadata.get(source.name) is None:
@@ -293,9 +304,13 @@ class MetadataLookup(VectorLookupTool):
             ready_task = asyncio.create_task(self._mark_ready_when_done(tasks, vector_store_id, processed_sources))
             ready_task.add_done_callback(self._handle_ready_task_done)
         else:
-            self._ready = True
+            self._ready = self._initialized = True
             # No tasks to wait for, so clean up immediately
             self._cleanup_sources_in_progress(vector_store_id, processed_sources)
+
+    def _handle_ready_task_done(self, task):
+        super()._handle_ready_task_done(task)
+        self._initialized = True
 
     def _cleanup_sources_in_progress(self, vector_store_id, processed_sources):
         """Clean up the sources_in_progress tracking after tasks are completed."""
@@ -304,10 +319,10 @@ class MetadataLookup(VectorLookupTool):
             async with self._progress_lock:
                 try:
                     log_debug(f"[MetadataLookup] Cleaning up sources: {processed_sources}")
-                    for source_name in processed_sources:
+                    for source_key in processed_sources:
                         if vector_store_id in self._sources_in_progress:
-                            self._sources_in_progress[vector_store_id].pop(source_name, None)
-                            log_debug(f"[MetadataLookup] Removed {source_name} from in-progress")
+                            self._sources_in_progress[vector_store_id].pop(source_key, None)
+                            log_debug(f"[MetadataLookup] Removed {source_key} from in-progress")
 
                     # Remove the vector_store_id entry if empty
                     if vector_store_id in self._sources_in_progress and not self._sources_in_progress[vector_store_id]:
@@ -457,6 +472,10 @@ class MetadataLookup(VectorLookupTool):
     async def _gather_info(self, messages: list[dict[str, str]], context: TContext) -> MetadataLookupOutputs:
         """Gather relevant information about the tables based on the user query."""
         query = messages[-1]["content"]
+        query_filters = {
+            "type": self._item_type_name,
+            "provenance_chain": self._get_provenance_chain(context),
+        }
 
         # Count total number of tables available across all sources
         total_tables = 0
@@ -466,12 +485,9 @@ class MetadataLookup(VectorLookupTool):
         # Skip query refinement if there are fewer than 5 tables
         if total_tables < 5:
             # Perform search without refinement
-            filters = {}
-            if self._item_type_name and "type" not in filters:
-                filters["type"] = self._item_type_name
-            results = await self.vector_store.query(query, top_k=self.n, filters=filters)
+            results = await self.vector_store.query(query, top_k=self.n, filters=query_filters)
         else:
-            results = await self._perform_search_with_refinement(query, context)
+            results = await self._perform_search_with_refinement(query, context, filters=query_filters)
 
         any_matches = any(result["similarity"] >= self.min_similarity for result in results)
         same_table = len([result["metadata"]["table_name"] for result in results])
@@ -560,3 +576,9 @@ class MetadataLookup(VectorLookupTool):
         # Run the process to build schema objects
         out_model = await self._gather_info(messages, context)
         return [self._format_context(out_model)], out_model
+
+    def _get_provenance_chain(self, context: TContext) -> list[str]:
+        chain = context.get("provenance_chain")
+        if not isinstance(chain, list) or not chain:
+            return ["global"]
+        return [str(v) for v in chain]

--- a/lumen/ai/tools/metadata_lookup.py
+++ b/lumen/ai/tools/metadata_lookup.py
@@ -118,6 +118,8 @@ class MetadataLookup(VectorLookupTool):
 
     # Class variable to track which sources are currently being processed
     _sources_in_progress = {}
+    _sources_processed = {}
+    _source_provenance = {}
     _progress_lock = asyncio.Lock()  # Lock for thread-safe access
 
     input_schema = MetadataLookupInputs
@@ -184,7 +186,13 @@ class MetadataLookup(VectorLookupTool):
             formatted_results.append(description)
         return "\n".join(formatted_results)
 
-    async def _enrich_metadata(self, source, table_name: str, context: TContext):
+    async def _enrich_metadata(
+        self,
+        source,
+        table_name: str,
+        context: TContext,
+        provenance_chain: list[str] | None = None,
+    ):
         """Fetch metadata for a table and return enriched entry for batch processing."""
         async with self._semaphore:
             source_metadata = self._raw_metadata[source.name]
@@ -217,7 +225,7 @@ class MetadataLookup(VectorLookupTool):
             "source": source.name,
             "table_name": table_name,
             "type": self._item_type_name,
-            "provenance_chain": self._get_provenance_chain(context),
+            "provenance_chain": provenance_chain or self._get_provenance_chain(context),
         }
         # the following is for the embeddings/vector store use only (i.e. filter from 1000s of tables)
         enriched_text = f"Table: {table_name}"
@@ -259,24 +267,35 @@ class MetadataLookup(VectorLookupTool):
 
         async with self._progress_lock:
             if vector_store_id not in self._sources_in_progress:
-                self._sources_in_progress[vector_store_id] = {}
+                self._sources_in_progress[vector_store_id] = set()
+            if vector_store_id not in self._sources_processed:
+                self._sources_processed[vector_store_id] = {}
+            if vector_store_id not in self._source_provenance:
+                self._source_provenance[vector_store_id] = {}
 
         log_debug(f"[MetadataLookup] Starting _update_vector_store for {len(sources)} sources")
 
         for source in sources:
             async with self._progress_lock:
+                source_provenance = self._source_provenance[vector_store_id].setdefault(
+                    source.name, provenance_chain
+                )
                 # Skip this source if already processed with the same (or more) tables
                 current_table_count = len(source.get_tables())
-                source_key = (source.name, provenance_chain)
-                known_count = self._sources_in_progress[vector_store_id].get(source_key, 0)
+                source_key = source.name
+                known_count = self._sources_processed[vector_store_id].get(source_key, 0)
+                if source_key in self._sources_in_progress[vector_store_id]:
+                    log_debug(f"[MetadataLookup] Skipping source {source.name} - already in progress")
+                    continue
                 if known_count >= current_table_count:
                     log_debug(
-                        f"[MetadataLookup] Skipping source {source.name} for provenance {provenance_chain} - already processed {known_count} tables"
+                        f"[MetadataLookup] Skipping source {source.name} at provenance {source_provenance} - already processed {known_count} tables"
                     )
                     continue
 
                 # Mark this source as in progress with current table count
-                self._sources_in_progress[vector_store_id][source_key] = current_table_count
+                self._sources_in_progress[vector_store_id].add(source_key)
+                self._sources_processed[vector_store_id][source_key] = current_table_count
                 processed_sources.append(source_key)
                 log_debug(f"[MetadataLookup] Processing source {source.name}")
 
@@ -292,11 +311,23 @@ class MetadataLookup(VectorLookupTool):
 
             if self.include_metadata:
                 for table in tables:
-                    task = asyncio.create_task(self._enrich_metadata(source, table, context))
+                    task = asyncio.create_task(
+                        self._enrich_metadata(
+                            source, table, context, provenance_chain=list(source_provenance)
+                        )
+                    )
                     tasks.append(task)
             else:
                 await self.vector_store.upsert(
-                    [{"text": table_name, "metadata": {"source": source.name, "table_name": table_name, "type": "table"}} for table_name in tables]
+                    [{
+                        "text": table_name,
+                        "metadata": {
+                            "source": source.name,
+                            "table_name": table_name,
+                            "type": "table",
+                            "provenance_chain": list(source_provenance),
+                        },
+                    } for table_name in tables]
                 )
 
         if tasks:
@@ -321,18 +352,15 @@ class MetadataLookup(VectorLookupTool):
                     log_debug(f"[MetadataLookup] Cleaning up sources: {processed_sources}")
                     for source_key in processed_sources:
                         if vector_store_id in self._sources_in_progress:
-                            self._sources_in_progress[vector_store_id].pop(source_key, None)
+                            self._sources_in_progress[vector_store_id].discard(source_key)
                             log_debug(f"[MetadataLookup] Removed {source_key} from in-progress")
 
-                    # Remove the vector_store_id entry if empty
-                    if vector_store_id in self._sources_in_progress and not self._sources_in_progress[vector_store_id]:
-                        del self._sources_in_progress[vector_store_id]
-                        log_debug(f"[MetadataLookup] Removed empty vector_store_id {vector_store_id}")
                 except Exception as e:
                     log_debug(f"[MetadataLookup] Error cleaning up sources_in_progress: {e!s}")
                     # Force cleanup on error
                     if vector_store_id in self._sources_in_progress:
-                        self._sources_in_progress[vector_store_id].clear()
+                        for source_key in processed_sources:
+                            self._sources_in_progress[vector_store_id].discard(source_key)
 
         # Schedule the async cleanup and store the task reference
         # This prevents the task from being garbage collected
@@ -496,6 +524,7 @@ class MetadataLookup(VectorLookupTool):
         for result in results:
             source_name = result["metadata"]["source"]
             table_name = result["metadata"]["table_name"]
+            provenance = result["metadata"].get("provenance_chain", ["global"])
             source_obj = None
             sql = None
             for source in context.get("sources", []):
@@ -507,7 +536,10 @@ class MetadataLookup(VectorLookupTool):
             similarity_score = result["similarity"]
             # Filter by visible_slugs if specified
             visible_slugs = context.get("visible_slugs")
-            if visible_slugs is not None and table_slug not in visible_slugs:
+
+            # For dynamically created sources we don't check visible_slugs since those
+            # only apply to global sources
+            if visible_slugs is not None and table_slug not in visible_slugs and len(provenance) == 1:
                 continue
 
             if any_matches and result["similarity"] < self.min_similarity and not same_table:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -631,6 +631,7 @@ class UI(Viewer):
         data: DataT | list[DataT] | dict[DataT] | None
             The data to resolve.
         """
+        self.context["provenance_chain"] = ["global"]
         self.context["sources"] = sources = self._resolve_data(data)
         if sources:
             self.context["source"] = sources[-1]
@@ -2116,6 +2117,12 @@ class ExplorerUI(UI):
     async def _add_exploration(self, plan: Plan, parent: Exploration) -> Exploration:
         is_home = parent is self._home
         parent_item = self._exploration
+        parent_chain = list(parent.context.get("provenance_chain", ["global"])) if parent.context else ["global"]
+        exploration_id = f"exploration_{id(plan)}"
+        provenance_chain = [*parent_chain, exploration_id]
+        # Ensure this plan executes in the new exploration scope without mutating parent context.
+        plan.context = {**(plan.context or {}), "provenance_chain": provenance_chain}
+        plan.out_context = {**(plan.out_context or {}), "provenance_chain": provenance_chain}
         if is_home:
             parent.conversation = []
         else:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -728,6 +728,10 @@ class UI(Viewer):
         """Get the currently active exploration."""
         return self._explorations.value['view']
 
+    def _exploration_has_outputs(self, exploration: Exploration) -> bool:
+        """Whether an exploration should be shown in split view."""
+        return exploration is not self._home
+
     @hold()
     def _update_main_view(self, force_report_mode: bool | None = None):
         """
@@ -775,9 +779,12 @@ class UI(Viewer):
                 else:
                     main_content = self._splash
                 self._output[1:] = []
-            else:
+            elif self._exploration_has_outputs(exploration):
                 main_content = self._split
                 self._output[1:] = [exploration]
+            else:
+                main_content = self.interface
+                self._output[1:] = []
             self._current_mode = "Exploration"
             self._navigation_caption.object = EXPLORATION_CAPTION
 
@@ -1707,6 +1714,21 @@ class ExplorerUI(UI):
         self._navigation.visible = active
         self._sidebar_menu.update_item(self._sidebar_menu.items[6], active=active, icon="layers" if active else "layers_outlined")
 
+    def _exploration_has_outputs(self, exploration: Exploration) -> bool:
+        """
+        Override base behavior: keep chat-only view until an exploration has
+        rendered output tabs (not just a placeholder).
+        """
+        if exploration is self._home or not exploration.view:
+            return False
+        tabs = exploration.view[0]
+        if len(tabs) == 0:
+            return False
+        if len(tabs) == 1 and not exploration.initialized:
+            # Placeholder-only state ("Waiting on data...")
+            return False
+        return True
+
     @param.depends("_exploration", watch=True)
     def _update_home(self):
         if not hasattr(self, '_page'):
@@ -2303,6 +2325,8 @@ class ExplorerUI(UI):
 
         tabs.extend(content)
         tabs.active = max(tabs.active, len(tabs)-1)
+        if self._exploration['view'] is exploration:
+            self._update_main_view()
         if self._split.collapsed:
             self._split.param.update(
                 sizes=self._split.expanded_sizes,
@@ -2341,6 +2365,12 @@ class ExplorerUI(UI):
             content.insert((idx or 0)+1, (title, vsplit))
         tabs[:] = content
         tabs.active = max(len(tabs)-1, 0)
+        if self._exploration['view'] is exploration:
+            self._update_main_view()
+        if self._split.collapsed:
+            self._split.param.update(
+                sizes=self._split.expanded_sizes,
+            )
 
     def _reset_error(self, plan: Plan, exploration: Exploration, replan: bool = False):
         plan.reset(plan._current)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -2360,10 +2360,11 @@ class ExplorerUI(UI):
         parent = prev["view"]
 
         # Check if we are adding to existing exploration or creating a new one
+        is_home = self._exploration['view'] is self._home
         new_exploration = (any(
             {"pipeline", "view"} & set(step.actor.output_schema.__required_keys__)
             for step in plan
-        ) and "pipeline" in parent.context) or self._exploration['view'] is self._home
+        ) and "pipeline" in parent.context) or is_home
 
         partial_plan = None
         if rerun:
@@ -2480,6 +2481,10 @@ class ExplorerUI(UI):
         self._update_main_view()
         with self._busy():
             exploration = self._exploration['view']
-            plan = await self._coordinator.respond(messages, exploration.context)
+            is_home = self._exploration['view'] is self._home
+            context = dict(exploration.context)
+            if not is_home:
+                context['prev_plan'] = exploration.plan
+            plan = await self._coordinator.respond(messages, context)
             if plan is not None:
                 await self._execute_plan(plan)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from functools import partial
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import param
@@ -1336,13 +1337,18 @@ class UI(Viewer):
                 self.context["visible_slugs"] = all_slugs
 
         if "source" in context:
+            source = context["source"]
             if "source" in self.context:
                 old_source = self.context["source"]
                 if "sources" not in self.context:
                     self.context["sources"] = [old_source]
                 elif old_source not in self.context["sources"]:
                     self.context["sources"].append(old_source)
-            self.context["source"] = context["source"]
+            elif "sources" not in self.context:
+                self.context["sources"] = []
+            if source not in self.context["sources"]:
+                self.context["sources"].append(source)
+            self.context["source"] = source
         if "table" in context:
             self.context["table"] = context["table"]
 
@@ -2399,6 +2405,14 @@ class ExplorerUI(UI):
         self, plan: Plan, exploration: Exploration, prev: dict, is_new: bool = False, partial_plan: Plan | None = None
     ):
         self._exploration['view'].conversation = self.interface.objects
+        sync_context = {
+            key: plan.out_context[key]
+            for key in ("sources", "source", "table")
+            if key in plan.out_context and
+            any(key in t.output_schema.__required_keys__ for t in plan if isinstance(t, ActorTask))
+        }
+        if sync_context:
+            await self._sync_sources(SimpleNamespace(new=sync_context))
         if "__error__" not in plan.out_context and plan.status != "error":
             if "pipeline" in plan.out_context:
                 await self._add_analysis_suggestions(plan)

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -1305,12 +1305,13 @@ class UI(Viewer):
             self._current_help_text = HELP_GETTING_STARTED
 
     @param.depends('context', on_init=True, watch=True)
-    async def _sync_sources(self, event=None):
-        context = event.new if event else self.context
+    async def _sync_sources(self, event=None, global_context=None):
+        global_context = self.context if global_context is None else global_context
+        context = event.new if event else global_context
         if 'sources' in context:
-            old_sources = self.context.get("sources", [self.context["source"]] if "source" in self.context else [])
+            old_sources = global_context.get("sources", [global_context["source"]] if "source" in global_context else [])
             new_sources = [src for src in context["sources"] if src not in old_sources]
-            self.context["sources"] = old_sources + new_sources
+            global_context["sources"] = old_sources + new_sources
 
             # Compute table slugs for old, new, and all sources
             old_slugs = set()
@@ -1321,7 +1322,7 @@ class UI(Viewer):
                     old_slugs.add(table_slug)
 
             all_slugs = set()
-            for source in self.context["sources"]:
+            for source in global_context["sources"]:
                 tables = source.get_tables()
                 for table in tables:
                     table_slug = f'{source.name}{SOURCE_TABLE_SEPARATOR}{table}'
@@ -1330,34 +1331,39 @@ class UI(Viewer):
             new_slugs = all_slugs - old_slugs
 
             # Update visible_slugs: preserve old table visibility, auto-check new tables
-            current_visible = self.context.get("visible_slugs")
+            current_visible = global_context.get("visible_slugs")
             if current_visible is not None:  # Check for None, not truthiness (empty set is valid!)
-                self.context["visible_slugs"] = current_visible.intersection(old_slugs) | new_slugs
-            else:
-                self.context["visible_slugs"] = all_slugs
+                global_context["visible_slugs"] = current_visible.intersection(old_slugs) | new_slugs
+            elif all_slugs:
+                global_context["visible_slugs"] = all_slugs
 
         if "source" in context:
             source = context["source"]
-            if "source" in self.context:
-                old_source = self.context["source"]
-                if "sources" not in self.context:
-                    self.context["sources"] = [old_source]
-                elif old_source not in self.context["sources"]:
-                    self.context["sources"].append(old_source)
-            elif "sources" not in self.context:
-                self.context["sources"] = []
-            if source not in self.context["sources"]:
-                self.context["sources"].append(source)
-            self.context["source"] = source
+            if "source" in global_context:
+                old_source = global_context["source"]
+                if "sources" not in global_context:
+                    global_context["sources"] = [old_source]
+                elif old_source not in global_context["sources"]:
+                    global_context["sources"].append(old_source)
+            elif "sources" not in global_context:
+                global_context["sources"] = []
+            if source not in global_context["sources"]:
+                global_context["sources"].append(source)
+            global_context["source"] = source
         if "table" in context:
-            self.context["table"] = context["table"]
+            global_context["table"] = context["table"]
 
         # Guard against early calls during init when components don't exist yet
         if hasattr(self, '_explorer'):
             await self._explorer.sync()
         # Only sync coordinator if we have sources and coordinator exists
-        if hasattr(self, '_coordinator') and self.context.get("sources"):
-            await self._coordinator.sync(self.context)
+        if hasattr(self, '_coordinator') and global_context.get("sources"):
+            await self._coordinator.sync(global_context)
+
+        # Only update source catalog and input tabs for truly global sources
+        if global_context is not self.context:
+            return
+
         if hasattr(self, '_source_catalog'):
             self._source_catalog.sync(self.context)
 
@@ -2327,7 +2333,7 @@ class ExplorerUI(UI):
             title, vsplit = self._render_view(exploration, view)
             content.insert((idx or 0)+1, (title, vsplit))
         tabs[:] = content
-        tabs.active = len(tabs)-1
+        tabs.active = max(len(tabs)-1, 0)
 
     def _reset_error(self, plan: Plan, exploration: Exploration, replan: bool = False):
         plan.reset(plan._current)
@@ -2347,10 +2353,10 @@ class ExplorerUI(UI):
         parent = prev["view"]
 
         # Check if we are adding to existing exploration or creating a new one
-        new_exploration = any(
+        new_exploration = (any(
             {"pipeline", "view"} & set(step.actor.output_schema.__required_keys__)
             for step in plan
-        )
+        ) and "pipeline" in parent.context) or self._exploration['view'] is self._home
 
         partial_plan = None
         if rerun:
@@ -2405,15 +2411,8 @@ class ExplorerUI(UI):
         self, plan: Plan, exploration: Exploration, prev: dict, is_new: bool = False, partial_plan: Plan | None = None
     ):
         self._exploration['view'].conversation = self.interface.objects
-        sync_context = {
-            key: plan.out_context[key]
-            for key in ("sources", "source", "table")
-            if key in plan.out_context and
-            any(key in t.output_schema.__required_keys__ for t in plan if isinstance(t, ActorTask))
-        }
-        if sync_context:
-            await self._sync_sources(SimpleNamespace(new=sync_context))
         if "__error__" not in plan.out_context and plan.status != "error":
+            await self._sync_sources(SimpleNamespace(new=plan.out_context), global_context=plan.out_context)
             if "pipeline" in plan.out_context:
                 await self._add_analysis_suggestions(plan)
 

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -28,6 +28,38 @@ from .models import YesNo
 from .utils import log_debug
 
 
+def _metadata_value_matches_filter(metadata_value: Any, filter_value: Any) -> bool:
+    """
+    Match a metadata value against a filter value.
+
+    Supports scalar-to-scalar equality plus list-aware semantics:
+    - scalar metadata vs list filter -> any match
+    - list metadata vs scalar filter -> containment
+    - list metadata vs list filter -> all filter values must be present
+    """
+    metadata_is_sequence = isinstance(metadata_value, (list, tuple, set))
+    filter_is_sequence = isinstance(filter_value, (list, tuple, set))
+
+    if metadata_is_sequence and filter_is_sequence:
+        metadata_values = set(metadata_value)
+        return all(v in metadata_values for v in filter_value)
+    if metadata_is_sequence:
+        return filter_value in metadata_value
+    if filter_is_sequence:
+        return metadata_value in filter_value
+    return metadata_value == filter_value
+
+
+def _metadata_matches_filters(metadata: dict[str, Any], filters: dict[str, Any] | None) -> bool:
+    """Check whether metadata matches all provided filters."""
+    if not filters:
+        return True
+    for key, value in filters.items():
+        if key not in metadata or not _metadata_value_matches_filter(metadata.get(key), value):
+            return False
+    return True
+
+
 class VectorStore(LLMUser):
     """Abstract base class for a vector store."""
 
@@ -817,7 +849,10 @@ class NumpyVectorStore(VectorStore):
         if filters and len(self.vectors) > 0:
             mask = np.ones(len(self.vectors), dtype=bool)
             for key, value in filters.items():
-                mask &= np.array([item.get(key) == value for item in self.metadata])
+                mask &= np.array([
+                    _metadata_value_matches_filter(item.get(key), value)
+                    for item in self.metadata
+                ])
             similarities = np.where(mask, similarities, -9999)
 
         results = []
@@ -863,7 +898,10 @@ class NumpyVectorStore(VectorStore):
 
         mask = np.ones(len(self.metadata), dtype=bool)
         for key, value in filters.items():
-            mask &= np.array([item.get(key) == value for item in self.metadata])
+            mask &= np.array([
+                _metadata_value_matches_filter(item.get(key), value)
+                for item in self.metadata
+            ])
 
         matching_indices = np.where(mask)[0]
 
@@ -1375,14 +1413,12 @@ class DuckDBVectorStore(VectorStore):
                 params.append(str(value))
 
         base_query += """
-            ORDER BY similarity DESC
-            LIMIT ?;
+            ORDER BY similarity DESC;
         """
-        params.append(top_k)
 
         try:
             result = self.connection.execute(base_query, params).fetchall()
-            return [
+            results = [
                 {
                     "id": row[0],
                     "text": row[1],
@@ -1391,6 +1427,9 @@ class DuckDBVectorStore(VectorStore):
                 }
                 for row in result
             ]
+            if filters:
+                results = [r for r in results if _metadata_matches_filters(r["metadata"], filters)]
+            return results[:top_k]
         except duckdb.Error as e:
             log_debug(f"Error during query: {e}")
             return []
@@ -1423,30 +1462,24 @@ class DuckDBVectorStore(VectorStore):
         """
         params = []
 
-        for key, value in filters.items():
-            base_query += f" AND json_extract_string(metadata, '$.{key}') = ?"
-            params.append(str(value))
-
-        if offset:
-            base_query += " OFFSET ?"
-            params.append(offset)
-
-        if limit is not None:
-            base_query += " LIMIT ?"
-            params.append(limit)
-
         base_query += ";"
 
         result = self.connection.execute(base_query, params).fetchall()
 
-        return [
+        output = [
             {
                 "id": row[0],
                 "text": row[1],
                 "metadata": json.loads(row[2]),
             }
             for row in result
+            if _metadata_matches_filters(json.loads(row[2]), filters)
         ]
+        if offset:
+            output = output[offset:]
+        if limit is not None:
+            output = output[:limit]
+        return output
 
     def delete(self, ids: list[int]) -> None:
         """
@@ -1783,7 +1816,14 @@ class ChromaDBVectorStore(VectorStore):
         """
         if not filters:
             return None
-        conditions = [{key: {"$eq": value}} for key, value in filters.items()]
+        scalar_types = (str, int, float, bool)
+        conditions = [
+            {key: {"$eq": value}}
+            for key, value in filters.items()
+            if isinstance(value, scalar_types)
+        ]
+        if not conditions:
+            return None
         if len(conditions) == 1:
             return conditions[0]
         return {"$and": conditions}
@@ -1908,7 +1948,7 @@ class ChromaDBVectorStore(VectorStore):
         where = self._build_where_clause(filters) if filters else None
 
         # ChromaDB errors if n_results > number of items in the index
-        n_results = min(top_k, count)
+        n_results = count if filters else min(top_k, count)
 
         kwargs: dict[str, t.Any] = {
             "n_results": n_results,
@@ -1936,14 +1976,19 @@ class ChromaDBVectorStore(VectorStore):
                 similarity = 1.0 - distance
                 if similarity < threshold:
                     continue
+                metadata = self._restore_metadata(results["metadatas"][0][i])
+                if filters and not _metadata_matches_filters(metadata, filters):
+                    continue
                 output.append(
                     {
                         "id": int(results["ids"][0][i]),
                         "text": results["documents"][0][i],
-                        "metadata": self._restore_metadata(results["metadatas"][0][i]),
+                        "metadata": metadata,
                         "similarity": float(similarity),
                     }
                 )
+                if len(output) >= top_k:
+                    break
         return output
 
     def filter_by(
@@ -1981,14 +2026,20 @@ class ChromaDBVectorStore(VectorStore):
 
         result = self._collection.get(**kwargs)
 
-        return [
+        output = [
             {
                 "id": int(result["ids"][i]),
                 "text": result["documents"][i],
                 "metadata": self._restore_metadata(result["metadatas"][i]),
             }
             for i in range(len(result["ids"]))
+            if _metadata_matches_filters(self._restore_metadata(result["metadatas"][i]), filters)
         ]
+        if offset:
+            output = output[offset:]
+        if limit is not None:
+            output = output[:limit]
+        return output
 
     def delete(self, ids: list[int]) -> None:
         """

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -1409,8 +1409,9 @@ class DuckDBVectorStore(VectorStore):
 
         if filters:
             for key, value in filters.items():
-                base_query += f" AND json_extract_string(metadata, '$.{key}') = ?"
-                params.append(str(value))
+                if isinstance(value, (str, int, float, bool)):
+                    base_query += f" AND json_extract_string(metadata, '$.{key}') = ?"
+                    params.append(str(value))
 
         base_query += """
             ORDER BY similarity DESC;

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -101,31 +101,6 @@ async def test_sql_agent(llm, duckdb_source, test_messages):
     )
     assert set(out_context) == {"data", "pipeline", "sql", "table", "source"}
 
-async def test_sql_agent_refreshes_stale_metaset(llm, duckdb_source, test_messages):
-    agent = SQLAgent(llm=llm)
-    stale_source = DuckDBSource(uri=":memory:", tables={"stale_table": "SELECT 1 as x"})
-
-    context = {
-        "source": duckdb_source,
-        "sources": [duckdb_source],
-        "metaset": await get_metaset([stale_source], ["stale_table"]),
-    }
-    SQLQueryWithTables = make_sql_model([(duckdb_source.name, "test_sql")])
-    llm.set_responses([
-        SQLQueryWithTables(
-            query="SELECT SUM(A) as A_sum FROM test_sql",
-            table_slug="test_sql_agg",
-            tables=["test_sql"]
-        ),
-    ])
-
-    out, out_context = await agent.respond(test_messages, context)
-
-    assert len(out) == 1
-    assert isinstance(out[0], SQLEditor)
-    assert out_context["table"] == "test_sql_agg"
-    assert f"{duckdb_source.name}::test_sql" in context["metaset"].catalog
-
 async def test_vegalite_agent(llm, duckdb_source, test_messages):
     """Test VegaLiteAgent instantiation and respond"""
 

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -101,6 +101,31 @@ async def test_sql_agent(llm, duckdb_source, test_messages):
     )
     assert set(out_context) == {"data", "pipeline", "sql", "table", "source"}
 
+async def test_sql_agent_refreshes_stale_metaset(llm, duckdb_source, test_messages):
+    agent = SQLAgent(llm=llm)
+    stale_source = DuckDBSource(uri=":memory:", tables={"stale_table": "SELECT 1 as x"})
+
+    context = {
+        "source": duckdb_source,
+        "sources": [duckdb_source],
+        "metaset": await get_metaset([stale_source], ["stale_table"]),
+    }
+    SQLQueryWithTables = make_sql_model([(duckdb_source.name, "test_sql")])
+    llm.set_responses([
+        SQLQueryWithTables(
+            query="SELECT SUM(A) as A_sum FROM test_sql",
+            table_slug="test_sql_agg",
+            tables=["test_sql"]
+        ),
+    ])
+
+    out, out_context = await agent.respond(test_messages, context)
+
+    assert len(out) == 1
+    assert isinstance(out[0], SQLEditor)
+    assert out_context["table"] == "test_sql_agg"
+    assert f"{duckdb_source.name}::test_sql" in context["metaset"].catalog
+
 async def test_vegalite_agent(llm, duckdb_source, test_messages):
     """Test VegaLiteAgent instantiation and respond"""
 

--- a/lumen/tests/ai/test_tools.py
+++ b/lumen/tests/ai/test_tools.py
@@ -10,6 +10,7 @@ from panel.viewable import Viewable
 from lumen.ai.coordinator import Coordinator
 from lumen.ai.tools import FunctionTool, MetadataLookup, define_tool
 from lumen.ai.vector_store import NumpyVectorStore
+from lumen.sources.duckdb import DuckDBSource
 
 
 def add(a: int, b: int) -> int:
@@ -110,3 +111,24 @@ class TestVectorLookupToolUser:
 
         # Each tool should have its own vector store that was passed in
         assert id(table_tool.vector_store) == id(vs1)
+
+
+async def test_metadata_lookup_source_keeps_first_provenance():
+    source = DuckDBSource(uri=":memory:", tables={"test_table": "SELECT 1 as id"})
+    tool = MetadataLookup(vector_store=NumpyVectorStore())
+
+    context_global = {"sources": [source], "provenance_chain": ["global"], "tables_metadata": {}}
+    await tool.sync(context_global)
+    await tool._ready_event.wait()
+
+    context_exploration = {
+        "sources": [source],
+        "provenance_chain": ["global", "exploration_1"],
+        "tables_metadata": {},
+    }
+    await tool.sync(context_exploration)
+    await tool._ready_event.wait()
+
+    entries = tool.vector_store.filter_by({"source": source.name, "type": "tables"})
+    assert len(entries) == 1
+    assert entries[0]["metadata"]["provenance_chain"] == ["global"]

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import duckdb
@@ -151,6 +152,34 @@ async def test_exploration_ui_error(explorer_ui_with_error):
     # Check Interface contents
     assert len(ui.interface) == 2
     assert len(ui.interface[1].footer_objects) == 2 # Rerun buttons
+
+async def test_sync_sources_keeps_source_and_sources_in_sync(explorer_ui):
+    ui = explorer_ui
+    previous_sources = list(ui.context["sources"])
+    new_source = DuckDBSource(uri=":memory:", tables={"new_table": "SELECT 1 as id"})
+
+    await ui._sync_sources(SimpleNamespace(new={"source": new_source}))
+
+    assert ui.context["source"] is new_source
+    assert new_source in ui.context["sources"]
+    for source in previous_sources:
+        assert source in ui.context["sources"]
+
+async def test_postprocess_exploration_syncs_source_into_global_context(explorer_ui):
+    ui = explorer_ui
+    previous_sources = list(ui.context["sources"])
+    new_source = DuckDBSource(uri=":memory:", tables={"fresh_table": "SELECT 1 as id"})
+
+    plan = Plan(title="sync source", out_context={"source": new_source}, status="success")
+    exploration = ui._explorations.value["view"]
+    prev = ui._explorations.value
+
+    await ui._postprocess_exploration(plan, exploration, prev, is_new=False)
+
+    assert ui.context["source"] is new_source
+    assert new_source in ui.context["sources"]
+    for source in previous_sources:
+        assert source in ui.context["sources"]
 
 async def test_exploration_ui_error_rerun(explorer_ui_with_error):
     ui = explorer_ui_with_error

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -468,6 +468,43 @@ async def test_exploration_parent_relationship(explorer_ui):
     assert exploration.parent.title == 'Home'
 
 
+async def test_exploration_sets_provenance_chain(explorer_ui):
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+    exploration = explorer_ui._explorations.items[1]['view']
+    provenance_chain = exploration.context.get("provenance_chain")
+    assert isinstance(provenance_chain, list)
+    assert provenance_chain[0] == "global"
+    assert len(provenance_chain) == 2
+
+
+async def test_followup_exploration_extends_provenance_chain(explorer_ui):
+    explorer_ui._explorer.param.update(table_slug="test_table")
+    await explorer_ui._add_exploration_from_explorer()
+    await async_wait_until(lambda: len(explorer_ui._explorations.items) > 1)
+    parent_item = explorer_ui._explorations.items[1]
+    parent_exploration = parent_item['view']
+    parent_chain = list(parent_exploration.context["provenance_chain"])
+
+    sql_agent = SQLAgent(llm=explorer_ui.llm)
+    child_plan = Plan(
+        ActorTask(sql_agent),
+        history=[{"content": "Show first 5 rows", "role": "user"}],
+        title="First 5 rows",
+        context=parent_exploration.context,
+        is_followup=True
+    )
+
+    await explorer_ui._add_exploration(child_plan, parent_exploration)
+    child_item = explorer_ui._explorations.items[1]['items'][0]
+    child_exploration = child_item['view']
+    child_chain = child_exploration.context["provenance_chain"]
+
+    assert child_chain[:len(parent_chain)] == parent_chain
+    assert len(child_chain) == len(parent_chain) + 1
+
+
 async def test_chat_upload_flow_processes_files_directly(explorer_ui, monkeypatch):
     """Test that file uploads via chat are processed directly without opening a dialog."""
     ui = explorer_ui

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -574,6 +574,24 @@ async def test_exploration_launch_transitions_to_split(explorer_ui):
     assert explorer_ui._splash not in explorer_ui._main
 
 
+async def test_new_exploration_without_outputs_keeps_chat_view(explorer_ui):
+    """A new exploration without outputs should not expand the split output pane."""
+    explorer_ui.llm.set_responses(["No output yet"])
+    chat_agent = ChatAgent(llm=explorer_ui.llm)
+    plan = Plan(
+        ActorTask(chat_agent),
+        history=[{"content": "Just answer in chat", "role": "user"}],
+        title="Chat only",
+        context=explorer_ui.context
+    )
+
+    await explorer_ui._execute_plan(plan)
+
+    assert len(explorer_ui._explorations.items) > 1
+    assert explorer_ui._main[1] is explorer_ui.interface
+    assert explorer_ui._split not in explorer_ui._main
+
+
 async def test_exploration_with_pipeline_data_shows_split(explorer_ui):
     """Test 2b: When plan produces data, should show split view with navigation."""
     # Create an exploration with pipeline data

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -165,22 +165,6 @@ async def test_sync_sources_keeps_source_and_sources_in_sync(explorer_ui):
     for source in previous_sources:
         assert source in ui.context["sources"]
 
-async def test_postprocess_exploration_syncs_source_into_global_context(explorer_ui):
-    ui = explorer_ui
-    previous_sources = list(ui.context["sources"])
-    new_source = DuckDBSource(uri=":memory:", tables={"fresh_table": "SELECT 1 as id"})
-
-    plan = Plan(title="sync source", out_context={"source": new_source}, status="success")
-    exploration = ui._explorations.value["view"]
-    prev = ui._explorations.value
-
-    await ui._postprocess_exploration(plan, exploration, prev, is_new=False)
-
-    assert ui.context["source"] is new_source
-    assert new_source in ui.context["sources"]
-    for source in previous_sources:
-        assert source in ui.context["sources"]
-
 async def test_exploration_ui_error_rerun(explorer_ui_with_error):
     ui = explorer_ui_with_error
     exploration = ui._exploration['view']

--- a/lumen/tests/ai/test_vector_store.py
+++ b/lumen/tests/ai/test_vector_store.py
@@ -81,6 +81,28 @@ class VectorStoreTestKit:
         assert filtered_offset[0]["text"] == "A second receipt with different details"
 
     @pytest.mark.asyncio
+    async def test_filter_by_list_matches_any_scalar_value(self, empty_store):
+        await empty_store.add([
+            {"text": "alpha doc", "metadata": {"scope": "alpha"}},
+            {"text": "beta doc", "metadata": {"scope": "beta"}},
+            {"text": "gamma doc", "metadata": {"scope": "gamma"}},
+        ])
+        filtered = empty_store.filter_by({"scope": ["alpha", "gamma"]})
+        scopes = {doc["metadata"]["scope"] for doc in filtered}
+        assert scopes == {"alpha", "gamma"}
+
+    @pytest.mark.asyncio
+    async def test_filter_by_list_requires_all_values_for_list_metadata(self, empty_store):
+        await empty_store.add([
+            {"text": "doc one", "metadata": {"provenance_chain": ["global", "a", "b"]}},
+            {"text": "doc two", "metadata": {"provenance_chain": ["global", "a"]}},
+            {"text": "doc three", "metadata": {"provenance_chain": ["global", "b"]}},
+        ])
+        filtered = empty_store.filter_by({"provenance_chain": ["global", "a"]})
+        assert len(filtered) == 2
+        assert {doc["text"] for doc in filtered} == {"doc one", "doc two"}
+
+    @pytest.mark.asyncio
     async def test_query_with_filter_title_org_chart(self, store_with_three_docs):
         query_text = "CEO reports to?"
         results = await store_with_three_docs.query(query_text)
@@ -92,6 +114,20 @@ class VectorStoreTestKit:
         assert len(results) == 1
         assert results[0]["metadata"]["title"] == "org_chart"
         assert "CEO" in results[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_query_with_list_filter(self, empty_store):
+        await empty_store.add([
+            {"text": "global only", "metadata": {"provenance_chain": ["global"]}},
+            {"text": "global and alpha", "metadata": {"provenance_chain": ["global", "alpha"]}},
+            {"text": "global alpha beta", "metadata": {"provenance_chain": ["global", "alpha", "beta"]}},
+        ])
+        results = await empty_store.query(
+            "alpha",
+            top_k=10,
+            filters={"provenance_chain": ["global", "alpha"]},
+        )
+        assert {result["text"] for result in results} == {"global and alpha", "global alpha beta"}
 
     @pytest.mark.asyncio
     async def test_query_1_threshold(self, store_with_three_docs):


### PR DESCRIPTION
## Summary
- Add provenance-chain awareness to exploration context and metadata indexing so metadata entries are scoped to the current exploration lineage instead of being globally mixed.
- Update `MetadataLookup` to write `provenance_chain` into vector-store metadata and apply provenance filters during lookup/refinement queries.
- Extend vector-store filtering semantics to support list-valued filters and list-valued metadata (including containment / all-values matching), with backend-specific handling for NumPy, DuckDB, and ChromaDB stores.
- Improve source/context synchronization in UI exploration flows and include source names in planner table context rendering.
- Add tests covering provenance chain propagation, source syncing behavior, stale metaset refresh, and list-based filter/query behavior across vector-store implementations.
