### PR TITLE
Simplify Planner reasoning and clarification

### DIFF
--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -41,6 +41,7 @@ class RawStep(BaseModel):
         Reflect exactly what the user asked for, nothing more and nothing less,
         i.e. if details/numbers are provided by the user, include them;
         if not, do not randomly add arbitrary numbers or details.
+        Do include any clarifications.
 
         - ❌ Too low: implementation details (SQL syntax, chart specs)
         - ❌ Too high: vague ("handle this", "process data")
@@ -56,6 +57,7 @@ class RawStep(BaseModel):
 
 
 class RawPlan(BaseModel):
+    chain_of_thought: str = Field(description="Summarize the user's goal and categorize the question type in 1-2 sentences.")
     title: str = Field(description="A title that describes this plan, up to three words.")
     steps: list[RawStep] = Field(
         description="""
@@ -66,24 +68,6 @@ class RawPlan(BaseModel):
         - Each step's instruction should be limited to that actor's task.
         - Do not include downstream objectives in upstream instructions.
         """
-    )
-
-
-class Reasoning(BaseModel):
-    chain_of_thought: str = Field(
-        description="""
-        Briefly summarize the user's goal and categorize the question type:
-        high-level, data-focused, or other. Identify the most relevant and compatible actors,
-        explaining their requirements, and what you already have satisfied. If there were previous failures, discuss them.
-        IMPORTANT: Ensure no consecutive steps use the same actor in your planned sequence.
-        For multi-metric queries (multiple charts or metrics), plan a single SQL step with JOINs.
-        Keep response to 1-2 sentences.
-        """,
-        examples=[
-            "Find which country hosted the most Winter Olympics—a data-focused query requiring aggregation. SQLAgent can handle this (requires source/metaset, both available) by filtering to Winter and counting by location, with no consecutive actor conflicts.",
-            "A horizontal bar chart of existing data. VegaLiteAgent is ready (requires pipeline/data/table, all satisfied from previous SQLAgent step) and will create the chart without consecutive actor issues.",
-            "SQLAgent should JOIN both tables on country/year in one query, then VegaLiteAgent creates the compound chart. Single SQL step avoids redundant queries."
-        ]
     )
 
 
@@ -336,49 +320,36 @@ class Planner(Coordinator):
         tools = [tool for tool in tools if len(set(tool.input_schema.__required_keys__) - all_provides) == 0]
         llm_tools = list(_merge_prompt_tools(self.llm_tools, None, context) or [])
         llm_tools.append(make_clarification_llm_tool(self.interface, context))
-        reasoning = None
-        while reasoning is None:
-            # candidates = agents and tools that can provide
-            # the unmet dependencies
-            agent_candidates = [agent for agent in agents if not unmet_dependencies or set(agent.output_schema.__annotations__) & unmet_dependencies]
-            tool_candidates = [tool for tool in tools if not unmet_dependencies or set(tool.output_schema.__annotations__) & unmet_dependencies]
-            model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
-            system = await self._render_prompt(
-                "main",
-                messages,
-                context,
-                model_spec=model_spec,
-                response_model=Reasoning,
-                agents=agents,
-                tools=tools,
-                unmet_dependencies=unmet_dependencies,
-                candidates=agent_candidates + tool_candidates,
-                previous_actors=previous_actors,
-                previous_plans=previous_plans,
-                follow_up_type=follow_up_type,
-            )
-            async for reasoning in self.llm.stream(
-                messages=messages,
-                system=system,
-                model_spec=model_spec,
-                response_model=Reasoning,
-                max_retries=3,
-                tools=llm_tools,
-            ):
-                if reasoning.chain_of_thought:  # do not replace with empty string
-                    context["reasoning"] = reasoning.chain_of_thought
-                    step.stream(reasoning.chain_of_thought, replace=True)
-                    previous_plans.append(reasoning.chain_of_thought)
 
-        raw_plan = None
+        # candidates = agents and tools that can provide
+        # the unmet dependencies
+        agent_candidates = [agent for agent in agents if not unmet_dependencies or set(agent.output_schema.__annotations__) & unmet_dependencies]
+        tool_candidates = [tool for tool in tools if not unmet_dependencies or set(tool.output_schema.__annotations__) & unmet_dependencies]
+        model_spec = self.prompts["main"].get("llm_spec", self.llm_spec_key)
+        system = await self._render_prompt(
+            "main",
+            messages,
+            context,
+            model_spec=model_spec,
+            response_model=plan_model,
+            agents=agents,
+            tools=tools,
+            unmet_dependencies=unmet_dependencies,
+            candidates=agent_candidates + tool_candidates,
+            previous_actors=previous_actors,
+            previous_plans=previous_plans,
+            follow_up_type=follow_up_type,
+        )
         async for raw_plan in self.llm.stream(
             messages=messages,
-            system=reasoning.chain_of_thought,
+            system=system,
             model_spec=model_spec,
             response_model=plan_model,
             max_retries=3,
             tools=llm_tools,
         ):
+            if raw_plan.chain_of_thought:
+                step.stream(raw_plan.chain_of_thought, replace=True)
             partial_todos = self._render_partial_todos(raw_plan)
             if partial_todos and self.steps_layout is not None:
                 self._todos_title.object = "📋 Building checklist..."

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -109,15 +109,23 @@ loop includes them.
 - Do not replicate an LLM tool's behavior in the plan as a sequence of steps.
   If the capability exists as a tool, the tool is the correct mechanism.
 
-### The clarification tool — always yours
-The clarification tool is the one exception to "default to delegate." Use it
-directly whenever the user's request is ambiguous or underspecified in a way
-that affects the plan. Resolve ambiguity *before* planning, not within it —
-agents cannot ask the user, only execute. By the time the plan runs, every
-term in it must have a definite meaning. After the user replies, you will
-plan again with the clarification in context.
+### The clarification tool
+The clarification tool is the one exception to "default to delegate". It is
+also the *only* channel for resolving ambiguity — never ask the user
+anything in message content, as content-mode questions do not reach the user
+in this system. If you find yourself wanting to ask, call the tool.
 
-- Ask one question per call. For multiple independent decisions, ask in
+Only resolve when:
+- no reasonable default would produce a meaningful plan
+- there are typos or abbreviations that are nonsensical
+- proceeding without an answer would clearly misrepresent the user's intent
+
+Resolve the ambiguity *before* planning, not within it — agents cannot ask
+the user, only execute. By the time the plan runs, every term in it must
+have a definite meaning. After the user replies, you will plan again with
+the resolved intent in context.
+
+- One question per call. For multiple independent decisions, resolve in
   sequence across separate calls — do not staple them together.
 - Frame each question so any plausible answer unblocks planning. If you
   cannot imagine an answer that lets you proceed, rewrite the question.

--- a/lumen/ai/tools/clarification_llm_tool.py
+++ b/lumen/ai/tools/clarification_llm_tool.py
@@ -4,7 +4,7 @@ import panel as pn
 
 from panel.chat import ChatFeed
 from panel_material_ui import (
-    Button, Column, RadioButtonGroup, TextInput, Typography,
+    Button, ChatAreaInput, Column, RadioBoxGroup, Typography,
 )
 
 from ..context import TContext
@@ -26,11 +26,11 @@ def make_clarification_llm_tool(
             The exact question shown to the user. One decision per call.
         options:
             Fixed answer choices for constrained decisions — the user picks one
-           via radio buttons and cannot type. Each option must be a complete
-           standalone answer; never include "(please specify)", "(other)", or
-           similar. Leave as None for free-form text replies, including any
-           question whose answer requires the user to supply information
-           (definitions, names, values, descriptions).
+            via radio buttons and cannot type. Each option must be a complete
+            standalone answer; never include "(please specify)", "(other)", or
+            similar. Leave as None for free-form text replies, including any
+            question whose answer requires the user to supply information
+            (definitions, names, values, descriptions).
         """
         if interface is None:
             return "Clarification unavailable because no chat interface is active."
@@ -40,22 +40,23 @@ def make_clarification_llm_tool(
             cleaned_options = [opt.strip() for opt in options if isinstance(opt, str) and opt.strip()]
 
         label = Typography(question, margin=10)
-        confirm = Button(icon="check", label="Confirm", margin=(5, 0, 20, 20))
+        enter_pressed = []
         if cleaned_options:
-            widget = RadioButtonGroup(options=cleaned_options, value=None, margin=(0, 20))
+            confirm = Button(icon="check", label="Confirm", margin=(5, 0, 20, 20))
+            widget = RadioBoxGroup(options=cleaned_options, inline=False, margin=(0, 20))
+            out = Column(label, widget, confirm, max_width=600)
         else:
-            widget = TextInput(sizing_mode="stretch_width", margin=(0, 20))
-            widget.param.enter_pressed.rx.pipe(lambda _: confirm.focus())
-            confirm.disabled = widget.rx().strip() == ""
-        out = Column(label, widget, confirm)
+            widget = ChatAreaInput(enable_upload=False, width=500, margin=(0, 20, 20, 20))
+            widget.param.watch(lambda _: enter_pressed.append(widget.value), "enter_pressed")
+            out = Column(label, widget, max_width=600)
         interface.send(out, user=user, respond=False)
 
         while True:
             await asyncio.sleep(0.1)
             widget.focus()
-            if not confirm.clicks:
+            if not ((options and confirm.clicks) or enter_pressed):
                 continue
-            value = widget.value.strip()
+            value = (enter_pressed[-1] if enter_pressed else widget.value).strip()
             with pn.io.hold():
                 label.object = f"{label.object}\n\n> {value}"
                 out[:] = [label]
@@ -64,11 +65,15 @@ def make_clarification_llm_tool(
     return FunctionTool(
         request_clarification,
         purpose=(
-            "Ask the user a focused clarifying question before planning when the "
-            "request is ambiguous, underspecified, or depends on a preference you "
-            "cannot infer. Prefer asking over guessing. Use when: (a) multiple "
-            "reasonable interpretations exist, (b) a required parameter is missing, "
-            "(c) the user's goal could be satisfied by substantially different plans. "
-            "Provide `question` always and `options` only for constrained choices."
+            "Resolve an ambiguous or underspecified request before planning. Returns "
+            "the disambiguated intent so planning can proceed with definite meanings. "
+            "Use when (a) multiple reasonable interpretations would lead to "
+            "substantially different plans, (b) a required parameter is missing and "
+            "cannot be sensibly defaulted, or (c) a term is genuinely unrecognized. "
+            "Prefer reasonable defaults and stated assumptions over resolving. "
+            "All ambiguity must be routed through this tool — never ask clarifying "
+            "questions in message content, as the user cannot respond to content-mode "
+            "questions in this system. Provide `question` always and `options` only "
+            "for constrained choices."
         )
     )

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -74,8 +74,7 @@ async def test_planner_empty_plan(llm):
     plan_model = make_plan_model(["ChatAgent"], [])
 
     llm.set_responses([
-        Reasoning(chain_of_thought="Just use ChatAgent"),
-        plan_model(title="Hello!", steps=[])
+        plan_model(chain_of_thought="Say Hello", title="Hello!", steps=[])
     ])
 
     planner = Planner(llm=llm)
@@ -100,8 +99,10 @@ async def test_planner_simple_plan(llm):
     (StepModel,) = get_args(PlanModel.__annotations__['steps'])
 
     llm.set_responses([
-        Reasoning(chain_of_thought="Just use ChatAgent"),
-        PlanModel(title="Hello!", steps=[
+        PlanModel(
+            chain_of_thought="Just use ChatAgent",
+            title="Hello!",
+            steps=[
             StepModel(
                 actor="ChatAgent",
                 instruction="Say Hello!",

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -22,7 +22,7 @@ from lumen.ai.controls.ingest import (
     BaseSourceControls, FileSourceControls, UploadedFileRow,
 )
 from lumen.ai.coordinator import Coordinator, Plan, Planner
-from lumen.ai.coordinator.planner import Reasoning, make_plan_model
+from lumen.ai.coordinator.planner import make_plan_model
 from lumen.ai.editors import SQLEditor
 from lumen.ai.models import ReplaceLine, RetrySpec
 from lumen.ai.report import ActorTask
@@ -719,8 +719,10 @@ async def test_planner_multimodal_user_message(llm):
     (StepModel,) = get_args(PlanModel.__annotations__['steps'])
 
     llm.set_responses([
-        Reasoning(chain_of_thought="Describe the image"),
-        PlanModel(title="Image Q&A", steps=[
+        PlanModel(
+            chain_of_thought="Describe the Image",
+            title="Image Q&A",
+            steps=[
             StepModel(
                 actor="ChatAgent",
                 instruction="Describe the uploaded image",

--- a/lumen/tests/ai/test_coordinator.py
+++ b/lumen/tests/ai/test_coordinator.py
@@ -144,9 +144,10 @@ async def test_planner_error(llm):
     (StepModel,) = get_args(PlanModel.__annotations__['steps'])
 
     llm.set_responses([
-        Reasoning(chain_of_thought="Just use ChatAgent"),
         lambda: PlanModel(
-            title="Hello!", steps=[
+            chain_of_thought="Just use ChatAgent",
+            title="Hello!",
+            steps=[
                 StepModel(
                     actor="Invalid",
                     instruction="Say Hello!",

--- a/lumen/tests/ai/test_tools.py
+++ b/lumen/tests/ai/test_tools.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:
 
 from panel.viewable import Viewable
 from panel_material_ui import (
-    Button, Column, RadioButtonGroup, TextInput,
+    Button, ChatAreaInput, Column, RadioBoxGroup,
 )
 
 from lumen.ai.coordinator import Coordinator
@@ -257,7 +257,7 @@ async def test_clarification_tool_requires_confirm_click_for_options():
     assert isinstance(layout, Column)
     widget = layout[1]
     confirm = layout[2]
-    assert isinstance(widget, RadioButtonGroup)
+    assert isinstance(widget, RadioBoxGroup)
     assert isinstance(confirm, Button)
     assert confirm.icon == "check"
 
@@ -282,16 +282,14 @@ async def test_clarification_tool_requires_confirm_click_for_text():
     layout = interface.objects[-1]
     assert isinstance(layout, Column)
     widget = layout[1]
-    confirm = layout[2]
-    assert isinstance(widget, TextInput)
-    assert isinstance(confirm, Button)
-    assert confirm.icon == "check"
+    assert isinstance(widget, ChatAreaInput)
+    assert len(layout) == 2
 
     widget.value = "   concise answers   "
     await asyncio.sleep(0.2)
     assert not task.done()
 
-    confirm.clicks += 1
+    widget.param.trigger("enter_pressed")
     result = await asyncio.wait_for(task, timeout=1)
     assert result == "User provided following clarification: concise answers"
     assert "clarification" not in context


### PR DESCRIPTION
Before the `Planner` took two stages for creating the `Plan`, one for reasoning and one for creating the actual plan. This was inefficient for multiple reasons:

1. We injected the whole system prompt twice
2. Each stage had access to tool calls but the results would not transfer between steps.

This means that it would often repeat the same things steps twice.

Secondly the clarification tool was not correctly instrumented for some scenarios. Specifically it was often over-eager to call it in some scenarios and under-eager in others. Most LLMs are instructed to ask for clarification via chat, which does not work. Therefore we have to trick it to invoke the clarification tool but only if it's really necessary.