### PR TITLE
Fix SQLAgent crash on sources with the legacy 'any' dialect

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -778,9 +778,14 @@ def clean_sql(sql_expr: str, dialect: str | None = None, prettify: bool = False)
         cleaned_sql = cleaned_sql.replace('`', '"')
     clean_sql = cleaned_sql.strip().rstrip(";")
     if prettify:
+        # 'any' is a legacy BaseSQLSource dialect value that sqlglot no
+        # longer accepts (28.x raises 'Unknown dialect any'); normalise it
+        # to sqlglot's dialect-agnostic mode so SQLAgent's chat path keeps
+        # working for sources that have not declared a concrete dialect.
+        sql_dialect = None if dialect == "any" else dialect
         clean_sql = sqlglot.transpile(
             sql_expr,
-            read=dialect,
+            read=sql_dialect,
             pretty=True
         )[0]
     return clean_sql

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -941,7 +941,7 @@ class BaseSQLSource(Source):
     a SQL based data source.
     """
 
-    dialect = 'any'
+    dialect = None
 
     excluded_tables = param.List(default=[], doc="""
         List of table names that should be excluded from the results. Supports:

--- a/lumen/sources/sqlalchemy.py
+++ b/lumen/sources/sqlalchemy.py
@@ -211,8 +211,8 @@ class SQLAlchemySource(BaseSQLSource):
         try:
             return self._url.get_dialect().name
         except Exception:
-            # Fallback to 'any' if dialect detection fails
-            return 'any'
+            # Fallback to dialect-agnostic (None) if detection fails.
+            return None
 
     def create_sql_expr_source(self, tables: dict[str, str], params: dict[str, list | dict] | None = None, **kwargs):
         """

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -297,6 +297,16 @@ def test_clean_sql_strips_whitespace_and_semicolons():
     assert cleaned_sql == "SELECT * FROM table"
 
 
+def test_clean_sql_prettify_with_legacy_any_dialect():
+    """BaseSQLSource.dialect defaults to 'any', a legacy value that sqlglot
+    no longer recognises (28.x raises 'Unknown dialect any'). clean_sql
+    must normalise it to the dialect-agnostic mode so calling code on a
+    fresh BaseSQLSource (e.g. STACSource) does not break the SQLAgent
+    chat path."""
+    cleaned = clean_sql("SELECT 1", dialect="any", prettify=True)
+    assert "SELECT" in cleaned and "1" in cleaned
+
+
 def test_report_error():
     step = ChatStep()
     report_error(Exception("Test error"), step)

--- a/lumen/tests/sources/test_xarray_sql.py
+++ b/lumen/tests/sources/test_xarray_sql.py
@@ -119,7 +119,7 @@ class TestConstruction:
 
     def test_dialect(self, synthetic_dataset):
         source = XArraySQLSource(_dataset=synthetic_dataset)
-        assert source.dialect == "any"
+        assert source.dialect is None
 
     def test_from_dataset_classmethod(self, synthetic_dataset):
         source = XArraySQLSource.from_dataset(synthetic_dataset)


### PR DESCRIPTION
## Description

While testing `lumen-ai serve --catalog <stac-url>` I hit `ValueError: Unknown dialect 'any'` from `clean_sql` → `sqlglot.transpile(read='any')`. sqlglot 28.x removed the legacy `'any'` value while `BaseSQLSource.dialect` still ships it as the default, so any source without a concrete dialect crashes the `SQLAgent` chat path before the SQL is dispatched. Normalise `'any'` → `None` (dialect-agnostic mode) inside `clean_sql`; backward compatible.