### PR TITLE
Ensure stream responses are handled correctly with tool calls

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -431,9 +431,20 @@ class Llm(param.Parameterized):
         max_tool_rounds: int = 16,
         **kwargs
     ) -> BaseModel | str:
+        requested_stream = bool(kwargs.get("stream", False))
+        if requested_stream and structured_model is None:
+            # In stream mode we can't know upfront whether a tool will be called.
+            # Return the provider stream and let stream() inspect chunks for tool calls.
+            kwargs.pop("response_model", None)
+            messages = self._normalize_multimodal_messages(messages)
+            return await self.run_client(model_spec, messages, **kwargs)
+
+        stream = False
         if structured_model is not None and not tool_instances:
             kwargs["response_model"] = structured_model
         else:
+            if tool_instances:
+                stream = kwargs.pop("stream", False)
             kwargs.pop("response_model", None)
             # Without response_model the raw client is used, which
             # cannot handle instructor Image objects in list content.
@@ -459,7 +470,7 @@ class Llm(param.Parameterized):
 
         if structured_model:
             kwargs["response_model"] = structured_model
-            output = await self.run_client(model_spec, messages_curr, **kwargs)
+            output = await self.run_client(model_spec, messages_curr, stream=stream, **kwargs)
         return output
 
     @classmethod
@@ -796,7 +807,7 @@ class Llm(param.Parameterized):
         The string or response_model field.
         """
         combined_tools = self._combine_tools(tools)
-        tool_specs, tool_instances, tool_contexts = self._normalize_tools(combined_tools)
+        _, tool_instances, tool_contexts = self._normalize_tools(combined_tools)
         messages, contains_image = self._check_for_image(messages)
         if self.logfire_tags is not None or contains_image:
             output = await self.invoke(
@@ -804,7 +815,7 @@ class Llm(param.Parameterized):
                 system=system,
                 response_model=response_model,
                 model_spec=model_spec,
-                tools=tool_specs,
+                tools=combined_tools,
                 **kwargs,
             )
             if response_model is not None:
@@ -826,7 +837,7 @@ class Llm(param.Parameterized):
                 system=system,
                 response_model=response_model,
                 model_spec=model_spec,
-                tools=tool_specs,
+                tools=combined_tools,
                 **kwargs,
             )
             yield self._get_content(output)
@@ -840,7 +851,7 @@ class Llm(param.Parameterized):
             stream=True,
             allow_partial=True,
             model_spec=model_spec,
-            tools=tool_specs,
+            tools=combined_tools,
             **kwargs,
         )
         if isinstance(chunks, BaseModel):
@@ -1271,6 +1282,11 @@ class OpenAI(Llm, OpenAIMixin):
                 messages, structured_model, tool_instances, tool_contexts, model_spec, max_tool_rounds, **kwargs
             )
 
+        requested_stream = bool(kwargs.get("stream", False))
+        if requested_stream and structured_model is None:
+            kwargs.pop("response_model", None)
+            return await self.run_client(model_spec, messages, **kwargs)
+
         has_inbuilt = any(
             isinstance(t, dict) and t.get("type") not in (None, "function")
             for t in kwargs.get("tools")
@@ -1284,7 +1300,6 @@ class OpenAI(Llm, OpenAIMixin):
             kwargs.pop("response_model", None)
 
         output = await self.run_client(model_spec, messages, **kwargs)
-
         if not tool_instances and not has_inbuilt:
             return output
 

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -276,6 +276,41 @@ async def test_openai_responses_stream_tool_loop_uses_function_call_output(monke
     assert second_kwargs["previous_response_id"] == "resp_1"
 
 
+async def test_stream_keeps_streaming_when_tools_registered_but_unused(monkeypatch):
+    """stream() should still yield deltas when tools are present but not called."""
+    llm = OpenAI(model_kwargs={"default": {"model": "gpt-4.1-mini"}})
+
+    def fake_normalize_tools(_tools):
+        return (
+            [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}],
+            {"lookup": object()},
+            {},
+        )
+
+    async def fake_run_client(_model_spec, _messages, **kwargs):
+        assert kwargs.get("stream") is True
+        return [
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="he", tool_calls=None))]
+            ),
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="llo", tool_calls=None))]
+            ),
+        ]
+
+    monkeypatch.setattr(llm, "_normalize_tools", fake_normalize_tools)
+    monkeypatch.setattr(llm, "run_client", fake_run_client)
+
+    outputs = []
+    async for chunk in llm.stream(
+        [{"role": "user", "content": "say hello"}],
+        tools=[{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}],
+    ):
+        outputs.append(chunk)
+
+    assert outputs == ["he", "hello"]
+
+
 def test_openai_responses_stream_tool_call_id_preserved_from_added_event():
     """Tool output call_id should come from function_call item (call_id), not item_id."""
     added_event = SimpleNamespace(


### PR DESCRIPTION
Without this tool calls would simply be dropped in streaming mode because the `_run_tool_loop` method could not extract tool calls from the streaming response and would therefore fall back to simply returning the completed response model.