### PR TITLE
Tweak revise prompt

### DIFF
--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
 
 class RawStep(BaseModel):
+    title: str
     actor: str
     instruction: str = Field(
         description="""
@@ -50,7 +51,6 @@ class RawStep(BaseModel):
             "Plot a line chart of sales over time.",
         ],
     )
-    title: str
 
 
 class RawPlan(BaseModel):

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -343,10 +343,7 @@ class VegaLiteEditor(LumenEditor):
             import vl_convert as vlc
             vlc.vegalite_to_vega(spec)
         except ValueError as e:
-            # Strip JavaScript stack trace noise from vl-convert errors
             msg = str(e)
-            if '\n    at ' in msg:
-                msg = msg[:msg.index('\n    at ')]
             raise RuntimeError(msg) from e
         return super().validate_spec(spec)
 

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -11,11 +11,8 @@ from io import BytesIO, StringIO
 from typing import TYPE_CHECKING, Any
 
 import param
-import requests
 
-from jsonschema import Draft7Validator, ValidationError
 from panel.config import config
-from panel.io import cache
 from panel.layout import Column, Row
 from panel.pane import (
     PDF, DeckGL, Markdown, panel as as_panel,
@@ -36,7 +33,7 @@ from ..pipeline import Pipeline
 from ..transforms.sql import SQLLimit
 from ..views.base import Panel, Table, View
 from .analysis import Analysis
-from .config import FORMAT_ICONS, FORMAT_LABELS, VEGA_ZOOMABLE_MAP_ITEMS
+from .config import FORMAT_ICONS, FORMAT_LABELS
 from .controls import AnnotationControls, CopyControls, RetryControls
 from .utils import describe_data, get_data
 
@@ -321,91 +318,6 @@ class VegaLiteEditor(LumenEditor):
 
         return BytesIO(out) if isinstance(out, bytes) else StringIO(out)
 
-    @cache
-    @staticmethod
-    def _load_vega_lite_schema(schema_url: str | None = None):
-        return requests.get(schema_url, timeout=0.5).json()
-
-    @staticmethod
-    def _format_validation_error(error: ValidationError) -> str:
-        """Turn a (possibly nested) JSONSchema ValidationError into readable lines."""
-
-        # 1) Collect leaf errors (ignore parents that just aggregate alternatives)
-        GROUP_VALIDATORS = {"anyOf", "oneOf", "allOf", "not"}
-
-        def iter_leaves(err: ValidationError):
-            # If this error has nested contexts, descend; otherwise it's a leaf
-            if err.context:
-                for e in err.context:
-                    yield from iter_leaves(e)
-            else:
-                yield err
-
-        leaves = list(iter_leaves(error))
-        if not leaves:
-            # Fallback: no leaves; return the top-level message
-            return f"{error.json_path}: {error.message}"
-
-        # 2) Remove group-validator parents that slipped through (rare on leaves, but safe)
-        leaves = [e for e in leaves if (e.validator or "") not in GROUP_VALIDATORS]
-
-        # 3) If there are any non-root errors, drop root-level `$` to reduce noise
-        if any(e.json_path != "$" for e in leaves):
-            leaves = [e for e in leaves if e.json_path != "$"]
-
-        # 4) Per-path choose the "best" error by (priority, -depth) then stable order
-        # Lower priority number wins; deeper path wins for ties
-        PRIORITY = {
-            "required": 0,
-            "additionalProperties": 1,
-            "enum": 2,
-            "const": 2,
-            "type": 3,
-            "format": 4,
-            "pattern": 4,
-        }
-
-        def path_depth(p: str) -> int:
-            # Rough depth metric: count of separators
-            return p.count(".") + p.count("[") + p.count("]")
-
-        def priority(err: ValidationError) -> tuple[int, int]:
-            return (PRIORITY.get(err.validator or "", 5), -path_depth(err.json_path))
-
-        winners: dict[str, ValidationError] = {}
-        for e in leaves:
-            p = e.json_path
-            if p not in winners or priority(e) < priority(winners[p]):
-                winners[p] = e
-
-        # 5) Nicely format each error; include a compact instance snippet when useful
-        def fmt_value(val) -> str:
-            try:
-                s = json.dumps(val, ensure_ascii=False)
-            except Exception:
-                s = repr(val)
-            if len(s) > 80:
-                s = s[:77] + "..."
-            return s
-
-        lines = []
-        # Sort by path, then by priority within the same path for deterministic output
-        for p, e in sorted(winners.items(), key=lambda kv: (kv[0], priority(kv[1]))):
-            # Some messages are already very clear; optionally append value snippet
-            suffix = ""
-            # Show the instance if it's short and the message isn't already repeating it
-            try:
-                inst = e.instance
-                if inst is not None and e.validator != "required":
-                    snippet = fmt_value(inst)
-                    if snippet and snippet not in e.message:
-                        suffix = f" (value={snippet})"
-            except Exception:
-                pass
-            lines.append(f"{p}: {e.message}{suffix}")
-
-        return "\n".join(lines)
-
     @classmethod
     def _serialize_component(cls, component: Component, spec_dict: dict[str, Any] | None = None) -> tuple[str, dict[str, Any]]:
         component_spec = spec_dict or component.to_spec()
@@ -428,23 +340,14 @@ class VegaLiteEditor(LumenEditor):
         if "spec" in spec:
             spec = spec["spec"]
         try:
-            vega_lite_schema = cls._load_vega_lite_schema(
-                spec.get("$schema", "https://vega.github.io/schema/vega-lite/v5.json")
-            )
-        except Exception:
-            return super().validate_spec(spec)
-        vega_lite_validator = Draft7Validator(vega_lite_schema)
-        try:
-            # the zoomable params work, but aren't officially valid
-            # so we need to remove them for validation
-            # https://stackoverflow.com/a/78342773/9324652
-            spec_copy = deepcopy(spec)
-            for key in VEGA_ZOOMABLE_MAP_ITEMS.get("projection", {}):
-                spec_copy.get("projection", {}).pop(key, None)
-            spec_copy.pop("params", None)
-            vega_lite_validator.validate(spec_copy)
-        except ValidationError as e:
-            raise RuntimeError(cls._format_validation_error(e)) from e
+            import vl_convert as vlc
+            vlc.vegalite_to_vega(spec)
+        except ValueError as e:
+            # Strip JavaScript stack trace noise from vl-convert errors
+            msg = str(e)
+            if '\n    at ' in msg:
+                msg = msg[:msg.index('\n    at ')]
+            raise RuntimeError(msg) from e
         return super().validate_spec(spec)
 
     def __str__(self):

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -344,6 +344,8 @@ class VegaLiteEditor(LumenEditor):
             vlc.vegalite_to_vega(spec)
         except ValueError as e:
             msg = str(e)
+            if '\n    at Nc.' in msg:
+                msg = msg[:msg.index('\n    at Nc.')]
             raise RuntimeError(msg) from e
         return super().validate_spec(spec)
 

--- a/lumen/ai/prompts/Actor/main.jinja2
+++ b/lumen/ai/prompts/Actor/main.jinja2
@@ -34,9 +34,9 @@ Note, your last output did not work as intended:
 {% endif %}
 {%- if errors is defined and errors %}
 Your task is to expertly address these errors so they do not occur again:
-```
-{{ errors }}
-```
+{% for error in errors %}
+- {{ error }}
+{% endfor %}
 {%- endif %}
 {%- endblock -%}
 

--- a/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
+++ b/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
@@ -1,20 +1,18 @@
 {% extends 'Agent/main.jinja2' %}
 
 {% block instructions %}
-You are an expert code editor and debugging specialist. Your task is to fix specific issues in the provided code based
-on user feedback.
+You are an expert code editor. Your task is to revise the provided code based on user feedback.
+
+Process:
+1. First, read the original code carefully and identify any existing structural issues (e.g. misplaced properties, incorrect nesting) — even ones the user didn't mention.
+2. Then, determine what the corrected code should look like to satisfy the feedback.
+3. Finally, produce the minimal set of line edits to get from the original to the corrected version.
 
 Critical Requirements:
-- Only modify the lines that need to be changed based on the feedback
-- Preserve all original formatting, indentation, and structure
-- Focus on the specific problems mentioned in the feedback
-- Do NOT add explanatory comments or additional code unless specifically requested
-- Maintain the exact same language and syntax style as the original
-- If the feedback mentions an error, ensure the fix directly addresses that error
-- Ground your response in the specific dataset at hand; do not try to guess column names
-- Declare if your edit is a "insert", "replace" or "delete" op
-
-Your response should contain ONLY the corrected code with no additional text.
+- Only modify lines that need to change, but DO fix pre-existing structural bugs if they affect the requested change
+- Preserve original formatting, indentation, and style
+- Ground your response in the specific dataset at hand; do not guess column names
+- Each edit must declare its op: "insert", "replace", or "delete"
 {% endblock %}
 
 {%- block context %}
@@ -33,6 +31,7 @@ Original code with line numbers:
 {{ numbered_text }}
 ```
 
-Please restate this feedback in your own words, and then try to fix the code based on the feedback provided:
-{{ feedback }}
+Feedback: {{ feedback }}
+
+Before editing, briefly audit the original code for any structural issues relevant to this feedback (e.g. properties nested under the wrong parent, missing sibling properties). Then produce your edits.
 {% endblock %}


### PR DESCRIPTION
Since we already have a vlc dependency to download images, let's also use it to validate the vegalite specs; it's removes the _format_validation_error complexity, the request to fetch schema, and it also gives better errors.

Here I asked it to overlay text on the largest and this was from the first retry:
```
Error: Invalid specification {"encoding":{"color":{"field":"impact_energy_kt","legend":{"title":"Impact energy (kt)"},"scale":{"scheme":"blues"},"type":"quantitative"},"latitude":{"field":"lat","type":"quantitative"},"longitude":{"field":"lon","type":"quantitative"},"size":{"field":"impact_energy_kt","legend":{"title":"Impact energy (kt)"},"scale":{"range":[20,700]},"type":"quantitative"},"tooltip":[{"field":"date","title":"Date","type":"temporal"},{"field":"lat","title":"Latitude","type":"quantitative"},{"field":"lon","title":"Longitude","type":"quantitative"},{"field":"impact_energy_kt","format":".2f","title":"Impact energy (kt)","type":"quantitative"},{"field":"optical_energy_GJ","format":".2f","title":"Optical energy (GJ)","type":"quantitative"}]}}. Make sure the specification includes at least one of the following properties: "mark", "layer", "facet", "hconcat", "vconcat", "concat", or "repeat".
```

<img width="1748" height="931" alt="image" src="https://github.com/user-attachments/assets/b8515e98-b880-49e1-87ae-3b3f086745fb" />

I also tighten the prompt language.

The original revise failed:
```
Feedback: overlay text on the largest:

Before editing, briefly audit the original code for any structural issues relevant to this feedback (e.g. properties nested under the wrong parent, missing sibling properties). Then produce your edits.

Your task is to expertly address these errors so they do not occur again:

['mapping values are not allowed here\n  in "<unicode string>", line 76, column 11:\n          type: quantitative\n              ^', 'mapping values are not allowed here\n  in "<unicode string>", line 82, column 15:\n            scheme: viridis\n                  ^']

...


expected <block end>, but found '-'
  in "<unicode string>", line 114, column 5:
        - field: optical_energy_GJ
        ^

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/site-packages/panel/io/server.py", line 158, in wrapped
    return await func(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/site-packages/param/parameterized.py", line 921, in _async_caller
    await function()
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/site-packages/param/depends.py", line 81, in _depends
    return await func(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/controls/revision.py", line 117, in _revise
    new_spec = await self.task.actor.revise(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/agents/vega_lite.py", line 651, in revise
    return await super().revise(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 310, in async_wrapper
    raise RetriesExceededError("Maximum number of retries exceeded.") from e
lumen.ai.config.RetriesExceededError: Maximum number of retries exceeded.
```

