### PR TITLE
Fix SQL agent crash when source.tables is a list

### DIFF
--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -438,6 +438,8 @@ class SQLAgent(BaseLumenAgent):
         """Execute SQL query and return pipeline and summary."""
         # Create SQL source
         source_tables = source.tables if source.tables is not None else {}
+        if isinstance(source_tables, list):
+            source_tables = {t: source.get_sql_expr(t) for t in source_tables}
         table_defs = {table: source_tables[table] for table in tables if table in source_tables}
         table_defs[expr_slug] = sql_query
 


### PR DESCRIPTION
## Problem

`SQLAgent._execute_query` at line 440 assumes `source.tables` is always a dict and subscripts it with `source_tables[table]`. But `BaseSQLSource` subclasses (like `XArraySQLSource`) may store `tables` as a list, causing:

```
TypeError: list indices must be integers or slices, not str
```

This crashes any SQL query on non-DuckDB sources that use list-based table storage.

## Fix

Convert list to dict via `get_sql_expr()` before subscripting (2 lines):

```python
if isinstance(source_tables, list):
    source_tables = {t: source.get_sql_expr(t) for t in source_tables}
```

## How to reproduce

```python
from lumen.sources.base import BaseSQLSource

class ListTableSource(BaseSQLSource):
    tables = ["my_table"]
    # ... _execute_query crashes with TypeError
```

