### PR TITLE
Load geospatial files (.geojson/.wkt/.shp) at startup

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -37,7 +37,7 @@ from ..pipeline import Pipeline
 from ..sources import Source
 from ..sources.duckdb import DuckDBSource
 from ..sources.xarray_sql import XArraySQLSource
-from ..util import check_xarray_available, log
+from ..util import check_xarray_available, log, normalize_table_name
 from .agents import (
     AnalysisAgent, BaseCodeAgent, ChatAgent, DocumentListAgent,
     DocumentSummarizerAgent, SourceAgent, SQLAgent, TableListAgent,
@@ -53,6 +53,7 @@ from .controls import (
     SourceCatalog, TableExplorer, UploadSourceControls,
 )
 from .controls.ingest.constants import XARRAY_EXTENSIONS
+from .controls.ingest.utils import read_geo_file
 from .coordinator import Coordinator, Plan, Planner
 from .editors import AnalysisOutput, LumenEditor, SQLEditor
 from .export import export_notebook
@@ -676,9 +677,6 @@ class UI(Viewer):
         DuckDB spatial (ST_GeomFromWKB) path the interactive upload uses, so
         startup and uploaded geospatial data behave identically (gh-1900).
         """
-        from ..util import normalize_table_name
-        from .controls.ingest.utils import read_geo_file
-
         path = Path(src).absolute()
         if not path.exists():
             raise FileNotFoundError(f"Data file not found: {src}")

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -638,6 +638,13 @@ class UI(Viewer):
                     sources.append(source)
                     continue
 
+                # Handle local geospatial files (GeoJSON, WKT, zipped shapefile)
+                # via the same read_geo_file -> DuckDB spatial path as file upload
+                geo_ext = Path(src).suffix.lstrip('.').lower()
+                if geo_ext in ('geojson', 'wkt', 'zip') and '://' not in src:
+                    sources.append(cls._resolve_geo_source(src, geo_ext))
+                    continue
+
                 if src.startswith('http'):
                     remote = True
                 if src.endswith(('.parq', '.parquet', '.csv', '.json', '.tsv', '.jsonl', '.ndjson')):
@@ -660,6 +667,45 @@ class UI(Viewer):
             sources.append(source)
 
         return sources
+
+    @classmethod
+    def _resolve_geo_source(cls, src: str, extension: str) -> Source:
+        """Load a geospatial file into an in-memory DuckDBSource.
+
+        Routes GeoJSON/WKT/zipped-shapefile through the same read_geo_file ->
+        DuckDB spatial (ST_GeomFromWKB) path the interactive upload uses, so
+        startup and uploaded geospatial data behave identically (gh-1900).
+        """
+        from ..util import normalize_table_name
+        from .controls.ingest.utils import read_geo_file
+
+        path = Path(src).absolute()
+        if not path.exists():
+            raise FileNotFoundError(f"Data file not found: {src}")
+
+        alias = normalize_table_name(path.stem)
+        with open(path, 'rb') as f:
+            result = read_geo_file(f, extension, alias)
+
+        source = DuckDBSource(
+            initializers=result.source_params.get('initializers', []),
+            tables={},
+            uri=':memory:',
+        )
+        conn = source._connection
+        for tbl_name, df in result.tables.items():
+            df_rel = conn.from_df(df)
+            if tbl_name in result.conversions:
+                conn.register(f"{tbl_name}_temp", df_rel)
+                # read_geo_file emits a CREATE TEMP TABLE, but DuckDBSource runs
+                # its queries on cursors that cannot see another connection's temp
+                # tables, so materialize a persistent (in-memory) table instead.
+                conn.execute(result.conversions[tbl_name].replace("TEMP TABLE", "TABLE", 1))
+                conn.unregister(f"{tbl_name}_temp")
+            else:
+                df_rel.to_view(tbl_name)
+            source.tables[tbl_name] = f"SELECT * FROM {tbl_name}"
+        return source
 
     @wrap_logfire(span_name="Chat Invoke")
     async def _chat_invoke(

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -1719,3 +1719,30 @@ async def test_edit_on_child_exploration_switches_to_parent(explorer_ui):
     # Parent and Home still intact
     assert len(ui._explorations.items) == 2
     assert parent_exploration.plan is not None
+
+
+def test_resolve_data_geojson_startup(tmp_path):
+    """A .geojson path at startup loads via read_geo_file instead of raising (gh-1900)."""
+    gpd = pytest.importorskip("geopandas")
+    from shapely.geometry import Polygon
+
+    gdf = gpd.GeoDataFrame(
+        {"county": ["A", "B"], "population": [10, 20]},
+        geometry=[
+            Polygon([(0, 0), (1, 0), (1, 1)]),
+            Polygon([(1, 1), (2, 1), (2, 2)]),
+        ],
+        crs="EPSG:4326",
+    )
+    path = tmp_path / "counties.geojson"
+    gdf.to_file(path, driver="GeoJSON")
+
+    sources = UI._resolve_data([str(path)])
+
+    assert len(sources) == 1
+    source = sources[0]
+    assert "counties" in source.get_tables()
+    # geometry is registered as a real GEOMETRY column; ST_AsText returns text so
+    # this verifies loading without needing the GEOMETRY fetch fix from #1903
+    wkt = source.execute("SELECT ST_AsText(geometry) AS wkt FROM counties LIMIT 1")
+    assert wkt["wkt"].iloc[0].startswith("POLYGON")


### PR DESCRIPTION
## Overview

Fixes #1900. Passing a geospatial file at startup (`lumen-ai serve x.geojson`, or `ExplorerUI(data=[...])`) raised "Could not determine how to load", even though the interactive upload already reads it. This routes local `.geojson`/`.wkt`/zipped-shapefile through the same `read_geo_file` to DuckDB spatial path so startup and upload behave the same. Pairs with #1903, which makes the loaded geometry queryable/renderable.

## Before / After

Before:
```
$ lumen-ai serve counties.geojson --provider openai
...
ValueError: Could not determine how to load counties.geojson file.
```

After:
```
$ lumen-ai serve counties.geojson --provider openai
# loads a source with a `counties` table (geometry registered via ST_GeomFromWKB),
# available at startup just like a .csv / .nc / .db
```