### PR TITLE
Add planned context to ChatAgent's prompt

### DIFF
--- a/lumen/ai/prompts/ChatAgent/main.jinja2
+++ b/lumen/ai/prompts/ChatAgent/main.jinja2
@@ -128,6 +128,11 @@ Premium plans maintain **87-92% retention** consistently, while Basic plans fluc
 {%- block context -%}
 {%- if memory.get('data') is not none %}
 
+{%- if memory.get('plan') %}
+## Response Plan:
+{{ memory.plan.render_task_history()[-1] }}
+{% endif -%}
+
 {%- if memory.get('reasoning') -%}
 ## Planning Context
 The system executed this plan:
@@ -141,7 +146,7 @@ The system executed this plan:
 **The query returned no rows.**
 
 Your task: Analyze the SQL query below to identify why it returned empty results. Suggest specific corrections (which columns to use, what values to filter for, etc.). Then prompt the user to click the rerun button if they'd like to try the corrected query.
-{%- else -%}
+{%- else %}
 Below is a summary of the data returned by the query. This includes:
 - **Shape**: number of rows and columns
 - **Statistics**: min, max, mean, standard deviation for numeric columns


### PR DESCRIPTION
Prior to this, I noticed that it correctly loaded the dataset, but it was complaining that it had no capability to do so.

Before:
<img width="1746" height="932" alt="image" src="https://github.com/user-attachments/assets/7504ae94-ca2c-400b-99b3-e1e5e132b3bd" />

After:
<img width="1724" height="932" alt="image" src="https://github.com/user-attachments/assets/c18e6bdd-5327-4e76-b921-b281d5f16700" />
