### PR TITLE
allow setting temp = none

### DIFF
--- a/docs/configuration/llm_providers.md
+++ b/docs/configuration/llm_providers.md
@@ -71,6 +71,16 @@ model_config = {
 
 Recommended ranges: 0.1 (SQL) to 0.4 (chat).
 
+### Disabling temperature
+
+Some newer models (e.g. reasoning models) reject a `temperature` argument. Set `temperature=None` to omit it from requests entirely, falling back to the provider's own default:
+
+``` py title="Omit temperature"
+llm = lmai.llm.Anthropic(temperature=None)
+```
+
+This works on every provider. Local backends (MLX, Llama.cpp) fall back to their built-in sampler default when `None`.
+
 ## Supported providers
 
 For installation and API key setup instructions, see the [Installation guide](../installation.md).

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -229,16 +229,11 @@ class Llm(param.Parameterized):
             kwargs.pop("max_retries", None)
         return kwargs
 
-    @staticmethod
-    def _drop_none(kwargs: dict[str, Any]) -> dict[str, Any]:
-        # temperature is allow_None so callers can opt out of sending it; some
-        # models reject the param. Drop any None-valued sampling kwarg rather
-        # than forwarding it. Uses ``is not None`` so a valid 0.0 is kept.
-        return {k: v for k, v in kwargs.items() if v is not None}
-
     @property
     def _client_kwargs(self) -> dict[str, Any]:
-        return {}
+        if self.temperature is None:
+            return {}
+        return {"temperature": self.temperature}
 
     def _create_base_client(self, **kwargs) -> Any:
         """Create the underlying SDK client (e.g., AsyncOpenAI, AsyncAnthropic)."""
@@ -1057,10 +1052,6 @@ class LlamaCpp(Llm, LlamaCppMixin):
         except Exception:
             return dict(model_kwargs)
 
-    @property
-    def _client_kwargs(self) -> dict[str, Any]:
-        return self._drop_none({"temperature": self.temperature})
-
     def _create_base_client(self, **kwargs) -> Any:
         return self._instantiate_client(**kwargs)
 
@@ -1185,10 +1176,6 @@ class OpenAI(Llm, OpenAIMixin):
         """Return the set of available model identifiers from OpenAI."""
         client = OpenAIClient(api_key=self.api_key, timeout=5)
         return {m.id for m in client.models.list().data}
-
-    @property
-    def _client_kwargs(self):
-        return self._drop_none({"temperature": self.temperature})
 
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
         model_kwargs = super()._get_model_kwargs(model_spec)
@@ -1454,10 +1441,6 @@ class AzureOpenAI(Llm, AzureOpenAIMixin):
 
     temperature = param.Number(default=1, bounds=(0, None), allow_None=True, constant=True)
 
-    @property
-    def _client_kwargs(self):
-        return self._drop_none({"temperature": self.temperature})
-
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
         model_kwargs = super()._get_model_kwargs(model_spec)
         instance_kwargs = self._instantiate_client_kwargs()
@@ -1518,10 +1501,6 @@ class MistralAI(Llm, MistralAIMixin):
         """Return the set of available model identifiers from Mistral."""
         from mistralai import Mistral
         return {m.id for m in Mistral(api_key=self.api_key).models.list().data}
-
-    @property
-    def _client_kwargs(self):
-        return self._drop_none({"temperature": self.temperature})
 
     def _create_base_client(self, **kwargs) -> Any:
         return self._instantiate_client(**kwargs)
@@ -1613,7 +1592,7 @@ class Anthropic(Llm, AnthropicMixin):
 
     @property
     def _client_kwargs(self):
-        return self._drop_none({"temperature": self.temperature, "max_tokens": 1024})
+        return {**super()._client_kwargs, "max_tokens": 1024}
 
     def _create_base_client(self, **kwargs) -> Any:
         client = self._instantiate_client(**kwargs)
@@ -1911,7 +1890,7 @@ class Bedrock(Llm, BedrockMixin):
 
     @property
     def _client_kwargs(self):
-        return self._drop_none({"temperature": self.temperature, "maxTokens": 4096})
+        return {**super()._client_kwargs, "maxTokens": 4096}
 
     def _create_base_client(self, **kwargs) -> Any:
         """Create boto3 bedrock-runtime client for inference."""
@@ -2579,7 +2558,7 @@ class MLX(Llm):
 
     @property
     def _client_kwargs(self) -> dict[str, Any]:
-        return self._drop_none({"temperature": self.temperature, "max_tokens": self.max_tokens})
+        return {**super()._client_kwargs, "max_tokens": self.max_tokens}
 
     @classmethod
     def warmup(cls, model_kwargs: dict | None):
@@ -2718,6 +2697,12 @@ class WebLLM(Llm):
 
     # WebLLM doesn't use from_* wrapper - uses patch(create=...)
     _instructor_wrapper = None
+
+    @property
+    def _client_kwargs(self) -> dict[str, Any]:
+        # WebLLM has never forwarded temperature through this path; the sampler
+        # is configured on the panel_web_llm component itself.
+        return {}
 
     def __init__(self, **params):
         from panel_web_llm import WebLLM as pnWebLLM
@@ -2883,9 +2868,7 @@ class LiteLLM(Llm):
     @property
     def _client_kwargs(self):
         """Base kwargs for all LiteLLM calls."""
-        kwargs = self._drop_none({"temperature": self.temperature})
-        kwargs.update(self.litellm_params)
-        return kwargs
+        return {**super()._client_kwargs, **self.litellm_params}
 
     def _create_base_client(self, **kwargs) -> Any:
         return self._get_router()

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -229,6 +229,13 @@ class Llm(param.Parameterized):
             kwargs.pop("max_retries", None)
         return kwargs
 
+    @staticmethod
+    def _drop_none(kwargs: dict[str, Any]) -> dict[str, Any]:
+        # temperature is allow_None so callers can opt out of sending it; some
+        # models reject the param. Drop any None-valued sampling kwarg rather
+        # than forwarding it. Uses ``is not None`` so a valid 0.0 is kept.
+        return {k: v for k, v in kwargs.items() if v is not None}
+
     @property
     def _client_kwargs(self) -> dict[str, Any]:
         return {}
@@ -1052,9 +1059,7 @@ class LlamaCpp(Llm, LlamaCppMixin):
 
     @property
     def _client_kwargs(self) -> dict[str, Any]:
-        if self.temperature is None:
-            return {}
-        return {"temperature": self.temperature}
+        return self._drop_none({"temperature": self.temperature})
 
     def _create_base_client(self, **kwargs) -> Any:
         return self._instantiate_client(**kwargs)
@@ -1183,9 +1188,7 @@ class OpenAI(Llm, OpenAIMixin):
 
     @property
     def _client_kwargs(self):
-        if self.temperature is None:
-            return {}
-        return {"temperature": self.temperature}
+        return self._drop_none({"temperature": self.temperature})
 
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
         model_kwargs = super()._get_model_kwargs(model_spec)
@@ -1453,9 +1456,7 @@ class AzureOpenAI(Llm, AzureOpenAIMixin):
 
     @property
     def _client_kwargs(self):
-        if self.temperature is None:
-            return {}
-        return {"temperature": self.temperature}
+        return self._drop_none({"temperature": self.temperature})
 
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
         model_kwargs = super()._get_model_kwargs(model_spec)
@@ -1520,9 +1521,7 @@ class MistralAI(Llm, MistralAIMixin):
 
     @property
     def _client_kwargs(self):
-        if self.temperature is None:
-            return {}
-        return {"temperature": self.temperature}
+        return self._drop_none({"temperature": self.temperature})
 
     def _create_base_client(self, **kwargs) -> Any:
         return self._instantiate_client(**kwargs)
@@ -1614,9 +1613,7 @@ class Anthropic(Llm, AnthropicMixin):
 
     @property
     def _client_kwargs(self):
-        if self.temperature is None:
-            return {"max_tokens": 1024}
-        return {"temperature": self.temperature, "max_tokens": 1024}
+        return self._drop_none({"temperature": self.temperature, "max_tokens": 1024})
 
     def _create_base_client(self, **kwargs) -> Any:
         client = self._instantiate_client(**kwargs)
@@ -1914,9 +1911,7 @@ class Bedrock(Llm, BedrockMixin):
 
     @property
     def _client_kwargs(self):
-        if self.temperature is None:
-            return {"maxTokens": 4096}
-        return {"temperature": self.temperature, "maxTokens": 4096}
+        return self._drop_none({"temperature": self.temperature, "maxTokens": 4096})
 
     def _create_base_client(self, **kwargs) -> Any:
         """Create boto3 bedrock-runtime client for inference."""
@@ -2584,9 +2579,7 @@ class MLX(Llm):
 
     @property
     def _client_kwargs(self) -> dict[str, Any]:
-        if self.temperature is None:
-            return {"max_tokens": self.max_tokens}
-        return {"temperature": self.temperature, "max_tokens": self.max_tokens}
+        return self._drop_none({"temperature": self.temperature, "max_tokens": self.max_tokens})
 
     @classmethod
     def warmup(cls, model_kwargs: dict | None):
@@ -2890,7 +2883,7 @@ class LiteLLM(Llm):
     @property
     def _client_kwargs(self):
         """Base kwargs for all LiteLLM calls."""
-        kwargs = {} if self.temperature is None else {"temperature": self.temperature}
+        kwargs = self._drop_none({"temperature": self.temperature})
         kwargs.update(self.litellm_params)
         return kwargs
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -141,8 +141,9 @@ class Llm(param.Parameterized):
 
     select_models = param.List(default=[], constant=True, doc="Available models for selection dropdowns")
 
-    temperature = param.Number(default=0.7, bounds=(0, None), constant=True, doc="""
-        The temperature to use for sampling.""")
+    temperature = param.Number(default=0.7, bounds=(0, None), allow_None=True, constant=True, doc="""
+        The temperature to use for sampling. Set to None to omit the
+        temperature from requests entirely, e.g. for models that reject it.""")
 
     timeout = param.Number(default=120, bounds=(1, None), constant=True, doc="""
         The timeout in seconds for API calls.""")
@@ -1026,7 +1027,7 @@ class LlamaCpp(Llm, LlamaCppMixin):
         "nvidia/Nemotron-3-Nano-30B-GGUF"
     ], constant=True)
 
-    temperature = param.Number(default=0.4, bounds=(0, None), constant=True)
+    temperature = param.Number(default=0.4, bounds=(0, None), allow_None=True, constant=True)
 
     # LlamaCpp doesn't use from_* wrapper - uses patch(create=...)
     _instructor_wrapper = None
@@ -1051,6 +1052,8 @@ class LlamaCpp(Llm, LlamaCppMixin):
 
     @property
     def _client_kwargs(self) -> dict[str, Any]:
+        if self.temperature is None:
+            return {}
         return {"temperature": self.temperature}
 
     def _create_base_client(self, **kwargs) -> Any:
@@ -1126,7 +1129,7 @@ class OpenAI(Llm, OpenAIMixin):
         "gpt-5.4-nano"
     ], constant=True, doc="""Warning: Reasoning models (gpt-5, o4-mini) are much slower and not suitable for dialog interfaces.""")
 
-    temperature = param.Number(default=0.25, bounds=(0, None), constant=True)
+    temperature = param.Number(default=0.25, bounds=(0, None), allow_None=True, constant=True)
 
     _supports_logfire = True
 
@@ -1180,6 +1183,8 @@ class OpenAI(Llm, OpenAIMixin):
 
     @property
     def _client_kwargs(self):
+        if self.temperature is None:
+            return {}
         return {"temperature": self.temperature}
 
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
@@ -1444,10 +1449,12 @@ class AzureOpenAI(Llm, AzureOpenAIMixin):
         "gpt-4o-mini"
     ], constant=True)
 
-    temperature = param.Number(default=1, bounds=(0, None), constant=True)
+    temperature = param.Number(default=1, bounds=(0, None), allow_None=True, constant=True)
 
     @property
     def _client_kwargs(self):
+        if self.temperature is None:
+            return {}
         return {"temperature": self.temperature}
 
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
@@ -1501,7 +1508,7 @@ class MistralAI(Llm, MistralAIMixin):
         "devstral-small-latest"
     ], constant=True)
 
-    temperature = param.Number(default=0.7, bounds=(0, 1), constant=True)
+    temperature = param.Number(default=0.7, bounds=(0, 1), allow_None=True, constant=True)
 
     _supports_model_stream = False  # instructor doesn't work with Mistral's streaming
     _instructor_wrapper = "mistral"
@@ -1513,6 +1520,8 @@ class MistralAI(Llm, MistralAIMixin):
 
     @property
     def _client_kwargs(self):
+        if self.temperature is None:
+            return {}
         return {"temperature": self.temperature}
 
     def _create_base_client(self, **kwargs) -> Any:
@@ -1590,7 +1599,7 @@ class Anthropic(Llm, AnthropicMixin):
         "claude-opus-4-5"
     ], constant=True)
 
-    temperature = param.Number(default=0.7, bounds=(0, 1), constant=True)
+    temperature = param.Number(default=0.7, bounds=(0, 1), allow_None=True, constant=True)
 
     _supports_logfire = True
     _supports_model_stream = True
@@ -1605,6 +1614,8 @@ class Anthropic(Llm, AnthropicMixin):
 
     @property
     def _client_kwargs(self):
+        if self.temperature is None:
+            return {"max_tokens": 1024}
         return {"temperature": self.temperature, "max_tokens": 1024}
 
     def _create_base_client(self, **kwargs) -> Any:
@@ -1895,7 +1906,7 @@ class Bedrock(Llm, BedrockMixin):
         "anthropic.claude-3-sonnet-20240229-v1:0",
     ], constant=True, doc="Available Claude models on Bedrock")
 
-    temperature = param.Number(default=0.7, bounds=(0, 1), constant=True)
+    temperature = param.Number(default=0.7, bounds=(0, 1), allow_None=True, constant=True)
 
     _instructor_wrapper = "bedrock"
     _supports_stream = True
@@ -1903,6 +1914,8 @@ class Bedrock(Llm, BedrockMixin):
 
     @property
     def _client_kwargs(self):
+        if self.temperature is None:
+            return {"maxTokens": 4096}
         return {"temperature": self.temperature, "maxTokens": 4096}
 
     def _create_base_client(self, **kwargs) -> Any:
@@ -2052,7 +2065,7 @@ class Google(Llm, GenAIMixin):
         "gemini-1.5-pro"
     ], constant=True)
 
-    temperature = param.Number(default=1, bounds=(0, 1), constant=True)
+    temperature = param.Number(default=1, bounds=(0, 1), allow_None=True, constant=True)
 
     _supports_logfire = True
     _supports_model_stream = True
@@ -2298,13 +2311,15 @@ class Google(Llm, GenAIMixin):
         tools = self._translate_tool_specs(kwargs.pop("tools", []))
         client = await self.get_client(model_spec, **kwargs)
         contents, system_instruction, instructor_messages = self._messages_to_contents(messages)
-        config = GenerateContentConfig(
+        config_kwargs = dict(
             http_options=http_options,
-            temperature=self.temperature,
             thinking_config=thinking_config,
             system_instruction=system_instruction,
             tools=tools,
         )
+        if self.temperature is not None:
+            config_kwargs["temperature"] = self.temperature
+        config = GenerateContentConfig(**config_kwargs)
 
         if response_model:
             result = await client(messages=instructor_messages, config=config, **kwargs)
@@ -2391,7 +2406,7 @@ class Ollama(OpenAI):
         "mistral-small3.2:24b",
     ], constant=True)
 
-    temperature = param.Number(default=0.25, bounds=(0, None), constant=True)
+    temperature = param.Number(default=0.25, bounds=(0, None), allow_None=True, constant=True)
 
     def models(self, endpoint: str | None = None) -> set[str]:
         """Return the set of available model identifiers from Ollama."""
@@ -2466,10 +2481,11 @@ class MLX(Llm):
         Note: in server mode this is sent as a per-request parameter
         and does NOT change the server's --max-tokens default.""")
 
-    temperature = param.Number(default=0.4, bounds=(0, None), constant=True, doc="""
+    temperature = param.Number(default=0.4, bounds=(0, None), allow_None=True, constant=True, doc="""
         The sampling temperature. Lower values produce more
         deterministic outputs. In server mode this is sent
-        per-request and does NOT change the server's --temp flag.""")
+        per-request and does NOT change the server's --temp flag.
+        When None, the backend's own default sampler is used.""")
 
     _instructor_wrapper = None
     _supports_vision = False
@@ -2521,6 +2537,8 @@ class MLX(Llm):
     def _make_sampler(self):
         """Create an MLX sampler from the configured temperature."""
         from mlx_lm.sample_utils import make_sampler
+        if self.temperature is None:
+            return make_sampler()
         return make_sampler(temp=self.temperature)
 
     def _create_chat_completion(self, messages: list[Message], **kwargs) -> Any:
@@ -2566,6 +2584,8 @@ class MLX(Llm):
 
     @property
     def _client_kwargs(self) -> dict[str, Any]:
+        if self.temperature is None:
+            return {"max_tokens": self.max_tokens}
         return {"temperature": self.temperature, "max_tokens": self.max_tokens}
 
     @classmethod
@@ -2701,7 +2721,7 @@ class WebLLM(Llm):
         "Qwen2.5-7B-Instruct-q4f16_1-MLC"
     ], constant=True)
 
-    temperature = param.Number(default=0.4, bounds=(0, None))
+    temperature = param.Number(default=0.4, bounds=(0, None), allow_None=True)
 
     # WebLLM doesn't use from_* wrapper - uses patch(create=...)
     _instructor_wrapper = None
@@ -2834,7 +2854,7 @@ class LiteLLM(Llm):
         "mistral/codestral-latest"
     ], constant=True)
 
-    temperature = param.Number(default=0.7, bounds=(0, 2), constant=True)
+    temperature = param.Number(default=0.7, bounds=(0, 2), allow_None=True, constant=True)
 
     _supports_logfire = True
     _supports_stream = True
@@ -2870,7 +2890,7 @@ class LiteLLM(Llm):
     @property
     def _client_kwargs(self):
         """Base kwargs for all LiteLLM calls."""
-        kwargs = {"temperature": self.temperature}
+        kwargs = {} if self.temperature is None else {"temperature": self.temperature}
         kwargs.update(self.litellm_params)
         return kwargs
 

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 # Helpers
 # ---------------------------------------------------------------------------
 
-# (cls, required_init_kwargs, non-temperature keys retained in _client_kwargs, default temperature)
+# (provider, required_init_kwargs, non-temperature keys retained in _client_kwargs, default temperature)
 PROVIDER_SPECS = [
     pytest.param(OpenAI, {}, set(), 0.25, id="openai"),
     pytest.param(AzureOpenAI, {"api_version": "av", "endpoint": "ep"}, set(), 1, id="azure"),
@@ -51,13 +51,13 @@ def _make_test_image() -> Image:
     return Image.from_raw_base64(pixel)
 
 
-def _make(cls, required, temperature="__default__"):
+def _make(provider, required, temperature="__default__"):
     # temperature is constant=True; the sentinel lets us build with the default too.
     kw = dict(required)
     kw["model_kwargs"] = {"default": {"model": "m"}}
     if temperature != "__default__":
         kw["temperature"] = temperature
-    return cls(**kw)
+    return provider(**kw)
 
 # ---------------------------------------------------------------------------
 # AzureOpenAI model kwargs tests
@@ -625,42 +625,51 @@ class TestPrepareVisionMessages:
         assert isinstance(content[1], Image)
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [Llm, LlamaCpp, OpenAI, AzureOpenAI, MistralAI, Anthropic, Bedrock,
-     Google, Ollama, MLX, LiteLLM, WebLLM, Groq],
-)
-def test_temperature_param_allows_none(cls):
-    assert cls.param["temperature"].allow_None is True
+def _all_llm_classes():
+    """Recursively collect ``Llm`` and every subclass so new providers are
+    covered automatically (``__subclasses__`` is not transitive)."""
+    seen = {Llm}
+    stack = [Llm]
+    while stack:
+        for sub in stack.pop().__subclasses__():
+            if sub not in seen:
+                seen.add(sub)
+                stack.append(sub)
+    return sorted(seen, key=lambda c: c.__name__)
+
+
+@pytest.mark.parametrize("provider", _all_llm_classes(), ids=lambda c: c.__name__)
+def test_temperature_param_allows_none(provider):
+    assert provider.param["temperature"].allow_None is True
 
 
 @pytest.mark.parametrize(
-    "cls, required, extra_keys, default_temp",
+    ("provider", "required", "extra_keys", "default_temp"),
     PROVIDER_SPECS + [pytest.param(Google, {}, set(), 1, id="google")],
 )
-def test_construct_with_temperature_none(cls, required, extra_keys, default_temp):
-    llm = _make(cls, required, temperature=None)
+def test_construct_with_temperature_none(provider, required, extra_keys, default_temp):
+    llm = _make(provider, required, temperature=None)
     assert llm.temperature is None
 
 
-@pytest.mark.parametrize("cls, required, extra_keys, default_temp", PROVIDER_SPECS)
-def test_client_kwargs_omits_temperature_when_none(cls, required, extra_keys, default_temp):
-    kwargs = _make(cls, required, temperature=None)._client_kwargs
+@pytest.mark.parametrize(("provider", "required", "extra_keys", "default_temp"), PROVIDER_SPECS)
+def test_client_kwargs_omits_temperature_when_none(provider, required, extra_keys, default_temp):
+    kwargs = _make(provider, required, temperature=None)._client_kwargs
     assert "temperature" not in kwargs
     assert set(kwargs) == extra_keys
 
 
 @pytest.mark.parametrize("temperature", [0.5, 0.0], ids=["positive", "zero_boundary"])
-@pytest.mark.parametrize("cls, required, extra_keys, default_temp", PROVIDER_SPECS)
-def test_client_kwargs_includes_temperature_when_set(cls, required, extra_keys, default_temp, temperature):
-    kwargs = _make(cls, required, temperature=temperature)._client_kwargs
+@pytest.mark.parametrize(("provider", "required", "extra_keys", "default_temp"), PROVIDER_SPECS)
+def test_client_kwargs_includes_temperature_when_set(provider, required, extra_keys, default_temp, temperature):
+    kwargs = _make(provider, required, temperature=temperature)._client_kwargs
     assert kwargs["temperature"] == temperature
     assert extra_keys <= set(kwargs)
 
 
-@pytest.mark.parametrize("cls, required, extra_keys, default_temp", PROVIDER_SPECS)
-def test_default_temperature_preserved(cls, required, extra_keys, default_temp):
-    llm = _make(cls, required)
+@pytest.mark.parametrize(("provider", "required", "extra_keys", "default_temp"), PROVIDER_SPECS)
+def test_default_temperature_preserved(provider, required, extra_keys, default_temp):
+    llm = _make(provider, required)
     assert llm.temperature == default_temp
     assert llm._client_kwargs["temperature"] == default_temp
 
@@ -668,6 +677,13 @@ def test_default_temperature_preserved(cls, required, extra_keys, default_temp):
 def test_google_client_kwargs_unaffected_by_temperature():
     assert Google(model_kwargs={"default": {"model": "m"}}, temperature=None)._client_kwargs == {}
     assert Google(model_kwargs={"default": {"model": "m"}}, temperature=0.5)._client_kwargs == {}
+
+
+def test_webllm_client_kwargs_never_includes_temperature():
+    # WebLLM configures sampling on the panel_web_llm component, not via _client_kwargs.
+    pytest.importorskip("panel_web_llm")
+    assert WebLLM(model_kwargs={"default": {"model": "m"}}, temperature=None)._client_kwargs == {}
+    assert WebLLM(model_kwargs={"default": {"model": "m"}}, temperature=0.5)._client_kwargs == {}
 
 
 def test_mlx_make_sampler_handles_none():

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -13,7 +13,8 @@ try:
 
     from lumen.ai.agents.vega_lite import VegaLiteAgent
     from lumen.ai.llm import (
-        Anthropic, AzureOpenAI, Google, Groq, Llm, Message, MistralAI, OpenAI,
+        MLX, Anthropic, AzureOpenAI, Bedrock, Google, Groq, LiteLLM, LlamaCpp,
+        Llm, Message, MistralAI, Ollama, OpenAI, WebLLM,
     )
 
 except ModuleNotFoundError:
@@ -25,6 +26,19 @@ from pydantic import BaseModel
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+# (cls, required_init_kwargs, non-temperature keys retained in _client_kwargs, default temperature)
+PROVIDER_SPECS = [
+    pytest.param(OpenAI, {}, set(), 0.25, id="openai"),
+    pytest.param(AzureOpenAI, {"api_version": "av", "endpoint": "ep"}, set(), 1, id="azure"),
+    pytest.param(MistralAI, {}, set(), 0.7, id="mistral"),
+    pytest.param(Anthropic, {}, {"max_tokens"}, 0.7, id="anthropic"),
+    pytest.param(Bedrock, {}, {"maxTokens"}, 0.7, id="bedrock"),
+    pytest.param(LlamaCpp, {}, set(), 0.4, id="llamacpp"),
+    pytest.param(MLX, {}, {"max_tokens"}, 0.4, id="mlx"),
+    pytest.param(LiteLLM, {}, set(), 0.7, id="litellm"),
+    pytest.param(Ollama, {}, set(), 0.25, id="ollama"),
+]
 
 def _make_test_image() -> Image:
     """Create a tiny 1x1 PNG encoded as an instructor Image."""
@@ -601,3 +615,70 @@ class TestPrepareVisionMessages:
         assert len(content) == 2
         assert content[0] == "Annotate this"
         assert isinstance(content[1], Image)
+
+
+def _make(cls, required, temperature="__default__"):
+    # temperature is constant=True; the sentinel lets us build with the default too.
+    kw = dict(required)
+    kw["model_kwargs"] = {"default": {"model": "m"}}
+    if temperature != "__default__":
+        kw["temperature"] = temperature
+    return cls(**kw)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [Llm, LlamaCpp, OpenAI, AzureOpenAI, MistralAI, Anthropic, Bedrock,
+     Google, Ollama, MLX, LiteLLM, WebLLM, Groq],
+)
+def test_temperature_param_allows_none(cls):
+    assert cls.param["temperature"].allow_None is True
+
+
+@pytest.mark.parametrize(
+    "cls, required, extra_keys, default_temp",
+    PROVIDER_SPECS + [pytest.param(Google, {}, set(), 1, id="google")],
+)
+def test_construct_with_temperature_none(cls, required, extra_keys, default_temp):
+    llm = _make(cls, required, temperature=None)
+    assert llm.temperature is None
+
+
+@pytest.mark.parametrize("cls, required, extra_keys, default_temp", PROVIDER_SPECS)
+def test_client_kwargs_omits_temperature_when_none(cls, required, extra_keys, default_temp):
+    kwargs = _make(cls, required, temperature=None)._client_kwargs
+    assert "temperature" not in kwargs
+    assert set(kwargs) == extra_keys
+
+
+@pytest.mark.parametrize("temperature", [0.5, 0.0], ids=["positive", "zero_boundary"])
+@pytest.mark.parametrize("cls, required, extra_keys, default_temp", PROVIDER_SPECS)
+def test_client_kwargs_includes_temperature_when_set(cls, required, extra_keys, default_temp, temperature):
+    kwargs = _make(cls, required, temperature=temperature)._client_kwargs
+    assert kwargs["temperature"] == temperature
+    assert extra_keys <= set(kwargs)
+
+
+@pytest.mark.parametrize("cls, required, extra_keys, default_temp", PROVIDER_SPECS)
+def test_default_temperature_preserved(cls, required, extra_keys, default_temp):
+    llm = _make(cls, required)
+    assert llm.temperature == default_temp
+    assert llm._client_kwargs["temperature"] == default_temp
+
+
+def test_anthropic_temperature_none_drops_deprecated_param():
+    llm = Anthropic(model_kwargs={"default": {"model": "claude-opus-4-8"}}, temperature=None)
+    assert llm._client_kwargs == {"max_tokens": 1024}
+
+
+def test_google_client_kwargs_unaffected_by_temperature():
+    assert Google(model_kwargs={"default": {"model": "m"}}, temperature=None)._client_kwargs == {}
+    assert Google(model_kwargs={"default": {"model": "m"}}, temperature=0.5)._client_kwargs == {}
+
+
+def test_mlx_make_sampler_handles_none():
+    pytest.importorskip("mlx_lm.sample_utils")
+    none_llm = MLX(model_kwargs={"default": {"model": "m"}}, temperature=None)
+    set_llm = MLX(model_kwargs={"default": {"model": "m"}}, temperature=0.5)
+    assert callable(none_llm._make_sampler())
+    assert callable(set_llm._make_sampler())

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -665,11 +665,6 @@ def test_default_temperature_preserved(cls, required, extra_keys, default_temp):
     assert llm._client_kwargs["temperature"] == default_temp
 
 
-def test_anthropic_temperature_none_drops_deprecated_param():
-    llm = Anthropic(model_kwargs={"default": {"model": "claude-opus-4-8"}}, temperature=None)
-    assert llm._client_kwargs == {"max_tokens": 1024}
-
-
 def test_google_client_kwargs_unaffected_by_temperature():
     assert Google(model_kwargs={"default": {"model": "m"}}, temperature=None)._client_kwargs == {}
     assert Google(model_kwargs={"default": {"model": "m"}}, temperature=0.5)._client_kwargs == {}

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -51,6 +51,14 @@ def _make_test_image() -> Image:
     return Image.from_raw_base64(pixel)
 
 
+def _make(cls, required, temperature="__default__"):
+    # temperature is constant=True; the sentinel lets us build with the default too.
+    kw = dict(required)
+    kw["model_kwargs"] = {"default": {"model": "m"}}
+    if temperature != "__default__":
+        kw["temperature"] = temperature
+    return cls(**kw)
+
 # ---------------------------------------------------------------------------
 # AzureOpenAI model kwargs tests
 # ---------------------------------------------------------------------------
@@ -615,15 +623,6 @@ class TestPrepareVisionMessages:
         assert len(content) == 2
         assert content[0] == "Annotate this"
         assert isinstance(content[1], Image)
-
-
-def _make(cls, required, temperature="__default__"):
-    # temperature is constant=True; the sentinel lets us build with the default too.
-    kw = dict(required)
-    kw["model_kwargs"] = {"default": {"model": "m"}}
-    if temperature != "__default__":
-        kw["temperature"] = temperature
-    return cls(**kw)
 
 
 @pytest.mark.parametrize(

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -37,7 +37,7 @@ PROVIDER_SPECS = [
     pytest.param(LlamaCpp, {}, set(), 0.4, id="llamacpp"),
     pytest.param(MLX, {}, {"max_tokens"}, 0.4, id="mlx"),
     pytest.param(LiteLLM, {}, set(), 0.7, id="litellm"),
-    pytest.param(Ollama, {}, set(), 0.25, id="ollama"),
+    pytest.param(Ollama, {"api_key": "ollama"}, set(), 0.25, id="ollama"),
 ]
 
 def _make_test_image() -> Image:


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Allows setting temperature=None so that there's an escape hatch for:

```python
from lumen.ai.llm import OpenAI

client = OpenAI(model_kwargs={"default": {"model": "o1"}})
await client.invoke(messages=[{"role": "user", "content": "What is the capital of France?"}])
```

> BadRequestError: Error code: 400 - {'error': {'message': "Unsupported parameter: 'temperature' is not supported with this model.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': 'unsupported_parameter'}}

```python
from lumen.ai.llm import OpenAI

client = OpenAI(model_kwargs={"default": {"model": "o1"}}, temperature=None)
await client.invoke(messages=[{"role": "user", "content": "What is the capital of France?"}])
```

> ...ChatCompletionMessage(content='The capital of France is Paris.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]...

I considered completely defaulting all temperatures = None, but I think that's breaking change, so this escape hatch is probably better for a micro version release.

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model:
Usage: Used to discuss pros and cons and implement.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR

## Checklist
<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
- [x] Added documentation
