### PR TITLE
Detect encoding when reading uploaded CSV/JSON/HTML

### DIFF
--- a/lumen/ai/controls/ingest/utils.py
+++ b/lumen/ai/controls/ingest/utils.py
@@ -13,7 +13,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pandas as pd
 
-from ....util import normalize_table_name
+from ....util import detect_file_encoding, normalize_table_name
 from .constants import (
     CONTENT_TYPE_TO_EXTENSION, METADATA_EXTENSIONS, TABLE_EXTENSIONS,
     DownloadConfig,
@@ -155,7 +155,7 @@ def read_html_tables(content: str | bytes, base_alias: str) -> dict[str, pd.Data
         If no HTML tables are found.
     """
     if isinstance(content, bytes):
-        content = content.decode("utf-8")
+        content = content.decode(detect_file_encoding(content))
     tables = pd.read_html(io.StringIO(content))
     if not tables:
         raise ValueError("No HTML tables found")
@@ -189,7 +189,7 @@ def read_json_to_dataframe(content: str | bytes) -> pd.DataFrame:
         If JSON structure is unsupported.
     """
     if isinstance(content, bytes):
-        content = content.decode("utf-8")
+        content = content.decode(detect_file_encoding(content))
     data = json.loads(content)
 
     if isinstance(data, list):
@@ -260,6 +260,8 @@ def read_file_to_dataframes(
     if extension == "csv":
         csv_kwargs = {"parse_dates": True, "sep": None, "engine": "python"}
         csv_kwargs.update(read_kwargs)
+        # detect the encoding so non-UTF-8 files (e.g. latin-1) parse
+        csv_kwargs.setdefault("encoding", detect_file_encoding(file_obj))
         df = pd.read_csv(file_obj, **csv_kwargs)
         return FileReadResult(tables={alias: df})
 

--- a/lumen/tests/ai/test_controls/test_ingest_utils.py
+++ b/lumen/tests/ai/test_controls/test_ingest_utils.py
@@ -1,0 +1,28 @@
+import io
+
+import pytest
+
+try:
+    import lumen.ai  # noqa
+except ModuleNotFoundError:
+    pytest.skip("lumen.ai could not be imported", allow_module_level=True)
+
+from lumen.ai.controls.ingest.utils import (
+    read_file_to_dataframes, read_json_to_dataframe,
+)
+
+
+def test_read_csv_non_utf8_encoding():
+    """A latin-1 CSV (byte 0xf1 is invalid UTF-8) is parsed via encoding detection."""
+    content = "name,county\nJose,Dona Ana\n".replace("Dona", "Do\xf1a").encode("latin-1")
+    result = read_file_to_dataframes(io.BytesIO(content), "csv", alias="counties")
+    df = result.tables["counties"]
+    assert list(df.columns) == ["name", "county"]
+    assert df["county"].iloc[0] == "Do\xf1a Ana"
+
+
+def test_read_json_non_utf8_encoding():
+    """A latin-1 JSON payload is decoded via encoding detection."""
+    content = '[{"county": "Do\xf1a Ana"}]'.encode("latin-1")
+    df = read_json_to_dataframe(content)
+    assert df["county"].iloc[0] == "Do\xf1a Ana"


### PR DESCRIPTION
## Description

Fixes #1901

The AI ingest readers hardcoded UTF-8, so a non-UTF-8 upload (e.g. a latin-1 CSV) failed to parse and surfaced as a retry loop. Use the existing `detect_file_encoding` util in the CSV/JSON/HTML readers, as the sibling ingest modules already do.

