### PR TITLE
Prevent error on reconnection

### DIFF
--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -1134,9 +1134,22 @@ class DuckDBVectorStore(VectorStore):
                 self.embeddings = NumpyEmbeddings()
             return
         uri_exists = Path(self.uri).exists()
+        direct_connection = False
         try:
             attach_mode = "READ_ONLY" if self.read_only else "READ_WRITE"
             connection.execute(f"ATTACH DATABASE '{self.uri}' AS embedded ({attach_mode});")
+        except (duckdb.BinderException, duckdb.IOException) as e:
+            err_msg = str(e).lower()
+            if "already attached" in err_msg or "unique file handle" in err_msg:
+                # File already held by another DuckDB connection in this process
+                # (e.g., during Panel hot-reload). Connect directly to the file instead.
+                connection.close()
+                connection = duckdb.connect(self.uri, read_only=self.read_only)
+                connection.execute("LOAD 'vss';")
+                connection.execute("SET hnsw_enable_experimental_persistence = true;")
+                direct_connection = True
+            else:
+                raise
         except duckdb.CatalogException:
             # handle "Failure while replaying WAL file"
             # remove .wal uri on corruption
@@ -1145,7 +1158,8 @@ class DuckDBVectorStore(VectorStore):
                 wal_path.unlink()
             attach_mode = "READ_ONLY" if self.read_only else "READ_WRITE"
             connection.execute(f"ATTACH DATABASE '{self.uri}' AS embedded ({attach_mode});")
-        connection.execute("USE embedded;")
+        if not direct_connection:
+            connection.execute("USE embedded;")
         self.connection = connection
         has_documents = (
             connection.execute(


### PR DESCRIPTION
Prevent
```
2026-03-25 15:02:07,621 Error running application handler <panel.io.handlers.ScriptHandler object at 0x12db9a660>: Binder Error: Unique file handle conflict: Cannot attach "embedded" - the database file "/Users/ahuang/repos/lumen-anndata/src/lumen_anndata/embeddings/scanpy.db" is already attached by database "embedded"
File 'vector_store.py', line 1139, in __init__:
connection.execute(f"ATTACH DATABASE '{self.uri}' AS embedded ({attach_mode});") Traceback (most recent call last):
  File "/Users/ahuang/miniconda3/envs/lumen-anndata/lib/python3.12/site-packages/panel/io/handlers.py", line 541, in run
    exec(self._code, module.__dict__)
  File "/Users/ahuang/repos/lumen-anndata/src/lumen_anndata/app.py", line 9, in <module>
    build_ui().servable()
    ^^^^^^^^^^
  File "/Users/ahuang/repos/lumen-anndata/src/lumen_anndata/ui.py", line 35, in build_ui
    vector_store = lmai.vector_store.DuckDBVectorStore(uri=db_uri, embeddings=lmai.embeddings.HuggingFaceEmbeddings())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/vector_store.py", line 1139, in __init__
    connection.execute(f"ATTACH DATABASE '{self.uri}' AS embedded ({attach_mode});")
_duckdb.BinderException: Binder Error: Unique file handle conflict: Cannot attach "embedded" - the database file "/Users/ahuang/repos/lumen-anndata/src/lumen_anndata/embeddings/scanpy.db" is already attached by database "embedded"

```