### PR TITLE
Add slice support to SQLFilter for BETWEEN queries

### DIFF
--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -276,6 +276,32 @@ def test_sql_filter_datetime_range():
     assert result == expected
 
 
+def test_sql_filter_slice_numeric():
+    result = SQLFilter.apply_to(
+        "SELECT * FROM TABLE", conditions=[("A", slice(20.0, 40.0))]
+    )
+    expected = "SELECT * FROM (SELECT * FROM TABLE) WHERE A BETWEEN '20.0' AND '40.0'"
+    assert result == expected
+
+
+def test_sql_filter_slice_date():
+    result = SQLFilter.apply_to(
+        "SELECT * FROM TABLE",
+        conditions=[("A", slice(dt.date(2017, 2, 22), dt.date(2017, 4, 14)))],
+    )
+    expected = "SELECT * FROM (SELECT * FROM TABLE) WHERE A BETWEEN '2017-02-22 00:00:00' AND '2017-04-14 23:59:59'"
+    assert result == expected
+
+
+def test_sql_filter_slice_datetime():
+    result = SQLFilter.apply_to(
+        "SELECT * FROM TABLE",
+        conditions=[("A", slice(dt.datetime(2017, 2, 22), dt.datetime(2017, 4, 14)))],
+    )
+    expected = "SELECT * FROM (SELECT * FROM TABLE) WHERE A BETWEEN '2017-02-22 00:00:00' AND '2017-04-14 00:00:00'"
+    assert result == expected
+
+
 def test_sql_prefilter_basic():
     """Test basic prefiltering on a single table."""
     result = SQLPreFilter.apply_to(

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -585,6 +585,19 @@ class SQLFilterBase(SQLTransform):
                     else:
                         # No None values
                         filters.append(column_expr.isin(*[SQLLiteral.string(str(v)) for v in val]))
+            elif isinstance(val, slice) and val.start is not None and val.stop is not None:
+                start, end = val.start, val.stop
+                if isinstance(start, dt.date) and not isinstance(start, dt.datetime):
+                    start_str = f"{start} 00:00:00"
+                else:
+                    start_str = str(start)
+
+                if isinstance(end, dt.date) and not isinstance(end, dt.datetime):
+                    end_str = f"{end} 23:59:59"
+                else:
+                    end_str = str(end)
+
+                filters.append(column_expr.between(SQLLiteral.string(start_str), SQLLiteral.string(end_str)))
             else:
                 self.param.warning(f"Condition {val!r} on {col!r} column not understood. Filter query will not be applied.")
                 continue


### PR DESCRIPTION
## Description

`SQLFilter._build_filter_conditions()` currently handles tuples, lists, dates, and scalars, but silently skips `slice` objects with a warning. This means any SQL source that receives slice-based range filters (e.g. `lat=slice(20.0, 40.0)`) must manually convert them to tuples before passing to SQLFilter.

I ran into this while working on `XArraySQLSource` (#1741), where Lumen's filter layer passes `slice` objects for range queries. The workaround was a manual `slice-to-tuple` conversion in `get()`, but the fix belongs in `SQLFilter` so all SQL sources benefit.

### What changed

Added native `slice(start, stop)` handling to `_build_filter_conditions()` that produces a `BETWEEN` clause, reusing the same date-aware logic as the existing tuple handler.

```python
# Before: silently skipped with warning
SQLFilter.apply_to("SELECT * FROM t", conditions=[("lat", slice(20, 40))])
# WARNING: Condition slice(20, 40, None) on 'lat' column not understood.

# After: generates BETWEEN
SQLFilter.apply_to("SELECT * FROM t", conditions=[("lat", slice(20, 40))])
# SELECT * FROM (SELECT * FROM t) WHERE lat BETWEEN '20' AND '40'
```

## How Has This Been Tested?

3 new tests covering numeric, date, and datetime slices. Full suite passes (107/107).

```bash
pytest lumen/tests/transforms/test_sql.py -v
```

## AI Disclosure

I identified this gap while developing XArraySQLSource. AI tools helped scaffold the implementation. I reviewed and tested all code manually.