### PR TITLE
Fix SQLAgent crash on columns absent from the source catalog

### DIFF
--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -238,8 +238,11 @@ def make_load_table_schemas_tool(metaset: Metaset) -> FunctionTool:
                 for k, v in live.items():
                     if k == "__len__":
                         continue
-                    col = col_info.get(k, {})
-                    if col.description:
+                    # col_info only carries cataloged columns; live keys not
+                    # in the catalog (e.g. xarray dim coordinates absent from
+                    # a STAC datacube extension) get the live schema as-is.
+                    col = col_info.get(k)
+                    if col is not None and col.description:
                         schema[k] = dict(col.description, **v)
                     else:
                         schema[k] = v


### PR DESCRIPTION
## Description

`SQLAgent.make_load_table_schemas_tool` does `col_info.get(k, {})` and then `col.description` on the `{}` default, raising `AttributeError` whenever the live SQL-engine schema returns any column the catalog does not declare (e.g. xarray dim coordinates like `time`/`x`/`y` that the STAC datacube extension does not list as data variables). Drop the `{}` fallback and guard against `None` instead; behaviourally equivalent to the original intent without crashing.