### PR TITLE
fix: stop max_retries leaking to bare SDK client in _run_tool_loop

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -431,27 +431,27 @@ class Llm(param.Parameterized):
         max_tool_rounds: int = 16,
         **kwargs
     ) -> BaseModel | str:
+        # ``max_retries`` is consumed by the instructor wrapper; on bare-client
+        # paths it leaks to the SDK and raises ``TypeError``. Pop once and
+        # re-attach only to the instructor (response_model) round-trip.
+        max_retries = kwargs.pop("max_retries", None)
         requested_stream = bool(kwargs.get("stream", False))
         if requested_stream and structured_model is None:
             # In stream mode we can't know upfront whether a tool will be called.
             # Return the provider stream and let stream() inspect chunks for tool calls.
             kwargs.pop("response_model", None)
-            kwargs.pop("max_retries", None)
             messages = self._normalize_multimodal_messages(messages)
             return await self.run_client(model_spec, messages, **kwargs)
 
         stream = False
-        # ``max_retries`` is consumed by the instructor wrapper; on the raw
-        # client path it leaks through to the SDK and raises ``TypeError``.
-        # Stash it so the final structured-output round-trip can still use it.
-        saved_max_retries = None
         if structured_model is not None and not tool_instances:
             kwargs["response_model"] = structured_model
+            if max_retries is not None:
+                kwargs["max_retries"] = max_retries
         else:
             if tool_instances:
                 stream = kwargs.pop("stream", False)
             kwargs.pop("response_model", None)
-            saved_max_retries = kwargs.pop("max_retries", None)
             # Without response_model the raw client is used, which
             # cannot handle instructor Image objects in list content.
             messages = self._normalize_multimodal_messages(messages)
@@ -476,8 +476,8 @@ class Llm(param.Parameterized):
 
         if structured_model:
             kwargs["response_model"] = structured_model
-            if saved_max_retries is not None:
-                kwargs["max_retries"] = saved_max_retries
+            if max_retries is not None:
+                kwargs["max_retries"] = max_retries
             output = await self.run_client(model_spec, messages_curr, stream=stream, **kwargs)
         return output
 
@@ -1298,10 +1298,10 @@ class OpenAI(Llm, OpenAIMixin):
                 messages, structured_model, tool_instances, tool_contexts, model_spec, max_tool_rounds, **kwargs
             )
 
+        max_retries = kwargs.pop("max_retries", None)
         requested_stream = bool(kwargs.get("stream", False))
         if requested_stream and structured_model is None:
             kwargs.pop("response_model", None)
-            kwargs.pop("max_retries", None)
             return await self.run_client(model_spec, messages, **kwargs)
 
         has_inbuilt = any(
@@ -1311,12 +1311,12 @@ class OpenAI(Llm, OpenAIMixin):
 
         # When there are NO inbuilt tools and NO function-tool instances we
         # can ask for the structured response in a single round-trip.
-        saved_max_retries = None
         if structured_model is not None and not tool_instances and not has_inbuilt:
             kwargs["response_model"] = structured_model
+            if max_retries is not None:
+                kwargs["max_retries"] = max_retries
         else:
             kwargs.pop("response_model", None)
-            saved_max_retries = kwargs.pop("max_retries", None)
 
         output = await self.run_client(model_spec, messages, **kwargs)
         if not tool_instances and not has_inbuilt:
@@ -1343,8 +1343,8 @@ class OpenAI(Llm, OpenAIMixin):
         if structured_model:
             final_kwargs = dict(kwargs)
             final_kwargs["response_model"] = structured_model
-            if saved_max_retries is not None:
-                final_kwargs["max_retries"] = saved_max_retries
+            if max_retries is not None:
+                final_kwargs["max_retries"] = max_retries
             response_id = getattr(output, "id", None)
             if response_id:
                 final_kwargs["previous_response_id"] = response_id

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -436,16 +436,22 @@ class Llm(param.Parameterized):
             # In stream mode we can't know upfront whether a tool will be called.
             # Return the provider stream and let stream() inspect chunks for tool calls.
             kwargs.pop("response_model", None)
+            kwargs.pop("max_retries", None)
             messages = self._normalize_multimodal_messages(messages)
             return await self.run_client(model_spec, messages, **kwargs)
 
         stream = False
+        # ``max_retries`` is consumed by the instructor wrapper; on the raw
+        # client path it leaks through to the SDK and raises ``TypeError``.
+        # Stash it so the final structured-output round-trip can still use it.
+        saved_max_retries = None
         if structured_model is not None and not tool_instances:
             kwargs["response_model"] = structured_model
         else:
             if tool_instances:
                 stream = kwargs.pop("stream", False)
             kwargs.pop("response_model", None)
+            saved_max_retries = kwargs.pop("max_retries", None)
             # Without response_model the raw client is used, which
             # cannot handle instructor Image objects in list content.
             messages = self._normalize_multimodal_messages(messages)
@@ -470,6 +476,8 @@ class Llm(param.Parameterized):
 
         if structured_model:
             kwargs["response_model"] = structured_model
+            if saved_max_retries is not None:
+                kwargs["max_retries"] = saved_max_retries
             output = await self.run_client(model_spec, messages_curr, stream=stream, **kwargs)
         return output
 
@@ -1293,6 +1301,7 @@ class OpenAI(Llm, OpenAIMixin):
         requested_stream = bool(kwargs.get("stream", False))
         if requested_stream and structured_model is None:
             kwargs.pop("response_model", None)
+            kwargs.pop("max_retries", None)
             return await self.run_client(model_spec, messages, **kwargs)
 
         has_inbuilt = any(
@@ -1302,10 +1311,12 @@ class OpenAI(Llm, OpenAIMixin):
 
         # When there are NO inbuilt tools and NO function-tool instances we
         # can ask for the structured response in a single round-trip.
+        saved_max_retries = None
         if structured_model is not None and not tool_instances and not has_inbuilt:
             kwargs["response_model"] = structured_model
         else:
             kwargs.pop("response_model", None)
+            saved_max_retries = kwargs.pop("max_retries", None)
 
         output = await self.run_client(model_spec, messages, **kwargs)
         if not tool_instances and not has_inbuilt:
@@ -1332,6 +1343,8 @@ class OpenAI(Llm, OpenAIMixin):
         if structured_model:
             final_kwargs = dict(kwargs)
             final_kwargs["response_model"] = structured_model
+            if saved_max_retries is not None:
+                final_kwargs["max_retries"] = saved_max_retries
             response_id = getattr(output, "id", None)
             if response_id:
                 final_kwargs["previous_response_id"] = response_id

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
     pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
 
 from instructor.processing.multimodal import Image
+from pydantic import BaseModel
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -331,6 +332,53 @@ def test_openai_responses_stream_tool_call_id_preserved_from_added_event():
     OpenAI._accumulate_tool_calls(accum, order, OpenAI._extract_stream_tool_calls(done_event))
     tool_calls = OpenAI._tool_calls_from_accum(accum, order)
     assert tool_calls[0]["id"] == "call_abc"
+
+
+async def test_run_tool_loop_drops_max_retries_on_bare_client(monkeypatch):
+    """Regression: ``max_retries`` is an instructor-only kwarg.
+
+    When both ``response_model`` and ``tools`` are supplied (the planner's
+    path), ``_run_tool_loop`` drops ``response_model`` and routes to the bare
+    SDK client.  Before the fix, ``max_retries`` was left in ``kwargs`` and
+    leaked through to ``AsyncMessages.create`` / ``AsyncCompletions.create``,
+    raising ``TypeError: got an unexpected keyword argument 'max_retries'``.
+    """
+
+    class _Plan(BaseModel):
+        next_step: str
+
+    llm = OpenAI(model_kwargs={"default": {"model": "gpt-4.1-mini"}})
+    calls: list[dict] = []
+
+    async def fake_run_client(_model_spec, _messages, **kwargs):
+        calls.append(dict(kwargs))
+        return SimpleNamespace(content="done", tool_calls=None)
+
+    monkeypatch.setattr(llm, "run_client", fake_run_client)
+    monkeypatch.setattr(llm, "_extract_tool_calls", lambda _output: [])
+
+    await llm._run_tool_loop(
+        messages=[{"role": "user", "content": "hi"}],
+        structured_model=_Plan,
+        tool_instances={"lookup": object()},
+        tool_contexts={},
+        max_retries=3,
+    )
+    # The first call uses the bare client (no response_model). It must not
+    # carry max_retries through, since the bare SDK rejects it.
+    bare_call = calls[0]
+    assert "response_model" not in bare_call
+    assert "max_retries" not in bare_call, (
+        "max_retries must be popped from kwargs on the bare-client path; "
+        "it is consumed by the instructor wrapper, not the underlying SDK."
+    )
+    # Final structured-output call (instructor) should still carry the
+    # user-passed max_retries so retry semantics are preserved end to end.
+    final_call = calls[-1]
+    assert final_call.get("response_model") is _Plan
+    assert final_call.get("max_retries") == 3
+
+
 # ---------------------------------------------------------------------------
 # _normalize_multimodal_messages tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When the planner asks for both a structured response and tools, `_run_tool_loop` drops `response_model` and falls back to the bare SDK client, but `max_retries` was left in `kwargs` and reached `AsyncMessages.create` / `AsyncCompletions.create`, which don't accept it. Result: any Anthropic chat that engages tools fails with `Planner could not settle on a plan of action`. Pops it alongside `response_model` on every bare-client branch, and stashes/restores it so the final structured round-trip still gets the caller's retry count.

**Before:**

```
TypeError: AsyncMessages.create() got an unexpected keyword argument 'max_retries'
```

**After:**

```
lumen/tests/ai/test_llm.py::test_run_tool_loop_drops_max_retries_on_bare_client PASSED
```