### PR TITLE
Fix empty prev_plan

### DIFF
--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -83,15 +83,15 @@ class Plan(Section):
             todos_list.append(f"- {status} {instruction}")
         todos = "\n".join(todos_list)
 
-        formatted_content = (
-            f"User: {user_query['content']!r}\n"
-            f"Roadmap:\n{indent(todos, '    ')}\n"
-            f"Tasks marked ⚪ are scheduled for others later. "
-            f"Your EXCLUSIVE goal is to focus on the 🟡 task"
-        )
         rendered_history = []
         for msg in self.history:
             if msg is user_query:
+                formatted_content = (
+                    f"User: {user_query['content']!r}\n"
+                    f"Roadmap:\n{indent(todos, '    ')}\n"
+                    f"Tasks marked ⚪ are scheduled for others later. "
+                    f"Your EXCLUSIVE goal is to focus on the 🟡 task"
+                )
                 rendered_history.append({"content": formatted_content, "role": "user"})
             else:
                 rendered_history.append(msg)


### PR DESCRIPTION
Closes https://github.com/holoviz/lumen/issues/1799

Starting a new exploration resulted in prev_plan's self.history = [].
```
  File "/Users/ahuang/repos/lumen/lumen/ai/prompts/Planner/main.jinja2", line 146, in block 'context'
    {{ memory['prev_plan'].render_task_history()[-1] }}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/coordinator/base.py", line 87, in render_task_history
    f"User: {user_query['content']!r}\n"
             ~~~~~~~~~~^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```
Solution is to just put formatted_content inside the loop