### PR TITLE
Tweak insert prompt

### DIFF
--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
 
 class RawStep(BaseModel):
+    title: str
     actor: str
     instruction: str = Field(
         description="""
@@ -50,7 +51,6 @@ class RawStep(BaseModel):
             "Plot a line chart of sales over time.",
         ],
     )
-    title: str
 
 
 class RawPlan(BaseModel):

--- a/lumen/ai/models.py
+++ b/lumen/ai/models.py
@@ -82,19 +82,20 @@ class FollowUpClassification(BaseModel):
 class InsertLine(BaseModel):
     op: Literal["insert"] = "insert"
     line_no: int = Field(ge=1, description=(
-        "Insert BEFORE this 1-based line number. "
-        "Use line_no == len(lines) to append at the end."
+        "Insert new content BEFORE this original line number (1-based). "
+        "To append after the last line, use line_no = last_line + 1. "
+        "Multiple inserts at the same line_no appear in the order given."
     ))
     line: str = Field(min_length=1, description="Content for the new line (must be non-empty).")
 
 class ReplaceLine(BaseModel):
     op: Literal["replace"] = "replace"
-    line_no: int = Field(ge=1, description="The 1-based line number to replace.")
+    line_no: int = Field(ge=1, description="The original line number (1-based) to replace.")
     line: str = Field(description="The new content for the line (empty string is allowed).")
 
 class DeleteLine(BaseModel):
     op: Literal["delete"] = "delete"
-    line_no: int = Field(ge=1, description="The 1-based line number to delete.")
+    line_no: int = Field(ge=1, description="The original line number (1-based) to delete.")
 
 LineEdit = Annotated[
     InsertLine | ReplaceLine | DeleteLine,

--- a/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
+++ b/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
@@ -13,6 +13,8 @@ Critical Requirements:
 - Preserve original formatting, indentation, and style
 - Ground your response in the specific dataset at hand; do not guess column names
 - Each edit must declare its op: "insert", "replace", or "delete"
+- All line_no values refer to the ORIGINAL numbering shown above — they do not shift as edits are applied
+- To insert a block of N lines before original line L, use N inserts all with line_no=L — they appear in order
 {% endblock %}
 
 {%- block context %}

--- a/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
+++ b/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
@@ -1,20 +1,18 @@
 {% extends 'Agent/main.jinja2' %}
 
 {% block instructions %}
-You are an expert code editor and debugging specialist. Your task is to fix specific issues in the provided code based
-on user feedback.
+You are an expert code editor. Your task is to revise the provided code based on user feedback.
+
+Process:
+1. First, read the original code carefully and identify any existing structural issues (e.g. misplaced properties, incorrect nesting) — even ones the user didn't mention.
+2. Then, determine what the corrected code should look like to satisfy the feedback.
+3. Finally, produce the minimal set of line edits to get from the original to the corrected version.
 
 Critical Requirements:
-- Only modify the lines that need to be changed based on the feedback
-- Preserve all original formatting, indentation, and structure
-- Focus on the specific problems mentioned in the feedback
-- Do NOT add explanatory comments or additional code unless specifically requested
-- Maintain the exact same language and syntax style as the original
-- If the feedback mentions an error, ensure the fix directly addresses that error
-- Ground your response in the specific dataset at hand; do not try to guess column names
-- Declare if your edit is a "insert", "replace" or "delete" op
-
-Your response should contain ONLY the corrected code with no additional text.
+- Only modify lines that need to change, but DO fix pre-existing structural bugs if they affect the requested change
+- Preserve original formatting, indentation, and style
+- Ground your response in the specific dataset at hand; do not guess column names
+- Each edit must declare its op: "insert", "replace", or "delete"
 {% endblock %}
 
 {%- block context %}
@@ -33,6 +31,7 @@ Original code with line numbers:
 {{ numbered_text }}
 ```
 
-Please restate this feedback in your own words, and then try to fix the code based on the feedback provided:
-{{ feedback }}
+Feedback: {{ feedback }}
+
+Before editing, briefly audit the original code for any structural issues relevant to this feedback (e.g. properties nested under the wrong parent, missing sibling properties). Then produce your edits.
 {% endblock %}


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/1774

I asked Claude about this:

```
pythonedits=[
    ReplaceLine(op='replace', line_no=60, line='- transform:'),
    InsertLine(op='insert', line_no=61, line='    - joinaggregate:'),
    InsertLine(op='insert', line_no=62, line='        - op: max'),
    InsertLine(op='insert', line_no=63, line='          field: optical_energy_GJ'),
    InsertLine(op='insert', line_no=64, line='          as: max_optical_energy_GJ'),
    InsertLine(op='insert', line_no=65, line='    - filter: datum.optical_energy_GJ == datum.max_optical_energy_GJ'),
    InsertLine(op='insert', line_no=66, line='  encoding:')
]
```

It identified that...

The problem: the LLM is using ascending line_no for inserts (61, 62, 63, 64, 65, 66) as if they're sequential lines in the final output. But InsertLine says "insert BEFORE this 1-based line number" — all these line numbers refer to the original document. After the first insert shifts everything down, the subsequent inserts' line numbers are off.
Looking at apply_changes, inserts are applied in ascending order and positions are capped at len(out), so sequential inserts at 61, 62, 63... would actually work correctly since they're applied after replaces/deletes. But the description is confusing — it says "insert BEFORE this 1-based line number" which makes the LLM think about original positions.
The key improvement: make the InsertLine description clearer about how consecutive inserts work, and improve the base prompt to explain the semantics briefly.

After, it's been one-shotting edits successfully! 