### PR TITLE
Do not use tool if empty

### DIFF
--- a/lumen/ai/tools/document_llm_tools.py
+++ b/lumen/ai/tools/document_llm_tools.py
@@ -38,8 +38,15 @@ def make_document_vector_llm_tools(context: TContext) -> list[Any]:
     """
 
     store: VectorStore | None = context.get("document_vector_store")
-    if store is None:
+    if store is None or len(store) == 0:
         return []
+
+    # When the document store is shared with the table-metadata store,
+    # len(store) > 0 can be true even with zero document entries.
+    # Check for actual document-type chunks before exposing the tools.
+    if context.get("document_vector_store") is context.get("vector_store"):
+        if not store.filter_by({"type": "document"}, limit=1):
+            return []
 
     visible_docs: set[str] | None = context.get("visible_docs")
     list_cap = 4000


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

I noticed the LLM invoked document tools every time, even though there were none. This optimizes it by checking if there are any documents first before adding it as a tool.

## How Has This Been Tested?

Shaves like 2-3 seconds. Before at 11:06 timestamp and After at 11:09
<img width="734" height="86" alt="image" src="https://github.com/user-attachments/assets/f1c10b0b-9a16-43aa-8c72-2b251c5433e6" />
