### PR TITLE
Do not format

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -78,6 +78,8 @@ def format_float(num):
     Process a float value, returning numeric types instead of strings.
     For very large/small numbers, returns a float that will display in scientific notation.
     """
+    if not isinstance(num, (int, float)):
+        return num
     if pd.isna(num) or math.isinf(num):
         return num
 


### PR DESCRIPTION
I noticed:
```

Traceback (most recent call last):
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 322, in async_wrapper
    output = await func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/agents/sql.py", line 576, in _render_execute_query
    pipeline, sql_expr_source, summary = await self._execute_query(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/agents/sql.py", line 431, in _execute_query
    summary = await describe_data(df, reduce_enums=False)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 764, in describe_data
    return await asyncio.to_thread(describe_data_sync, df, enum_limit, reduce_enums)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 714, in describe_data_sync
    values = [format_float(v) for v in values]
              ^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 81, in format_float
    if pd.isna(num) or math.isinf(num):
                       ^^^^^^^^^^^^^^^
TypeError: must be real number, not str
```