### PR TITLE
Clarify follow up

### DIFF
--- a/lumen/ai/prompts/Planner/follow_up.jinja2
+++ b/lumen/ai/prompts/Planner/follow_up.jinja2
@@ -49,6 +49,12 @@ new:
 User: "Show me the whole month"
 In-memory data: daily weather for Apr 7–13 (fetched from external API for that date range)
 → new — data was fetched for a narrow date range; broadening requires a fresh external fetch
+
+new:
+User: "Show me all the rows that make up that result"
+In-memory data: single-row result from LIMIT 1 or an aggregate
+Derived tables: top_result (from raw_data) ★ — but only 1 row
+→ new — derived table is a reduced subset (LIMIT 1 / aggregate); expanding requires querying the original source table, not the derived one
 {% endblock %}
 
 {% block context -%}


### PR DESCRIPTION
Sometimes, the LLM gets stuck in the derived table--e.g. I ask it to get the highest cumulative value, and then I want to get the values making up that cumulative value, but it keeps selecting the derived result (n=1) instead of the original result. This nudges it in the other direction.