### PR TITLE
Patch validation agent to handle chat and more explicit about views

### DIFF
--- a/lumen/ai/agents/chat.py
+++ b/lumen/ai/agents/chat.py
@@ -64,5 +64,4 @@ class ChatAgent(Agent):
             context["sql"] = f"{context['sql']}\n-- No data was returned from the query."
 
         result = await self._stream(messages, context, **prompt_context)
-        chat_text = result.object if hasattr(result, 'object') else str(result)
-        return [result], {"chat": chat_text}
+        return [result], {"chat": result.object}

--- a/lumen/ai/agents/chat.py
+++ b/lumen/ai/agents/chat.py
@@ -1,12 +1,17 @@
-from typing import Any
+from typing import Any, NotRequired
 
 import param
 
 from ..config import PROMPTS_DIR
-from ..context import TContext
+from ..context import ContextModel, TContext
 from ..llm import Message
 from ..schemas import get_metaset
 from .base import Agent
+
+
+class ChatOutputs(ContextModel):
+
+    chat: NotRequired[str]
 
 
 class ChatAgent(Agent):
@@ -40,6 +45,8 @@ class ChatAgent(Agent):
         }
     )
 
+    output_schema = ChatOutputs
+
     async def respond(
         self,
         messages: list[Message],
@@ -56,4 +63,6 @@ class ChatAgent(Agent):
         if len(context.get("data", [])) == 0 and context.get("sql"):
             context["sql"] = f"{context['sql']}\n-- No data was returned from the query."
 
-        return [await self._stream(messages, context, **prompt_context)], {}
+        result = await self._stream(messages, context, **prompt_context)
+        chat_text = result.object if hasattr(result, 'object') else str(result)
+        return [result], {"chat": chat_text}

--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -31,6 +31,8 @@ class QueryCompletionValidation(BaseModel):
 
 class ValidationInputs(ContextModel):
 
+    chat: NotRequired[str]
+
     data: NotRequired[Any]
 
     sql: NotRequired[str]

--- a/lumen/ai/prompts/ValidationAgent/main.jinja2
+++ b/lumen/ai/prompts/ValidationAgent/main.jinja2
@@ -2,6 +2,7 @@
 
 {%- block instructions %}
 ## Instructions
+{% if memory.get('sql') %}
 Analyze if the SQL query matches the user's request by checking:
 1. What the user asked for
 2. What the SQL actually does (read it carefully)
@@ -11,10 +12,20 @@ VALID = SQL implements the user's intent correctly
 - Check actual SQL syntax, not assumptions
 - Verify GROUP BY, WHERE, SELECT match request
 - Accept reasonable interpretations; do not over-interpret `limit` (100,000 is default)
+{% endif %}
+{% if memory.get('view') %}
+Analyze if the generated view matches the user's visualization request.
+VALID = view type, encodings, and data mappings reflect the user's intent
+{% endif %}
+{% if memory.get('chat') %}
+Analyze if the assistant's response answers the user's request.
+VALID = all parts of the query addressed using available data context correctly
+{% endif %}
 {%- endblock %}
 
 {%- block examples %}
 ## Examples
+{% if memory.get('sql') %}
 User: "by region?"
 SQL: SELECT region, SUM(sales) FROM data GROUP BY region
 ✓ VALID - has GROUP BY region
@@ -34,6 +45,15 @@ SQL: SELECT * FROM data LIMIT 50
 User: "total by state"
 SQL: SELECT state, SUM(amount) FROM data GROUP BY state
 ✓ VALID - groups by state with SUM
+{% endif %}
+{% if memory.get('chat') %}
+User: "Summarize the survey results" → Response with field breakdowns and patterns → ✓ VALID
+User: "What are the top selling products?" → Generic discussion, no rankings → ✗ INVALID
+{% endif %}
+{% if memory.get('view') %}
+User: "bar chart of sales by region" → bar mark with region on x, sales on y → ✓ VALID
+User: "line chart over time" → bar chart with no time axis → ✗ INVALID
+{% endif %}
 {%- endblock %}
 
 {% block context %}
@@ -54,5 +74,9 @@ Generated View:
 ```yaml
 {{ memory["view"] | json_to_yaml }}
 ```
+{%- endif -%}
+{% if memory.get('chat') %}
+Assistant Response:
+{{ memory['chat'] }}
 {%- endif -%}
 {%- endblock -%}

--- a/lumen/ai/prompts/ValidationAgent/main.jinja2
+++ b/lumen/ai/prompts/ValidationAgent/main.jinja2
@@ -77,6 +77,8 @@ Generated View:
 {%- endif -%}
 {% if memory.get('chat') %}
 Assistant Response:
+"""
 {{ memory['chat'] }}
+"""
 {%- endif -%}
 {%- endblock -%}

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -72,7 +72,7 @@ async def test_chat_agent_with_data(llm, duckdb_source, test_messages):
     out, out_context = await agent.respond(test_messages, context)
     assert len(out) == 1
     assert out[0].object == "Analysis of data"
-    assert out_context == {}
+    assert out_context == {'chat': 'Analysis of data'}
 
 async def test_sql_agent(llm, duckdb_source, test_messages):
     agent = SQLAgent(llm=llm)


### PR DESCRIPTION
Previously, ValidationAgent was not validating chat; this inserts context so it's aware of it.
<img width="1507" height="876" alt="image" src="https://github.com/user-attachments/assets/d7202722-754a-4376-b72e-f0ee5aa0a16a" />

Example system prompt
```
Do not excessively reason in responses; there are chain_of_thought fields for that, but those should also be concise (1-2 sentences).
The current date time is Apr 08, 2026 09:45 AM
## Instructions

Analyze if the SQL query matches the user's request by checking:
1. What the user asked for
2. What the SQL actually does (read it carefully)
3. If they align

VALID = SQL implements the user's intent correctly
- Check actual SQL syntax, not assumptions
- Verify GROUP BY, WHERE, SELECT match request
- Accept reasonable interpretations; do not over-interpret `limit` (100,000 is default)



Analyze if the assistant's response answers the user's request.
VALID = all parts of the query addressed using available data context correctly

## Examples

User: "by region?"
SQL: SELECT region, SUM(sales) FROM data GROUP BY region
✓ VALID - has GROUP BY region

User: "by region?"
SQL: SELECT SUM(sales) FROM data
✗ INVALID - missing GROUP BY region

User: "top 5"
SQL: SELECT * FROM data ORDER BY revenue DESC LIMIT 5
✓ VALID - has LIMIT 5

User: "show 1000 rows"
SQL: SELECT * FROM data LIMIT 50
✗ INVALID - wrong LIMIT value

User: "total by state"
SQL: SELECT state, SUM(amount) FROM data GROUP BY state
✓ VALID - groups by state with SUM


User: "Summarize the survey results" → Response with field breakdowns and patterns → ✓ VALID
User: "What are the top selling products?" → Generic discussion, no rankings → ✗ INVALID



Current context contains the following keys: agent_tool_contexts, provenance_chain, sources, source, source_catalog, tables_metadata, visible_slugs, metaset, reasoning, sql, pipeline, table, data, chat


SQL: `SELECT
  MIN("year") AS "year_start",
  MAX("year") AS "year_end"
FROM data_oni_csv
WHERE
  NOT TRY_CAST("year" AS INT) IS NULL`
Data Overview:
|   year_start |   year_end |
|-------------:|-----------:|
|         1950 |       2024 |
Assistant Response:
"""
The query finds the **earliest and latest valid year** in `data_oni_csv` by taking the **minimum** and **maximum** of the `year` field, while excluding values that can’t be safely cast to an integer. In plain terms, it is checking the dataset’s year coverage and filtering out non-numeric year entries before summarizing the range.

The result shows a **year start of 1950** and a **year end of 2024**. That means the dataset spans **1950 through 2024** based on the valid `year` values present. **Validation looks clean** from this result: the query returned a single range with no conflicting values, so the retrieved start/end years are consistent with the data summary provided.
"""
```