### PR TITLE
Support auto catalog source

### DIFF
--- a/lumen/ai/agents/source.py
+++ b/lumen/ai/agents/source.py
@@ -23,7 +23,8 @@ from ...sources.duckdb import DuckDBSource
 from ...util import normalize_table_name
 from ..config import PROMPTS_DIR
 from ..context import ContextModel, TContext
-from ..controls import CatalogSourceControls, ParametricSourceControls
+from ..controls.ingest.base import BaseSourceControls
+from ..controls.ingest.parametric import ParametricSourceControls
 from ..controls.ingest.result import SourceResult
 from ..llm import Message
 from ..schemas import Metaset, get_metaset
@@ -67,7 +68,7 @@ def _build_catalog_summary(context: TContext) -> str:
 
     lines = []
     for ctrl in controls:
-        if not isinstance(ctrl, (ParametricSourceControls, CatalogSourceControls)):
+        if not ctrl._supports_tools:
             continue
         ctrl_label = getattr(ctrl, "label", ctrl.__class__.__name__)
         lines.append(f"### {ctrl_label}")
@@ -223,10 +224,7 @@ class SourceAgent(Agent):
     @classmethod
     async def applies(cls, context: TContext) -> bool:
         controls = context.get("source_controls", [])
-        return any(
-            isinstance(c, (ParametricSourceControls, CatalogSourceControls))
-            for c in controls
-        )
+        return any(c._supports_tools for c in controls)
 
     # ------------------------------------------------------------------
     # Tool building
@@ -246,9 +244,9 @@ class SourceAgent(Agent):
         in all controls.
         """
         controls = context.get("source_controls", [])
-        ctrl_map: dict[str, ParametricSourceControls | CatalogSourceControls] = {}
+        ctrl_map: dict[str, BaseSourceControls] = {}
         for c in controls:
-            if isinstance(c, (ParametricSourceControls, CatalogSourceControls)):
+            if c._supports_tools:
                 from ..tools.source_lookup import _control_hash
                 ctrl_map[_control_hash(c)] = c
 

--- a/lumen/ai/agents/source.py
+++ b/lumen/ai/agents/source.py
@@ -23,7 +23,7 @@ from ...sources.duckdb import DuckDBSource
 from ...util import normalize_table_name
 from ..config import PROMPTS_DIR
 from ..context import ContextModel, TContext
-from ..controls import ParametricSourceControls
+from ..controls import CatalogSourceControls, ParametricSourceControls
 from ..controls.ingest.result import SourceResult
 from ..llm import Message
 from ..schemas import Metaset, get_metaset
@@ -67,7 +67,7 @@ def _build_catalog_summary(context: TContext) -> str:
 
     lines = []
     for ctrl in controls:
-        if not isinstance(ctrl, ParametricSourceControls):
+        if not isinstance(ctrl, (ParametricSourceControls, CatalogSourceControls)):
             continue
         ctrl_label = getattr(ctrl, "label", ctrl.__class__.__name__)
         lines.append(f"### {ctrl_label}")
@@ -220,12 +220,13 @@ class SourceAgent(Agent):
     input_schema = SourceInputs
     output_schema = SourceOutputs
 
-
-
     @classmethod
     async def applies(cls, context: TContext) -> bool:
         controls = context.get("source_controls", [])
-        return any(isinstance(c, ParametricSourceControls) for c in controls)
+        return any(
+            isinstance(c, (ParametricSourceControls, CatalogSourceControls))
+            for c in controls
+        )
 
     # ------------------------------------------------------------------
     # Tool building
@@ -245,9 +246,9 @@ class SourceAgent(Agent):
         in all controls.
         """
         controls = context.get("source_controls", [])
-        ctrl_map: dict[str, ParametricSourceControls] = {}
+        ctrl_map: dict[str, ParametricSourceControls | CatalogSourceControls] = {}
         for c in controls:
-            if isinstance(c, ParametricSourceControls):
+            if isinstance(c, (ParametricSourceControls, CatalogSourceControls)):
                 from ..tools.source_lookup import _control_hash
                 ctrl_map[_control_hash(c)] = c
 

--- a/lumen/ai/controls/ingest/base.py
+++ b/lumen/ai/controls/ingest/base.py
@@ -71,6 +71,8 @@ class BaseSourceControls(Viewer):
 
     __abstract = True
 
+    _supports_tools = False
+
     def __init__(self, **params):
         super().__init__(**params)
         self._init_ui_components()

--- a/lumen/ai/controls/ingest/catalog.py
+++ b/lumen/ai/controls/ingest/catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 
 import pandas as pd
 import panel as pn
@@ -61,6 +62,8 @@ class CatalogSourceControls(BaseSourceControls):
     load_mode = "manual"  # Row clicks trigger loading, not a button
 
     label = "Catalog"
+
+    _cached_catalog_tools: list[tuple[str, callable]] | None = None
 
     __abstract = True
 
@@ -254,3 +257,107 @@ class CatalogSourceControls(BaseSourceControls):
 
         if items:
             await self.vector_store.upsert(items)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Agent / tool integration
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def _tool_name(self) -> str:
+        """Display name for the tool returned by ``as_tools()``.
+
+        Override in subclasses for a custom name.
+        """
+        clean = re.sub(r'<[^>]+>', '', self.label).strip() if self.label else type(self).__name__
+        return f"Search and load from {clean}"
+
+    async def _agent_load_dataset(self, query: str) -> SourceResult:
+        """Search the catalog for a dataset matching the query and load it.
+
+        Args:
+            query: Natural language description, dataset name, collection
+                name, or identifier to search for in the catalog.
+        """
+        if self.catalog_df is None or self.catalog_df.empty:
+            return SourceResult.empty("Catalog not yet loaded.")
+
+        match_idx = await self._search_catalog(query)
+        if match_idx is None:
+            return SourceResult.empty(
+                f"No dataset matching '{query}' found in catalog."
+            )
+
+        entry = self.catalog_df.iloc[match_idx]
+        try:
+            result = await self._fetch_entry(entry)
+            # Register the source on the control so the UI's
+            # _sync_sources watcher fires and the SourceCatalog
+            # ("Available Sources") is updated.  When invoked
+            # via the Tabulator click path this happens inside
+            # _run_load → _handle_success; the SourceAgent path
+            # bypasses _run_load so we do it explicitly here.
+            if result and result.sources:
+                existing = self.context.get("sources", [])
+                for src in result.sources:
+                    if src not in existing:
+                        self._register_source_output(src)
+                self.param.trigger("outputs")
+            return result
+        finally:
+            # _fetch_entry may update the progress bar (e.g.
+            # "Processing …") but only _run_load clears it.
+            # When called via SourceAgent we bypass _run_load,
+            # so clean up here to avoid a stuck progress bar.
+            self.progress.clear()
+
+    def as_tools(
+        self, query: str | None = None, top_k: int = 5,
+    ) -> list[tuple[str, callable]]:
+        """Return ``(name, callable)`` pairs for SourceAgent / SourceLookup.
+
+        Exposes one tool that searches the catalog via vector similarity
+        (or text fallback) and loads the best-matching entry.
+        Results are cached so ``_control_hash`` remains stable.
+        """
+        if self._cached_catalog_tools is not None:
+            return self._cached_catalog_tools
+        tools = [(self._tool_name(), self._agent_load_dataset)]
+        self._cached_catalog_tools = tools
+        return tools
+
+    async def _search_catalog(self, query: str) -> int | None:
+        """Find the best matching catalog row index for *query*.
+
+        Uses vector search when a ``vector_store`` is available and
+        falls back to keyword matching on ``search_columns``.
+        """
+        # ── vector search path ──
+        if self.vector_store is not None:
+            try:
+                results = await self.vector_store.query(query, top_k=5)
+                for r in results:
+                    meta = r.get("metadata", {})
+                    if (
+                        meta.get("type") == "catalog_entry"
+                        and meta.get("_control_id") == id(self)
+                    ):
+                        return meta["_row_idx"]
+            except Exception:
+                pass  # fall through to text search
+
+        # ── text fallback ──
+        if self.catalog_df is None or not self.search_columns:
+            return None
+
+        query_lower = query.lower()
+        query_words = query_lower.split()
+        best_idx = None
+        best_score = 0
+
+        for idx, row in self.catalog_df.iterrows():
+            text = self._entry_to_text(row).lower()
+            score = sum(1 for word in query_words if word in text)
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+
+        return best_idx if best_score > 0 else None

--- a/lumen/ai/controls/ingest/catalog.py
+++ b/lumen/ai/controls/ingest/catalog.py
@@ -272,7 +272,7 @@ class CatalogSourceControls(BaseSourceControls):
         clean = re.sub(r'<[^>]+>', '', self.label).strip() if self.label else type(self).__name__
         return f"Search and load from {clean}"
 
-    async def _agent_load_dataset(self, query: str) -> SourceResult:
+    async def _load_from_query(self, query: str) -> SourceResult:
         """Search the catalog for a dataset matching the query and load it.
 
         Args:
@@ -322,7 +322,7 @@ class CatalogSourceControls(BaseSourceControls):
         """
         if self._cached_catalog_tools is not None:
             return self._cached_catalog_tools
-        tools = [(self._tool_name(), self._agent_load_dataset)]
+        tools = [(self._tool_name(), self._load_from_query)]
         self._cached_catalog_tools = tools
         return tools
 

--- a/lumen/ai/controls/ingest/catalog.py
+++ b/lumen/ai/controls/ingest/catalog.py
@@ -63,6 +63,8 @@ class CatalogSourceControls(BaseSourceControls):
 
     label = "Catalog"
 
+    _supports_tools = True
+
     _cached_catalog_tools: list[tuple[str, callable]] | None = None
 
     __abstract = True
@@ -193,7 +195,7 @@ class CatalogSourceControls(BaseSourceControls):
 
         # Background embed — fire and forget, same pattern as SourceCatalog
         if self.vector_store is not None and self.catalog_df is not None:
-            asyncio.create_task(self._embed_catalog())  # noqa: RUF006
+            asyncio.create_task(self._embed())  # noqa: RUF006
 
     async def _on_row_click(self, event):
         """Handle Tabulator row click — delegates to _run_load."""
@@ -226,7 +228,7 @@ class CatalogSourceControls(BaseSourceControls):
             sizing_mode="stretch_width",
         )
 
-    async def _embed_catalog(self):
+    async def _embed(self):
         """
         Embed all catalog entries into the vector store for agent search.
         Called as a background asyncio task after _load_catalog completes.

--- a/lumen/ai/controls/ingest/code.py
+++ b/lumen/ai/controls/ingest/code.py
@@ -156,7 +156,7 @@ class CodeSourceControls(ParametricSourceControls):
         )
 
         if self.vector_store is not None:
-            pn.state.execute(self._embed_actions)
+            pn.state.execute(self._embed)
 
     async def _fetch_data(self, action_name: str, **params) -> SourceResult:
         func = self._actions[action_name]

--- a/lumen/ai/controls/ingest/parametric.py
+++ b/lumen/ai/controls/ingest/parametric.py
@@ -53,6 +53,8 @@ class ParametricSourceControls(BaseSourceControls):
     load_button_label = "Fetch Data"
     load_button_icon = "download"
 
+    _supports_tools = True
+
     __abstract = True
 
     def __init__(self, **params):
@@ -270,7 +272,7 @@ class ParametricSourceControls(BaseSourceControls):
     # Agent integration
     # ──────────────────────────────────────────────────────────────────────────
 
-    async def _embed_actions(self):
+    async def _embed(self):
         """Embed action names + docstrings into vector store."""
         if self.vector_store is None:
             return

--- a/lumen/ai/tools/source_lookup.py
+++ b/lumen/ai/tools/source_lookup.py
@@ -14,7 +14,7 @@ import param
 
 from ..config import PROMPTS_DIR
 from ..context import ContextModel, TContext
-from ..controls import CatalogSourceControls, ParametricSourceControls
+from ..controls.ingest.base import BaseSourceControls
 from ..llm import Message
 from ..translate import doc_descriptions, function_to_model
 from ..utils import deterministic_hash, log_debug
@@ -24,7 +24,7 @@ from .vector_lookup import VectorLookupTool, make_refined_query_model
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _control_hash(ctrl: ParametricSourceControls | CatalogSourceControls) -> str:
+def _control_hash(ctrl: BaseSourceControls) -> str:
     """Stable hash for a control based on its class name + action signatures.
 
     Unlike ``id(ctrl)``, this survives garbage-collection and
@@ -118,10 +118,7 @@ class SourceLookup(VectorLookupTool):
     @classmethod
     async def applies(cls, context: TContext) -> bool:
         controls = context.get("source_controls", [])
-        return any(
-            isinstance(c, (ParametricSourceControls, CatalogSourceControls))
-            for c in controls
-        )
+        return any(c._supports_tools for c in controls)
 
     # ------------------------------------------------------------------
     # Sync / index
@@ -136,7 +133,7 @@ class SourceLookup(VectorLookupTool):
 
         entries = []
         for ctrl in controls:
-            if not isinstance(ctrl, (ParametricSourceControls, CatalogSourceControls)):
+            if not ctrl._supports_tools:
                 continue
             ctrl_key = _control_hash(ctrl)
             if ctrl_key in self._indexed_controls:
@@ -200,7 +197,7 @@ class SourceLookup(VectorLookupTool):
         total_actions = sum(
             len(ctrl.as_tools())
             for ctrl in context.get("source_controls", [])
-            if isinstance(ctrl, (ParametricSourceControls, CatalogSourceControls))
+            if ctrl._supports_tools
         )
 
         if total_actions < 5:
@@ -214,7 +211,7 @@ class SourceLookup(VectorLookupTool):
         controls = context.get("source_controls", [])
         ctrl_map = {
             _control_hash(c): c for c in controls
-            if isinstance(c, (ParametricSourceControls, CatalogSourceControls))
+            if c._supports_tools
         }
 
         source_actions: dict[str, Any] = {}

--- a/lumen/ai/tools/source_lookup.py
+++ b/lumen/ai/tools/source_lookup.py
@@ -14,7 +14,7 @@ import param
 
 from ..config import PROMPTS_DIR
 from ..context import ContextModel, TContext
-from ..controls import ParametricSourceControls
+from ..controls import CatalogSourceControls, ParametricSourceControls
 from ..llm import Message
 from ..translate import doc_descriptions, function_to_model
 from ..utils import deterministic_hash, log_debug
@@ -24,7 +24,7 @@ from .vector_lookup import VectorLookupTool, make_refined_query_model
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _control_hash(ctrl: ParametricSourceControls) -> str:
+def _control_hash(ctrl: ParametricSourceControls | CatalogSourceControls) -> str:
     """Stable hash for a control based on its class name + action signatures.
 
     Unlike ``id(ctrl)``, this survives garbage-collection and
@@ -118,7 +118,10 @@ class SourceLookup(VectorLookupTool):
     @classmethod
     async def applies(cls, context: TContext) -> bool:
         controls = context.get("source_controls", [])
-        return any(isinstance(c, ParametricSourceControls) for c in controls)
+        return any(
+            isinstance(c, (ParametricSourceControls, CatalogSourceControls))
+            for c in controls
+        )
 
     # ------------------------------------------------------------------
     # Sync / index
@@ -133,7 +136,7 @@ class SourceLookup(VectorLookupTool):
 
         entries = []
         for ctrl in controls:
-            if not isinstance(ctrl, ParametricSourceControls):
+            if not isinstance(ctrl, (ParametricSourceControls, CatalogSourceControls)):
                 continue
             ctrl_key = _control_hash(ctrl)
             if ctrl_key in self._indexed_controls:
@@ -197,7 +200,7 @@ class SourceLookup(VectorLookupTool):
         total_actions = sum(
             len(ctrl.as_tools())
             for ctrl in context.get("source_controls", [])
-            if isinstance(ctrl, ParametricSourceControls)
+            if isinstance(ctrl, (ParametricSourceControls, CatalogSourceControls))
         )
 
         if total_actions < 5:
@@ -210,7 +213,8 @@ class SourceLookup(VectorLookupTool):
         # Build action info mapping
         controls = context.get("source_controls", [])
         ctrl_map = {
-            _control_hash(c): c for c in controls if isinstance(c, ParametricSourceControls)
+            _control_hash(c): c for c in controls
+            if isinstance(c, (ParametricSourceControls, CatalogSourceControls))
         }
 
         source_actions: dict[str, Any] = {}

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -40,8 +40,8 @@ from ..sources.xarray_sql import XArraySQLSource
 from ..util import check_xarray_available, log
 from .agents import (
     AnalysisAgent, BaseCodeAgent, ChatAgent, DocumentListAgent,
-    DocumentSummarizerAgent, SQLAgent, TableListAgent, ValidationAgent,
-    VegaLiteAgent,
+    DocumentSummarizerAgent, SourceAgent, SQLAgent, TableListAgent,
+    ValidationAgent, VegaLiteAgent,
 )
 from .config import (
     DEMO_MESSAGES, GETTING_STARTED_SUGGESTIONS, PROVIDED_SOURCE_NAME,
@@ -408,7 +408,7 @@ class UI(Viewer):
 
     default_agents = param.List(default=[
         TableListAgent, ChatAgent, DocumentListAgent, DocumentSummarizerAgent,
-        SQLAgent, VegaLiteAgent, ValidationAgent, DeckGLAgent
+        SQLAgent, SourceAgent, VegaLiteAgent, ValidationAgent, DeckGLAgent
     ], doc="""List of default agents which will always be added.""")
 
     demo_inputs = param.List(default=DEMO_MESSAGES, doc="""


### PR DESCRIPTION
Previously only supported ParametricSourceControls for auto-loading sources; here we follow the same paradigm (as_tools) for CatalogSourceControls. Also introduce `_supports_tools`.

Chat to auto load:
<img width="1292" height="924" alt="image" src="https://github.com/user-attachments/assets/a47cabb1-f879-4d2a-8a77-985eca281847" />

View the catalog to verify it auto loaded:
<img width="956" height="719" alt="image" src="https://github.com/user-attachments/assets/44640aa3-88b2-49e9-8561-bdec5a126a6c" />
