### PR TITLE
Fix provenence bug

### DIFF
--- a/lumen/ai/tools/metadata_lookup.py
+++ b/lumen/ai/tools/metadata_lookup.py
@@ -531,6 +531,18 @@ class MetadataLookup(VectorLookupTool):
         else:
             results = await self._perform_search_with_refinement(query, context, filters=query_filters)
 
+        # If no results found and provenance chain is longer than ['global'],
+        # retry with progressively shorter chains to find parent-scoped tables.
+        provenance_chain = list(query_filters["provenance_chain"])
+        while not results and len(provenance_chain) > 1:
+            provenance_chain = provenance_chain[:-1]
+            fallback_filters = {**query_filters, "provenance_chain": provenance_chain}
+            log_debug(f"[MetadataLookup] No results with provenance {query_filters['provenance_chain']}, retrying with {provenance_chain}")
+            if total_tables < 5:
+                results = await self.vector_store.query(query, top_k=self.n, filters=fallback_filters)
+            else:
+                results = await self._perform_search_with_refinement(query, context, filters=fallback_filters)
+
         any_matches = any(result["similarity"] >= self.min_similarity for result in results)
         same_table = len([result["metadata"]["table_name"] for result in results])
 

--- a/lumen/tests/ai/test_tools.py
+++ b/lumen/tests/ai/test_tools.py
@@ -130,3 +130,81 @@ async def test_metadata_lookup_source_keeps_first_provenance():
     entries = tool.vector_store.filter_by({"source": source.name, "type": "tables"})
     assert len(entries) == 1
     assert entries[0]["metadata"]["provenance_chain"] == ["global"]
+
+
+async def test_metadata_lookup_exploration_finds_global_tables():
+    """Tables stored at global provenance should be discoverable from an exploration context."""
+    source = DuckDBSource(uri=":memory:", tables={"test_table": "SELECT 1 as id"})
+    tool = MetadataLookup(vector_store=NumpyVectorStore())
+
+    # Sync at global scope — tables get stored with provenance ['global']
+    context = {
+        "sources": [source],
+        "provenance_chain": ["global"],
+        "tables_metadata": {},
+    }
+    await tool.sync(context)
+
+    # Query from an exploration context with longer provenance chain
+    exploration_context = {
+        "sources": [source],
+        "provenance_chain": ["global", "exploration_123"],
+        "tables_metadata": context["tables_metadata"],
+    }
+    messages = [{"role": "user", "content": "Show me test_table"}]
+    _, outputs = await tool.respond(messages, exploration_context)
+    metaset = outputs["metaset"]
+
+    assert len(metaset.catalog) > 0, (
+        "Exploration context should find global-scoped tables via provenance fallback"
+    )
+    slugs = list(metaset.catalog.keys())
+    assert any("test_table" in s for s in slugs)
+
+
+async def test_metadata_lookup_exploration_finds_global_tables_deeply_nested():
+    """Provenance fallback should work even for deeply nested exploration chains."""
+    source = DuckDBSource(uri=":memory:", tables={"sales": "SELECT 1 as revenue"})
+    tool = MetadataLookup(vector_store=NumpyVectorStore())
+
+    context = {
+        "sources": [source],
+        "provenance_chain": ["global"],
+        "tables_metadata": {},
+    }
+    await tool.sync(context)
+
+    # Three levels deep
+    deep_context = {
+        "sources": [source],
+        "provenance_chain": ["global", "exploration_1", "exploration_2"],
+        "tables_metadata": context["tables_metadata"],
+    }
+    messages = [{"role": "user", "content": "Show sales data"}]
+    _, outputs = await tool.respond(messages, deep_context)
+    metaset = outputs["metaset"]
+
+    assert len(metaset.catalog) > 0, (
+        "Deeply nested exploration should still find global-scoped tables"
+    )
+
+
+async def test_metadata_lookup_global_context_still_works():
+    """Querying from global context should continue to work without fallback."""
+    source = DuckDBSource(uri=":memory:", tables={"orders": "SELECT 1 as id"})
+    tool = MetadataLookup(vector_store=NumpyVectorStore())
+
+    context = {
+        "sources": [source],
+        "provenance_chain": ["global"],
+        "tables_metadata": {},
+    }
+    await tool.sync(context)
+
+    messages = [{"role": "user", "content": "What data is available?"}]
+    _, outputs = await tool.respond(messages, context)
+    metaset = outputs["metaset"]
+
+    assert len(metaset.catalog) > 0
+    slugs = list(metaset.catalog.keys())
+    assert any("orders" in s for s in slugs)


### PR DESCRIPTION
## Description

Not entirely sure if this is the right fix, but I noticed an issue where initially, it showed data sources:

```
Data sources:
- AnnDataSource00657 ⦙ obs
- AnnDataSource00657 ⦙ obsm_X_tsne
- AnnDataSource00657 ⦙ obsm_X_umap

Others available:
- AnnDataSource00657 ⦙ var
- AnnDataSource00657 ⦙ obsm_X_draw_graph_fr
- AnnDataSource00657 ⦙ obsm_X_pca
- AnnDataSource00657 ⦙ varm_PCs
```

But on the second Planner call (after table list):
```
Data sources:
No data sources or documentation available.
```

<img width="735" height="839" alt="image" src="https://github.com/user-attachments/assets/c21ece01-49fb-4af1-b990-2cf4ad52bf00" />

My guess is that table list does NOT create a new table so it's unable to find the latest table. Should probably release 1.1.1 with this since this will stop consequent conversations on table list agent.

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: {e.g., Cursor + Sonnet 4.6, Claude Code + Opus 4.6, Antigravity + Gemini Flash 3, ChatGPT, etc.}

## Checklist

<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
- [ ] Added documentation
