### PR TITLE
Fix image with tools

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -307,6 +307,37 @@ class Llm(param.Parameterized):
                 messages[i]["content"] = new_content
         return messages, contains_image
 
+    @staticmethod
+    def _normalize_multimodal_messages(messages: list[Message]) -> list[Message]:
+        """Convert instructor Image objects and bare strings in list content
+        to OpenAI-native content-part dicts.
+
+        When response_model is absent (e.g. during the tool-loop phase),
+        the raw OpenAI client is used and it cannot handle instructor
+        Image objects.  This method normalises them.
+        """
+        for message in messages:
+            content = message.get("content")
+            if isinstance(content, Image):
+                message["content"] = [{
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{content.media_type};base64,{content.source}"},
+                }]
+            elif isinstance(content, list):
+                new_content = []
+                for item in content:
+                    if isinstance(item, Image):
+                        new_content.append({
+                            "type": "image_url",
+                            "image_url": {"url": f"data:{item.media_type};base64,{item.source}"},
+                        })
+                    elif isinstance(item, str):
+                        new_content.append({"type": "text", "text": item})
+                    else:
+                        new_content.append(item)
+                message["content"] = new_content
+        return messages
+
     @classmethod
     def warmup(cls, model_kwargs: dict | None):
         """
@@ -404,6 +435,9 @@ class Llm(param.Parameterized):
             kwargs["response_model"] = structured_model
         else:
             kwargs.pop("response_model", None)
+            # Without response_model the raw client is used, which
+            # cannot handle instructor Image objects in list content.
+            messages = self._normalize_multimodal_messages(messages)
 
         output = await self.run_client(model_spec, messages, **kwargs)
         if not tool_instances:

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -13,7 +13,7 @@ try:
 
     from lumen.ai.agents.vega_lite import VegaLiteAgent
     from lumen.ai.llm import (
-        Anthropic, AzureOpenAI, Google, Groq, Message, MistralAI, OpenAI,
+        Anthropic, AzureOpenAI, Google, Groq, Llm, Message, MistralAI, OpenAI,
     )
 
 except ModuleNotFoundError:
@@ -296,6 +296,90 @@ def test_openai_responses_stream_tool_call_id_preserved_from_added_event():
     OpenAI._accumulate_tool_calls(accum, order, OpenAI._extract_stream_tool_calls(done_event))
     tool_calls = OpenAI._tool_calls_from_accum(accum, order)
     assert tool_calls[0]["id"] == "call_abc"
+# ---------------------------------------------------------------------------
+# _normalize_multimodal_messages tests
+# ---------------------------------------------------------------------------
+
+class TestNormalizeMultimodalMessages:
+    """Tests for Llm._normalize_multimodal_messages.
+
+    When response_model is absent (e.g. during the tool-loop phase),
+    the raw OpenAI client is used and cannot handle instructor Image
+    objects.  _normalize_multimodal_messages converts them to
+    OpenAI-native content-part dicts.
+    """
+
+    def test_standalone_image_converted(self):
+        """A bare Image as content is wrapped in an image_url dict list."""
+        img = _make_test_image()
+        messages: list[Message] = [{"role": "user", "content": img}]
+        result = Llm._normalize_multimodal_messages(messages)
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        assert len(content) == 1
+        assert content[0]["type"] == "image_url"
+        assert "base64," in content[0]["image_url"]["url"]
+
+    def test_list_image_and_string_converted(self):
+        """A [str, Image] list is converted to [{type: text}, {type: image_url}]."""
+        img = _make_test_image()
+        messages: list[Message] = [
+            {"role": "user", "content": ["Describe this:", img]},
+        ]
+        result = Llm._normalize_multimodal_messages(messages)
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        assert len(content) == 2
+        assert content[0] == {"type": "text", "text": "Describe this:"}
+        assert content[1]["type"] == "image_url"
+        assert "base64," in content[1]["image_url"]["url"]
+
+    def test_plain_text_unchanged(self):
+        """Plain string content passes through untouched."""
+        messages: list[Message] = [{"role": "user", "content": "Hello"}]
+        result = Llm._normalize_multimodal_messages(messages)
+        assert result[0]["content"] == "Hello"
+
+    def test_already_normalized_dicts_unchanged(self):
+        """Content that is already OpenAI-native dicts passes through."""
+        messages: list[Message] = [{"role": "user", "content": [
+            {"type": "text", "text": "Hi"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]}]
+        result = Llm._normalize_multimodal_messages(messages)
+        content = result[0]["content"]
+        assert content[0] == {"type": "text", "text": "Hi"}
+        assert content[1] == {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+
+    def test_multiple_images_in_list(self):
+        """Multiple Image objects in a list are all converted."""
+        img1 = _make_test_image()
+        img2 = _make_test_image()
+        messages: list[Message] = [
+            {"role": "user", "content": ["Compare:", img1, img2]},
+        ]
+        result = Llm._normalize_multimodal_messages(messages)
+        content = result[0]["content"]
+        assert len(content) == 3
+        assert content[0] == {"type": "text", "text": "Compare:"}
+        assert content[1]["type"] == "image_url"
+        assert content[2]["type"] == "image_url"
+
+    def test_mixed_messages_only_image_ones_affected(self):
+        """Non-image messages in the list are left alone."""
+        img = _make_test_image()
+        messages: list[Message] = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "user", "content": ["Chart:", img]},
+        ]
+        result = Llm._normalize_multimodal_messages(messages)
+        assert result[0]["content"] == "You are helpful."
+        assert result[1]["content"] == "Hello"
+        assert result[2]["content"][0] == {"type": "text", "text": "Chart:"}
+        assert result[2]["content"][1]["type"] == "image_url"
+
+
 # ---------------------------------------------------------------------------
 # _check_for_image tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Fixes issue:
```
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid type for 'messages[6].content[0]': expected an object, but got a string instead.", 'type': 'invalid_request_error', 'param': 'messages[6].content[0]', 'code': 'invalid_type'}}
```

I was so stumped. Initially I thought I was double nesting the [[str, Image]], but it turns out the tools PR removed the response model, so instructor.Image no longer works. The solution is to cast into an image dict.

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

To reproduce, simply ask for a plot on main branch; it'll crash on `_polish_image` or any image serialization.

No more errors now:
<img width="1274" height="888" alt="image" src="https://github.com/user-attachments/assets/83f3bdf9-498b-49a2-8b84-998646af10a5" />


## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: {e.g., Cursor + Sonnet 4.6, Claude Code + Opus 4.6, Antigravity + Gemini Flash 3, ChatGPT, etc.}

## Checklist

<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
- [ ] Added documentation
