### PR TITLE
Add HTML export option for Reports

### DIFF
--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -641,10 +641,9 @@ class TaskGroup(Task):
             raise RuntimeError(
                 "Report has not been executed, run report before exporting to html."
             )
-        html_buffer = io.StringIO()
-        self.__panel__().save(html_buffer, title=self.title or "Report")
-        html_buffer.seek(0)
-        return html_buffer.getvalue()
+        buf = io.StringIO()
+        self.__panel__().save(buf, title=self.title or "Report")
+        return buf.getvalue()
 
     def validate(
         self,
@@ -857,7 +856,6 @@ class Report(TaskGroup):
             icon="settings", on_click=self._open_settings, size="large", color="default",
             margin=0, description="Configure Report", visible=False
         )
-        self._export_fmt = "ipynb"
         self._export = MenuButton(
             label="", icon="get_app", variant="text", color="default",
             margin=0, size="large", visible=False,
@@ -866,13 +864,25 @@ class Report(TaskGroup):
                 {"label": "Notebook (.ipynb)", "format": "ipynb", "icon": "description"},
                 {"label": "HTML (.html)", "format": "html", "icon": "language"},
             ],
-            on_click=self._on_export_click,
+            on_click=lambda _: self._download._transfer(),
+            icon_size="36px",
+            sx={
+                "& .MuiButton-endIcon": {"display": "none"},
+                "& .MuiButton-startIcon": {"margin": 0},
+                "minWidth": "unset",
+                "width": "60px",
+                "height": "60px",
+                "borderRadius": "50%",
+                "padding": 0,
+            },
         )
         self._download = FileDownload(
-            callback=self._export_report,
+            auto=True,
+            callback=param.bind(self._export_report, self._export),
             filename=f"{self.title or 'Report'}.ipynb",
             visible=False,
         )
+        self._export.attached.append(self._download)
         self._dialog = Dialog(
             TextInput.from_param(self.param.title, margin=(10, 0, 0, 0), sizing_mode="stretch_width"),
             show_close_button=True,
@@ -933,20 +943,10 @@ class Report(TaskGroup):
             self.reset()
         elif icon in ("description", "language"):
             fmt = item.get("format", "ipynb")
-            self._trigger_download(fmt=fmt)
+            self._export.value = {"format": fmt}
+            self._download._transfer()
         elif icon == "settings":
             self._open_settings()
-
-    def _on_export_click(self, item):
-        fmt = item.get("format", "ipynb") if isinstance(item, dict) else "ipynb"
-        self._trigger_download(fmt=fmt)
-
-    def _trigger_download(self, event=None, fmt="ipynb"):
-        self._export_fmt = fmt
-        title = self.title or "Report"
-        ext = "html" if fmt == "html" else "ipynb"
-        self._download.filename = f"{title}.{ext}"
-        self._download.transfer()
 
     @param.depends('_current', '_tasks', watch=True)
     def _update_run_state(self):
@@ -977,10 +977,14 @@ class Report(TaskGroup):
         await asyncio.sleep(0.01)  # yield the event loop to allow button loading state to update
         await self.execute()
 
-    async def _export_report(self):
+    async def _export_report(self, item=None):
         if len(self) and self.status != "success":
             await self.execute()
-        if self._export_fmt == "html":
+        fmt = item.get("format", "ipynb") if isinstance(item, dict) else "ipynb"
+        title = self.title or "Report"
+        ext = "html" if fmt == "html" else "ipynb"
+        self._download.filename = f"{title}.{ext}"
+        if fmt == "html":
             return io.StringIO(self.to_html())
         return io.StringIO(self.to_notebook())
 

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -23,7 +23,7 @@ from panel.pane import Markdown
 from panel.viewable import Viewable, Viewer
 from panel_material_ui import (
     Accordion, BreakpointSwitcher, Button, Card, ChatFeed, ChatMessage,
-    Container, Dialog, Divider, FileDownload, IconButton, Progress, Select,
+    Container, Dialog, Divider, FileDownload, IconButton, MenuButton, Progress, Select,
     SpeedDial, TextAreaInput, TextInput, Typography,
 )
 
@@ -633,6 +633,32 @@ class TaskGroup(Task):
         cells = make_preamble("", extensions=extensions) + cells
         return write_notebook(cells)
 
+    def to_html(self):
+        """
+        Returns the HTML representation of the report.
+        """
+        if len(self) and not self.status == "success":
+            raise RuntimeError(
+                "Report has not been executed, run report before exporting to html."
+            )
+        content = []
+        for out in self.views:
+            if isinstance(out, Typography):
+                level = int(out.variant[1:]) if out.variant and out.variant.startswith('h') else 0
+                prefix = f"{'#'*level} " if level else ''
+                content.append(Markdown(f"{prefix}{out.object}"))
+            elif isinstance(out, Markdown):
+                content.append(out)
+            elif isinstance(out, LumenEditor):
+                content.append(out.component.__panel__())
+            elif isinstance(out, Viewable):
+                content.append(out)
+        col = Column(*content, sizing_mode="stretch_width")
+        html_buffer = io.StringIO()
+        col.save(html_buffer, title=self.title or "Report")
+        html_buffer.seek(0)
+        return html_buffer.getvalue()
+
     def validate(
         self,
         context: TContext | None = None,
@@ -844,13 +870,23 @@ class Report(TaskGroup):
             icon="settings", on_click=self._open_settings, size="large", color="default",
             margin=0, description="Configure Report", visible=False
         )
-        self._export = IconButton(
-            icon="get_app", on_click=self._trigger_download, size="large", color="default",
-            margin=0, description="Export Report to .ipynb", visible=False
+        self._export = MenuButton(
+            label="", icon="get_app", variant="text", color="default",
+            margin=0, size="large", visible=False,
+            description="Export Report",
+            items=[
+                {"label": "Notebook (.ipynb)", "format": "ipynb", "icon": "description"},
+                {"label": "HTML (.html)", "format": "html", "icon": "language"},
+            ],
+            on_click=lambda _: self._download._transfer(),
         )
         self._download = FileDownload(
-            callback=self._notebook_export, filename=f"{self.title or 'Report'}.ipynb", visible=False
+            auto=True,
+            callback=param.bind(self._export_report, self._export),
+            filename=f"{self.title or 'Report'}.ipynb",
+            visible=False,
         )
+        self._export.attached.append(self._download)
         self._dialog = Dialog(
             TextInput.from_param(self.param.title, margin=(10, 0, 0, 0), sizing_mode="stretch_width"),
             show_close_button=True,
@@ -864,14 +900,14 @@ class Report(TaskGroup):
             self._collapse,
             self._export,
             self._settings,
-            self._download,
             sizing_mode="stretch_width"
         )
         self._dial = SpeedDial(
             items=[
                 {"label": "Execute Report", "icon": "play_arrow"},
                 {"label": "Clear Report", "icon": "clear"},
-                {"label": "Export Report to Notebook", "icon": "get_app"},
+                {"label": "Export as Notebook", "icon": "description", "format": "ipynb"},
+                {"label": "Export as HTML", "icon": "language", "format": "html"},
                 {"label": "Configure Report", "icon": "settings"}
             ],
             color="default",
@@ -909,13 +945,18 @@ class Report(TaskGroup):
             await self._execute_event()
         elif icon == "clear":
             self.reset()
-        elif icon == "get_app":
-            self._trigger_download()
+        elif icon in ("description", "language"):
+            fmt = item.get("format", "ipynb")
+            self._trigger_download(fmt=fmt)
         elif icon == "settings":
             self._open_settings()
 
-    def _trigger_download(self, event=None):
-        self._download.filename = f"{self.title or 'Report'}.ipynb"
+    def _trigger_download(self, event=None, fmt="ipynb"):
+        title = self.title or "Report"
+        ext = "html" if fmt == "html" else "ipynb"
+        self._download.filename = f"{title}.{ext}"
+        # Set MenuButton value so the bound callback gets the right format
+        self._export.value = {"format": fmt}
         self._download.transfer()
 
     @param.depends('_current', '_tasks', watch=True)
@@ -947,9 +988,15 @@ class Report(TaskGroup):
         await asyncio.sleep(0.01)  # yield the event loop to allow button loading state to update
         await self.execute()
 
-    async def _notebook_export(self):
+    async def _export_report(self, item):
+        fmt = item.get("format", "ipynb") if isinstance(item, dict) else "ipynb"
         if len(self) and self.status != "success":
             await self.execute()
+        title = self.title or "Report"
+        if fmt == "html":
+            self._download.filename = f"{title}.html"
+            return io.StringIO(self.to_html())
+        self._download.filename = f"{title}.ipynb"
         return io.StringIO(self.to_notebook())
 
     def _expand_all(self, event=None):

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -23,8 +23,8 @@ from panel.pane import Markdown
 from panel.viewable import Viewable, Viewer
 from panel_material_ui import (
     Accordion, BreakpointSwitcher, Button, Card, ChatFeed, ChatMessage,
-    Container, Dialog, Divider, FileDownload, IconButton, MenuButton, Progress, Select,
-    SpeedDial, TextAreaInput, TextInput, Typography,
+    Container, Dialog, Divider, FileDownload, IconButton, MenuButton, Progress,
+    Select, SpeedDial, TextAreaInput, TextInput, Typography,
 )
 
 from ..views.base import Panel, View

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -642,7 +642,7 @@ class TaskGroup(Task):
                 "Report has not been executed, run report before exporting to html."
             )
         buf = io.StringIO()
-        self.__panel__().save(buf, title=self.title or "Report")
+        self._view.save(buf, title=self.title or "Report")
         return buf.getvalue()
 
     def validate(
@@ -869,6 +869,7 @@ class Report(TaskGroup):
             sx={
                 "& .MuiButton-endIcon": {"display": "none"},
                 "& .MuiButton-startIcon": {"margin": 0},
+                "& .MuiIcon-root": {"color": "var(--mui-palette-action-active)"},
                 "minWidth": "unset",
                 "width": "60px",
                 "height": "60px",

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -637,25 +637,12 @@ class TaskGroup(Task):
         """
         Returns the HTML representation of the report.
         """
-        if len(self) and not self.status == "success":
+        if len(self) and self.status != "success":
             raise RuntimeError(
                 "Report has not been executed, run report before exporting to html."
             )
-        content = []
-        for out in self.views:
-            if isinstance(out, Typography):
-                level = int(out.variant[1:]) if out.variant and out.variant.startswith('h') else 0
-                prefix = f"{'#'*level} " if level else ''
-                content.append(Markdown(f"{prefix}{out.object}"))
-            elif isinstance(out, Markdown):
-                content.append(out)
-            elif isinstance(out, LumenEditor):
-                content.append(out.component.__panel__())
-            elif isinstance(out, Viewable):
-                content.append(out)
-        col = Column(*content, sizing_mode="stretch_width")
         html_buffer = io.StringIO()
-        col.save(html_buffer, title=self.title or "Report")
+        self.__panel__().save(html_buffer, title=self.title or "Report")
         html_buffer.seek(0)
         return html_buffer.getvalue()
 
@@ -870,6 +857,7 @@ class Report(TaskGroup):
             icon="settings", on_click=self._open_settings, size="large", color="default",
             margin=0, description="Configure Report", visible=False
         )
+        self._export_fmt = "ipynb"
         self._export = MenuButton(
             label="", icon="get_app", variant="text", color="default",
             margin=0, size="large", visible=False,
@@ -878,15 +866,13 @@ class Report(TaskGroup):
                 {"label": "Notebook (.ipynb)", "format": "ipynb", "icon": "description"},
                 {"label": "HTML (.html)", "format": "html", "icon": "language"},
             ],
-            on_click=lambda _: self._download._transfer(),
+            on_click=self._on_export_click,
         )
         self._download = FileDownload(
-            auto=True,
-            callback=param.bind(self._export_report, self._export),
+            callback=self._export_report,
             filename=f"{self.title or 'Report'}.ipynb",
             visible=False,
         )
-        self._export.attached.append(self._download)
         self._dialog = Dialog(
             TextInput.from_param(self.param.title, margin=(10, 0, 0, 0), sizing_mode="stretch_width"),
             show_close_button=True,
@@ -951,12 +937,15 @@ class Report(TaskGroup):
         elif icon == "settings":
             self._open_settings()
 
+    def _on_export_click(self, item):
+        fmt = item.get("format", "ipynb") if isinstance(item, dict) else "ipynb"
+        self._trigger_download(fmt=fmt)
+
     def _trigger_download(self, event=None, fmt="ipynb"):
+        self._export_fmt = fmt
         title = self.title or "Report"
         ext = "html" if fmt == "html" else "ipynb"
         self._download.filename = f"{title}.{ext}"
-        # Set MenuButton value so the bound callback gets the right format
-        self._export.value = {"format": fmt}
         self._download.transfer()
 
     @param.depends('_current', '_tasks', watch=True)
@@ -988,15 +977,11 @@ class Report(TaskGroup):
         await asyncio.sleep(0.01)  # yield the event loop to allow button loading state to update
         await self.execute()
 
-    async def _export_report(self, item):
-        fmt = item.get("format", "ipynb") if isinstance(item, dict) else "ipynb"
+    async def _export_report(self):
         if len(self) and self.status != "success":
             await self.execute()
-        title = self.title or "Report"
-        if fmt == "html":
-            self._download.filename = f"{title}.html"
+        if self._export_fmt == "html":
             return io.StringIO(self.to_html())
-        self._download.filename = f"{title}.ipynb"
         return io.StringIO(self.to_notebook())
 
     def _expand_all(self, event=None):

--- a/lumen/tests/ai/test_report.py
+++ b/lumen/tests/ai/test_report.py
@@ -369,3 +369,26 @@ async def test_report_to_notebook():
 
     assert cell3['cell_type'] == 'markdown'
     assert cell3['source'] == ["**Hello**"]
+
+
+async def test_report_to_html():
+    report = Report(
+        Section(
+            HelloAction()
+        ),
+        title='Hello Report'
+    )
+
+    with pytest.raises(RuntimeError):
+        report.to_html()
+
+    await report.execute()
+
+    assert len(report.views) == 2
+
+    html_string = report.to_html()
+
+    assert isinstance(html_string, str)
+    assert "<html" in html_string.lower()
+    assert "Hello Report" in html_string
+    assert "Hello" in html_string


### PR DESCRIPTION
Closes #1790

Reports currently only export to Jupyter Notebook (.ipynb). This adds HTML as a second export format using Panel's built-in `.save()` method.
## Demo

https://github.com/user-attachments/assets/6e613e3d-4eaa-4725-94cb-469b932abe18

## Changes

- Add `to_html()` method on `TaskGroup` that converts report views (headings, markdown, charts/tables) into a Panel Column and calls `.save()` for standalone HTML
- Replace the single-format export `IconButton` with a `MenuButton` dropdown offering both Notebook (.ipynb) and HTML (.html)
- Update SpeedDial menu (mobile view) with both export options
- Add `test_report_to_html` mirroring the existing notebook export test


## AI Disclosure

I identified the gap from issue #1790, designed the approach (reusing the `to_notebook()` pattern + editors.py `MenuButton` pattern), and verified the implementation. AI helped scaffold the code and tests.