### PR TITLE
Implement per-step validation and replanning

### DIFF
--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -143,7 +143,7 @@ class Plan(Section):
 
             context_keys = ", ".join(f"`{k}`" for k in task_context)
             step.stream(f"Generated {len(outputs)} and provided {context_keys}.")
-            task_context = await self._validate_and_maybe_replan(i, task, context, task_context, outputs, history, step)
+            outputs, task_context = await self._validate_and_maybe_replan(i, task, context, task_context, outputs, history, step)
             step.success_title = f"Task {task.title!r} successfully completed"
             log_debug(f"\033[96mCompleted: {task.title}\033[0m", show_length=False)
         return outputs, task_context
@@ -212,7 +212,7 @@ class Plan(Section):
                 "title": done_task.title,
                 "instruction": done_task.instruction,
             }
-            for done_task in self._tasks[:i+1]
+            for done_task in self._tasks[:i]
             if isinstance(done_task, ActorTask)
         ]
         remaining_steps = [
@@ -221,7 +221,7 @@ class Plan(Section):
                 "title": pending_task.title,
                 "instruction": pending_task.instruction,
             }
-            for pending_task in self._tasks[i+1:]
+            for pending_task in self._tasks[i:]
             if isinstance(pending_task, ActorTask)
         ]
         return {
@@ -246,12 +246,9 @@ class Plan(Section):
         outputs: list[Any],
         history: list[Message],
         step: ChatStep,
-    ) -> TContext:
+    ) -> tuple[list[Any], TContext]:
         if not self._should_fast_validate(task):
-            return task_context
-        if i >= len(self._tasks) - 1:
-            # Nothing remains to replan after the current step.
-            return task_context
+            return outputs, task_context
 
         step_result = self._serialize_step_outputs(outputs)
         validation_context = merge_contexts(LWW, [
@@ -271,11 +268,11 @@ class Plan(Section):
         if reasoning:
             step.stream(f"\n\nFast validation: {reasoning}")
         if not getattr(validation, "yes", False):
-            return task_context
+            return outputs, task_context
 
         if self._partial_replans >= self.max_partial_replans:
             step.stream("\n\nFast validation requested replanning, but the maximum replan attempts was reached. Continuing current plan.")
-            return dict(task_context, replan_trigger_reason="max_partial_replans_reached")
+            return outputs, dict(task_context, replan_trigger_reason="max_partial_replans_reached")
 
         self._partial_replans += 1
         payload = self._build_partial_replan_payload(i, task, reasoning or "validator requested replanning", step_result)
@@ -288,12 +285,16 @@ class Plan(Section):
         )
         if new_plan is None:
             step.stream("\n\nFast validation requested replanning, but planner returned no replacement steps.")
-            return dict(task_context, replan_trigger_reason="partial_replan_failed")
+            return outputs, dict(task_context, replan_trigger_reason="partial_replan_failed")
 
         new_tasks = list(new_plan)
-        self._replace_remaining_tasks(i+1, new_tasks)
-        step.stream(f"\n\nFast validation triggered partial replanning and replaced {len(new_tasks)} remaining task(s).")
-        return dict(task_context, replan_trigger_reason="partial_replan_applied")
+        if not new_tasks:
+            step.stream("\n\nFast validation requested replanning, but no replacement steps were returned.")
+            return outputs, dict(task_context, replan_trigger_reason="partial_replan_empty")
+        self._replace_remaining_tasks(i, new_tasks)
+        step.stream(f"\n\nFast validation rolled back the current step and replaced {len(new_tasks)} task(s) from this point.")
+        rewritten_outputs, rewritten_context = await self._run_task(i, self._tasks[i], context)
+        return rewritten_outputs, dict(rewritten_context, replan_trigger_reason="partial_replan_applied")
 
     async def _handle_task_execution_error(self, e: Exception, task: Self | Actor, context: TContext, step: ChatStep, i: int) -> tuple[list[Any], TContext]:
         """

--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -4,6 +4,7 @@ import asyncio
 import re
 import traceback
 
+from copy import deepcopy
 from functools import partial
 from textwrap import dedent, indent
 from types import FunctionType
@@ -23,10 +24,12 @@ from panel_material_ui import (
 from ..actor import Actor
 from ..agents import Agent, AnalysisAgent, ChatAgent
 from ..config import PROMPTS_DIR, MissingContextError
-from ..context import TContext
+from ..context import LWW, TContext, merge_contexts
 from ..llm import LlamaCpp, Llm, Message
 from ..models import ThinkingYesNo
-from ..report import ActorTask, Section, TaskGroup
+from ..report import (
+    ActorTask, Section, Task, TaskGroup,
+)
 from ..tools import MetadataLookup, Tool, VectorLookupToolUser
 from ..utils import (
     describe_data_sync, fuse_messages, get_root_exception, log_debug,
@@ -60,6 +63,14 @@ class Plan(Section):
     is_followup = param.Boolean(default=False)
 
     _tasks = param.List(item_type=ActorTask)
+
+    max_partial_replans = param.Integer(
+        default=3,
+        doc="""
+        Maximum number of partial replans allowed within one execute run.""",
+    )
+
+    _partial_replans = param.Integer(default=0)
 
     def render_task_history(self, i: int | None = None, failed: bool = False) -> tuple[list[Message], str]:
         i = self._current if i is None else i
@@ -132,9 +143,157 @@ class Plan(Section):
 
             context_keys = ", ".join(f"`{k}`" for k in task_context)
             step.stream(f"Generated {len(outputs)} and provided {context_keys}.")
+            task_context = await self._validate_and_maybe_replan(i, task, context, task_context, outputs, history, step)
             step.success_title = f"Task {task.title!r} successfully completed"
             log_debug(f"\033[96mCompleted: {task.title}\033[0m", show_length=False)
         return outputs, task_context
+
+    def _should_fast_validate(self, task: Task) -> bool:
+        coordinator = self.coordinator
+        if not isinstance(task, ActorTask):
+            return False
+        if not coordinator or not getattr(coordinator, "validation_enabled", False):
+            return False
+        prompts = getattr(coordinator, "prompts", {})
+        if "validate" not in prompts:
+            return False
+        actor_name = normalized_name(task.actor)
+        if actor_name == "ValidationAgent":
+            return False
+        instruction = (task.instruction or "").strip().lower()
+        if instruction.startswith("summarize the results"):
+            return False
+        return True
+
+    def _render_plan_outline(self, completed_until: int) -> str:
+        lines = []
+        for idx, task in enumerate(self._tasks):
+            prefix = "✅" if idx <= completed_until else "⬜"
+            lines.append(f"{prefix} {normalized_name(task.actor)}: {task.instruction}")
+        return "\n".join(lines)
+
+    def _serialize_step_outputs(self, outputs: list[Any]) -> str:
+        if not outputs:
+            return "No visible outputs were generated."
+        serialized = []
+        serializer = getattr(self.coordinator, "_serialize", None)
+        for out in outputs:
+            try:
+                serialized.append(serializer(out) if serializer else str(out))
+            except Exception:
+                serialized.append(str(out))
+        return "\n\n".join(serialized)
+
+    def _replace_remaining_tasks(self, start_index: int, new_tasks: list[Task]) -> None:
+        removed = list(self._tasks[start_index:])
+        for task in removed:
+            watcher = self._task_watchers.pop(task, None)
+            if watcher is not None:
+                task.param.unwatch(watcher)
+        for task in new_tasks:
+            task.parent = self
+            if isinstance(task, Task):
+                self._task_watchers[task] = task.param.watch(self._sync_context, "out_context")
+        self._tasks[start_index:] = new_tasks
+        if not self.running:
+            self._populate_view()
+            self._init_views()
+
+    def _build_partial_replan_payload(
+        self,
+        i: int,
+        task: ActorTask,
+        validation_reason: str,
+        step_result: str,
+    ) -> dict[str, Any]:
+        completed_steps = [
+            {
+                "actor": normalized_name(done_task.actor),
+                "title": done_task.title,
+                "instruction": done_task.instruction,
+            }
+            for done_task in self._tasks[:i+1]
+            if isinstance(done_task, ActorTask)
+        ]
+        remaining_steps = [
+            {
+                "actor": normalized_name(pending_task.actor),
+                "title": pending_task.title,
+                "instruction": pending_task.instruction,
+            }
+            for pending_task in self._tasks[i+1:]
+            if isinstance(pending_task, ActorTask)
+        ]
+        return {
+            "current_step_index": i,
+            "current_step": {
+                "actor": normalized_name(task.actor),
+                "title": task.title,
+                "instruction": task.instruction,
+            },
+            "validation_reason": validation_reason,
+            "step_result": step_result,
+            "completed_steps": completed_steps,
+            "remaining_steps": remaining_steps,
+        }
+
+    async def _validate_and_maybe_replan(
+        self,
+        i: int,
+        task: Task,
+        context: TContext,
+        task_context: TContext,
+        outputs: list[Any],
+        history: list[Message],
+        step: ChatStep,
+    ) -> TContext:
+        if not self._should_fast_validate(task):
+            return task_context
+        if i >= len(self._tasks) - 1:
+            # Nothing remains to replan after the current step.
+            return task_context
+
+        step_result = self._serialize_step_outputs(outputs)
+        validation_context = merge_contexts(LWW, [
+            context,
+            task_context,
+            {
+                "user_query": next(
+                    (msg["content"] for msg in reversed(self.history) if msg.get("role") == "user"),
+                    "",
+                ),
+                "plan": self._render_plan_outline(i),
+                "step_result": step_result,
+            },
+        ])
+        validation = await self.coordinator._invoke_prompt("validate", history, validation_context)
+        reasoning = getattr(validation, "chain_of_thought", "")
+        if reasoning:
+            step.stream(f"\n\nFast validation: {reasoning}")
+        if not getattr(validation, "yes", False):
+            return task_context
+
+        if self._partial_replans >= self.max_partial_replans:
+            step.stream("\n\nFast validation requested replanning, but the maximum replan attempts was reached. Continuing current plan.")
+            return dict(task_context, replan_trigger_reason="max_partial_replans_reached")
+
+        self._partial_replans += 1
+        payload = self._build_partial_replan_payload(i, task, reasoning or "validator requested replanning", step_result)
+        replan_context = merge_contexts(LWW, [context, task_context, payload])
+        new_plan = await self.coordinator.respond(
+            self.history,
+            replan_context,
+            partial_replan=True,
+            partial_replan_payload=payload,
+        )
+        if new_plan is None:
+            step.stream("\n\nFast validation requested replanning, but planner returned no replacement steps.")
+            return dict(task_context, replan_trigger_reason="partial_replan_failed")
+
+        new_tasks = list(new_plan)
+        self._replace_remaining_tasks(i+1, new_tasks)
+        step.stream(f"\n\nFast validation triggered partial replanning and replaced {len(new_tasks)} remaining task(s).")
+        return dict(task_context, replan_trigger_reason="partial_replan_applied")
 
     async def _handle_task_execution_error(self, e: Exception, task: Self | Actor, context: TContext, step: ChatStep, i: int) -> tuple[list[Any], TContext]:
         """
@@ -237,6 +396,7 @@ class Plan(Section):
 
     async def execute(self, context: TContext = None, **kwargs) -> list[Any]:
         context = context or self.context
+        self._partial_replans = 0
         if "__error__" in context:
             del context["__error__"]
         outputs, out_context = await super().execute(context, **kwargs)
@@ -386,17 +546,21 @@ class Coordinator(Viewer, VectorLookupToolUser):
         return tools
 
     def _process_prompts(self, prompts: dict[str, dict[str, Any]], tools: list[type[Tool] | Tool]) -> dict[str, dict[str, Any]]:
-        # Add user-provided tools to the list of tools of the coordinator
-        if prompts is None:
-            prompts = {}
+        # Merge any explicit prompt overrides into class defaults, then
+        # append runtime tools to main prompt without discarding other prompts.
+        merged_prompts = deepcopy(self.prompts)
+        if prompts:
+            for prompt_name, prompt_config in prompts.items():
+                if prompt_name not in merged_prompts:
+                    merged_prompts[prompt_name] = {}
+                merged_prompts[prompt_name].update(prompt_config)
 
-        if "main" not in prompts:
-            prompts["main"] = {}
-
-        if "tools" not in prompts["main"]:
-            prompts["main"]["tools"] = []
-        prompts["main"]["tools"] += [tool for tool in tools]
-        return prompts
+        if "main" not in merged_prompts:
+            merged_prompts["main"] = {}
+        if "tools" not in merged_prompts["main"]:
+            merged_prompts["main"]["tools"] = []
+        merged_prompts["main"]["tools"] += [tool for tool in tools]
+        return merged_prompts
 
     async def _fill_model(self, messages, system, agent_model):
         model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
@@ -426,7 +590,15 @@ class Coordinator(Viewer, VectorLookupToolUser):
         tools = {tool_name: tool for (tool_name, tool), tapply in zip(tools.items(), applies, strict=False) if tapply}
         return agents, tools, {}
 
-    async def _compute_plan(self, messages: list[Message], context: TContext, agents: dict[str, Agent], tools: dict[str, Tool], pre_plan_output: dict) -> Plan:
+    async def _compute_plan(
+        self,
+        messages: list[Message],
+        context: TContext,
+        agents: dict[str, Agent],
+        tools: dict[str, Tool],
+        pre_plan_output: dict,
+        **kwargs: Any,
+    ) -> Plan:
         """
         Compute the execution graph for the given messages and agents.
         The graph is a list of ExecutionNode objects that represent
@@ -487,7 +659,7 @@ class Coordinator(Viewer, VectorLookupToolUser):
             self.steps_layout = Card(header=todos_layout, collapsed=not self.verbose, elevation=2)
             self.interface.stream(self.steps_layout, user="Planner")
             agents, tools, pre_plan_output = await self._pre_plan(messages, context, agents, tools)
-            plan = await self._compute_plan(messages, context, agents, tools, pre_plan_output)
+            plan = await self._compute_plan(messages, context, agents, tools, pre_plan_output, **kwargs)
         if plan is not None:
             self.steps_layout.header[0].object = "🧾 Checklist ready..."
             _, todos = plan.render_task_history(-1)

--- a/lumen/ai/coordinator/dependency.py
+++ b/lumen/ai/coordinator/dependency.py
@@ -79,7 +79,13 @@ class DependencyResolver(Coordinator):
         return await self._fill_model(messages, system, agent_model)
 
     async def _compute_plan(
-        self, messages: list[Message], context: TContext, agents: dict[str, Agent], tools: dict[str, Tool], pre_plan_output: dict[str, Any]
+        self,
+        messages: list[Message],
+        context: TContext,
+        agents: dict[str, Agent],
+        tools: dict[str, Tool],
+        pre_plan_output: dict[str, Any],
+        **kwargs: Any,
     ) -> Plan | None:
         if len(agents) == 1:
             agent = next(iter(agents.values()))

--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -19,7 +19,7 @@ from ..context import (
     LWW, ContextError, TContext, merge_contexts,
 )
 from ..llm import Message
-from ..models import FollowUpClassification
+from ..models import FollowUpClassification, ThinkingYesNo
 from ..report import ActorTask
 from ..tools import MetadataLookup, Tool
 from ..utils import log_debug, wrap_logfire

--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -112,11 +112,26 @@ class Planner(Coordinator):
         to making a plan.""",
     )
 
+    final_validation_enabled = param.Boolean(
+        default=False,
+        allow_refs=True,
+        doc="""
+        Whether to append a final ValidationAgent step after planning.""",
+    )
+
     prompts = param.Dict(
         default={
             "main": {
                 "template": PROMPTS_DIR / "Planner" / "main.jinja2",
                 "response_model": make_plan_model,
+            },
+            "partial_replan": {
+                "template": PROMPTS_DIR / "Planner" / "partial_replan.jinja2",
+                "response_model": make_plan_model,
+            },
+            "validate": {
+                "template": PROMPTS_DIR / "Planner" / "validate.jinja2",
+                "response_model": ThinkingYesNo,
             },
             "follow_up": {
                 "template": PROMPTS_DIR / "Planner" / "follow_up.jinja2",
@@ -298,6 +313,8 @@ class Planner(Coordinator):
         plan_model: type[RawPlan],
         step: ChatStep,
         is_follow_up: bool = False,
+        prompt_key: str = "main",
+        partial_replan_payload: dict[str, Any] | None = None,
     ) -> BaseModel:
         agents = list(agents.values())
         tools = list(tools.values())
@@ -322,9 +339,10 @@ class Planner(Coordinator):
             agent_candidates = [agent for agent in agents if not unmet_dependencies or set(agent.output_schema.__annotations__) & unmet_dependencies]
             tool_candidates = [tool for tool in tools if not unmet_dependencies or set(tool.output_schema.__annotations__) & unmet_dependencies]
             llm_tools, _, _ = self.llm._normalize_tools(self.llm.tools)
-            model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
+            active_prompt_key = prompt_key if prompt_key in self.prompts else "main"
+            model_spec = self.prompts[active_prompt_key].get("llm_spec", self.llm_spec_key)
             system = await self._render_prompt(
-                "main",
+                active_prompt_key,
                 messages,
                 context,
                 model_spec=model_spec,
@@ -336,7 +354,8 @@ class Planner(Coordinator):
                 previous_actors=previous_actors,
                 previous_plans=previous_plans,
                 is_follow_up=is_follow_up,
-                llm_tools=llm_tools
+                llm_tools=llm_tools,
+                partial_replan_payload=partial_replan_payload or {},
             )
             async for reasoning in self.llm.stream(
                 messages=messages,
@@ -480,7 +499,12 @@ class Planner(Coordinator):
             )
             actors_in_graph.add(actor)
 
-        if "ValidationAgent" in agents and len(actors_in_graph) > 1 and self.validation_enabled:
+        if (
+            "ValidationAgent" in agents and
+            len(actors_in_graph) > 1 and
+            self.validation_enabled and
+            self.final_validation_enabled
+        ):
             validation_step = type(step)(
                 actor="ValidationAgent",
                 instruction="Validate whether the executed plan fully answered the user's original query.",
@@ -497,12 +521,20 @@ class Planner(Coordinator):
         return plan, actors
 
     async def _compute_plan(
-        self, messages: list[Message], context: TContext, agents: dict[str, Agent], tools: dict[str, Tool], pre_plan_output: dict[str, Any]
+        self,
+        messages: list[Message],
+        context: TContext,
+        agents: dict[str, Agent],
+        tools: dict[str, Tool],
+        pre_plan_output: dict[str, Any],
+        **kwargs: Any,
     ) -> Plan:
         tool_names = list(tools)
         agent_names = list(agents)
         plan_model = self._get_model("main", agents=agent_names, tools=tool_names)
         is_followup = pre_plan_output["is_follow_up"]
+        partial_replan = bool(kwargs.get("partial_replan", False))
+        partial_replan_payload = kwargs.get("partial_replan_payload", {})
 
         planned = False
         unmet_dependencies = set()
@@ -527,6 +559,8 @@ class Planner(Coordinator):
                         plan_model,
                         istep,
                         is_follow_up=is_followup,
+                        prompt_key="partial_replan" if partial_replan else "main",
+                        partial_replan_payload=partial_replan_payload,
                     )
                 except asyncio.CancelledError as e:
                     self._todos_title.object = istep.failed_title = "Planning was cancelled, please try again."

--- a/lumen/ai/prompts/Planner/partial_replan.jinja2
+++ b/lumen/ai/prompts/Planner/partial_replan.jinja2
@@ -1,0 +1,46 @@
+{% extends 'Planner/main.jinja2' %}
+
+{%- block instructions %}
+You are performing a **partial replan** during execution.
+
+Your output must be a replacement plan tail only.
+
+Rules:
+- Do not recreate or rewrite already completed steps.
+- Focus on correcting the current failing direction and the remaining work.
+- Keep the plan minimal and dependency-safe.
+- Explicitly address the validator feedback.
+- If remaining steps are still valid, keep them with minimal edits.
+- Only return steps that should run **after** the completed steps.
+- NEVER use the same actor consecutively.
+{%- endblock -%}
+
+{% block context %}
+{{ super() }}
+
+## Partial Replan Payload
+{% if partial_replan_payload %}
+Current step index: {{ partial_replan_payload.get("current_step_index") }}
+
+Current step:
+{{ partial_replan_payload.get("current_step") }}
+
+Validator feedback:
+{{ partial_replan_payload.get("validation_reason", "") }}
+
+Current step result:
+{{ partial_replan_payload.get("step_result", "") }}
+
+Completed steps (must remain unchanged):
+{% for step in partial_replan_payload.get("completed_steps", []) %}
+- {{ step }}
+{% endfor %}
+
+Remaining steps to replace:
+{% for step in partial_replan_payload.get("remaining_steps", []) %}
+- {{ step }}
+{% endfor %}
+{% else %}
+No partial replan payload was provided. Produce the smallest safe continuation plan.
+{% endif %}
+{% endblock %}

--- a/lumen/ai/prompts/Planner/validate.jinja2
+++ b/lumen/ai/prompts/Planner/validate.jinja2
@@ -1,0 +1,72 @@
+{% extends 'Actor/main.jinja2' %}
+
+{%- block instructions %}
+You are a validation layer that runs **after each step** of a plan.
+
+Your job is to decide if the assistant should:
+
+- **CONTINUE**: keep executing the current plan as-is
+- **REPLAN**: stop the current plan and create a new one
+
+Base your decision on:
+
+1. The original user query
+2. The original plan and reasoning
+3. The current step description and its result
+4. The current data and SQL in memory (if any)
+
+Return yes if you are very confident that the current plan won't produce the correct results.
+
+Answer yes if any of these are true:
+
+- The current step result shows:
+  - Missing or wrong columns/data for what the user asked
+  - Empty or clearly irrelevant results
+  - Errors that indicate the current plan assumptions are wrong
+- The plan is clearly heading in the wrong direction relative to the user query
+- The user query cannot be satisfied with the current metaset/data in memory
+- Later steps in the plan depend on assumptions that are now known to be false
+
+### When to CONTINUE
+
+Answer no if:
+
+- The current step succeeded and produced data/results that match the plan
+- Any issues are minor and do not require changing the overall plan
+- The next steps can still be executed meaningfully with the current data and context
+
+Ground your reasoning in **concrete details** from:
+- The user query
+- The plan / reasoning
+- The current step description and its result
+- The current SQL/data in memory
+{%- endblock -%}
+
+{% block context %}
+Original user query:
+{{ memory.get('user_query', '') }}
+
+{% if memory.get('reasoning') %}
+Previous planning reasoning:
+{{ memory['reasoning'] }}
+{% endif %}
+
+{% if memory.get('plan') %}
+Planned steps:
+{{ memory['plan'] }}
+{% endif %}
+
+Current step result:
+{{ memory.get('step_result', '') }}
+
+{%- if 'sql' in memory %}
+🗃️ Current SQL:
+```sql
+{{ memory['sql'] }}
+{%- endif %}
+
+{%- if 'data' in memory %}
+📊 Data summary:
+{{ memory['data'] }}
+{%- endif %}
+{% endblock %}

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -423,6 +423,62 @@ async def test_planner_make_plan_uses_partial_replan_prompt(llm):
     assert captured["payload"] == payload
 
 
+async def test_plan_fast_validation_handles_expanded_replan(llm):
+    class DummyCoordinator(param.Parameterized):
+        validation_enabled = True
+        prompts = {"validate": {"template": None}}
+
+        def __init__(self):
+            self.partial_replan_calls = 0
+            self._validate_calls = 0
+
+        def _serialize(self, obj):
+            return str(obj)
+
+        async def _invoke_prompt(self, prompt, messages, context, **kwargs):
+            self._validate_calls += 1
+            # Trigger replanning only once on the second original task.
+            if self._validate_calls == 2:
+                return ThinkingYesNo(chain_of_thought="Second step is incorrect, replan from here.", yes=True)
+            return ThinkingYesNo(chain_of_thought="Continue.", yes=False)
+
+        async def respond(self, messages, context, **kwargs):
+            self.partial_replan_calls += 1
+            return Plan(
+                ActorTask(ChatAgent(llm=llm), title="Rewritten B1", instruction="Rewrite current step"),
+                ActorTask(ChatAgent(llm=llm), title="Added B2", instruction="New follow-up task"),
+                ActorTask(ChatAgent(llm=llm), title="Added B3", instruction="Another follow-up task"),
+                history=messages,
+                context=context,
+                coordinator=self,
+            )
+
+    llm.set_responses([
+        "output-a",     # original A
+        "output-b",     # original B (will be invalidated)
+        "output-b1",    # rewritten current step
+        "output-b2",    # extra task 1
+        "output-b3",    # extra task 2
+    ])
+    coordinator = DummyCoordinator()
+    plan = Plan(
+        ActorTask(ChatAgent(llm=llm), title="Original A", instruction="First"),
+        ActorTask(ChatAgent(llm=llm), title="Original B", instruction="Second"),
+        history=[{"role": "user", "content": "Do a multi-step task"}],
+        context={},
+        coordinator=coordinator,
+    )
+
+    await plan.execute()
+
+    assert plan.status == "success"
+    assert coordinator.partial_replan_calls == 1
+    titles = [task.title for task in plan]
+    assert titles == ["Original A", "Rewritten B1", "Added B2", "Added B3"]
+    assert all(task.status == "success" for task in plan)
+    assert plan._current == len(plan)
+
+
 # -------------------------------------------------------------------
 # Tests for chat file upload fix (reuse ephemeral source + MetadataLookup tracking)
 # -------------------------------------------------------------------

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -333,7 +333,7 @@ async def test_plan_fast_validation_triggers_partial_replan(llm):
     call = coordinator.partial_replan_calls[0]
     assert call.kwargs["partial_replan"] is True
     assert call.kwargs["partial_replan_payload"]["current_step_index"] == 0
-    assert call.kwargs["partial_replan_payload"]["remaining_steps"][0]["title"] == "Second"
+    assert call.kwargs["partial_replan_payload"]["remaining_steps"][0]["title"] == "First"
 
 
 async def test_plan_fast_validation_respects_replan_limit(llm):

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -1,8 +1,10 @@
 import io
 
+from types import SimpleNamespace
 from typing import get_args
 
 import pandas as pd
+import param
 import pytest
 
 try:
@@ -19,7 +21,7 @@ from lumen.ai.controls.base import BaseSourceControls, UploadedFileRow
 from lumen.ai.coordinator import Coordinator, Plan, Planner
 from lumen.ai.coordinator.planner import Reasoning, make_plan_model
 from lumen.ai.editors import SQLEditor
-from lumen.ai.models import ReplaceLine, RetrySpec
+from lumen.ai.models import ReplaceLine, RetrySpec, ThinkingYesNo
 from lumen.ai.report import ActorTask
 from lumen.ai.schemas import get_metaset
 from lumen.ai.tools import FunctionTool, define_tool
@@ -29,6 +31,15 @@ from lumen.sources.duckdb import DuckDBSource
 
 async def test_planner_instantiate():
     Planner()
+
+
+async def test_planner_preserves_prompt_defaults_on_init():
+    planner = Planner()
+    assert set(planner.prompts) >= {"main", "partial_replan", "validate", "follow_up"}
+    assert "template" in planner.prompts["main"]
+    assert "response_model" in planner.prompts["partial_replan"]
+    assert "response_model" in planner.prompts["validate"]
+    assert planner.prompts["main"]["tools"]
 
 
 def _add_one(value: int) -> int:
@@ -281,6 +292,135 @@ async def test_plan_revise(sql_plan):
     )
     await async_wait_until(lambda: len(sql_plan.views) == 4)
     assert sql_plan.views[3].object == "Result: 10.5"
+
+
+async def test_plan_fast_validation_triggers_partial_replan(llm):
+    class DummyCoordinator(param.Parameterized):
+        validation_enabled = True
+        prompts = {"validate": {"template": None}}
+
+        def __init__(self):
+            self.partial_replan_calls = []
+
+        def _serialize(self, obj):
+            return str(obj)
+
+        async def _invoke_prompt(self, prompt, messages, context, **kwargs):
+            assert prompt == "validate"
+            return ThinkingYesNo(chain_of_thought="Current direction is wrong.", yes=True)
+
+        async def respond(self, messages, context, **kwargs):
+            self.partial_replan_calls.append(SimpleNamespace(messages=messages, context=context, kwargs=kwargs))
+            replacement_task = ActorTask(ChatAgent(llm=llm), title="Replacement", instruction="Run replacement step")
+            return Plan(replacement_task, history=messages, context=context, coordinator=self)
+
+    llm.set_responses(["first output", "replacement output", "extra output", "extra output 2"])
+    coordinator = DummyCoordinator()
+    plan = Plan(
+        ActorTask(ChatAgent(llm=llm), title="First", instruction="Run first step"),
+        ActorTask(ChatAgent(llm=llm), title="Second", instruction="Run second step"),
+        history=[{"role": "user", "content": "Do two steps"}],
+        context={},
+        coordinator=coordinator,
+    )
+
+    await plan.execute()
+
+    assert plan.status == "success"
+    assert any(task.title == "Replacement" for task in plan)
+    assert all(task.title != "Second" for task in plan)
+    assert len(coordinator.partial_replan_calls) >= 1
+    call = coordinator.partial_replan_calls[0]
+    assert call.kwargs["partial_replan"] is True
+    assert call.kwargs["partial_replan_payload"]["current_step_index"] == 0
+    assert call.kwargs["partial_replan_payload"]["remaining_steps"][0]["title"] == "Second"
+
+
+async def test_plan_fast_validation_respects_replan_limit(llm):
+    class DummyCoordinator(param.Parameterized):
+        validation_enabled = True
+        prompts = {"validate": {"template": None}}
+
+        def __init__(self):
+            self.partial_replan_calls = 0
+
+        def _serialize(self, obj):
+            return str(obj)
+
+        async def _invoke_prompt(self, prompt, messages, context, **kwargs):
+            return ThinkingYesNo(chain_of_thought="Replan requested.", yes=True)
+
+        async def respond(self, messages, context, **kwargs):
+            self.partial_replan_calls += 1
+            replacement_task = ActorTask(ChatAgent(llm=llm), title="Replacement", instruction="Run replacement step")
+            return Plan(replacement_task, history=messages, context=context, coordinator=self)
+
+    llm.set_responses(["first output", "second output"])
+    coordinator = DummyCoordinator()
+    plan = Plan(
+        ActorTask(ChatAgent(llm=llm), title="First", instruction="Run first step"),
+        ActorTask(ChatAgent(llm=llm), title="Second", instruction="Run second step"),
+        history=[{"role": "user", "content": "Do two steps"}],
+        context={},
+        coordinator=coordinator,
+        max_partial_replans=0,
+    )
+
+    await plan.execute()
+
+    assert plan.status == "success"
+    rendered = [view.object for view in plan.views if isinstance(view, ChatMessage)]
+    assert "first output" in rendered
+    assert "second output" in rendered
+    assert coordinator.partial_replan_calls == 0
+
+
+async def test_planner_make_plan_uses_partial_replan_prompt(llm):
+    plan_model = make_plan_model(["ChatAgent"], [])
+    (StepModel,) = get_args(plan_model.__annotations__['steps'])
+    llm.set_responses([
+        Reasoning(chain_of_thought="Adjust only remaining steps."),
+        plan_model(title="Partial", steps=[
+            StepModel(actor="ChatAgent", instruction="Continue with corrected step", title="Corrected step")
+        ]),
+    ])
+
+    planner = Planner(llm=llm)
+    planner.prompts = {
+        **planner.prompts,
+        "partial_replan": {
+            "template": None,
+            "response_model": make_plan_model,
+        },
+    }
+    chat_agent = ChatAgent(llm=llm)
+    captured = {}
+
+    async def _capture_render(prompt_key, messages, context, **kwargs):
+        captured["prompt_key"] = prompt_key
+        captured["payload"] = kwargs.get("partial_replan_payload")
+        return "Render output"
+
+    planner._render_prompt = _capture_render
+    step = SimpleNamespace(stream=lambda *args, **kwargs: None)
+    payload = {"validation_reason": "Wrong table selected"}
+    raw_plan = await planner._make_plan(
+        messages=[{"role": "user", "content": "Fix the plan"}],
+        context={},
+        agents={"ChatAgent": chat_agent},
+        tools={},
+        unmet_dependencies=set(),
+        previous_actors=[],
+        previous_plans=[],
+        plan_model=plan_model,
+        step=step,
+        prompt_key="partial_replan",
+        partial_replan_payload=payload,
+    )
+
+    assert raw_plan.title == "Partial"
+    assert captured["prompt_key"] == "partial_replan"
+    assert captured["payload"] == payload
 
 
 # -------------------------------------------------------------------

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -231,6 +231,27 @@ async def test_exploration_ui_error_replan(explorer_ui_with_error):
     tabs = exploration.view[0]
     assert len(tabs) == 2
 
+async def test_replan_requests_new_plan(explorer_ui_with_error, monkeypatch):
+    ui = explorer_ui_with_error
+    exploration = ui._exploration["view"]
+    current_plan = exploration.plan
+
+    new_plan = Plan(
+        ActorTask(ChatAgent(llm=ui.llm)),
+        history=current_plan.history,
+        title="Replanned",
+        context=ui.context,
+    )
+    respond = AsyncMock(return_value=new_plan)
+    execute_plan = AsyncMock()
+    monkeypatch.setattr(ui._coordinator, "respond", respond)
+    monkeypatch.setattr(ui, "_execute_plan", execute_plan)
+
+    await ui._replan(current_plan, ui._explorations.value)
+
+    assert respond.await_count == 1
+    assert execute_plan.await_count == 1
+
 async def test_add_exploration_from_explorer(explorer_ui):
     """Test creating an exploration from the table explorer."""
     # Set up the explorer to have a table selected


### PR DESCRIPTION
## Description

- Add a post-step validation hook in the plan execution loop (after each primary actor task output is available).
- If step validation fails/incomplete, gather compact replanning context (original user goal, completed steps, failed/current step, validation findings, available agents/tools, current execution context).
- Invoke Planner in partial replan mode using a new prompt template and update only the remaining plan segment.
- Continue execution from the newly spliced plan tail.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

Wrote detailed specification of what I wanted the validation / replan loop to look like and reviewed the generated code in detail.

Tools and Models: 5.3 Codex

## Checklist

- [x] Tests added and are passing
- [ ] Added documentation
