### PR TITLE
ci: Align build and docs actions with other repos

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
           install: false
       - name: conda build
         run: pixi run -e build build-conda
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: conda
@@ -64,7 +64,7 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: conda
           path: dist/
@@ -100,7 +100,7 @@ jobs:
           install: false
       - name: Build package
         run: pixi run -e build build-pip
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: pip
@@ -112,10 +112,10 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: [pip_build]
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: pip
           path: dist/
@@ -130,7 +130,7 @@ jobs:
     needs: [pip_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: pip
           path: dist/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,6 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+a[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+b[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
-  # Dry-run only
   workflow_dispatch:
   schedule:
     - cron: "0 17 * * SUN"
@@ -16,8 +15,8 @@ defaults:
     shell: bash -e {0}
 
 env:
-  PYTHON_VERSION: "3.11"
   PACKAGE: "lumen"
+  PYTHON_VERSION: "3.11"
 
 jobs:
   waiting_room:
@@ -51,8 +50,8 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: conda
-          path: dist/*.tar.bz2
+          name: artifacts-conda
+          path: dist/*.conda
           if-no-files-found: error
 
   conda_publish:
@@ -60,33 +59,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [conda_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    defaults:
-      run:
-        shell: bash -el {0}
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: conda
+          name: artifacts-conda
           path: dist/
-      - name: Set environment variables
+      - name: anaconda setup
         run: |
-          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniconda-version: "latest"
-          channels: "conda-forge"
-      - name: conda setup
+          pipx install anaconda-client
+          binstar --version
+      - name: anaconda dev upload
+        if: contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')
         run: |
-          conda install -y anaconda-client
-      - name: conda dev upload
-        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
+          binstar --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev dist/*.conda
+      - name: anaconda upload
+        if: (!(contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')))
         run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
-      - name: conda main upload
-        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
-        run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
+          binstar --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main dist/*.conda
 
   pip_build:
     name: Build PyPI
@@ -103,7 +92,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: pip
+          name: artifacts-pip
           path: dist/
           if-no-files-found: error
 
@@ -117,7 +106,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/download-artifact@v8
         with:
-          name: pip
+          name: artifacts-pip
           path: dist/
       - name: Install package
         run: python -m pip install dist/*.whl
@@ -129,14 +118,46 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pip_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: pip
+          name: artifacts-pip
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  announce:
+    name: Announce GitHub
+    runs-on: ubuntu-latest
+    needs: [waiting_room]
+    permissions:
+      contents: write
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    env:
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
-          user: ${{ secrets.PPU }}
-          password: ${{ secrets.PPP }}
-          repository-url: "https://upload.pypi.org/legacy/"
+          pattern: artifacts-*
+          path: artifacts/
+          merge-multiple: true
+      - name: Extract changelog section
+        run: |
+          awk -v ver="## Version ${TAG#v}" '
+            $0 == ver {flag=1; next}
+            /^#{2} Version / && flag {exit}
+            flag && !/^(\*\*.*\*\*)$/
+          ' CHANGELOG.md | tee RELEASE_BODY.md
+      - name: Create draft GitHub release with dist artifacts
+        if: (!(contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$TAG" \
+            --title "Version ${TAG#v}" \
+            --notes-file RELEASE_BODY.md \
+            --draft \
+            artifacts/*

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -46,7 +46,7 @@ jobs:
           environments: docs
       - name: Build documentation
         run: pixi run -e docs docs-build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: docs
@@ -66,7 +66,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: docs
           path: builtdocs/
@@ -74,7 +74,7 @@ jobs:
         id: vars
         run: echo "tag=${{ needs.docs_build.outputs.tag }}" >> $GITHUB_OUTPUT
       - name: upload dev
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
           (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
@@ -87,7 +87,7 @@ jobs:
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
           (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./builtdocs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -52,9 +52,6 @@ jobs:
           name: docs
           if-no-files-found: error
           path: builtdocs
-      - name: Set output
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
   docs_publish:
     name: Publish Documentation
@@ -62,22 +59,16 @@ jobs:
     needs: [docs_build]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     steps:
       - uses: actions/download-artifact@v8
         with:
           name: docs
           path: builtdocs/
-      - name: Set output
-        id: vars
-        run: echo "tag=${{ needs.docs_build.outputs.tag }}" >> $GITHUB_OUTPUT
       - name: upload dev
         uses: peaceiris/actions-gh-pages@v4
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
-          (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          (github.event_name == 'push' && (contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')))
         with:
           personal_token: ${{ secrets.ACCESS_TOKEN }}
           external_repository: holoviz-dev/lumen
@@ -86,7 +77,7 @@ jobs:
       - name: upload main
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
-          (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          (github.event_name == 'push' && !(contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')))
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gallery.yaml
+++ b/.github/workflows/gallery.yaml
@@ -26,11 +26,11 @@ jobs:
         shell: bash -el {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Set and echo git ref
@@ -40,7 +40,7 @@ jobs:
         run: |
           echo "Deploying from ref $HEAD_BRANCH"
           echo "tag=$HEAD_BRANCH" >> $GITHUB_OUTPUT
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           auto-update-conda: true

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -16,7 +16,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v6
         with:
           issue-inactive-days: "100"
           pr-inactive-days: "100"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
         if: needs.setup.outputs.img_change == 'true'
         with:
           extra_args: -a --hook-stage manual oxipng || true --
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v7
         if: needs.setup.outputs.img_change == 'true'
         with:
           commit_message: "Optimize PNG images (lossless)"
@@ -60,10 +60,10 @@ jobs:
       img_change: ${{ steps.filter.outputs.img }}
       matrix: ${{ env.MATRIX }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request'
       - name: Check for code changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -129,7 +129,7 @@ jobs:
       - name: Test Unit
         run: |
           pixi run -e ${{ matrix.environment }} test-unit $COV
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -9,6 +9,6 @@ python -m build --sdist .
 VERSION=$(python -c "import $PACKAGE; print($PACKAGE._version.__version__)")
 export VERSION
 
-conda build scripts/conda/recipe --no-anaconda-upload --no-verify -c conda-forge --package-format 1
+conda build scripts/conda/recipe --no-anaconda-upload --no-verify -c conda-forge --package-format 2
 
-mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2" dist
+mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.conda" dist


### PR DESCRIPTION
## Description

Updates CI workflow to match with work I have done in our other projects.

- Bump action versions
- Make conda package version 2
- Use PyPI for anaconda-client install 
- Use trusted publisher for PyPI
- Use `github.ref_name` instead of extracting that manually to figure out tag
- Add an announce step to release which will draft a Github release with artifacts.

## How Has This Been Tested?

CI

<img width="1574" height="272" alt="image" src="https://github.com/user-attachments/assets/f34f4649-838f-4944-8fb5-bd1c0b50bddc" />
