### PR TITLE
Dont show copy if no editor

### DIFF
--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -59,7 +59,10 @@ class Analysis(param.ParameterizedFunction):
         return applies
 
     def controls(self, context: TContext) -> Param | None:
-        config_options = [p for p in self.param if p not in Analysis.param and self.param[p].precedence > 0]
+        config_options = [
+            p for p in self.param
+            if p not in Analysis.param and (self.param[p].precedence or 0) > 0
+        ]
         if not config_options:
             return None
         return Param(self.param, parameters=config_options, margin=0, show_name=False)

--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -61,7 +61,8 @@ class Analysis(param.ParameterizedFunction):
     def controls(self, context: TContext) -> Param | None:
         config_options = [
             p for p in self.param
-            if p not in Analysis.param and (self.param[p].precedence or 0) > 0
+            if p not in Analysis.param
+            and (self.param[p].precedence is None or self.param[p].precedence >= 0)
         ]
         if not config_options:
             return None

--- a/lumen/ai/controls/copy.py
+++ b/lumen/ai/controls/copy.py
@@ -19,6 +19,12 @@ class CopyControls(Viewer):
 
     def __init__(self, **params):
         super().__init__(**params)
+        editor = getattr(self.view, "_editor", None)
+        if editor is None:
+            # Some editors (e.g. AnalysisOutput, DocumentEditor) don't render a
+            # CodeEditor, so there's nothing to copy and we show no icon.
+            self._row = Row(**self.layout_kwargs)
+            return
         # Dynamically set description based on the language of the view
         language = getattr(self.view, 'language', 'yaml').upper()
         copy_icon = IconButton(
@@ -32,7 +38,7 @@ class CopyControls(Viewer):
             icon_size="0.9em",
         )
         copy_icon.js_on_click(
-            args={"code_editor": self.view._editor},
+            args={"code_editor": editor},
             code="navigator.clipboard.writeText(code_editor.code);",
         )
         self._row = Row(copy_icon, **self.layout_kwargs)

--- a/lumen/tests/ai/test_controls/test_copy.py
+++ b/lumen/tests/ai/test_controls/test_copy.py
@@ -239,7 +239,7 @@ class TestCopyControls:
         assert row.width == 200
 
     def test_view_without_editor(self):
-        """Test CopyControls handles view without editor gracefully."""
+        """A view without an editor renders no copy icon instead of erroring."""
         interface = MockInterface()
         view = Mock(spec=["spec", "language"])
         view.spec = "type: bar"
@@ -247,13 +247,15 @@ class TestCopyControls:
         # Intentionally no editor attribute
         task = MockTask()
 
-        # Should raise AttributeError when trying to access editor
-        with pytest.raises(AttributeError):
-            controls = CopyControls(
-                interface=interface,
-                view=view,
-                task=task
-            )
+        # Should not raise; there is nothing to copy, so no icon is shown.
+        controls = CopyControls(
+            interface=interface,
+            view=view,
+            task=task
+        )
+
+        assert len(controls._row.objects) == 0
+        assert controls.__panel__() is controls._row
 
     def test_different_view_specs(self):
         """Test CopyControls with different spec content."""


### PR DESCRIPTION
Solves lumen-anndata crashing on _editor. https://github.com/holoviz-topics/lumen-anndata/pull/47

Also fixes:
```

2026-06-01 13:11:36,336 LLM Response: analysis='RankGenesGroupsTracksplot'
---
Traceback (most recent call last):
  File "/Users/ahuang/repos/lumen/lumen/ai/coordinator/base.py", line 133, in _run_task
    outputs, task_context = await task.execute(subcontext, **kwargs)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 1230, in async_wrapper
    return await func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/report.py", line 237, in execute
    views, out_context = await self._execute(context, **kwargs)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/report.py", line 1314, in _execute
    raise e
  File "/Users/ahuang/repos/lumen/lumen/ai/report.py", line 1308, in _execute
    outputs, out_context = await self.actor.respond(messages, subcontext, **kwargs)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/utils.py", line 1230, in async_wrapper
    return await func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/agents/analysis.py", line 143, in respond
    out = self._editor_type(
          ^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/editors.py", line 467, in __init__
    super().__init__(**params)
  File "/Users/ahuang/repos/lumen/lumen/ai/editors.py", line 81, in __init__
    self.editor = self._render_editor()
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/editors.py", line 470, in _render_editor
    controls = self.analysis.controls(self.context)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahuang/repos/lumen/lumen/ai/analysis.py", line 62, in controls
    config_options = [p for p in self.param if p not in Analysis.param and self.param[p].precedence > 0]
                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

Cast to int, and make >= 0 instead of > 0 because:

```
import param
import panel
class Test(param.Parameterized):
    a = param.Integer(default=1, bounds=(0, 10), precedence=1)
    b = param.String(default="hello", precedence=0)

panel.Param(Test).show()
```
<img width="392" height="220" alt="image" src="https://github.com/user-attachments/assets/bed20502-7700-45a9-a0e7-612a030f583b" />
