### PR TITLE
Add support for Kaggle datasets under DownloadSourceControls

### DIFF
--- a/docs/configuration/controls.md
+++ b/docs/configuration/controls.md
@@ -29,9 +29,27 @@ Common use cases include:
 | Control | Use for |
 |---------|---------|
 | `UploadControls` | Uploading local files (CSV, Excel, etc.) |
-| `DownloadControls` | Fetching data from URLs |
+| `DownloadControls` | Fetching data from URLs (including Kaggle datasets) |
 
 `UploadControls` stages selected files before processing. After selecting files, click `Confirm file(s)` to process them, or `Clear selected` to reset the staged selection.
+
+#### Kaggle datasets
+
+`DownloadControls` can fetch datasets directly from Kaggle. Paste a Kaggle dataset URL into the URL input field:
+
+```
+https://www.kaggle.com/datasets/sharmajicoder/gen-z-social-media-usage-dataset
+```
+
+Each file in the dataset becomes a separate table in the same data source. This also works through the agent — users can ask the AI to load a Kaggle dataset by providing the URL.
+
+Requires the `kagglehub` package:
+
+```bash
+pip install kagglehub
+```
+
+On first use, `kagglehub` will prompt for Kaggle API credentials (or reads them from `~/.kaggle/kaggle.json`). If `kagglehub` is not installed, Kaggle URL support is silently disabled.
 
 ### Creating custom controls
 

--- a/docs/configuration/controls.md
+++ b/docs/configuration/controls.md
@@ -49,7 +49,7 @@ Requires the `kagglehub` package:
 pip install kagglehub
 ```
 
-On first use, `kagglehub` will prompt for Kaggle API credentials (or reads them from `~/.kaggle/kaggle.json`). If `kagglehub` is not installed, Kaggle URL support is silently disabled.
+If `kagglehub` is not installed, Kaggle URL support is silently disabled.
 
 ### Creating custom controls
 

--- a/lumen/ai/controls/ingest/__init__.py
+++ b/lumen/ai/controls/ingest/__init__.py
@@ -14,6 +14,7 @@ from .rest_api import RESTAPISourceControls
 from .result import SourceResult
 from .upload import UploadSourceControls
 from .url import URLSourceControls
+from .utils import FileReadResult  # noqa: F401 — re-exported
 from .utils import download_file
 
 __all__ = (

--- a/lumen/ai/controls/ingest/__init__.py
+++ b/lumen/ai/controls/ingest/__init__.py
@@ -14,8 +14,7 @@ from .rest_api import RESTAPISourceControls
 from .result import SourceResult
 from .upload import UploadSourceControls
 from .url import URLSourceControls
-from .utils import FileReadResult  # noqa: F401 — re-exported
-from .utils import download_file
+from .utils import FileReadResult, download_file
 
 __all__ = (
     "METADATA_EXTENSIONS",
@@ -26,6 +25,7 @@ __all__ = (
     "CodeSourceControls",
     "DownloadConfig",
     "DownloadSourceControls",
+    "FileReadResult",
     "FileSourceControls",
     "OpenAPISourceControls",
     "ParametricSourceControls",

--- a/lumen/ai/controls/ingest/download.py
+++ b/lumen/ai/controls/ingest/download.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import asyncio
 import io
 import pathlib
+import re
 
 from urllib.parse import urlparse
 
-import pandas as pd
 import param
 
 from panel_material_ui import (
@@ -15,9 +15,14 @@ from panel_material_ui import (
 
 from ....sources.duckdb import DuckDBSource
 from ....util import normalize_table_name
+from .constants import TABLE_EXTENSIONS
 from .file import FileSourceControls
 from .result import SourceResult
-from .utils import download_file, read_html_tables, read_json_to_dataframe
+from .utils import download_file, read_file_to_dataframe, read_html_tables
+
+_KAGGLE_URL_RE = re.compile(
+    r'(?:https?://)?(?:www\.)?kaggle\.com/datasets/([^/?#]+/[^/?#]+)',
+)
 
 
 class DownloadSourceControls(FileSourceControls):
@@ -26,6 +31,10 @@ class DownloadSourceControls(FileSourceControls):
 
     Supports CSV, JSON, Parquet, Excel, and HTML files. For HTML pages,
     all tables are extracted and loaded as separate database tables.
+
+    Kaggle dataset URLs (e.g. ``https://www.kaggle.com/datasets/owner/name``)
+    are also supported and will download all data files in the dataset into
+    a single source with one table per file.
     """
 
     download_url = param.String(
@@ -49,6 +58,74 @@ class DownloadSourceControls(FileSourceControls):
     label = '<span class="material-icons" style="vertical-align: middle;">download</span> Fetch Remote Data'
 
     _supports_tools = True
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        try:
+            import kagglehub
+            self._kagglehub = kagglehub
+        except ModuleNotFoundError:
+            self._kagglehub = None
+        if self._kagglehub is not None:
+            self.input_placeholder = (
+                "Enter URLs, one per line, and press <Shift+Enter> to download.\n"
+                "Kaggle dataset URLs are also supported."
+            )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Kaggle helpers
+    # ──────────────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _parse_kaggle_ref(url: str) -> str | None:
+        """Extract ``'owner/dataset'`` from a Kaggle URL, or ``None``."""
+        m = _KAGGLE_URL_RE.match(url.strip())
+        return m.group(1).rstrip("/") if m else None
+
+    async def _download_kaggle_files(self, ref: str) -> tuple[dict[str, bytes], str | None]:
+        """
+        Download a Kaggle dataset and read supported files into memory.
+
+        Returns
+        -------
+        tuple[dict[str, bytes], str | None]
+            ``(files_dict, error_message)``
+        """
+        if self._kagglehub is None:
+            return {}, (
+                "kagglehub is required to download Kaggle datasets. "
+                "Install it with: pip install kagglehub"
+            )
+
+        self.progress(f"Downloading Kaggle dataset '{ref}'…")
+
+        try:
+            path = await asyncio.get_event_loop().run_in_executor(
+                None, self._kagglehub.dataset_download, ref,
+            )
+        except Exception as e:
+            return {}, f"Kaggle download failed for '{ref}': {e}"
+
+        dataset_dir = pathlib.Path(path)
+        if not dataset_dir.is_dir():
+            return {}, f"Kaggle download path is not a directory: {path}"
+
+        self.progress("Reading downloaded files…")
+
+        files: dict[str, bytes] = {}
+        for file_path in sorted(dataset_dir.rglob("*")):
+            if not file_path.is_file():
+                continue
+            if file_path.suffix.lstrip(".").lower() in TABLE_EXTENSIONS:
+                files[file_path.name] = file_path.read_bytes()
+
+        if not files:
+            return {}, (
+                f"No supported data files found in Kaggle dataset '{ref}'. "
+                f"Directory contained: {[f.name for f in dataset_dir.rglob('*') if f.is_file()]}"
+            )
+
+        return files, None
 
     def _render_layout(self):
         """Build download-specific layout with URL input."""
@@ -155,14 +232,22 @@ class DownloadSourceControls(FileSourceControls):
                 self._message_placeholder.object = (
                     f"Processing {i} of {len(urls)}: {url[:50]}{'...' if len(url) > 50 else ''}"
                 )
-                filename, content, error = await self._download_file(url)
 
-                if error:
-                    if "cancelled" in error.lower():
-                        break
-                    errors.append(f"{url}: {error}")
+                kaggle_ref = self._parse_kaggle_ref(url)
+                if kaggle_ref:
+                    files, error = await self._download_kaggle_files(kaggle_ref)
+                    if error:
+                        errors.append(f"{url}: {error}")
+                    else:
+                        downloaded_files.update(files)
                 else:
-                    downloaded_files[filename] = content
+                    filename, content, error = await self._download_file(url)
+                    if error:
+                        if "cancelled" in error.lower():
+                            break
+                        errors.append(f"{url}: {error}")
+                    else:
+                        downloaded_files[filename] = content
 
         except asyncio.CancelledError:
             self.progress.bar.visible = False
@@ -238,6 +323,8 @@ class DownloadSourceControls(FileSourceControls):
 
             Supports CSV, JSON, Parquet, Excel (.xlsx), and HTML files.
             For HTML pages, extracts all tables found on the page.
+            Kaggle dataset URLs are also supported (e.g.
+            ``https://www.kaggle.com/datasets/owner/dataset``).
 
             Parameters
             ----------
@@ -259,6 +346,10 @@ class DownloadSourceControls(FileSourceControls):
         if not self._is_valid_url(url):
             return SourceResult.empty(f"Invalid URL: {url}")
 
+        kaggle_ref = self._parse_kaggle_ref(url)
+        if kaggle_ref:
+            return await self._fetch_kaggle(kaggle_ref)
+
         self.progress(f"Fetching {url[:80]}{'…' if len(url) > 80 else ''}…")
         filename, content, error = await download_file(url, progress=self.progress)
 
@@ -266,6 +357,55 @@ class DownloadSourceControls(FileSourceControls):
             return SourceResult.empty(f"Download failed: {error}")
 
         return await self._content_to_result(url, filename, content)
+
+    async def _fetch_kaggle(self, ref: str) -> SourceResult:
+        """Download a Kaggle dataset and load all files into a single source."""
+        files, error = await self._download_kaggle_files(ref)
+        if error:
+            return SourceResult.empty(error)
+
+        source_id = f"{self.source_name_prefix}{self._count:06d}"
+        source = DuckDBSource(uri=":memory:", ephemeral=True, name=source_id, tables={})
+        self._count += 1
+
+        total_rows = 0
+        tables_loaded = []
+        for filename, content in files.items():
+            suffix = pathlib.Path(filename).suffix.lstrip(".").lower()
+            base_name = pathlib.Path(filename).stem
+            alias = normalize_table_name(base_name) or "data"
+
+            file_obj = io.BytesIO(content)
+            try:
+                df = read_file_to_dataframe(file_obj, suffix)
+            except Exception as e:
+                tables_loaded.append(f"'{filename}' (error: {e})")
+                continue
+
+            if df is None or df.empty:
+                continue
+
+            source._connection.from_df(df).to_view(alias)
+            source.tables[alias] = f"SELECT * FROM {alias}"
+            source.metadata[alias] = {"filename": filename, "kaggle_ref": ref}
+            total_rows += len(df)
+            tables_loaded.append(f"'{alias}' ({len(df):,} rows)")
+
+        if not source.tables:
+            return SourceResult.empty(
+                f"No tables could be parsed from Kaggle dataset '{ref}'."
+            )
+
+        first_table = next(iter(source.tables))
+        if len(source.tables) == 1:
+            message = f"Loaded {total_rows:,} rows from Kaggle dataset '{ref}' into '{first_table}'"
+        else:
+            message = (
+                f"Loaded {len(source.tables)} tables ({total_rows:,} total rows) "
+                f"from Kaggle dataset '{ref}': {', '.join(tables_loaded)}"
+            )
+
+        return SourceResult.from_source(source, table=first_table, message=message)
 
     async def _content_to_result(self, url: str, filename: str, content: bytes) -> SourceResult:
         """Convert downloaded content to a SourceResult with DuckDB tables and/or document."""
@@ -290,17 +430,11 @@ class DownloadSourceControls(FileSourceControls):
 
         # Try to extract tabular data
         try:
-            file_obj.seek(0)
-            if suffix == "csv":
-                dfs = {alias: pd.read_csv(file_obj, parse_dates=True, sep=None, engine="python")}
-            elif suffix in ("parq", "parquet"):
-                dfs = {alias: pd.read_parquet(file_obj)}
-            elif suffix == "json":
-                dfs = {alias: read_json_to_dataframe(file_obj.read())}
-            elif suffix == "xlsx":
-                dfs = {alias: pd.read_excel(file_obj)}
+            df = read_file_to_dataframe(file_obj, suffix)
+            if df is not None:
+                dfs = {alias: df}
             else:
-                # HTML - try to extract tables, but don't fail if none found
+                # HTML or unknown — try to extract tables
                 try:
                     dfs = read_html_tables(content, alias)
                 except ValueError:

--- a/lumen/ai/controls/ingest/download.py
+++ b/lumen/ai/controls/ingest/download.py
@@ -439,16 +439,13 @@ class DownloadSourceControls(FileSourceControls):
         alias = normalize_table_name(base_name) or "data"
 
         file_obj = io.BytesIO(content)
-        is_html = suffix in ("html", "htm") or suffix not in ("csv", "parq", "parquet", "json", "xlsx")
 
         # Try to extract tabular data
         try:
             result = read_file_to_dataframes(file_obj, suffix, alias=alias)
             dfs = result.tables if result is not None else {}
         except Exception as e:
-            if not is_html:
-                return SourceResult.empty(f"Could not parse {filename!r}: {e}")
-            dfs = {}  # For HTML, continue to try document extraction
+            return SourceResult.empty(f"Could not parse {filename!r}: {e}")
 
         # Load tables into DuckDB
         total_rows = 0
@@ -462,9 +459,9 @@ class DownloadSourceControls(FileSourceControls):
             total_rows += len(df)
             tables_loaded.append(f"'{table_name}' ({len(df):,} rows)")
 
-        # For HTML, also extract text content as a document
+        # For HTML pages, also extract text content as a document
         doc_added = False
-        if is_html and self.source_catalog:
+        if suffix in ("html", "htm") and self.source_catalog:
             text_content = self._extract_metadata_content(io.BytesIO(content), ".html")
             if text_content and len(text_content.strip()) > 100:
                 doc_added = await self._add_document(url, alias, text_content)

--- a/lumen/ai/controls/ingest/download.py
+++ b/lumen/ai/controls/ingest/download.py
@@ -18,7 +18,7 @@ from ....util import normalize_table_name
 from .constants import TABLE_EXTENSIONS
 from .file import FileSourceControls
 from .result import SourceResult
-from .utils import download_file, read_file_to_dataframe, read_html_tables
+from .utils import download_file, read_file_to_dataframes
 
 _KAGGLE_URL_RE = re.compile(
     r'(?:https?://)?(?:www\.)?kaggle\.com/datasets/([^/?#]+/[^/?#]+)',
@@ -367,6 +367,7 @@ class DownloadSourceControls(FileSourceControls):
         source_id = f"{self.source_name_prefix}{self._count:06d}"
         source = DuckDBSource(uri=":memory:", ephemeral=True, name=source_id, tables={})
         self._count += 1
+        conn = source._connection
 
         total_rows = 0
         tables_loaded = []
@@ -377,19 +378,32 @@ class DownloadSourceControls(FileSourceControls):
 
             file_obj = io.BytesIO(content)
             try:
-                df = read_file_to_dataframe(file_obj, suffix)
+                result = read_file_to_dataframes(file_obj, suffix, alias=alias)
             except Exception as e:
                 tables_loaded.append(f"'{filename}' (error: {e})")
                 continue
 
-            if df is None or df.empty:
+            if result is None:
                 continue
 
-            source._connection.from_df(df).to_view(alias)
-            source.tables[alias] = f"SELECT * FROM {alias}"
-            source.metadata[alias] = {"filename": filename, "kaggle_ref": ref}
-            total_rows += len(df)
-            tables_loaded.append(f"'{alias}' ({len(df):,} rows)")
+            source.param.update(result.source_params)
+            for init in result.source_params.get("initializers", []):
+                conn.execute(init)
+
+            for tbl_name, df in result.tables.items():
+                if df is None or df.empty:
+                    continue
+                df_rel = conn.from_df(df)
+                if tbl_name in result.conversions:
+                    conn.register(f"{tbl_name}_temp", df_rel)
+                    conn.execute(result.conversions[tbl_name])
+                    conn.unregister(f"{tbl_name}_temp")
+                else:
+                    df_rel.to_view(tbl_name)
+                source.tables[tbl_name] = f"SELECT * FROM {tbl_name}"
+                source.metadata[tbl_name] = {"filename": filename, "kaggle_ref": ref}
+                total_rows += len(df)
+                tables_loaded.append(f"'{tbl_name}' ({len(df):,} rows)")
 
         if not source.tables:
             return SourceResult.empty(
@@ -425,24 +439,16 @@ class DownloadSourceControls(FileSourceControls):
         alias = normalize_table_name(base_name) or "data"
 
         file_obj = io.BytesIO(content)
-        dfs = {}
         is_html = suffix in ("html", "htm") or suffix not in ("csv", "parq", "parquet", "json", "xlsx")
 
         # Try to extract tabular data
         try:
-            df = read_file_to_dataframe(file_obj, suffix)
-            if df is not None:
-                dfs = {alias: df}
-            else:
-                # HTML or unknown — try to extract tables
-                try:
-                    dfs = read_html_tables(content, alias)
-                except ValueError:
-                    dfs = {}  # No tables found, will extract as document
+            result = read_file_to_dataframes(file_obj, suffix, alias=alias)
+            dfs = result.tables if result is not None else {}
         except Exception as e:
             if not is_html:
                 return SourceResult.empty(f"Could not parse {filename!r}: {e}")
-            # For HTML, continue to try document extraction
+            dfs = {}  # For HTML, continue to try document extraction
 
         # Load tables into DuckDB
         total_rows = 0

--- a/lumen/ai/controls/ingest/file.py
+++ b/lumen/ai/controls/ingest/file.py
@@ -148,7 +148,7 @@ class FileSourceControls(BaseSourceControls):
                 result = FileReadResult(tables={alias: df})
             else:
                 result = read_file_to_dataframes(
-                    file, extension, alias=alias, sheet=card.sheet,
+                    file, extension, alias=alias, sheet_name=card.sheet,
                 )
                 if result is None:
                     self._error_placeholder.object += (

--- a/lumen/ai/controls/ingest/file.py
+++ b/lumen/ai/controls/ingest/file.py
@@ -17,7 +17,7 @@ from ...utils import log_debug
 from .base import BaseSourceControls
 from .constants import TABLE_EXTENSIONS
 from .file_row import UploadedFileRow
-from .utils import read_html_tables
+from .utils import read_file_to_dataframe, read_html_tables
 
 
 class FileSourceControls(BaseSourceControls):
@@ -147,22 +147,18 @@ class FileSourceControls(BaseSourceControls):
 
         try:
             file.seek(0)
-            if extension.endswith("csv"):
-                df = pd.read_csv(file, parse_dates=True, sep=None, engine="python")
-            elif extension.endswith(("parq", "parquet")):
-                df = pd.read_parquet(file)
-            elif extension.endswith("json"):
+            if extension.endswith("json"):
                 df = self._read_json_file(file, filename)
-            elif extension.endswith("xlsx"):
-                df = pd.read_excel(file, sheet_name=card.sheet)
             elif extension.endswith(("geojson", "wkt", "zip")):
                 df, conversion, params = self._read_geo_file(file, extension, table, conn)
             elif extension.endswith(("html", "htm")):
                 return self._add_html_tables(duckdb_source, file, card)
             else:
-                self._error_placeholder.object += f"\n⚠️ Could not convert {filename!r}: unsupported format."
-                self._error_placeholder.visible = True
-                return 0
+                df = read_file_to_dataframe(file, extension, sheet=card.sheet)
+                if df is None:
+                    self._error_placeholder.object += f"\n⚠️ Could not convert {filename!r}: unsupported format."
+                    self._error_placeholder.visible = True
+                    return 0
         except Exception as e:
             self._error_placeholder.object += f"\n⚠️ Error processing {filename!r}: {e}"
             self._error_placeholder.visible = True

--- a/lumen/ai/controls/ingest/file.py
+++ b/lumen/ai/controls/ingest/file.py
@@ -4,7 +4,6 @@ import asyncio
 import io
 import json
 import pathlib
-import zipfile
 
 import pandas as pd
 import param
@@ -17,7 +16,7 @@ from ...utils import log_debug
 from .base import BaseSourceControls
 from .constants import TABLE_EXTENSIONS
 from .file_row import UploadedFileRow
-from .utils import read_file_to_dataframe, read_html_tables
+from .utils import FileReadResult, read_file_to_dataframes
 
 
 class FileSourceControls(BaseSourceControls):
@@ -139,24 +138,22 @@ class FileSourceControls(BaseSourceControls):
     ) -> int:
         conn = duckdb_source._connection
         extension = card.extension
-        table = card.alias
-        sql_expr = f"SELECT * FROM {table}"
-        params = {}
-        conversion = None
+        alias = card.alias
         filename = f"{card.filename}.{extension}"
 
         try:
-            file.seek(0)
             if extension.endswith("json"):
+                # Use the more robust JSON parser on this class
                 df = self._read_json_file(file, filename)
-            elif extension.endswith(("geojson", "wkt", "zip")):
-                df, conversion, params = self._read_geo_file(file, extension, table, conn)
-            elif extension.endswith(("html", "htm")):
-                return self._add_html_tables(duckdb_source, file, card)
+                result = FileReadResult(tables={alias: df})
             else:
-                df = read_file_to_dataframe(file, extension, sheet=card.sheet)
-                if df is None:
-                    self._error_placeholder.object += f"\n⚠️ Could not convert {filename!r}: unsupported format."
+                result = read_file_to_dataframes(
+                    file, extension, alias=alias, sheet=card.sheet,
+                )
+                if result is None:
+                    self._error_placeholder.object += (
+                        f"\n⚠️ Could not convert {filename!r}: unsupported format."
+                    )
                     self._error_placeholder.visible = True
                     return 0
         except Exception as e:
@@ -164,30 +161,47 @@ class FileSourceControls(BaseSourceControls):
             self._error_placeholder.visible = True
             return 0
 
-        if df is None or df.empty:
+        # Apply source-level params (e.g. spatial initializers)
+        if result.source_params:
+            duckdb_source.param.update(result.source_params)
+            for init in result.source_params.get("initializers", []):
+                conn.execute(init)
+
+        added = 0
+        first_table = None
+        for tbl_name, df in result.tables.items():
+            if df is None or df.empty:
+                continue
+
+            # Convert pandas StringDtype columns to object for DuckDB compatibility
+            for col in df.columns:
+                if isinstance(df[col].dtype, pd.StringDtype):
+                    df[col] = df[col].astype(object)
+
+            df_rel = conn.from_df(df)
+            if tbl_name in result.conversions:
+                conn.register(f"{tbl_name}_temp", df_rel)
+                conn.execute(result.conversions[tbl_name])
+                conn.unregister(f"{tbl_name}_temp")
+            else:
+                df_rel.to_view(tbl_name)
+
+            duckdb_source.tables[tbl_name] = f"SELECT * FROM {tbl_name}"
+            if first_table is None:
+                first_table = tbl_name
+            added += 1
+
+        if added > 0:
+            self._register_source_output(duckdb_source)
+            self.outputs["table"] = first_table
+            self.param.trigger("outputs")
+            self._last_table = first_table
+
+        if added == 0:
             self._error_placeholder.object += f"\n⚠️ {filename!r} contains no data."
             self._error_placeholder.visible = True
-            return 0
 
-        # Convert pandas StringDtype columns to object for DuckDB compatibility
-        for col in df.columns:
-            if isinstance(df[col].dtype, pd.StringDtype):
-                df[col] = df[col].astype(object)
-
-        duckdb_source.param.update(params)
-        df_rel = conn.from_df(df)
-        if conversion:
-            conn.register(f"{table}_temp", df_rel)
-            conn.execute(conversion)
-            conn.unregister(f"{table}_temp")
-        else:
-            df_rel.to_view(table)
-        duckdb_source.tables[table] = sql_expr
-        self._register_source_output(duckdb_source)
-        self.outputs["table"] = table
-        self.param.trigger("outputs")
-        self._last_table = table
-        return 1
+        return added
 
     def _read_json_file(self, file: io.BytesIO | io.StringIO, filename: str) -> pd.DataFrame:
         file.seek(0)
@@ -229,76 +243,6 @@ class FileSourceControls(BaseSourceControls):
                 raise ValueError("JSON structure is not tabular.") from e
 
         raise ValueError(f"JSON root must be an object or array, got {type(data).__name__}")
-
-    def _read_geo_file(self, file: io.BytesIO, extension: str, table: str, conn) -> tuple[pd.DataFrame, str | None, dict]:
-        if extension.endswith("zip"):
-            zf = zipfile.ZipFile(file)
-            if not any(f.filename.endswith("shp") for f in zf.filelist):
-                raise ValueError("ZIP file does not contain a shapefile (.shp)")
-            file.seek(0)
-
-        import geopandas as gpd
-        geo_df = gpd.read_file(file)
-
-        if geo_df.empty:
-            raise ValueError("Geospatial file contains no features")
-
-        df = pd.DataFrame(geo_df)
-        df["geometry"] = geo_df["geometry"].to_wkb()
-
-        params = {"initializers": ["INSTALL spatial;\nLOAD spatial;"]}
-        conn.execute(params["initializers"][0])
-
-        cols = ", ".join(f'"{c}"' for c in df.columns if c != "geometry")
-        conversion = f"CREATE TEMP TABLE {table} AS SELECT {cols}, ST_GeomFromWKB(geometry) as geometry FROM {table}_temp"
-
-        return df, conversion, params
-
-    def _add_html_tables(
-        self,
-        duckdb_source: DuckDBSource,
-        file: io.BytesIO | io.StringIO,
-        card: UploadedFileRow,
-    ) -> int:
-        """Read all HTML tables from file and add each as a separate table."""
-        conn = duckdb_source._connection
-        filename = f"{card.filename}.{card.extension}"
-
-        file.seek(0)
-        content = file.read()
-
-        try:
-            tables = read_html_tables(content, card.alias)
-        except Exception as e:
-            self._error_placeholder.object += f"\n⚠️ Error processing {filename!r}: {e}"
-            self._error_placeholder.visible = True
-            return 0
-
-        added = 0
-        first_table = None
-        for table_name, df in tables.items():
-            if df.empty:
-                continue
-
-            sql_expr = f"SELECT * FROM {table_name}"
-
-            for col in df.columns:
-                if isinstance(df[col].dtype, pd.StringDtype):
-                    df[col] = df[col].astype(object)
-
-            conn.from_df(df).to_view(table_name)
-            duckdb_source.tables[table_name] = sql_expr
-            if first_table is None:
-                first_table = table_name
-            added += 1
-
-        if added > 0:
-            self._register_source_output(duckdb_source)
-            self.outputs["table"] = first_table
-            self.param.trigger("outputs")
-            self._last_table = first_table
-
-        return added
 
     # ──────────────────────────────────────────────────────────────────────────
     # Metadata handling

--- a/lumen/ai/controls/ingest/url.py
+++ b/lumen/ai/controls/ingest/url.py
@@ -177,7 +177,7 @@ class URLSourceControls(ParametricSourceControls):
     def _read_content(self, file_obj, suffix: str, card) -> dict[str, pd.DataFrame]:
         """Parse file bytes into a dict of {table_name: DataFrame}."""
         alias = card.alias
-        result = read_file_to_dataframes(file_obj, suffix, alias=alias, sheet=card.sheet)
+        result = read_file_to_dataframes(file_obj, suffix, alias=alias, sheet_name=card.sheet)
         if result is not None:
             return result.tables
         return read_html_tables(file_obj.read(), alias)

--- a/lumen/ai/controls/ingest/url.py
+++ b/lumen/ai/controls/ingest/url.py
@@ -11,7 +11,7 @@ from ...translate import params_to_callable
 from .file_row import UploadedFileRow
 from .parametric import ParametricSourceControls
 from .result import SourceResult
-from .utils import download_file, read_file_to_dataframe, read_html_tables
+from .utils import download_file, read_file_to_dataframes, read_html_tables
 
 # ─────────────────────────────────────────────────────────────────────────────
 # URL SOURCE CONTROLS
@@ -177,7 +177,7 @@ class URLSourceControls(ParametricSourceControls):
     def _read_content(self, file_obj, suffix: str, card) -> dict[str, pd.DataFrame]:
         """Parse file bytes into a dict of {table_name: DataFrame}."""
         alias = card.alias
-        df = read_file_to_dataframe(file_obj, suffix, sheet=card.sheet)
-        if df is not None:
-            return {alias: df}
+        result = read_file_to_dataframes(file_obj, suffix, alias=alias, sheet=card.sheet)
+        if result is not None:
+            return result.tables
         return read_html_tables(file_obj.read(), alias)

--- a/lumen/ai/controls/ingest/url.py
+++ b/lumen/ai/controls/ingest/url.py
@@ -11,7 +11,7 @@ from ...translate import params_to_callable
 from .file_row import UploadedFileRow
 from .parametric import ParametricSourceControls
 from .result import SourceResult
-from .utils import download_file, read_html_tables, read_json_to_dataframe
+from .utils import download_file, read_file_to_dataframe, read_html_tables
 
 # ─────────────────────────────────────────────────────────────────────────────
 # URL SOURCE CONTROLS
@@ -177,12 +177,7 @@ class URLSourceControls(ParametricSourceControls):
     def _read_content(self, file_obj, suffix: str, card) -> dict[str, pd.DataFrame]:
         """Parse file bytes into a dict of {table_name: DataFrame}."""
         alias = card.alias
-        if suffix == "csv":
-            return {alias: pd.read_csv(file_obj, parse_dates=True, sep=None, engine="python")}
-        if suffix in ("parq", "parquet"):
-            return {alias: pd.read_parquet(file_obj)}
-        if suffix == "json":
-            return {alias: read_json_to_dataframe(file_obj.read())}
-        if suffix == "xlsx":
-            return {alias: pd.read_excel(file_obj, sheet_name=card.sheet)}
+        df = read_file_to_dataframe(file_obj, suffix, sheet=card.sheet)
+        if df is not None:
+            return {alias: df}
         return read_html_tables(file_obj.read(), alias)

--- a/lumen/ai/controls/ingest/utils.py
+++ b/lumen/ai/controls/ingest/utils.py
@@ -5,12 +5,15 @@ import datetime
 import io
 import json
 import re
+import zipfile
 
+from dataclasses import dataclass, field
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pandas as pd
 
+from ....util import normalize_table_name
 from .constants import (
     CONTENT_TYPE_TO_EXTENSION, METADATA_EXTENSIONS, TABLE_EXTENSIONS,
     DownloadConfig,
@@ -199,46 +202,127 @@ def read_json_to_dataframe(content: str | bytes) -> pd.DataFrame:
     raise ValueError(f"Unsupported JSON root type: {type(data).__name__}")
 
 
-def read_file_to_dataframe(
+@dataclass
+class FileReadResult:
+    """Result of parsing a file into DataFrames."""
+
+    tables: dict[str, pd.DataFrame]
+    """Mapping of table names to DataFrames."""
+
+    source_params: dict = field(default_factory=dict)
+    """Extra params for ``DuckDBSource`` (e.g. spatial initializers)."""
+
+    conversions: dict[str, str] = field(default_factory=dict)
+    """Per-table SQL to execute after registering the DataFrame as
+    ``{table}_temp``.  When present the caller should:
+
+    1. ``conn.register(f"{table}_temp", df_rel)``
+    2. ``conn.execute(conversion)``
+    3. ``conn.unregister(f"{table}_temp")``
+    """
+
+
+def read_file_to_dataframes(
     file_obj: io.BytesIO | io.StringIO,
     extension: str,
     *,
-    sheet: str | int = 0,
-) -> pd.DataFrame | None:
+    alias: str = "data",
+    sheet: str | int | None = None,
+) -> FileReadResult | None:
     """
-    Parse a file object into a DataFrame based on its extension.
+    Parse a file object into one or more DataFrames.
 
-    Handles CSV, Parquet, JSON, and Excel. Returns ``None`` for
-    unrecognised extensions so the caller can fall back to format-specific
-    logic (HTML tables, geospatial, etc.).
+    Handles CSV, Parquet, JSON, Excel (single or all sheets), HTML
+    (all tables), and geospatial formats (GeoJSON, WKT, zipped
+    shapefiles).  Returns ``None`` for unrecognised extensions.
 
     Parameters
     ----------
     file_obj : io.BytesIO | io.StringIO
-        Seekable file-like object containing the data.
+        Seekable file-like object.
     extension : str
-        Lowercase file extension without the leading dot
-        (e.g. ``"csv"``, ``"parquet"``).
-    sheet : str | int, optional
-        Sheet name or index for Excel files (default ``0``).
+        Lowercase extension without dot (e.g. ``"csv"``).
+    alias : str
+        Base table name.  Single-result formats use this directly;
+        multi-result formats append a suffix.
+    sheet : str | int | None
+        For xlsx: specific sheet name/index, or ``None`` to read all.
 
     Returns
     -------
-    pd.DataFrame | None
-        The parsed DataFrame, or ``None`` if the extension is not
-        one of the four supported formats.
+    FileReadResult | None
     """
     file_obj.seek(0)
+
+    # ── single-DataFrame formats ──────────────────────────────────────────
     if extension == "csv":
-        return pd.read_csv(file_obj, parse_dates=True, sep=None, engine="python")
+        df = pd.read_csv(file_obj, parse_dates=True, sep=None, engine="python")
+        return FileReadResult(tables={alias: df})
+
     if extension in ("parq", "parquet"):
-        return pd.read_parquet(file_obj)
+        return FileReadResult(tables={alias: pd.read_parquet(file_obj)})
+
     if extension == "json":
         content = file_obj.read()
-        return read_json_to_dataframe(content)
+        return FileReadResult(tables={alias: read_json_to_dataframe(content)})
+
+    # ── Excel (single sheet or all sheets) ────────────────────────────────
     if extension == "xlsx":
-        return pd.read_excel(file_obj, sheet_name=sheet)
+        if sheet is not None:
+            df = pd.read_excel(file_obj, sheet_name=sheet)
+            return FileReadResult(tables={alias: df})
+        # Read all sheets
+        sheets = pd.read_excel(file_obj, sheet_name=None)  # dict[str, DataFrame]
+        if len(sheets) == 1:
+            return FileReadResult(tables={alias: next(iter(sheets.values()))})
+        tables = {
+            f"{alias}_{normalize_table_name(name)}": df
+            for name, df in sheets.items()
+        }
+        return FileReadResult(tables=tables)
+
+    # ── HTML tables ───────────────────────────────────────────────────────
+    if extension in ("html", "htm"):
+        content = file_obj.read()
+        return FileReadResult(tables=read_html_tables(content, alias))
+
+    # ── Geospatial (GeoJSON / WKT / zipped shapefile) ─────────────────────
+    if extension in ("geojson", "wkt", "zip"):
+        return read_geo_file(file_obj, extension, alias)
+
     return None
+
+
+def read_geo_file(
+    file_obj: io.BytesIO, extension: str, alias: str,
+) -> FileReadResult:
+    """Parse a geospatial file, returning WKB geometry + conversion SQL."""
+    if extension == "zip":
+        zf = zipfile.ZipFile(file_obj)
+        if not any(f.filename.endswith("shp") for f in zf.filelist):
+            raise ValueError("ZIP file does not contain a shapefile (.shp)")
+        file_obj.seek(0)
+
+    import geopandas as gpd
+
+    geo_df = gpd.read_file(file_obj)
+    if geo_df.empty:
+        raise ValueError("Geospatial file contains no features")
+
+    df = pd.DataFrame(geo_df)
+    df["geometry"] = geo_df["geometry"].to_wkb()
+
+    cols = ", ".join(f'"{c}"' for c in df.columns if c != "geometry")
+    conversion = (
+        f"CREATE TEMP TABLE {alias} AS SELECT {cols}, "
+        f"ST_GeomFromWKB(geometry) as geometry FROM {alias}_temp"
+    )
+
+    return FileReadResult(
+        tables={alias: df},
+        source_params={"initializers": ["INSTALL spatial;\nLOAD spatial;"]},
+        conversions={alias: conversion},
+    )
 
 
 def normalize_json_response(data) -> pd.DataFrame:

--- a/lumen/ai/controls/ingest/utils.py
+++ b/lumen/ai/controls/ingest/utils.py
@@ -199,6 +199,48 @@ def read_json_to_dataframe(content: str | bytes) -> pd.DataFrame:
     raise ValueError(f"Unsupported JSON root type: {type(data).__name__}")
 
 
+def read_file_to_dataframe(
+    file_obj: io.BytesIO | io.StringIO,
+    extension: str,
+    *,
+    sheet: str | int = 0,
+) -> pd.DataFrame | None:
+    """
+    Parse a file object into a DataFrame based on its extension.
+
+    Handles CSV, Parquet, JSON, and Excel. Returns ``None`` for
+    unrecognised extensions so the caller can fall back to format-specific
+    logic (HTML tables, geospatial, etc.).
+
+    Parameters
+    ----------
+    file_obj : io.BytesIO | io.StringIO
+        Seekable file-like object containing the data.
+    extension : str
+        Lowercase file extension without the leading dot
+        (e.g. ``"csv"``, ``"parquet"``).
+    sheet : str | int, optional
+        Sheet name or index for Excel files (default ``0``).
+
+    Returns
+    -------
+    pd.DataFrame | None
+        The parsed DataFrame, or ``None`` if the extension is not
+        one of the four supported formats.
+    """
+    file_obj.seek(0)
+    if extension == "csv":
+        return pd.read_csv(file_obj, parse_dates=True, sep=None, engine="python")
+    if extension in ("parq", "parquet"):
+        return pd.read_parquet(file_obj)
+    if extension == "json":
+        content = file_obj.read()
+        return read_json_to_dataframe(content)
+    if extension == "xlsx":
+        return pd.read_excel(file_obj, sheet_name=sheet)
+    return None
+
+
 def normalize_json_response(data) -> pd.DataFrame:
     """
     Flatten a JSON API response into a DataFrame.

--- a/lumen/ai/controls/ingest/utils.py
+++ b/lumen/ai/controls/ingest/utils.py
@@ -227,7 +227,7 @@ def read_file_to_dataframes(
     extension: str,
     *,
     alias: str = "data",
-    sheet: str | int | None = None,
+    **read_kwargs,
 ) -> FileReadResult | None:
     """
     Parse a file object into one or more DataFrames.
@@ -245,8 +245,9 @@ def read_file_to_dataframes(
     alias : str
         Base table name.  Single-result formats use this directly;
         multi-result formats append a suffix.
-    sheet : str | int | None
-        For xlsx: specific sheet name/index, or ``None`` to read all.
+    **read_kwargs
+        Passed through to the underlying reader.  Common examples:
+        ``sheet_name`` for Excel files, ``sep`` for CSV.
 
     Returns
     -------
@@ -256,11 +257,13 @@ def read_file_to_dataframes(
 
     # ── single-DataFrame formats ──────────────────────────────────────────
     if extension == "csv":
-        df = pd.read_csv(file_obj, parse_dates=True, sep=None, engine="python")
+        csv_kwargs = {"parse_dates": True, "sep": None, "engine": "python"}
+        csv_kwargs.update(read_kwargs)
+        df = pd.read_csv(file_obj, **csv_kwargs)
         return FileReadResult(tables={alias: df})
 
     if extension in ("parq", "parquet"):
-        return FileReadResult(tables={alias: pd.read_parquet(file_obj)})
+        return FileReadResult(tables={alias: pd.read_parquet(file_obj, **read_kwargs)})
 
     if extension == "json":
         content = file_obj.read()
@@ -268,11 +271,12 @@ def read_file_to_dataframes(
 
     # ── Excel (single sheet or all sheets) ────────────────────────────────
     if extension == "xlsx":
+        sheet = read_kwargs.pop("sheet_name", None)
         if sheet is not None:
-            df = pd.read_excel(file_obj, sheet_name=sheet)
+            df = pd.read_excel(file_obj, sheet_name=sheet, **read_kwargs)
             return FileReadResult(tables={alias: df})
         # Read all sheets
-        sheets = pd.read_excel(file_obj, sheet_name=None)  # dict[str, DataFrame]
+        sheets = pd.read_excel(file_obj, sheet_name=None, **read_kwargs)
         if len(sheets) == 1:
             return FileReadResult(tables={alias: next(iter(sheets.values()))})
         tables = {

--- a/lumen/ai/controls/ingest/utils.py
+++ b/lumen/ai/controls/ingest/utils.py
@@ -254,6 +254,7 @@ def read_file_to_dataframes(
     FileReadResult | None
     """
     file_obj.seek(0)
+    sheet = read_kwargs.pop("sheet_name", None)
 
     # ── single-DataFrame formats ──────────────────────────────────────────
     if extension == "csv":
@@ -271,7 +272,6 @@ def read_file_to_dataframes(
 
     # ── Excel (single sheet or all sheets) ────────────────────────────────
     if extension == "xlsx":
-        sheet = read_kwargs.pop("sheet_name", None)
         if sheet is not None:
             df = pd.read_excel(file_obj, sheet_name=sheet, **read_kwargs)
             return FileReadResult(tables={alias: df})

--- a/lumen/tests/ai/test_controls/test_kaggle.py
+++ b/lumen/tests/ai/test_controls/test_kaggle.py
@@ -1,0 +1,291 @@
+"""Tests for Kaggle dataset integration in DownloadSourceControls."""
+import os
+import tempfile
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    import lumen.ai  # noqa
+except ModuleNotFoundError:
+    pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
+
+from lumen.ai.controls.ingest.download import DownloadSourceControls
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _parse_kaggle_ref
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestParseKaggleRef:
+    """Tests for Kaggle URL parsing."""
+
+    @pytest.mark.parametrize("url,expected", [
+        ("https://www.kaggle.com/datasets/owner/dataset", "owner/dataset"),
+        ("https://kaggle.com/datasets/owner/dataset", "owner/dataset"),
+        ("http://www.kaggle.com/datasets/owner/dataset", "owner/dataset"),
+        ("https://www.kaggle.com/datasets/owner/dataset/data", "owner/dataset"),
+        ("https://www.kaggle.com/datasets/owner/dataset?select=file.csv", "owner/dataset"),
+        ("https://www.kaggle.com/datasets/owner/dataset#overview", "owner/dataset"),
+    ])
+    def test_valid_kaggle_urls(self, url, expected):
+        assert DownloadSourceControls._parse_kaggle_ref(url) == expected
+
+    @pytest.mark.parametrize("url", [
+        "https://www.kaggle.com/competitions/some-comp",
+        "https://www.kaggle.com/owner/dataset",  # missing /datasets/
+        "https://example.com/datasets/owner/dataset",
+        "https://www.kaggle.com/datasets/",  # no owner/dataset
+        "owner/dataset",  # bare slug, no kaggle.com
+        "",
+    ])
+    def test_non_kaggle_urls(self, url):
+        assert DownloadSourceControls._parse_kaggle_ref(url) is None
+
+    def test_whitespace_is_stripped(self):
+        assert DownloadSourceControls._parse_kaggle_ref(
+            "  https://www.kaggle.com/datasets/owner/dataset  "
+        ) == "owner/dataset"
+
+    def test_trailing_slash_is_stripped(self):
+        assert DownloadSourceControls._parse_kaggle_ref(
+            "https://www.kaggle.com/datasets/owner/dataset/"
+        ) == "owner/dataset"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _kagglehub init
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestKagglehubInit:
+    """Tests for kagglehub availability detection at init time."""
+
+    def test_kagglehub_attr_exists(self, download_controls):
+        """self._kagglehub is set (module or None depending on env)."""
+        assert hasattr(download_controls, "_kagglehub")
+
+    def test_kagglehub_none_when_missing(self, context, source_catalog):
+        """If kagglehub is not importable, self._kagglehub is None."""
+        import builtins
+        real_import = builtins.__import__
+
+        def _block_kagglehub(name, *args, **kwargs):
+            if name == "kagglehub":
+                raise ModuleNotFoundError("mocked")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=_block_kagglehub):
+            controls = DownloadSourceControls(
+                context=context, source_catalog=source_catalog,
+            )
+        assert controls._kagglehub is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _download_kaggle_files
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestDownloadKaggleFiles:
+    """Tests for the Kaggle file download method."""
+
+    async def test_returns_error_when_kagglehub_missing(self, download_controls):
+        download_controls._kagglehub = None
+        files, error = await download_controls._download_kaggle_files("owner/ds")
+        assert files == {}
+        assert "pip install kagglehub" in error
+
+    async def test_reads_supported_files(self, download_controls):
+        """Mocks kagglehub.dataset_download to return a temp dir with files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write test files
+            csv_path = os.path.join(tmpdir, "data.csv")
+            json_path = os.path.join(tmpdir, "extra.json")
+            txt_path = os.path.join(tmpdir, "readme.txt")  # not a TABLE_EXTENSIONS
+            with open(csv_path, "w") as f:
+                f.write("a,b\n1,2\n")
+            with open(json_path, "w") as f:
+                f.write('[{"x": 1}]')
+            with open(txt_path, "w") as f:
+                f.write("not a table")
+
+            mock_kagglehub = MagicMock()
+            mock_kagglehub.dataset_download.return_value = tmpdir
+            download_controls._kagglehub = mock_kagglehub
+
+            files, error = await download_controls._download_kaggle_files("owner/ds")
+
+            assert error is None
+            assert "data.csv" in files
+            assert "extra.json" in files
+            # txt is in METADATA_EXTENSIONS, not TABLE_EXTENSIONS
+            assert "readme.txt" not in files
+            mock_kagglehub.dataset_download.assert_called_once_with("owner/ds")
+
+    async def test_reads_files_in_subdirectories(self, download_controls):
+        """Files nested in subdirs should be found via rglob."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "subdir")
+            os.makedirs(subdir)
+            with open(os.path.join(subdir, "nested.csv"), "w") as f:
+                f.write("x,y\n1,2\n")
+
+            mock_kagglehub = MagicMock()
+            mock_kagglehub.dataset_download.return_value = tmpdir
+            download_controls._kagglehub = mock_kagglehub
+
+            files, error = await download_controls._download_kaggle_files("owner/ds")
+            assert error is None
+            assert "nested.csv" in files
+
+    async def test_returns_error_when_no_supported_files(self, download_controls):
+        """Empty or unsupported-only dataset should return an error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "model.pkl"), "wb") as f:
+                f.write(b"pickle data")
+
+            mock_kagglehub = MagicMock()
+            mock_kagglehub.dataset_download.return_value = tmpdir
+            download_controls._kagglehub = mock_kagglehub
+
+            files, error = await download_controls._download_kaggle_files("owner/ds")
+            assert files == {}
+            assert "No supported data files" in error
+
+    async def test_returns_error_on_download_failure(self, download_controls):
+        mock_kagglehub = MagicMock()
+        mock_kagglehub.dataset_download.side_effect = RuntimeError("auth failed")
+        download_controls._kagglehub = mock_kagglehub
+
+        files, error = await download_controls._download_kaggle_files("owner/ds")
+        assert files == {}
+        assert "auth failed" in error
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _fetch_kaggle (agent tool path)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestFetchKaggle:
+    """Tests for the agent-facing Kaggle fetch method."""
+
+    async def test_single_csv_produces_one_table(self, download_controls):
+        download_controls._kagglehub = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "users.csv"), "w") as f:
+                f.write("name,age\nAlice,30\nBob,25\n")
+            download_controls._kagglehub.dataset_download.return_value = tmpdir
+
+            result = await download_controls._fetch_kaggle("owner/ds")
+
+        assert len(result.sources) == 1
+        source = result.sources[0]
+        assert "users" in source.tables
+        df = source.get("users")
+        assert len(df) == 2
+        assert result.table == "users"
+
+    async def test_multiple_files_produce_multiple_tables_in_one_source(self, download_controls):
+        download_controls._kagglehub = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "orders.csv"), "w") as f:
+                f.write("id,amount\n1,100\n2,200\n")
+            with open(os.path.join(tmpdir, "customers.csv"), "w") as f:
+                f.write("id,name\n1,Alice\n2,Bob\n")
+            download_controls._kagglehub.dataset_download.return_value = tmpdir
+
+            result = await download_controls._fetch_kaggle("owner/ds")
+
+        assert len(result.sources) == 1
+        source = result.sources[0]
+        tables = set(source.get_tables())
+        assert tables == {"customers", "orders"}
+
+    async def test_metadata_includes_kaggle_ref(self, download_controls):
+        download_controls._kagglehub = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "data.csv"), "w") as f:
+                f.write("x\n1\n")
+            download_controls._kagglehub.dataset_download.return_value = tmpdir
+
+            result = await download_controls._fetch_kaggle("alice/my-dataset")
+
+        source = result.sources[0]
+        assert source.metadata["data"]["kaggle_ref"] == "alice/my-dataset"
+
+    async def test_empty_result_when_kagglehub_missing(self, download_controls):
+        download_controls._kagglehub = None
+        result = await download_controls._fetch_kaggle("owner/ds")
+        assert not result.sources
+        assert "pip install kagglehub" in result.message
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _fetch_url integration (Kaggle URL detection in agent path)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestFetchUrlKaggleDetection:
+    """Tests that _fetch_url routes Kaggle URLs correctly."""
+
+    async def test_kaggle_url_routed_to_fetch_kaggle(self, download_controls):
+        download_controls._kagglehub = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "data.csv"), "w") as f:
+                f.write("col\n1\n")
+            download_controls._kagglehub.dataset_download.return_value = tmpdir
+
+            result = await download_controls._fetch_url(
+                "https://www.kaggle.com/datasets/owner/ds"
+            )
+
+        assert len(result.sources) == 1
+        assert "data" in result.sources[0].tables
+
+    async def test_non_kaggle_url_not_routed_to_kaggle(self, download_controls):
+        """A normal URL should not go through the Kaggle path."""
+        with patch.object(download_controls, "_fetch_kaggle") as mock_kaggle:
+            with patch(
+                "lumen.ai.controls.ingest.download.download_file",
+                return_value=("data.csv", b"x\n1\n", None),
+            ):
+                await download_controls._fetch_url("https://example.com/data.csv")
+            mock_kaggle.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _download_and_process_urls (UI flow)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestDownloadAndProcessUrlsKaggle:
+    """Tests that the UI download path handles Kaggle URLs."""
+
+    async def test_kaggle_url_generates_file_cards(self, download_controls):
+        download_controls._kagglehub = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "sales.csv"), "w") as f:
+                f.write("month,revenue\nJan,100\n")
+            download_controls._kagglehub.dataset_download.return_value = tmpdir
+
+            await download_controls._download_and_process_urls(
+                ["https://www.kaggle.com/datasets/owner/ds"]
+            )
+
+        assert len(download_controls._file_cards) == 1
+        assert download_controls._file_cards[0].filename == "sales"
+
+    async def test_kaggle_error_appended_to_errors(self, download_controls):
+        download_controls._kagglehub = None
+        await download_controls._download_and_process_urls(
+            ["https://www.kaggle.com/datasets/owner/ds"]
+        )
+        assert download_controls._error_placeholder.visible is True
+        assert "kagglehub" in download_controls._error_placeholder.object


### PR DESCRIPTION
## Description

I was trying to find more datasets to experiment with, and I realized Kaggle is a great source for example datasets, so I added it to `DownloadSourceControls`. I imagine we can use it for tutorials / examples in docs, and maybe even down the line, add training ML-models as part of Lumen?? It can also be helpful for us to experiment with Lumen and see if it can reproduce some kaggle analysis.

I was debating whether to have a separate `KaggleSourceControl` but I decided to merge these for convenience. Alternatively, I suppose we could have a separate `KaggleSourceControls` that inherits from DownloadSourceControls, and then it would be the default for UI so new users can easily try out Lumen with Kaggle datasets.

Separately, this PR addresses duplications of translating files into dataframes -> `read_file_to_dataframes` 

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

<img width="1743" height="939" alt="image" src="https://github.com/user-attachments/assets/57cfbf40-25a9-43d3-aafe-e88546dcf62a" />


## AI Disclosure

Used Opus 4.6 to plan and imp

## Checklist

<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
- [x] Added documentation
