### PR TITLE
Tweak schema

### DIFF
--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -174,7 +174,7 @@ class Metaset:
         if include_schema and self.has_schemas:
             schema = self.schemas.get(table_slug)
             if schema and schema.get("__len__"):
-                data['n_rows'] = len(schema)
+                data['n_rows'] = schema["__len__"]
 
         if include_lineage and catalog_entry.derived_from:
             data['derived_from'] = [

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -720,25 +720,7 @@ def describe_data_sync(df: pd.DataFrame, enum_limit: int = 3, reduce_enums: bool
     for col in df.select_dtypes(include=["float64"]).columns:
         df[col] = df[col].apply(format_float)
 
-    # === Detect structural patterns ===
     n_rows, n_cols = shape
-    structure = {}
-
-    # Dimension vs measure classification
-    dimensions, measures = [], []
-    for col in df.columns:
-        dtype = df[col].dtype
-        nunique = df[col].nunique()
-        ratio = nunique / n_rows if n_rows else 0
-        if ratio <= 0.8:  # Not an identifier
-            if dtype == 'object' or nunique <= max(20, n_rows * 0.1):
-                dimensions.append(col)
-            elif dtype in ('int64', 'float64'):
-                measures.append(col)
-    if dimensions:
-        structure["dimensions"] = dimensions
-    if measures:
-        structure["measures"] = measures
 
     # Add head and tail samples (2 rows each); deduplicate if identical
     head_sample = df.head(2).to_dict('records')
@@ -753,8 +735,6 @@ def describe_data_sync(df: pd.DataFrame, enum_limit: int = 3, reduce_enums: bool
         },
         "stats": df_describe_dict,
     }
-    if structure:
-        result["summary"]["structure"] = structure
     if head_sample == tail_sample:
         result["sample"] = head_sample[0] if head_sample else {}
     else:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -617,10 +617,19 @@ def describe_data_sync(df: pd.DataFrame, enum_limit: int = 3, reduce_enums: bool
     size = df.size
     shape = df.shape
     if shape[0] == 1 or size < 10 or (shape[1] > 8 and size < 100):
-        # df -> dict -> YAML
-        return yaml.dump(df.to_dict(orient='records'), default_flow_style=False, allow_unicode=True, sort_keys=False)
+        records = df.to_dict(orient='records')
+        result = {
+            "data_shape": [int(shape[0]), int(shape[1])],
+            "is_sampled": False,
+            "records": records,
+        }
+        return yaml.dump(result, default_flow_style=False, allow_unicode=True, sort_keys=False)
     if size < 100:
-        return df.to_markdown(index=False)
+        header = yaml.dump(
+            {"data_shape": [int(shape[0]), int(shape[1])], "is_sampled": False},
+            default_flow_style=False, allow_unicode=True, sort_keys=False,
+        )
+        return header + df.to_markdown(index=False)
 
     is_sampled = False
     if shape[0] > 5000:
@@ -671,6 +680,25 @@ def describe_data_sync(df: pd.DataFrame, enum_limit: int = 3, reduce_enums: bool
         except AttributeError:
             pass
 
+    # Low-cardinality integer columns (e.g. status codes, ratings)
+    for col in df.select_dtypes(include=["int64"]).columns:
+        nunique = df[col].nunique()
+        if nunique <= 10:
+            if col not in df_describe_dict:
+                df_describe_dict[col] = {}
+            unique_values = sorted(df[col].dropna().unique().tolist())
+            temp_spec = {"enum": unique_values}
+            updated_spec, _ = process_enums(
+                temp_spec,
+                num_cols=len(df.columns),
+                limit=enum_limit,
+                include_enum=True,
+                reduce_enums=reduce_enums,
+            )
+            if "enum" in updated_spec:
+                df_describe_dict[col]["enum"] = updated_spec["enum"]
+            df_describe_dict[col]["nunique"] = int(nunique)
+
     for col in df.columns:
         if col not in df_describe_dict:
             df_describe_dict[col] = {}
@@ -692,22 +720,46 @@ def describe_data_sync(df: pd.DataFrame, enum_limit: int = 3, reduce_enums: bool
     for col in df.select_dtypes(include=["float64"]).columns:
         df[col] = df[col].apply(format_float)
 
-    # Add head and tail samples (2 row each)
+    # === Detect structural patterns ===
+    n_rows, n_cols = shape
+    structure = {}
+
+    # Dimension vs measure classification
+    dimensions, measures = [], []
+    for col in df.columns:
+        dtype = df[col].dtype
+        nunique = df[col].nunique()
+        ratio = nunique / n_rows if n_rows else 0
+        if ratio <= 0.8:  # Not an identifier
+            if dtype == 'object' or nunique <= max(20, n_rows * 0.1):
+                dimensions.append(col)
+            elif dtype in ('int64', 'float64'):
+                measures.append(col)
+    if dimensions:
+        structure["dimensions"] = dimensions
+    if measures:
+        structure["measures"] = measures
+
+    # Add head and tail samples (2 rows each); deduplicate if identical
     head_sample = df.head(2).to_dict('records')
     tail_sample = df.tail(2).to_dict('records')
 
     result = {
         "summary": {
             "n_cells": size,
-            "n_rows": shape[0],
-            "n_cols": shape[1],
+            "data_shape": [n_rows, n_cols],
             "sampled_cols": sampled_columns,
             "is_sampled": is_sampled,
         },
         "stats": df_describe_dict,
-        "head": head_sample[0] if head_sample else {},
-        "tail": tail_sample[0] if tail_sample else {},
     }
+    if structure:
+        result["summary"]["structure"] = structure
+    if head_sample == tail_sample:
+        result["sample"] = head_sample[0] if head_sample else {}
+    else:
+        result["head"] = head_sample[0] if head_sample else {}
+        result["tail"] = tail_sample[0] if tail_sample else {}
 
     return yaml.dump(result, default_flow_style=False, allow_unicode=True, sort_keys=False)
 

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -616,19 +616,13 @@ def describe_data_sync(df: pd.DataFrame, enum_limit: int = 3, reduce_enums: bool
     """
     size = df.size
     shape = df.shape
+    shape_header = {"data_shape": [int(shape[0]), int(shape[1])], "is_sampled": False}
     if shape[0] == 1 or size < 10 or (shape[1] > 8 and size < 100):
         records = df.to_dict(orient='records')
-        result = {
-            "data_shape": [int(shape[0]), int(shape[1])],
-            "is_sampled": False,
-            "records": records,
-        }
+        result = {**shape_header, "records": records}
         return yaml.dump(result, default_flow_style=False, allow_unicode=True, sort_keys=False)
     if size < 100:
-        header = yaml.dump(
-            {"data_shape": [int(shape[0]), int(shape[1])], "is_sampled": False},
-            default_flow_style=False, allow_unicode=True, sort_keys=False,
-        )
+        header = yaml.dump(shape_header, default_flow_style=False, allow_unicode=True, sort_keys=False)
         return header + df.to_markdown(index=False)
 
     is_sampled = False

--- a/lumen/tests/ai/test_schemas.py
+++ b/lumen/tests/ai/test_schemas.py
@@ -198,7 +198,7 @@ class TestRowCount:
         output = ms.compact_context()
         parsed = yaml.safe_load(output)
         assert "n_rows" in parsed["t"]
-        assert parsed["t"]["n_rows"] == len(schemas[slug])
+        assert parsed["t"]["n_rows"] == schemas[slug]["__len__"]
 
     def test_n_rows_absent_without_schema(self):
         e = _entry(f"S{SEP}t")


### PR DESCRIPTION
## Description

It was not invalidating past results because the LLM wasn't aware it was a subset/sample of the original data without the shape or mention.

For a status column with values [0, 1, 2] or a rating column with [1, 2, 3, 4, 5]. The existing code only does enum detection for string/object columns, so integer columns with few distinct values get described with just mean/std/min/max instead of showing the actual values.

Also fix n_rows returning the wrong length.

<img width="1675" height="931" alt="image" src="https://github.com/user-attachments/assets/09288d89-d418-40c1-bdb2-535f51661330" />
