### PR TITLE
Fix for built-in tools

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1256,21 +1256,6 @@ class OpenAI(Llm, OpenAIMixin):
 
         return super()._extract_stream_tool_calls(chunk)
 
-    @staticmethod
-    def _has_inbuilt_tools(tools: list[dict[str, Any]] | None) -> bool:
-        """Return True if *tools* contains any OpenAI inbuilt tool.
-
-        Inbuilt tools (e.g. ``web_search``, ``code_interpreter``) are
-        handled server-side by the Responses API.  They are plain dicts
-        whose ``type`` is **not** ``"function"``.
-        """
-        if not tools:
-            return False
-        return any(
-            isinstance(t, dict) and t.get("type") not in (None, "function")
-            for t in tools
-        )
-
     async def _run_tool_loop(
         self,
         messages: list[Message],
@@ -1286,7 +1271,10 @@ class OpenAI(Llm, OpenAIMixin):
                 messages, structured_model, tool_instances, tool_contexts, model_spec, max_tool_rounds, **kwargs
             )
 
-        has_inbuilt = self._has_inbuilt_tools(kwargs.get("tools"))
+        has_inbuilt = any(
+            isinstance(t, dict) and t.get("type") not in (None, "function")
+            for t in kwargs.get("tools")
+        )
 
         # When there are NO inbuilt tools and NO function-tool instances we
         # can ask for the structured response in a single round-trip.
@@ -1300,7 +1288,7 @@ class OpenAI(Llm, OpenAIMixin):
         if not tool_instances and not has_inbuilt:
             return output
 
-        # --- function-tool loop (unchanged) ---
+        # --- function-tool loop ---
         for _ in range(max_tool_rounds):
             tool_calls = self._extract_tool_calls(output)
             if not tool_calls:
@@ -1323,11 +1311,6 @@ class OpenAI(Llm, OpenAIMixin):
         if structured_model:
             final_kwargs = dict(kwargs)
             final_kwargs["response_model"] = structured_model
-            # Drop inbuilt tools from the final call so the model
-            # produces only the structured output.
-            if has_inbuilt:
-                final_kwargs.pop("tools", None)
-                final_kwargs.pop("tool_choice", None)
             response_id = getattr(output, "id", None)
             if response_id:
                 final_kwargs["previous_response_id"] = response_id

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1288,7 +1288,6 @@ class OpenAI(Llm, OpenAIMixin):
         if not tool_instances and not has_inbuilt:
             return output
 
-        # --- function-tool loop ---
         for _ in range(max_tool_rounds):
             tool_calls = self._extract_tool_calls(output)
             if not tool_calls:
@@ -1307,7 +1306,6 @@ class OpenAI(Llm, OpenAIMixin):
                 next_kwargs["previous_response_id"] = response_id
             output = await self.run_client(model_spec, tool_outputs, **next_kwargs)
 
-        # --- structured-output pass ---
         if structured_model:
             final_kwargs = dict(kwargs)
             final_kwargs["response_model"] = structured_model

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1256,6 +1256,21 @@ class OpenAI(Llm, OpenAIMixin):
 
         return super()._extract_stream_tool_calls(chunk)
 
+    @staticmethod
+    def _has_inbuilt_tools(tools: list[dict[str, Any]] | None) -> bool:
+        """Return True if *tools* contains any OpenAI inbuilt tool.
+
+        Inbuilt tools (e.g. ``web_search``, ``code_interpreter``) are
+        handled server-side by the Responses API.  They are plain dicts
+        whose ``type`` is **not** ``"function"``.
+        """
+        if not tools:
+            return False
+        return any(
+            isinstance(t, dict) and t.get("type") not in (None, "function")
+            for t in tools
+        )
+
     async def _run_tool_loop(
         self,
         messages: list[Message],
@@ -1271,15 +1286,21 @@ class OpenAI(Llm, OpenAIMixin):
                 messages, structured_model, tool_instances, tool_contexts, model_spec, max_tool_rounds, **kwargs
             )
 
-        if structured_model is not None and not tool_instances:
+        has_inbuilt = self._has_inbuilt_tools(kwargs.get("tools"))
+
+        # When there are NO inbuilt tools and NO function-tool instances we
+        # can ask for the structured response in a single round-trip.
+        if structured_model is not None and not tool_instances and not has_inbuilt:
             kwargs["response_model"] = structured_model
         else:
             kwargs.pop("response_model", None)
 
         output = await self.run_client(model_spec, messages, **kwargs)
-        if not tool_instances:
+
+        if not tool_instances and not has_inbuilt:
             return output
 
+        # --- function-tool loop (unchanged) ---
         for _ in range(max_tool_rounds):
             tool_calls = self._extract_tool_calls(output)
             if not tool_calls:
@@ -1298,9 +1319,15 @@ class OpenAI(Llm, OpenAIMixin):
                 next_kwargs["previous_response_id"] = response_id
             output = await self.run_client(model_spec, tool_outputs, **next_kwargs)
 
+        # --- structured-output pass ---
         if structured_model:
             final_kwargs = dict(kwargs)
             final_kwargs["response_model"] = structured_model
+            # Drop inbuilt tools from the final call so the model
+            # produces only the structured output.
+            if has_inbuilt:
+                final_kwargs.pop("tools", None)
+                final_kwargs.pop("tool_choice", None)
             response_id = getattr(output, "id", None)
             if response_id:
                 final_kwargs["previous_response_id"] = response_id


### PR DESCRIPTION
## Description

I was testing OpenAI built-in web search with the responses api and I noticed it would NOT run the web search every time. 

## How Has This Been Tested?

```python
"""Minimal reproducible example: web search + structured output via LumenOpenAI.

Run with:  python test_research.py
"""

import asyncio
from pydantic import BaseModel, Field
from lumen.ai.llm import OpenAI as LumenOpenAI


class PersonProfile(BaseModel):
    """Research result for a single meeting attendee."""
    name: str = Field(description="Person's full name")
    title: str = Field(description="Current job title/role, or 'Unknown'")
    summary: str = Field(description="One sentence on their background and relevance")
    context: str = Field(description="Extra context: recent posts, talks, publications. Empty string if none")


PEOPLE_PROMPT = """\
You are a research assistant preparing an account executive for a meeting.
Given a person's name and their company domain, use web_search to research them.
Search for the person's name + company name on LinkedIn and the web.
Be concise and factual. If you cannot find someone after searching, set
their title to "Unknown" and note it in the summary."""

DOMAIN = "anaconda.com"
COMPANY_SEARCH_HINT = "Anaconda"
PEOPLE = ["Andrew H"]


async def test_people_research(client: LumenOpenAI) -> None:
    """Test People research — each person searched individually."""
    company_name = DOMAIN.split(".")[0].title()

    for person_name in PEOPLE:
        print(f"\n--- Test 2: People research for {person_name} at {company_name} ---")
        try:
            response = await client.invoke(
                model="gpt-5.4-mini",
                tools=[{"type": "web_search"}],
                tool_choice="required",
                include=["web_search_call.action.sources"],
                instructions=PEOPLE_PROMPT,
                messages=[
                    {
                        "role": "user",
                        "content": (
                            f"Research {person_name} who works at {company_name} ({DOMAIN}). "
                            f"Always use web search."
                        ),
                    }
                ],
                response_model=PersonProfile,
            )
            print(f"Type: {type(response)}")
            print(f"Value: {response}")
        except Exception as e:
            print(f"FAILED for {person_name}: {e}")


async def main():
    client = LumenOpenAI(api="responses")
    await test_people_research(client)


if __name__ == "__main__":
    asyncio.run(main())
```

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: {e.g., Cursor + Sonnet 4.6, Claude Code + Opus 4.6, Antigravity + Gemini Flash 3, ChatGPT, etc.}

Used Opus 4.6 to patch.

## Checklist

<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
- [ ] Added documentation
