### PR TITLE
Improve planner validation flow and add clarification LLM tool

### DIFF
--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -9,6 +9,7 @@ from ..config import PROMPTS_DIR
 from ..context import ContextModel, TContext
 from ..llm import Message
 from ..models import BaseModel
+from ..utils import content_to_text
 from .base import Agent
 
 
@@ -107,11 +108,12 @@ class ValidationAgent(Agent):
     ) -> tuple[list[Any], ValidationOutputs]:
         interface = self.interface
         def on_click(event):
-            if messages:
-                user_messages = [msg for msg in reversed(messages) if msg.get("role") == "user"]
-                original_query = user_messages[0].get("content", "").split("-- For context...")[0]
+            user_messages = [msg for msg in reversed(messages) if msg.get("role") == "user"]
+            if not user_messages:
+                return
+            text_content = content_to_text(user_messages[0].get("content", ""))
             suggestions_list = '\n- '.join(result.suggestions)
-            interface.send(f"Follow these suggestions to fulfill the original intent {original_query}\n\n{suggestions_list}")
+            interface.send(f"Follow these suggestions to fulfill the original intent:\n\n> {text_content}\n\n{suggestions_list}")
 
         result = await self._invoke_prompt("main", messages, context)
         if result.correct:

--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -19,7 +19,8 @@ ChatMessage.default_avatars.update({
     "Runner": {"type": "icon", "icon": "playlist_play"},
     "SQL": {"type": "icon", "icon": "storage"},
     "Source": {"type": "icon", "icon": "cloud_download"},
-    "DBT": {"type": "icon", "icon": "analytics"}
+    "DBT": {"type": "icon", "icon": "analytics"},
+    "Clarification": {"type": "icon", "icon": "live_help"}
 })
 
 FORMAT_ICONS = {

--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -39,9 +39,8 @@ from ..tools import (
 from ..tools.document_llm_tools import make_document_vector_llm_tools
 from ..tools.metaset_docs_llm_tools import make_load_metaset_relevant_docs_tool
 from ..utils import (
-    content_to_text, describe_data_sync, fuse_messages, get_root_exception,
-    log_debug, mutate_user_message, normalized_name, set_content_text,
-    wrap_logfire,
+    describe_data_sync, fuse_messages, get_root_exception, log_debug,
+    mutate_user_message, normalized_name, wrap_logfire,
 )
 from ..vector_store import NumpyVectorStore
 
@@ -96,21 +95,16 @@ class Plan(Section):
 
         rendered_history = []
         for msg in self.history:
+            rendered_history.append(msg)
             if msg is user_query:
-                user_content = user_query["content"]
-                if not isinstance(user_content, (str, list)):
-                    user_content = [user_content]
-                user_text = content_to_text(user_content)
-                roadmap_text = (
-                    f"User: {user_text!r}\n"
-                    f"Roadmap:\n{indent(todos, '    ')}\n"
+                roadmap_system = (
+                    f"<roadmap>\n{indent(todos, '  ')}\n</roadmap>\n"
                     f"Tasks marked ⚪ are scheduled for others later. "
-                    f"Your EXCLUSIVE goal is to focus on the 🟡 task"
+                    f"Your exclusive goal is the 🟡 task."
                 )
-                formatted_content = set_content_text(roadmap_text, user_content)
-                rendered_history.append({"content": formatted_content, "role": "user"})
-            else:
-                rendered_history.append(msg)
+                rendered_history.append(
+                    {"role": "system", "content": roadmap_system}
+                )
         return rendered_history, todos
 
     async def _run_task(self, i: int, task: Self | Actor, context: TContext, **kwargs):

--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -23,6 +23,7 @@ from ..llm import Message
 from ..models import FollowUpClassification
 from ..report import ActorTask
 from ..tools import MetadataLookup, SourceLookup, Tool
+from ..tools.clarification_llm_tool import make_clarification_llm_tool
 from ..utils import content_to_text, log_debug, wrap_logfire
 from .base import Coordinator, Plan
 
@@ -333,7 +334,8 @@ class Planner(Coordinator):
         # also filter out agents where excluded keys exist in context
         agents = [agent for agent in agents if len(set(agent.input_schema.__required_keys__) - all_provides) == 0 and type(agent).__name__ != "ValidationAgent"]
         tools = [tool for tool in tools if len(set(tool.input_schema.__required_keys__) - all_provides) == 0]
-        llm_tools = _merge_prompt_tools(self.llm_tools, None, context)
+        llm_tools = list(_merge_prompt_tools(self.llm_tools, None, context) or [])
+        llm_tools.append(make_clarification_llm_tool(self.interface, context))
         reasoning = None
         while reasoning is None:
             # candidates = agents and tools that can provide

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -942,9 +942,12 @@ class Llm(param.Parameterized):
                 )
             previous_role = role
 
+        response_model = kwargs.get("response_model")
         client = await self.get_client(model_spec, **kwargs)
+        if not response_model:
+            kwargs.pop("max_retries", None)
         result = await client(messages=messages, **kwargs)
-        if response_model := kwargs.get("response_model"):
+        if response_model:
             log_debug(f"Response model: \033[93m{response_model.__name__!r}\033[0m")
             if isinstance(result, ImageResponse):
                 result = result.output

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -84,16 +84,53 @@ Conditions:
 Should never be used together with: `{{ agent.not_with | join('`, `') }}`{%- endif %}
 {% endfor %}
 
-## LLM Tools
+## Tool Usage
 
-The LLM is capable of invoking tools directly.
+Two distinct mechanisms exist for using tools. The planner must treat them differently.
 
-If a required capability is covered by one of these tools:
-- Do NOT attempt to replicate the tool's functionality in the plan
-- Do NOT construct or infer the tool's output yourself
-- Instead, delegate to an agent that can leverage the tool, or allow the LLM to call the tool directly
+### Plan tools
+Capabilities invoked as steps within the plan. The planner references them by
+name; an executor runs them when the step fires.
 
-The planner's role is to coordinate agents, not to replace tool usage.
+- Include plan tools as explicit steps when an agent needs their output to
+  complete its task.
+- Do not pre-compute, infer, or fabricate a plan tool's output in the plan
+  description — the step's purpose is to produce that output at execution time.
+
+### LLM tools
+Tools the LLM can call directly inside its own generation loop (tool-calling API).
+These are available to you right now, as the planner, and to any agent whose
+loop includes them.
+
+- Call an LLM tool yourself **only when planning requires it** — e.g., you
+  need the tool's output to decide the shape of the plan.
+- Otherwise, delegate: assign the task to an agent whose loop has access to
+  the tool it needs. The agent will invoke the tool during its own execution.
+- Do not replicate an LLM tool's behavior in the plan as a sequence of steps.
+  If the capability exists as a tool, the tool is the correct mechanism.
+
+### The clarification tool — always yours
+The clarification tool is the one exception to "default to delegate." Use it
+directly whenever the user's request is ambiguous or underspecified in a way
+that affects the plan. Resolve ambiguity *before* planning, not within it —
+agents cannot ask the user, only execute. By the time the plan runs, every
+term in it must have a definite meaning. After the user replies, you will
+plan again with the clarification in context.
+
+- Ask one question per call. For multiple independent decisions, ask in
+  sequence across separate calls — do not staple them together.
+- Frame each question so any plausible answer unblocks planning. If you
+  cannot imagine an answer that lets you proceed, rewrite the question.
+- Use options only when you can enumerate every reasonable answer and each
+  option is a complete answer on its own. If you would want an "other" or
+  "please specify" choice, ask free-form instead.
+- For unrecognized terms, ask the user to define them free-form. Do not
+  offer guesses about the term's category as options.
+
+### The underlying principle
+
+Your job is to coordinate, not to execute. Call tools (of either kind) only when
+the act of planning itself depends on their output. Everything else is delegation.
 
 ## Current Data Context
 

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -151,23 +151,28 @@ class Task(Viewer):
 
     def _render_message_history(self, context: TContext) -> list[Message]:
         messages = list(self.history)
-        if not self.instruction:
+        if not self.instruction or any(self.instruction in content_to_text(msg.get("content")) for msg in messages):
             return messages
 
-        user_msg = None
-        for msg in messages[::-1]:
-            if msg.get("role") == "user":
-                user_msg = msg
+        # Find the last user message
+        last_user_idx = None
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
                 break
-        if not user_msg:
-            messages.append({"role": "user", "content": self.instruction})
-        else:
-            content = user_msg.get("content")
-            text_content = content_to_text(content)
-            if self.instruction not in text_content:
-                updated_text = f'{text_content}\n\nInstruction: {self.instruction}'
-                user_msg["content"] = set_content_text(updated_text, content)
-        return messages
+
+        if last_user_idx is None:
+            return [*messages, {"role": "user", "content": self.instruction}]
+
+        user_msg = messages[last_user_idx]
+        content = user_msg.get("content")
+        text_content = content_to_text(content)
+        updated_text = f"{text_content}\n\nInstruction: {self.instruction}"
+        updated_msg = {
+            **user_msg,
+            "content": set_content_text(updated_text, content),
+        }
+        return [*messages[:last_user_idx], updated_msg, *messages[last_user_idx + 1:]]
 
     def _render_output(self, out):
         if isinstance(out, str):

--- a/lumen/ai/tools/base.py
+++ b/lumen/ai/tools/base.py
@@ -87,6 +87,8 @@ class FunctionTool(Tool):
     keys listed in the provides parameter will be copied into working memory.
     """
 
+    conditions = param.List(default=[])
+
     formatter = param.Parameter(default="{function}({arguments}) returned: {output}", doc="""
         Formats the return value for inclusion in the global context.
         Accepts the 'function', 'arguments' and 'output' as formatting variables.""")

--- a/lumen/ai/tools/clarification_llm_tool.py
+++ b/lumen/ai/tools/clarification_llm_tool.py
@@ -1,0 +1,74 @@
+import asyncio
+
+import panel as pn
+
+from panel.chat import ChatFeed
+from panel_material_ui import (
+    Button, Column, RadioButtonGroup, TextInput, Typography,
+)
+
+from ..context import TContext
+from .base import FunctionTool
+
+
+def make_clarification_llm_tool(
+    interface: ChatFeed | None,
+    context: TContext,
+    user: str = "Clarification",
+) -> FunctionTool:
+    async def request_clarification(question: str, options: list[str] | None = None) -> str:
+        """
+        Ask the user one focused question and wait for their reply.
+
+        Parameters
+        ----------
+        question:
+            The exact question shown to the user. One decision per call.
+        options:
+            Fixed answer choices for constrained decisions — the user picks one
+           via radio buttons and cannot type. Each option must be a complete
+           standalone answer; never include "(please specify)", "(other)", or
+           similar. Leave as None for free-form text replies, including any
+           question whose answer requires the user to supply information
+           (definitions, names, values, descriptions).
+        """
+        if interface is None:
+            return "Clarification unavailable because no chat interface is active."
+
+        cleaned_options = None
+        if options:
+            cleaned_options = [opt.strip() for opt in options if isinstance(opt, str) and opt.strip()]
+
+        label = Typography(question, margin=10)
+        confirm = Button(icon="check", label="Confirm", margin=(5, 0, 20, 20))
+        if cleaned_options:
+            widget = RadioButtonGroup(options=cleaned_options, value=None, margin=(0, 20))
+        else:
+            widget = TextInput(sizing_mode="stretch_width", margin=(0, 20))
+            widget.param.enter_pressed.rx.pipe(lambda _: confirm.focus())
+            confirm.disabled = widget.rx().strip() == ""
+        out = Column(label, widget, confirm)
+        interface.send(out, user=user, respond=False)
+
+        while True:
+            await asyncio.sleep(0.1)
+            widget.focus()
+            if not confirm.clicks:
+                continue
+            value = widget.value.strip()
+            with pn.io.hold():
+                label.object = f"{label.object}\n\n> {value}"
+                out[:] = [label]
+            return f"User provided following clarification: {value}"
+
+    return FunctionTool(
+        request_clarification,
+        purpose=(
+            "Ask the user a focused clarifying question before planning when the "
+            "request is ambiguous, underspecified, or depends on a preference you "
+            "cannot infer. Prefer asking over guessing. Use when: (a) multiple "
+            "reasonable interpretations exist, (b) a required parameter is missing, "
+            "(c) the user's goal could be satisfied by substantially different plans. "
+            "Provide `question` always and `options` only for constrained choices."
+        )
+    )

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -651,9 +651,10 @@ class TestRenderTaskHistoryMultimodal:
         )
         rendered, todos = plan.render_task_history(0)
         user_msg = next(m for m in rendered if m["role"] == "user")
+        roadmap_msg = next(m for m in rendered if m["role"] == "system" and "<roadmap>" in m["content"])
         assert isinstance(user_msg["content"], str)
         assert "Hello" in user_msg["content"]
-        assert "🟡" in user_msg["content"]
+        assert "🟡 say hi" in roadmap_msg["content"]
 
     def test_multimodal_content_preserves_image(self, llm):
         img = object()
@@ -665,12 +666,13 @@ class TestRenderTaskHistoryMultimodal:
         )
         rendered, todos = plan.render_task_history(0)
         user_msg = next(m for m in rendered if m["role"] == "user")
+        roadmap_msg = next(m for m in rendered if m["role"] == "system" and "<roadmap>" in m["content"])
         # Should be a list with formatted text + original image
         assert isinstance(user_msg["content"], list)
         assert img in user_msg["content"]
         text = content_to_text(user_msg["content"])
         assert "What is this?" in text
-        assert "🟡" in text
+        assert "🟡 describe" in roadmap_msg["content"]
 
     def test_multimodal_multiple_tasks(self, llm):
         img = object()
@@ -685,11 +687,12 @@ class TestRenderTaskHistoryMultimodal:
         )
         rendered, todos = plan.render_task_history(0)
         user_msg = next(m for m in rendered if m["role"] == "user")
+        roadmap_msg = next(m for m in rendered if m["role"] == "system" and "<roadmap>" in m["content"])
         assert isinstance(user_msg["content"], list)
         assert img in user_msg["content"]
         text = content_to_text(user_msg["content"])
-        assert "🟡 step 1" in text
-        assert "⚪ step 2" in text
+        assert "🟡 step 1" in roadmap_msg["content"]
+        assert "⚪ step 2" in roadmap_msg["content"]
 
     def test_assistant_messages_unchanged(self, llm):
         task = ActorTask(ChatAgent(), instruction="reply", title="Reply")

--- a/lumen/tests/ai/test_tools.py
+++ b/lumen/tests/ai/test_tools.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 try:
@@ -6,10 +8,14 @@ except ModuleNotFoundError:
     pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
 
 from panel.viewable import Viewable
+from panel_material_ui import (
+    Button, Column, RadioButtonGroup, TextInput,
+)
 
 from lumen.ai.coordinator import Coordinator
 from lumen.ai.schemas import DocumentChunk, Metaset, TableCatalogEntry
 from lumen.ai.tools import FunctionTool, MetadataLookup, define_tool
+from lumen.ai.tools.clarification_llm_tool import make_clarification_llm_tool
 from lumen.ai.tools.document_llm_tools import make_document_vector_llm_tools
 from lumen.ai.vector_store import NumpyVectorStore
 from lumen.config import SOURCE_TABLE_SEPARATOR
@@ -225,3 +231,67 @@ async def test_document_llm_tools_list_and_search():
     assert "zoo.md" in listed
     searched = await tools[1].function(query="penguins", top_k=3, min_similarity=-1.0)
     assert "cold water" in searched
+
+
+class _DummyInterface:
+
+    def __init__(self):
+        self.objects = []
+
+    def send(self, obj, **kwargs):
+        self.objects.append(obj)
+
+
+async def test_clarification_tool_requires_confirm_click_for_options():
+    context: dict = {}
+    interface = _DummyInterface()
+    tool = make_clarification_llm_tool(interface=interface, context=context)
+
+    task = asyncio.create_task(
+        tool.function("Pick one", options=["Option A", "Option B"])
+    )
+
+    await asyncio.sleep(0.05)
+    assert interface.objects
+    layout = interface.objects[-1]
+    assert isinstance(layout, Column)
+    widget = layout[1]
+    confirm = layout[2]
+    assert isinstance(widget, RadioButtonGroup)
+    assert isinstance(confirm, Button)
+    assert confirm.icon == "check"
+
+    widget.value = "Option A"
+    await asyncio.sleep(0.2)
+    assert not task.done()
+
+    confirm.clicks += 1
+    result = await asyncio.wait_for(task, timeout=1)
+    assert result == "User clarification: Option A"
+    assert context["clarification"] == "Option A"
+
+
+async def test_clarification_tool_requires_confirm_click_for_text():
+    context: dict = {}
+    interface = _DummyInterface()
+    tool = make_clarification_llm_tool(interface=interface, context=context)
+
+    task = asyncio.create_task(tool.function("Describe preference"))
+
+    await asyncio.sleep(0.05)
+    layout = interface.objects[-1]
+    assert isinstance(layout, Column)
+    widget = layout[1]
+    confirm = layout[2]
+    assert isinstance(widget, TextInput)
+    assert isinstance(confirm, Button)
+    assert confirm.icon == "check"
+
+    widget.value = "   concise answers   "
+    await asyncio.sleep(0.2)
+    assert not task.done()
+
+    confirm.clicks += 1
+    result = await asyncio.wait_for(task, timeout=1)
+    assert result == "User clarification: concise answers"
+    assert context["clarification"] == "concise answers"

--- a/lumen/tests/ai/test_tools.py
+++ b/lumen/tests/ai/test_tools.py
@@ -267,8 +267,8 @@ async def test_clarification_tool_requires_confirm_click_for_options():
 
     confirm.clicks += 1
     result = await asyncio.wait_for(task, timeout=1)
-    assert result == "User clarification: Option A"
-    assert context["clarification"] == "Option A"
+    assert result == "User provided following clarification: Option A"
+    assert "clarification" not in context
 
 
 async def test_clarification_tool_requires_confirm_click_for_text():
@@ -293,5 +293,5 @@ async def test_clarification_tool_requires_confirm_click_for_text():
 
     confirm.clicks += 1
     result = await asyncio.wait_for(task, timeout=1)
-    assert result == "User clarification: concise answers"
-    assert context["clarification"] == "concise answers"
+    assert result == "User provided following clarification: concise answers"
+    assert "clarification" not in context


### PR DESCRIPTION
- Introduces a new clarification LLM tool that lets the planner ask one focused follow-up question when a request is ambiguous, with support for free-form and option-based replies.
- Refines planner/tool guidance and roadmap injection so planning behavior is clearer, especially around when to call LLM tools directly versus delegating to agents.
- Improves validation/report message handling to preserve user intent more reliably and avoid duplicate instruction injection.