### PR TITLE
Ensure Planner does not add redundant ValidationAgent

### DIFF
--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -491,7 +491,12 @@ class Planner(Coordinator):
             )
             actors_in_graph.add(actor)
 
-        if "ValidationAgent" in agents and len(actors_in_graph) > 1 and self.validation_enabled:
+        if (
+            "ValidationAgent" in agents and
+            len(actors_in_graph) > 1 and
+            self.validation_enabled and
+            "ValidationAgent" not in actors_in_graph
+        ):
             validation_step = type(step)(
                 actor="ValidationAgent",
                 instruction="Validate whether the executed plan fully answered the user's original query.",


### PR DESCRIPTION
The `Planner` did not check if there was already a validation agent added to the plan, so it sometimes generated plans with duplicated validation steps.