### PR TITLE
Various minor UI polish fixes

### DIFF
--- a/lumen/ai/agents/analysis.py
+++ b/lumen/ai/agents/analysis.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, NotRequired
 
 import param
 
-from panel.pane import panel as as_panel
+from panel.pane import Markdown, panel as as_panel
 from panel.viewable import Viewable
 from pydantic import create_model
 from pydantic.fields import FieldInfo
@@ -121,11 +121,14 @@ class AnalysisAgent(BaseLumenAgent):
                 analysis_callable.param[field].objects = list(data.columns)
 
             if analysis.autorun:
-                if asyncio.iscoroutinefunction(analysis_callable.__call__):
-                    view = await analysis_callable(pipeline, context)
-                else:
-                    view = await asyncio.to_thread(analysis_callable, pipeline, context)
-                view = as_panel(view)
+                try:
+                    if asyncio.iscoroutinefunction(analysis_callable.__call__):
+                        view = await analysis_callable(pipeline, context)
+                    else:
+                        view = await asyncio.to_thread(analysis_callable, pipeline, context)
+                    view = as_panel(view)
+                except Exception as e:
+                    view = Markdown(f"**❌ Analysis failed with following error:**\n\n{e}")
                 if isinstance(view, Viewable):
                     view = Panel(object=view, pipeline=context.get("pipeline"))
                 step.stream(f"Generated view of type {type(view).__name__}")

--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -127,7 +127,7 @@ class ValidationAgent(Agent):
             for i, suggestion in enumerate(result.suggestions, 1):
                 response_parts.append(f"{i}. {suggestion}")
 
-        button = Button(name="Rerun", on_click=on_click)
+        button = Button(icon="autorenew", label="Rerun", on_click=on_click)
         footer_objects = [button]
         formatted_response = "\n\n".join(response_parts)
         if interface is not None:

--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import panel as pn
 import param
 
 from panel.chat import ChatFeed
+from panel.param import Param
 from panel.viewable import Viewable
 
 from ..base import Component
@@ -58,10 +58,11 @@ class Analysis(param.ParameterizedFunction):
                 applies &= col in data.columns
         return applies
 
-    def controls(self, context: TContext):
-        config_options = [p for p in self.param if p not in Analysis.param]
-        if config_options:
-            return pn.Param(self.param, parameters=config_options, margin=0, show_name=False)
+    def controls(self, context: TContext) -> Param | None:
+        config_options = [p for p in self.param if p not in Analysis.param and self.param[p].precedence > 0]
+        if not config_options:
+            return None
+        return Param(self.param, parameters=config_options, margin=0, show_name=False)
 
     def __call__(self, pipeline: Pipeline, context: TContext) -> Component | Viewable:
         return pipeline

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -469,7 +469,7 @@ class AnalysisOutput(LumenEditor):
     def _render_editor(self):
         controls = self.analysis.controls(self.context)
         if controls is None and self.analysis.autorun:
-            return super()._render_editor()
+            return None
 
         if self.analysis._run_button:
             run_button = self.analysis._run_button

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -2618,18 +2618,27 @@ class ExplorerUI(UI):
             return
 
         # On error we have to sync the conversation, unwatch the plan,
-        # and remove the exploration if it was newly created
-        replan_button = Button(
-            label="Replan", icon="alt_route", on_click=lambda _: state.execute(partial(self._replan, plan, prev, partial_plan)),
-            description="Replan and generate a new execution strategy"
-        )
-        rerun_button = Button(
-            label="Rerun", icon="autorenew", on_click=lambda _: state.execute(partial(self._execute_plan, plan, rerun=True)),
-            description="Rerun with the same plan and context"
-        )
+        # and remove the exploration if it was newly create
         last_message = self.interface.objects[-1]
         footer_objects = last_message.footer_objects or []
-        last_message.footer_objects = footer_objects + [rerun_button, replan_button]
+        buttons = []
+        if is_new:
+            replan_button = Button(
+                label="Replan", icon="alt_route", on_click=lambda _: state.execute(partial(self._replan, plan, prev, partial_plan)),
+                description="Replan and generate a new execution strategy"
+            )
+            rerun_button = Button(
+                label="Rerun", icon="autorenew", on_click=lambda _: state.execute(partial(self._execute_plan, plan, rerun=True)),
+                description="Rerun with the same plan and context"
+            )
+            buttons = [rerun_button, replan_button]
+        elif not any(isinstance(fo, Button) and fo.label == "Retry" for fo in footer_objects):
+            retry_button = Button(
+                label="Retry", icon="replay", on_click=lambda _: state.execute(partial(self._execute_plan, plan, rerun=True)),
+                description="Try re-running failed steps"
+            )
+            buttons = [retry_button]
+        last_message.footer_objects = footer_objects + buttons
         if exploration.parent:
             exploration.parent.conversation = exploration.conversation
 


### PR DESCRIPTION
- Do no duplicate rerun/replan/retry buttons: When two plan stages fail consecutively we should not render buttons every time
- Align validation rerun button with UI rerun button: Same icon
- Improve analysis error handling and UI rendering: Handle errors during analysis execution and do not render editor controls if no parameters are published