### PR TITLE
Directly access metadata in Metadata Lookup tool

### DIFF
--- a/lumen/ai/tools/metadata_lookup.py
+++ b/lumen/ai/tools/metadata_lookup.py
@@ -453,8 +453,7 @@ class MetadataLookup(VectorLookupTool):
             filters = {"type": "document"}
 
         # Get all document filenames from vector store
-        all_doc_results = await doc_store.query(text="", top_k=1000, filters=filters)
-        all_filenames = {r["metadata"]["filename"] for r in all_doc_results if "filename" in r["metadata"]}
+        all_filenames = {md["filename"] for md in doc_store.metadata if "filename" in md}
 
         # Get visible docs (if specified, only include these; otherwise include all)
         visible_docs = context.get("visible_docs")


### PR DESCRIPTION
The `MetadataLookup` tool used an empty query to try to access all the items. This was a hack that isn't supported by many vector databases. Instead we access the `metadata` parameter/property on the `VectorStore` directly.