### PR TITLE
Add coordinate-aware filters to exploration outputs (completes #1599)

### DIFF
--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -574,6 +574,27 @@ class SQLAgent(BaseLumenAgent):
             mirrors[renamed_table] = (sources[(m.source, m.table)], m.table)
         return DuckDBSource(uri=":memory:", mirrors=mirrors), list(mirrors)
 
+    @staticmethod
+    def _active_filters(pipeline: Pipeline | None) -> list[str] | None:
+        """Describe the interactive filters currently applied to ``pipeline`` as
+        WHERE-style conditions so a follow-up query can preserve the subset.
+        Returns None when there is no pipeline or no active filter."""
+        if pipeline is None:
+            return None
+        conditions = []
+        for filt in pipeline.filters:
+            query = filt.query
+            if query is None:
+                continue
+            if isinstance(query, tuple) and len(query) == 2:
+                condition = f"between {query[0]} and {query[1]}"
+            elif isinstance(query, (list, set)):
+                condition = f"in ({', '.join(repr(v) for v in query)})"
+            else:
+                condition = f"= {query!r}"
+            conditions.append(f"{filt.field} {condition}")
+        return conditions or None
+
     @retry_llm_output()
     async def _render_execute_query(
         self,
@@ -644,6 +665,7 @@ class SQLAgent(BaseLumenAgent):
                 sql_plan_context=None,
                 errors=errors,
                 discovery_context=discovery_context,
+                active_filters=self._active_filters(context.get("pipeline")),
                 source_names=sorted({s for s, _ in sources}),
                 tools=tool_list,
             )

--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -1,5 +1,6 @@
 import typing as t
 
+import pandas as pd
 import param
 import yaml
 
@@ -7,6 +8,7 @@ from panel.chat import ChatStep
 from pydantic import BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
 
+from ...filters import ConstantFilter
 from ...pipeline import Pipeline
 from ...sources.base import BaseSQLSource, Source
 from ...sources.duckdb import DuckDBSource
@@ -273,6 +275,93 @@ def make_load_table_schemas_tool(metaset: Metaset) -> FunctionTool:
     )
 
 
+_RANGE_FIELD_TYPES = ("number", "integer")
+
+
+def _coerce_filter_value(field_schema: dict[str, t.Any], value: t.Any) -> t.Any:
+    """Coerce an LLM-supplied filter value to what the Source expects.
+
+    A two-element ``[lo, hi]`` list on a numeric or datetime field becomes a
+    ``(lo, hi)`` tuple (interpreted as an inclusive range / ``BETWEEN``); datetime
+    bounds are parsed to timestamps. Scalars (equality) and longer lists
+    (membership / ``IN``) are passed through unchanged.
+    """
+    is_datetime = field_schema.get("format") in ("date", "date-time", "datetime")
+    if isinstance(value, (list, tuple)) and len(value) == 2 and (
+        field_schema.get("type") in _RANGE_FIELD_TYPES or is_datetime
+    ):
+        lo, hi = value
+        if is_datetime:
+            lo, hi = pd.Timestamp(lo), pd.Timestamp(hi)
+        return (lo, hi)
+    return value
+
+
+def make_apply_filter_tool(pipeline: Pipeline) -> FunctionTool:
+    """Build a :class:`~lumen.ai.tools.FunctionTool` that filters ``pipeline``.
+
+    The tool lets the chat agent narrow the data already loaded in the current
+    exploration -- subsetting an xarray coordinate dimension (``time``/``lat``/
+    ``lon``/level) or a tabular column. It adds a
+    :class:`~lumen.filters.base.Filter` to the pipeline (the same machinery as
+    the manual "Add Filter" UI), which subsets the data without modifying the
+    SQL query.
+
+    Known limitation: this tool is registered on :class:`SQLAgent`, whose
+    response also emits a SQL query. A single "filter" request can therefore
+    both apply this in-place pipeline filter to the current exploration and open
+    a new exploration whose SQL carries an equivalent ``WHERE`` clause. Giving
+    the tool a dedicated, non-SQL-emitting home is tracked as follow-up work.
+    """
+    schema = pipeline.schema or {}
+    filterable = [c for c in schema if c != "__len__"]
+
+    async def apply_filter(field: str, value: t.Any) -> str:
+        if field not in filterable:
+            return (
+                f"Cannot filter on {field!r}: not a column of this table. "
+                f"Filterable fields: {', '.join(filterable) or '(none)'}."
+            )
+        try:
+            coerced = _coerce_filter_value(schema[field], value)
+            filt = ConstantFilter(field=field, value=coerced, schema=schema)
+            # Replace any existing filter on the same field so repeated calls
+            # refine rather than stack contradictory conditions.
+            pipeline.filters = [f for f in pipeline.filters if f.field != field]
+            pipeline.add_filter(filt)
+        except Exception as exc:
+            return f"Could not apply filter on {field!r} with value {value!r}: {exc}"
+        return f"Applied filter on {field!r} ({value!r}); {len(pipeline.data)} rows match."
+
+    fields = ", ".join(filterable) or "(none)"
+    apply_filter.__doc__ = (
+        "Filter the current exploration's data on a single field. "
+        f"Filterable fields: {fields}. "
+        "Pass a [min, max] list for a numeric or datetime range, a single value "
+        "for an exact match, or a list of values for membership."
+    )
+    return FunctionTool(
+        apply_filter,
+        purpose=(
+            "Subset the data already loaded in the current exploration (e.g. an "
+            "xarray coordinate such as time/lat/lon, or a tabular column). Prefer "
+            "this over rewriting SQL when the user wants to narrow the existing result."
+        ),
+    )
+
+
+def make_apply_filter_llm_tool(context: TContext):
+    """Expose :func:`make_apply_filter_tool` as a context-gated ``llm_tools`` entry.
+
+    Returns the tool only when a pipeline is present in working memory, so it is
+    offered to the LLM exactly when there is an existing exploration to filter.
+    """
+    pipeline = context.get("pipeline")
+    if pipeline is None:
+        return []
+    return make_apply_filter_tool(pipeline)
+
+
 class SQLInputs(ContextModel):
 
     data: t.NotRequired[t.Any]
@@ -313,6 +402,12 @@ class SQLAgent(BaseLumenAgent):
     )
 
     exclusions = param.List(default=["dbtsl_metaset"])
+
+    # When an exploration pipeline is already in context, let the LLM narrow it
+    # with apply_filter. NOTE: SQLAgent also emits a SQL query, so a filter
+    # request may both apply this in-place filter and open a new SQL exploration
+    # (see make_apply_filter_tool for the known limitation / follow-up).
+    llm_tools = param.List(default=[make_apply_filter_llm_tool])
 
     not_with = param.List(default=["DbtslAgent", "MetadataLookup", "TableListAgent"])
 

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -523,15 +523,18 @@ class SQLEditor(LumenEditor):
         self._filters: dict[str, WidgetFilter] = {}
         self._filter_area = FlexBox(
             sizing_mode="stretch_width", justify_content="space-evenly",
-            max_height=300, styles={"overflow-y": "auto"},
+            styles={"gap": "8px", "align-content": "flex-start"},
         )
         # The filter widgets live in a Paper that the exploration view places
         # above the editor/table split (see ExplorerUI._render_view), so adding
         # filters pushes both the SQL editor and the results table down. Only
-        # shown once at least one filter has been added.
+        # shown once at least one filter has been added. The Paper fills its
+        # split pane and scrolls internally (padding for margins) so tall
+        # multi-select filters stay contained instead of overlapping the editor.
         self._filter_paper = Paper(
-            self._filter_area, elevation=2, margin=(5, 10),
-            sizing_mode="stretch_width", visible=False,
+            self._filter_area, elevation=2, margin=(8, 10),
+            sizing_mode="stretch_both", styles={"overflow-y": "auto", "padding": "10px"},
+            visible=False,
         )
         return editor
 
@@ -595,14 +598,16 @@ class SQLEditor(LumenEditor):
                 # Cap each filter's width so two fit per row; the FlexBox's
                 # space-evenly justification gives equal gaps. Use the compact
                 # size, hide the always-on value, and surface the range as a
-                # hover tooltip (description). size/show_value are slider-only,
-                # so guard for non-slider filters (e.g. Select).
+                # hover tooltip (description).
                 widget_opts = {
                     "width": 180, "margin": (8, 5),
                     "description": self._filter_tooltip(self.component.schema[field]),
                 }
                 params = filt.widget.param
-                if "size" in params:
+                # `size` is a small/medium/large Selector on sliders but a
+                # visible-rows Integer on MultiChoice/TextInput, so only set it
+                # where "small" is a valid choice. show_value is slider-only.
+                if "size" in params and "small" in (getattr(params["size"], "objects", None) or []):
                     widget_opts["size"] = "small"
                 if "show_value" in params:
                     widget_opts["show_value"] = False

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -549,15 +549,23 @@ class SQLEditor(LumenEditor):
             return "text_fields"
         return self._filter_icons.get(col_type, "help")
 
-    def _filter_items(self) -> list[dict[str, str]]:
+    def _filter_items(self) -> list[dict[str, Any]]:
         # Coordinate dimensions (if any) are listed first, then data variables /
         # tabular columns. Tabular sources carry no "dimension" flag, so their
-        # ordering is unchanged.
+        # ordering is unchanged. Columns with an active filter show a filled
+        # check (review: make the active state visible in the menu).
+        active = {filt.field for filt in self.component.filters}
         dimensions, variables = [], []
         for col, col_schema in self.component.schema.items():
             if col == "__len__":
                 continue
-            item = {"label": col, "icon": self._filter_icon(col_schema)}
+            item = {
+                "label": col,
+                "icon": self._filter_icon(col_schema),
+                "active_icon": "check_circle",
+                "active_color": "primary",
+                "toggled": col in active,
+            }
             (dimensions if col_schema.get("dimension") else variables).append(item)
         return dimensions + variables
 
@@ -569,8 +577,13 @@ class SQLEditor(LumenEditor):
                 filt = WidgetFilter(field=field, schema=self.component.schema)
                 # Cap each filter's width (review: it was too long) so two fit
                 # per row; the FlexBox's space-evenly justification gives equal
-                # gaps before, between and after them. Vertical margin only.
-                filt.widget.param.update(width=180, margin=(10, 0))
+                # gaps before, between and after them. Small vertical margin.
+                widget_opts = {"width": 180, "margin": (5, 0)}
+                # Hide the slider value readout for a cleaner look (review);
+                # non-slider filter widgets (e.g. Select) lack this param.
+                if "show_value" in filt.widget.param:
+                    widget_opts["show_value"] = False
+                filt.widget.param.update(**widget_opts)
                 self._filters[field] = filt
             self._filter_area.append(filt.widget)
             self.component.add_filter(filt)

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -549,6 +549,19 @@ class SQLEditor(LumenEditor):
             return "text_fields"
         return self._filter_icons.get(col_type, "help")
 
+    def _filter_tooltip(self, col_schema: dict[str, Any]) -> str:
+        # Hover hint showing the column's filterable range (min .. max) or, for
+        # categorical columns, its options. Empty when neither is available.
+        lo, hi = col_schema.get("inclusiveMinimum"), col_schema.get("inclusiveMaximum")
+        if lo is not None and hi is not None:
+            if col_schema.get("type") in ("number", "integer"):
+                return f"{lo:g} .. {hi:g}"
+            return f"{lo} .. {hi}"
+        enum = col_schema.get("enum")
+        if enum:
+            return ", ".join(map(str, enum[:6])) + (", ..." if len(enum) > 6 else "")
+        return ""
+
     def _filter_items(self) -> list[dict[str, Any]]:
         # Coordinate dimensions (if any) are listed first, then data variables /
         # tabular columns. Tabular sources carry no "dimension" flag, so their
@@ -566,6 +579,9 @@ class SQLEditor(LumenEditor):
                 "active_color": "primary",
                 "toggled": col in active,
             }
+            tooltip = self._filter_tooltip(col_schema)
+            if tooltip:
+                item["tooltip"] = tooltip
             (dimensions if col_schema.get("dimension") else variables).append(item)
         return dimensions + variables
 
@@ -578,7 +594,12 @@ class SQLEditor(LumenEditor):
                 # Cap each filter's width (review: it was too long) so two fit
                 # per row; the FlexBox's space-evenly justification gives equal
                 # gaps before, between and after them. Small vertical margin.
-                widget_opts = {"width": 180, "margin": (5, 0)}
+                # The range is surfaced as a hover tooltip (description) since the
+                # always-on value readout is hidden below.
+                widget_opts = {
+                    "width": 180, "margin": (5, 0),
+                    "description": self._filter_tooltip(self.component.schema[field]),
+                }
                 # Hide the slider value readout for a cleaner look (review);
                 # non-slider filter widgets (e.g. Select) lack this param.
                 if "show_value" in filt.widget.param:

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -23,7 +23,7 @@ from panel.widgets import CodeEditor
 from panel_gwalker import GraphicWalker
 from panel_material_ui import (
     Alert, Button, Checkbox, CircularProgress, FileDownload, FlexBox,
-    FloatInput, MenuButton, MenuToggle, Tabs,
+    FloatInput, MenuButton, MenuToggle, Paper, Tabs,
 )
 from PIL import Image
 
@@ -521,8 +521,15 @@ class SQLEditor(LumenEditor):
     def _render_editor(self):
         editor = super()._render_editor()
         self._filters: dict[str, WidgetFilter] = {}
-        self._filter_area = FlexBox(width_policy="max")
-        editor.insert(0, self._filter_area)
+        self._filter_area = FlexBox(sizing_mode="stretch_width")
+        # The filter widgets live in a Paper that the exploration view places
+        # above the editor/table split (see ExplorerUI._render_view), so adding
+        # filters pushes both the SQL editor and the results table down. Only
+        # shown once at least one filter has been added.
+        self._filter_paper = Paper(
+            self._filter_area, elevation=2, margin=(5, 10),
+            sizing_mode="stretch_width", visible=False,
+        )
         return editor
 
     def _filter_icon(self, col_schema: dict[str, Any]) -> str:
@@ -555,13 +562,16 @@ class SQLEditor(LumenEditor):
     def _add_filter(self, item):
         field = item["label"]
         if item["toggled"]:
-            if field not in self._filters:
-                self._filters[field] = WidgetFilter(
-                    field=field, schema=self.component.schema
-                )
-            filt = self._filters[field]
+            filt = self._filters.get(field)
+            if filt is None:
+                filt = WidgetFilter(field=field, schema=self.component.schema)
+                # Stretch to fill the panel, with margin so the handle is not
+                # flush against the edge (per review feedback).
+                filt.widget.param.update(sizing_mode="stretch_width", margin=(10, 15))
+                self._filters[field] = filt
             self._filter_area.append(filt.widget)
             self.component.add_filter(filt)
+            self._filter_paper.visible = True
             return
         removed = [filt for filt in self.component.filters if filt.field == field]
         removed_widgets = [filt.widget for filt in removed]
@@ -569,6 +579,7 @@ class SQLEditor(LumenEditor):
         self.component.filters = [
             filt for filt in self.component.filters if filt not in removed
         ]
+        self._filter_paper.visible = bool(len(self._filter_area))
 
     def render_controls(self, task: Task, interface: ChatFeed):
         controls = super().render_controls(task, interface)

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -522,7 +522,8 @@ class SQLEditor(LumenEditor):
         editor = super()._render_editor()
         self._filters: dict[str, WidgetFilter] = {}
         self._filter_area = FlexBox(
-            sizing_mode="stretch_width", justify_content="space-evenly"
+            sizing_mode="stretch_width", justify_content="space-evenly",
+            max_height=300, styles={"overflow-y": "auto"},
         )
         # The filter widgets live in a Paper that the exploration view places
         # above the editor/table split (see ExplorerUI._render_view), so adding
@@ -591,18 +592,19 @@ class SQLEditor(LumenEditor):
             filt = self._filters.get(field)
             if filt is None:
                 filt = WidgetFilter(field=field, schema=self.component.schema)
-                # Cap each filter's width (review: it was too long) so two fit
-                # per row; the FlexBox's space-evenly justification gives equal
-                # gaps before, between and after them. Small vertical margin.
-                # The range is surfaced as a hover tooltip (description) since the
-                # always-on value readout is hidden below.
+                # Cap each filter's width so two fit per row; the FlexBox's
+                # space-evenly justification gives equal gaps. Use the compact
+                # size, hide the always-on value, and surface the range as a
+                # hover tooltip (description). size/show_value are slider-only,
+                # so guard for non-slider filters (e.g. Select).
                 widget_opts = {
-                    "width": 180, "margin": (5, 0),
+                    "width": 180, "margin": (8, 5),
                     "description": self._filter_tooltip(self.component.schema[field]),
                 }
-                # Hide the slider value readout for a cleaner look (review);
-                # non-slider filter widgets (e.g. Select) lack this param.
-                if "show_value" in filt.widget.param:
+                params = filt.widget.param
+                if "size" in params:
+                    widget_opts["size"] = "small"
+                if "show_value" in params:
                     widget_opts["show_value"] = False
                 filt.widget.param.update(**widget_opts)
                 self._filters[field] = filt

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -23,12 +23,13 @@ from panel.widgets import CodeEditor
 from panel_gwalker import GraphicWalker
 from panel_material_ui import (
     Alert, Button, Checkbox, CircularProgress, FileDownload, FlexBox,
-    FloatInput, MenuButton, Tabs,
+    FloatInput, MenuButton, MenuToggle, Tabs,
 )
 from PIL import Image
 
 from ..base import Component
 from ..config import dump_yaml, load_yaml
+from ..filters import WidgetFilter
 from ..pipeline import Pipeline
 from ..transforms.sql import SQLLimit
 from ..views.base import Panel, Table, View
@@ -509,6 +510,78 @@ class SQLEditor(LumenEditor):
 
     export_formats = ("sql", "csv", "xlsx", "json", "markdown")
     _label = "Table"
+
+    # Icon shown in the "Add Filter" menu for each schema type.
+    _filter_icons = {
+        "number": "calculate",
+        "integer": "numbers",
+        "boolean": "toggle_on",
+    }
+
+    def _render_editor(self):
+        editor = super()._render_editor()
+        self._filters: dict[str, WidgetFilter] = {}
+        self._filter_area = FlexBox(width_policy="max")
+        editor.insert(0, self._filter_area)
+        return editor
+
+    def _filter_icon(self, col_schema: dict[str, Any]) -> str:
+        if col_schema.get("dimension"):
+            # Coordinate axis of an xarray source (time/lat/lon/level, ...).
+            if col_schema.get("format") == "datetime":
+                return "schedule"
+            return "straighten"
+        col_type = col_schema.get("type")
+        if col_type == "string":
+            if "enum" in col_schema:
+                return "format_list_bulleted"
+            elif col_schema.get("format") == "datetime":
+                return "calendar_month"
+            return "text_fields"
+        return self._filter_icons.get(col_type, "help")
+
+    def _filter_items(self) -> list[dict[str, str]]:
+        # Coordinate dimensions (if any) are listed first, then data variables /
+        # tabular columns. Tabular sources carry no "dimension" flag, so their
+        # ordering is unchanged.
+        dimensions, variables = [], []
+        for col, col_schema in self.component.schema.items():
+            if col == "__len__":
+                continue
+            item = {"label": col, "icon": self._filter_icon(col_schema)}
+            (dimensions if col_schema.get("dimension") else variables).append(item)
+        return dimensions + variables
+
+    def _add_filter(self, item):
+        field = item["label"]
+        if item["toggled"]:
+            if field not in self._filters:
+                self._filters[field] = WidgetFilter(
+                    field=field, schema=self.component.schema
+                )
+            filt = self._filters[field]
+            self._filter_area.append(filt.widget)
+            self.component.add_filter(filt)
+            return
+        removed = [filt for filt in self.component.filters if filt.field == field]
+        removed_widgets = [filt.widget for filt in removed]
+        self._filter_area[:] = [w for w in self._filter_area if w not in removed_widgets]
+        self.component.filters = [
+            filt for filt in self.component.filters if filt not in removed
+        ]
+
+    def render_controls(self, task: Task, interface: ChatFeed):
+        controls = super().render_controls(task, interface)
+        filter_controls = MenuToggle(
+            items=self._filter_items(),
+            label="Add Filter",
+            icon="filter_list",
+            margin=0,
+            variant="text",
+            on_click=self._add_filter,
+        )
+        controls.insert(1, filter_controls)
+        return controls
 
     def export(self, fmt: str) -> StringIO | BytesIO:
         super().export(fmt)

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -521,7 +521,9 @@ class SQLEditor(LumenEditor):
     def _render_editor(self):
         editor = super()._render_editor()
         self._filters: dict[str, WidgetFilter] = {}
-        self._filter_area = FlexBox(sizing_mode="stretch_width")
+        self._filter_area = FlexBox(
+            sizing_mode="stretch_width", justify_content="space-evenly"
+        )
         # The filter widgets live in a Paper that the exploration view places
         # above the editor/table split (see ExplorerUI._render_view), so adding
         # filters pushes both the SQL editor and the results table down. Only
@@ -565,9 +567,10 @@ class SQLEditor(LumenEditor):
             filt = self._filters.get(field)
             if filt is None:
                 filt = WidgetFilter(field=field, schema=self.component.schema)
-                # Stretch to fill the panel, with margin so the handle is not
-                # flush against the edge (per review feedback).
-                filt.widget.param.update(sizing_mode="stretch_width", margin=(10, 15))
+                # Cap each filter's width (review: it was too long) so two fit
+                # per row; the FlexBox's space-evenly justification gives equal
+                # gaps before, between and after them. Vertical margin only.
+                filt.widget.param.update(width=180, margin=(10, 0))
                 self._filters[field] = filt
             self._filter_area.append(filt.widget)
             self.component.add_filter(filt)

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -66,6 +66,14 @@ Step {{ step_number }}: {{ current_step }}
 
 Use materialized tables above instead of rebuilding CTEs
 {%- endif %}
+
+{%- if active_filters %}
+## Active exploration filters
+The user has interactively subset the current data with these filters. Add the equivalent WHERE conditions so the results stay consistent with what they are looking at:
+{% for condition in active_filters %}
+- {{ condition }}
+{%- endfor %}
+{%- endif %}
 {% endblock %}
 
 {%- block errors %}

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -19,6 +19,7 @@ from panel.config import panel_extension
 from panel.io.document import hold
 from panel.io.state import state
 from panel.layout import Column, FlexBox
+from panel.param import ParamFunction
 from panel.pane import SVG, Image, Markdown
 from panel.util import edit_readonly
 from panel.viewable import (
@@ -2480,7 +2481,28 @@ class ExplorerUI(UI):
             styles={"overflow": "auto"},
             stylesheets=SPLITJS_STYLESHEETS
         )
-        view = Column(controls, vsplit)
+        # Only when filters are present, show them in a Paper above the
+        # editor/table split with a draggable divider just above the SQL editor
+        # (so the user can resize the filter area). With no filters there is no
+        # extra split above the editor.
+        filter_paper = getattr(view, "_filter_paper", None)
+        if filter_paper is None:
+            body = vsplit
+        else:
+            def _filter_split(visible):
+                if not visible:
+                    return vsplit
+                return VSplit(
+                    filter_paper, vsplit,
+                    expanded_sizes=(30, 70), sizes=(30, 70),
+                    sizing_mode="stretch_both", styles={"overflow": "auto"},
+                    stylesheets=SPLITJS_STYLESHEETS,
+                )
+            body = ParamFunction(
+                param.bind(_filter_split, filter_paper.param.visible),
+                sizing_mode="stretch_both",
+            )
+        view = Column(controls, body)
         controls.append(self._render_pop_out(exploration, view, title))
         return (title, view)
 

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -20,7 +20,6 @@ from panel.io.document import hold
 from panel.io.state import state
 from panel.layout import Column, FlexBox
 from panel.pane import SVG, Image, Markdown
-from panel.param import ParamFunction
 from panel.util import edit_readonly
 from panel.viewable import (
     Child, Children, Viewable, Viewer,
@@ -2481,44 +2480,51 @@ class ExplorerUI(UI):
             styles={"overflow": "auto"},
             stylesheets=SPLITJS_STYLESHEETS
         )
-        # Only when filters are present, show them in a Paper above the
-        # editor/table split with a draggable divider just above the SQL editor
-        # (so the user can resize the filter area). With no filters there is no
-        # extra split above the editor.
+        # When filters are present, show them in a Paper above the editor/table
+        # split with a draggable divider just above the SQL editor (so the user
+        # can resize the filter area); with no filters the body stays the bare
+        # editor/table split, so no extra divider appears. The split is kept as
+        # the Column's body (a watcher swaps it in and out) rather than wrapped
+        # in a reactive pane, so the pop-out helpers still find it as a VSplit.
         filter_paper = getattr(view, "_filter_paper", None)
-        if filter_paper is None:
-            body = vsplit
-        else:
-            def _filter_split(visible):
-                if not visible:
-                    return vsplit
-                return VSplit(
-                    filter_paper, vsplit,
-                    expanded_sizes=(15, 85), sizes=(15, 85),
-                    sizing_mode="stretch_both", styles={"overflow": "auto"},
-                    stylesheets=SPLITJS_STYLESHEETS,
-                )
-            body = ParamFunction(
-                param.bind(_filter_split, filter_paper.param.visible),
-                sizing_mode="stretch_both",
-            )
-        view = Column(controls, body)
+        view = Column(controls, vsplit)
+        if filter_paper is not None:
+            def _toggle_filter_pane(event):
+                if event.new:
+                    view[1] = VSplit(
+                        filter_paper, vsplit,
+                        expanded_sizes=(15, 85), sizes=(15, 85),
+                        sizing_mode="stretch_both", styles={"overflow": "auto"},
+                        stylesheets=SPLITJS_STYLESHEETS,
+                    )
+                else:
+                    view[1] = vsplit
+            filter_paper.param.watch(_toggle_filter_pane, "visible")
         controls.append(self._render_pop_out(exploration, view, title))
         return (title, view)
+
+    def _vsplit_has_view(self, content, view) -> bool:
+        # The body is the editor/table VSplit, or - when filters are active - a
+        # filter VSplit wrapping it one level deeper. Search both so pop-out can
+        # locate the table view regardless of whether the filter pane is shown.
+        if not isinstance(content, VSplit):
+            return False
+        if view in content:
+            return True
+        return any(self._vsplit_has_view(child, view) for child in content)
 
     def _find_view_in_tabs(self, exploration: Exploration, out: LumenEditor):
         tabs = exploration.view[0]
         for i, tab in enumerate(tabs[1:], start=1):
             content = tab[1][1] if isinstance(tab, tuple) and len(tab) > 1 else tab[1]
-            if isinstance(content, VSplit) and out.view in content:
+            if self._vsplit_has_view(content, out.view):
                 return i
         return None
 
     def _find_view_in_popped_out(self, exploration: Exploration, out: LumenEditor):
         for i, standalone in enumerate(exploration.view[1:], start=1):
             if isinstance(standalone, Column) and len(standalone) > 1:
-                vsplit = standalone[1][1]
-                if isinstance(vsplit, VSplit) and out.view in vsplit:
+                if self._vsplit_has_view(standalone[1][1], out.view):
                     return i
         return None
 

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -2493,7 +2493,7 @@ class ExplorerUI(UI):
                 if event.new:
                     view[1] = VSplit(
                         filter_paper, vsplit,
-                        expanded_sizes=(15, 85), sizes=(15, 85),
+                        expanded_sizes=(25, 75), sizes=(25, 75),
                         sizing_mode="stretch_both", styles={"overflow": "auto"},
                         stylesheets=SPLITJS_STYLESHEETS,
                     )

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -19,8 +19,8 @@ from panel.config import panel_extension
 from panel.io.document import hold
 from panel.io.state import state
 from panel.layout import Column, FlexBox
-from panel.param import ParamFunction
 from panel.pane import SVG, Image, Markdown
+from panel.param import ParamFunction
 from panel.util import edit_readonly
 from panel.viewable import (
     Child, Children, Viewable, Viewer,

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -2494,7 +2494,7 @@ class ExplorerUI(UI):
                     return vsplit
                 return VSplit(
                     filter_paper, vsplit,
-                    expanded_sizes=(30, 70), sizes=(30, 70),
+                    expanded_sizes=(15, 85), sizes=(15, 85),
                     sizing_mode="stretch_both", styles={"overflow": "auto"},
                     stylesheets=SPLITJS_STYLESHEETS,
                 )

--- a/lumen/filters/base.py
+++ b/lumen/filters/base.py
@@ -334,7 +334,7 @@ class WidgetFilter(BaseWidgetFilter):
             self.widget.options = options
         self.widget.param.update(
             disabled=self.disabled,
-            label=self.label,
+            label=self.label or self.field,
             visible=self.visible
         )
         val = self.value

--- a/lumen/schema.py
+++ b/lumen/schema.py
@@ -3,7 +3,7 @@ import panel as pn
 import param  # type: ignore
 
 from panel_material_ui import (
-    Checkbox, DatePicker, DateRangeSlider, DatetimeInput, DatetimePicker,
+    Checkbox, DatePicker, DateRangeSlider, DatetimePicker, DatetimeRangeSlider,
     FloatInput, FloatSlider, IntInput, IntRangeSlider, IntSlider, LiteralInput,
     MultiChoice, RangeSlider, Select, TextInput,
 )
@@ -50,17 +50,8 @@ class JSONSchema(pn.pane.PaneBase):
     _literal_widget = LiteralInput
     _unbounded_date_widget = DatePicker
     _date_range_widget = DateRangeSlider
-
-    try:
-        _datetime_range_widget = pn.widgets.DatetimeRangeInput
-    except Exception:
-        _datetime_range_widget = DateRangeSlider
-
-    try:
-        _unbounded_datetime_widget = DatetimePicker
-        _datetime_range_widget = pn.widgets.DatetimeRangePicker
-    except Exception:
-        _unbounded_datetime_widget = DatetimeInput
+    _unbounded_datetime_widget = DatetimePicker
+    _datetime_range_widget = DatetimeRangeSlider
 
     def _array_type(self, schema):
         if 'items' in schema and not schema.get('additionalItems', True):
@@ -160,7 +151,7 @@ class JSONSchema(pn.pane.PaneBase):
         values = {} if self.object is None else self.object
         widgets = []
         for p, schema in self.schema.items():
-            if p == '__len__' or self.properties and p not in self.properties:
+            if p == '__len__' or (self.properties and p not in self.properties):
                 continue
             for prop in self._precedence:
                 if prop in schema:

--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -205,7 +205,30 @@ class XArraySQLSource(BaseSQLSource):
     def get_schema(self, table=None, limit=None, shuffle=False):
         # DataFusion supports neither TABLESAMPLE nor ORDER BY RAND(),
         # so force shuffle=False to make the parent use SQLLimit instead.
-        return super().get_schema(table, limit, shuffle=False)
+        schema = super().get_schema(table, limit, shuffle=False)
+        if table is None:
+            for tname, tschema in schema.items():
+                self._annotate_dimensions(tname, tschema)
+        else:
+            self._annotate_dimensions(table, schema)
+        return schema
+
+    def _annotate_dimensions(self, table: str, tschema: dict[str, Any]) -> None:
+        """Flag coordinate-dimension columns so filter UIs can surface them.
+
+        A column is marked ``"dimension": True`` when it is a dimension
+        coordinate of the dataset (a label-based axis such as ``time``/``lat``/
+        ``lon``). This holds for any table exposing those columns -- the raw
+        data variable as well as the derived/exploration tables produced by SQL
+        queries -- not just the data-variable table itself. The flag is
+        additive: consumers that do not understand it (tabular filter widgets,
+        ``auto_filters``) ignore it.
+        """
+        ds = self._dataset
+        dim_coords = {dim for dim in ds.dims if dim in ds.coords}
+        for col, col_schema in tschema.items():
+            if col in dim_coords and isinstance(col_schema, dict):
+                col_schema["dimension"] = True
 
     # ---- BaseSQLSource required overrides ----
 

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -1,6 +1,7 @@
 import json
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -274,3 +275,47 @@ class TestTemplateOverrides:
         messages = [{"role": "user", "content": "test"}]
         prompt = await agent._render_prompt("main", messages, {})
         assert "Footer appended." in prompt
+
+
+def test_sqlagent_active_filters_describes_conditions():
+    """SQLAgent._active_filters turns the interactive slider filters into
+    WHERE-style conditions (skipping inactive/full-range ones) so a follow-up
+    query can preserve the subset."""
+    class _Filter:
+        def __init__(self, field, query):
+            self.field, self._query = field, query
+
+        @property
+        def query(self):
+            return self._query
+
+    pipeline = SimpleNamespace(filters=[
+        _Filter("game_year", (2000, 2016)),
+        _Filter("game_season", ["Summer", "Winter"]),
+        _Filter("game_location", "Japan"),
+        _Filter("game_slug", None),  # full range / nothing selected -> skipped
+    ])
+    assert SQLAgent._active_filters(pipeline) == [
+        "game_year between 2000 and 2016",
+        "game_season in ('Summer', 'Winter')",
+        "game_location = 'Japan'",
+    ]
+    assert SQLAgent._active_filters(None) is None
+    assert SQLAgent._active_filters(SimpleNamespace(filters=[])) is None
+
+
+async def test_sqlagent_prompt_surfaces_active_filters(llm):
+    """Active exploration filters are surfaced in the SQL agent's prompt so a
+    follow-up query keeps the subset."""
+    agent = SQLAgent(llm=llm)
+    messages = [{"role": "user", "content": "top 5 rows"}]
+    prompt = await agent._render_prompt(
+        "main", messages, {},
+        dialect="duckdb", is_final_step=True, step_number=1, current_step="",
+        sql_query_history={}, current_iteration=1, sql_plan_context=None,
+        errors=None, discovery_context=None, source_names=["src"],
+        active_filters=["game_year between 2000 and 2016", "game_season in ('Summer')"],
+    )
+    assert "Active exploration filters" in prompt
+    assert "game_year between 2000 and 2016" in prompt
+    assert "game_season in ('Summer')" in prompt

--- a/lumen/tests/ai/test_editors.py
+++ b/lumen/tests/ai/test_editors.py
@@ -166,6 +166,18 @@ def test_add_filter_creates_labeled_widget(sql_pipeline_editor):
     assert filt.widget in list(editor._filter_area)
 
 
+def test_add_filter_creates_string_widget(sql_pipeline_editor):
+    # A string/categorical column yields a MultiChoice whose `size` param is an
+    # integer, not the slider's small/medium/large selector; adding it must not
+    # crash on the compact-size styling (regression: it raised ValueError, so the
+    # string filter never rendered).
+    editor = sql_pipeline_editor
+    editor._add_filter({"label": "category", "toggled": True})
+    filt = editor._filters["category"]
+    assert filt in editor.component.filters
+    assert filt.widget in list(editor._filter_area)
+
+
 def test_filter_subsets_and_restores_data(sql_pipeline_editor):
     editor = sql_pipeline_editor
     pipeline = editor.component

--- a/lumen/tests/ai/test_editors.py
+++ b/lumen/tests/ai/test_editors.py
@@ -13,6 +13,8 @@ import lumen.ai.editors as editors_module
 
 from lumen.ai.editors import LumenEditor, SQLEditor, VegaLiteEditor
 from lumen.base import Component
+from lumen.pipeline import Pipeline
+from lumen.sources.duckdb import DuckDBSource
 
 
 class MockComponent(Component):
@@ -128,6 +130,116 @@ def test_vegalite_pillow_export(vegalite_editor, mock_panel, fmt, validate):
     assert mock_panel.calls[-1] == ("png", {"scale": 2})
 
 
+@pytest.fixture
+def sql_pipeline_editor(monkeypatch):
+    """Return a SQLEditor wrapping a real Pipeline over an in-memory DuckDB source."""
+    source = DuckDBSource(tables={
+        'tiny': """
+            SELECT * FROM (
+              VALUES (1,'A',10.5),
+                     (2,'B',20.0),
+                     (3,'A', 7.5)
+            ) AS t(id, category, value)
+        """
+    })
+    pipeline = Pipeline(source=source, table='tiny')
+    monkeypatch.setattr(editors_module, 'ParamMethod', lambda *args, **kwargs: None)
+    return SQLEditor(component=pipeline, spec="SELECT * FROM tiny")
+
+
+def test_filter_menu_items_skip_len_and_pick_icons(sql_pipeline_editor):
+    items = sql_pipeline_editor._filter_items()
+    by_label = {it["label"]: it["icon"] for it in items}
+    assert "__len__" not in by_label
+    assert by_label["id"] == "numbers"            # integer
+    assert by_label["category"] == "format_list_bulleted"  # enum string
+    assert by_label["value"] == "calculate"       # number
+
+
+def test_add_filter_creates_labeled_widget(sql_pipeline_editor):
+    editor = sql_pipeline_editor
+    editor._add_filter({"label": "value", "toggled": True})
+    filt = editor._filters["value"]
+    # Label falls back to the field name when no explicit label is given.
+    assert filt.widget.label == "value"
+    assert filt in editor.component.filters
+    assert filt.widget in list(editor._filter_area)
+
+
+def test_filter_subsets_and_restores_data(sql_pipeline_editor):
+    editor = sql_pipeline_editor
+    pipeline = editor.component
+    assert len(pipeline.data) == 3
+
+    editor._add_filter({"label": "value", "toggled": True})
+    editor._filters["value"].widget.value = (15.0, 25.0)
+    assert list(pipeline.data["value"]) == [20.0]
+
+    editor._add_filter({"label": "value", "toggled": False})
+    assert all(f.field != "value" for f in pipeline.filters)
+    assert editor._filters["value"].widget not in list(editor._filter_area)
+    assert len(pipeline.data) == 3
+
+
+def test_render_controls_inserts_add_filter_menu(sql_pipeline_editor):
+    controls = sql_pipeline_editor.render_controls(task=None, interface=None)
+    labels = [getattr(c, "label", None) for c in controls]
+    assert "Add Filter" in labels
+
+
+@pytest.fixture
+def xarray_pipeline_editor(monkeypatch):
+    """SQLEditor over an xarray source so coordinate dimensions are exercised."""
+    xr = pytest.importorskip("xarray")
+    pytest.importorskip("xarray_sql")
+    import numpy as np
+
+    from lumen.sources.xarray_sql import XArraySQLSource
+
+    times = pd.date_range("2020-01-01", periods=6, freq="D")
+    ds = xr.Dataset(
+        {"temperature": (["time", "lat", "lon"], np.random.default_rng(0).random((6, 3, 2)))},
+        coords={"time": times,
+                "lat": ("lat", np.array([10.0, 20.0, 30.0])),
+                "lon": ("lon", np.array([100.0, 110.0]))},
+    )
+    pipeline = Pipeline(source=XArraySQLSource(_dataset=ds), table="temperature")
+    monkeypatch.setattr(editors_module, 'ParamMethod', lambda *args, **kwargs: None)
+    return SQLEditor(component=pipeline, spec="SELECT * FROM temperature")
+
+
+def test_coordinate_dimensions_listed_first(xarray_pipeline_editor):
+    items = xarray_pipeline_editor._filter_items()
+    labels = [it["label"] for it in items]
+    # The data variable comes after all coordinate dimensions.
+    assert set(labels[:3]) == {"time", "lat", "lon"}
+    assert labels[-1] == "temperature"
+    icons = {it["label"]: it["icon"] for it in items}
+    assert icons["time"] == "schedule"        # datetime axis
+    assert icons["lat"] == "straighten"       # numeric axis
+    assert icons["temperature"] == "calculate"  # data variable
+
+
+def test_datetime_axis_widget_supports_label(xarray_pipeline_editor):
+    # Regression: the datetime range widget must accept a label (PMUI, not
+    # plain panel) or constructing the time filter raises TypeError.
+    xarray_pipeline_editor._add_filter({"label": "time", "toggled": True})
+    widget = xarray_pipeline_editor._filters["time"].widget
+    assert "label" in widget.param
+    assert widget.label == "time"
+
+
+def test_coordinate_range_filter_subsets_like_sel(xarray_pipeline_editor):
+    editor = xarray_pipeline_editor
+    pipeline = editor.component
+    editor._add_filter({"label": "lat", "toggled": True})
+    editor._filters["lat"].widget.value = (20.0, 30.0)
+    ds = pipeline.source.dataset
+    expected = ds.sel(lat=slice(20.0, 30.0)).to_dataframe().reset_index().shape[0]
+    assert len(pipeline.data) == expected
+    assert set(pipeline.data["lat"].unique()) == {20.0, 30.0}
+
+
 def test_class_name_to_filename():
     """Test CamelCase to snake_case conversion for base class."""
     assert LumenEditor._class_name_to_download_filename("yaml") == "lumen_editor.yaml"
@@ -138,7 +250,7 @@ def test_class_name_with_acronyms():
     """Test handling of acronyms in class names."""
     class SQLEditor(LumenEditor):
         pass
-    
+
     assert SQLEditor._class_name_to_download_filename("yaml") == "sql_editor.yaml"
 
 
@@ -146,5 +258,5 @@ def test_class_name_with_numbers():
     """Test handling of numbers in class names."""
     class Editor2D(LumenEditor):
         pass
-    
+
     assert Editor2D._class_name_to_download_filename("png") == "editor2_d.png"

--- a/lumen/tests/ai/test_tools.py
+++ b/lumen/tests/ai/test_tools.py
@@ -293,3 +293,80 @@ async def test_clarification_tool_requires_confirm_click_for_text():
     result = await asyncio.wait_for(task, timeout=1)
     assert result == "User provided following clarification: concise answers"
     assert "clarification" not in context
+
+
+# ---- apply_filter tool (SQLAgent) ----
+
+from lumen.ai.agents.sql import (
+    _coerce_filter_value, make_apply_filter_llm_tool, make_apply_filter_tool,
+)
+from lumen.pipeline import Pipeline
+
+
+@pytest.fixture
+def tiny_filter_pipeline():
+    src = DuckDBSource(tables={
+        't': "SELECT * FROM (VALUES (1,'A',10.5),(2,'B',20.0),(3,'A',7.5)) AS t(id, cat, val)"
+    })
+    return Pipeline(source=src, table='t')
+
+
+def test_coerce_filter_value_ranges_and_passthrough():
+    assert _coerce_filter_value({"type": "number"}, [10, 20]) == (10, 20)
+    assert _coerce_filter_value({"type": "integer"}, [1, 3]) == (1, 3)
+    assert _coerce_filter_value({"type": "number"}, 5) == 5
+    assert _coerce_filter_value({"type": "string"}, ["A", "B"]) == ["A", "B"]
+    lo, hi = _coerce_filter_value(
+        {"type": "string", "format": "datetime"}, ["2020-01-02", "2020-01-05"]
+    )
+    assert (str(lo), str(hi)) == ("2020-01-02 00:00:00", "2020-01-05 00:00:00")
+
+
+async def test_apply_filter_tool_unknown_field_is_graceful(tiny_filter_pipeline):
+    tool = make_apply_filter_tool(tiny_filter_pipeline)
+    msg = await tool.function(field="nope", value=1)
+    assert "Cannot filter" in msg
+    assert len(tiny_filter_pipeline.data) == 3  # unchanged
+
+
+async def test_apply_filter_tool_numeric_range(tiny_filter_pipeline):
+    tool = make_apply_filter_tool(tiny_filter_pipeline)
+    await tool.function(field="val", value=[8, 15])
+    assert list(tiny_filter_pipeline.data["val"]) == [10.5]
+
+
+async def test_apply_filter_tool_replaces_existing_filter(tiny_filter_pipeline):
+    tool = make_apply_filter_tool(tiny_filter_pipeline)
+    await tool.function(field="cat", value=["A"])
+    await tool.function(field="cat", value=["B"])
+    assert set(tiny_filter_pipeline.data["cat"]) == {"B"}
+    assert len([f for f in tiny_filter_pipeline.filters if f.field == "cat"]) == 1
+
+
+def test_apply_filter_llm_tool_is_context_gated(tiny_filter_pipeline):
+    assert make_apply_filter_llm_tool({}) == []
+    assert make_apply_filter_llm_tool({"pipeline": None}) == []
+    tool = make_apply_filter_llm_tool({"pipeline": tiny_filter_pipeline})
+    assert isinstance(tool, FunctionTool)
+    # pipeline is closed over; the LLM only supplies field + value.
+    assert set(tool._model.model_fields) == {"field", "value"}
+
+
+def test_apply_filter_tool_subsets_xarray_like_sel():
+    xr = pytest.importorskip("xarray")
+    pytest.importorskip("xarray_sql")
+    import numpy as np
+
+    from lumen.sources.xarray_sql import XArraySQLSource
+
+    ds = xr.Dataset(
+        {"temperature": (["lat", "lon"], np.arange(6.0).reshape(3, 2))},
+        coords={"lat": ("lat", np.array([10.0, 20.0, 30.0])),
+                "lon": ("lon", np.array([100.0, 110.0]))},
+    )
+    pipeline = Pipeline(source=XArraySQLSource(_dataset=ds), table="temperature")
+    tool = make_apply_filter_tool(pipeline)
+    asyncio.run(tool.function(field="lat", value=[20.0, 30.0]))
+    expected = ds.sel(lat=slice(20.0, 30.0)).to_dataframe().reset_index().shape[0]
+    assert len(pipeline.data) == expected
+    assert set(pipeline.data["lat"].unique()) == {20.0, 30.0}

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -428,6 +428,18 @@ async def test_find_view_in_popped_out(explorer_ui):
     assert popped_idx >= 1  # Index 0 is tabs
 
 
+async def test_vsplit_has_view_finds_view_under_filter_split(explorer_ui):
+    """Pop-out helpers locate the table view whether or not a filter pane wraps
+    the editor/table split one level deeper."""
+    table = Column()
+    editor_table = VSplit(Column(), table)
+    with_filters = VSplit(Column(), editor_table)
+
+    assert explorer_ui._vsplit_has_view(editor_table, table)   # no filters
+    assert explorer_ui._vsplit_has_view(with_filters, table)   # filters active
+    assert not explorer_ui._vsplit_has_view(VSplit(Column(), Column()), table)
+
+
 async def test_exploration_context_isolation(explorer_ui):
     """Test that different explorations maintain separate contexts."""
     # Create first exploration

--- a/lumen/tests/sources/test_xarray_sql.py
+++ b/lumen/tests/sources/test_xarray_sql.py
@@ -359,6 +359,38 @@ class TestSchemaMetadata:
         schema = source.get_schema("temperature")
         assert "inclusiveMinimum" in schema.get("lat", {}) or "inclusiveMinimum" in schema.get("temperature", {})
 
+    def test_get_schema_flags_coordinate_dimensions(self, synthetic_dataset):
+        source = XArraySQLSource(_dataset=synthetic_dataset)
+        schema = source.get_schema("temperature")
+        # Coordinate dimensions are flagged so filter UIs can surface them.
+        assert schema["time"].get("dimension") is True
+        assert schema["lat"].get("dimension") is True
+        assert schema["lon"].get("dimension") is True
+        # The data variable itself is not a dimension.
+        assert "dimension" not in schema["temperature"]
+        # The flag must not leak onto the bookkeeping key.
+        assert schema["__len__"] == int(synthetic_dataset["temperature"].size)
+
+    def test_get_schema_all_tables_flags_dimensions(self, synthetic_dataset):
+        source = XArraySQLSource(_dataset=synthetic_dataset)
+        schemas = source.get_schema()
+        for table in ("temperature", "pressure"):
+            assert schemas[table]["lat"].get("dimension") is True
+            assert "dimension" not in schemas[table][table]
+
+    def test_get_schema_flags_dimensions_on_derived_table(self, synthetic_dataset):
+        # Explorations query a derived slug table, not the raw data variable.
+        # Coordinate dimensions must still be flagged there.
+        source = XArraySQLSource(_dataset=synthetic_dataset)
+        derived = source.create_sql_expr_source(
+            {"derived_slug": "SELECT * FROM temperature"}
+        )
+        schema = derived.get_schema("derived_slug")
+        assert schema["lat"].get("dimension") is True
+        assert schema["lon"].get("dimension") is True
+        assert schema["time"].get("dimension") is True
+        assert "dimension" not in schema["temperature"]
+
     def test_get_schema_with_limit(self, synthetic_dataset):
         source = XArraySQLSource(_dataset=synthetic_dataset)
         schema = source.get_schema("temperature", limit=5)


### PR DESCRIPTION
## Overview

Completes Philipp's stalled draft #1599: exploration outputs get an "Add Filter" menu, and for xarray sources it surfaces coordinate dimensions (time, lat, lon) first and filters them through the existing pipeline. Also adds an `apply_filter` tool the chat agent can use. Built on the existing filter machinery, not a parallel widget stack.

## Demo
https://github.com/user-attachments/assets/8a128f08-b75d-46f3-89b2-29e50e474259

