### PR TITLE
Add try_import_xarray helper (mirror try_import_geopandas)

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -37,7 +37,7 @@ from ..pipeline import Pipeline
 from ..sources import Source
 from ..sources.duckdb import DuckDBSource
 from ..sources.xarray_sql import XArraySQLSource
-from ..util import check_xarray_available, log, normalize_table_name
+from ..util import log, normalize_table_name, try_import_xarray
 from .agents import (
     AnalysisAgent, BaseCodeAgent, ChatAgent, DocumentListAgent,
     DocumentSummarizerAgent, SourceAgent, SQLAgent, TableListAgent,
@@ -537,7 +537,7 @@ class UI(Viewer):
             _temp_files.append(tmp.name)
             return XArraySQLSource(uri=tmp.name, name=alias)
 
-        if not check_xarray_available():
+        if try_import_xarray() is None:
             return {}
 
         _temp_files: list[str] = []

--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar
 import param
 
 from ..transforms.sql import SQLFilter
-from ..util import check_xarray_available
+from ..util import check_xarray_available, try_import_xarray
 from .base import BaseSQLSource, cached
 
 
@@ -161,7 +161,7 @@ class XArraySQLSource(BaseSQLSource):
                 kw["engine"] = resolved_engine
             if chunks is not None:
                 kw["chunks"] = chunks
-            import xarray as xr
+            xr = try_import_xarray()
             ds = xr.open_dataset(uri, **kw)
         else:
             raise ValueError("Either 'uri' or '_dataset' must be provided.")

--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar
 import param
 
 from ..transforms.sql import SQLFilter
-from ..util import check_xarray_available, try_import_xarray
+from ..util import try_import_xarray
 from .base import BaseSQLSource, cached
 
 
@@ -93,7 +93,7 @@ class XArraySQLSource(BaseSQLSource):
         The SQL expression template for table queries.""")
 
     def __init__(self, _dataset=None, _ctx=None, **params):
-        if not check_xarray_available():
+        if try_import_xarray() is None:
             raise ImportError(
                 "xarray and xarray-sql are required for XArraySQLSource. "
                 "Install them with: pip install lumen[xarray]"

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -1153,7 +1153,7 @@ class TestResolveData:
 
     def test_resolve_data_xarray_import_error(self):
         """Test graceful error when xarray-sql not installed."""
-        with patch('lumen.sources.xarray_sql.check_xarray_available', return_value=False):
+        with patch('lumen.sources.xarray_sql.try_import_xarray', return_value=None):
             with pytest.raises(ImportError, match="xarray"):
                 UI._resolve_data('data.nc')
 
@@ -1232,7 +1232,7 @@ class TestXarrayUploadHandler:
 
     def test_upload_handler_returns_empty_without_xarray(self):
         """Upload handlers should be empty if xarray-sql not installed."""
-        with patch('lumen.ai.ui.check_xarray_available', return_value=False):
+        with patch('lumen.ai.ui.try_import_xarray', return_value=None):
             handlers = UI._get_xarray_upload_handlers()
             assert handlers == {}
 

--- a/lumen/tests/sources/test_optional_imports.py
+++ b/lumen/tests/sources/test_optional_imports.py
@@ -14,6 +14,8 @@ from unittest.mock import patch
 
 import pytest
 
+from lumen.util import try_import_xarray
+
 # Each entry: (module_path, class_name, guard_package, pip_extra)
 OPTIONAL_SOURCES = [
     ("lumen.sources.sqlalchemy", "SQLAlchemySource", "sqlalchemy", "sql"),
@@ -90,14 +92,11 @@ def test_try_import_xarray_returns_module_when_installed():
     """try_import_xarray returns the xarray module when xarray and xarray-sql are installed."""
     xr = pytest.importorskip("xarray")
     pytest.importorskip("xarray_sql")
-    from lumen.util import try_import_xarray
     assert try_import_xarray() is xr
 
 
 def test_try_import_xarray_none_when_missing():
     """try_import_xarray returns None (not raises) when xarray-sql is absent."""
-    from lumen.util import try_import_xarray
-
     real_import = builtins.__import__
 
     def mock_import(name, *args, **kwargs):

--- a/lumen/tests/sources/test_optional_imports.py
+++ b/lumen/tests/sources/test_optional_imports.py
@@ -84,3 +84,33 @@ def test_import_raises_when_dependency_missing(module_path, class_name, guard_pa
     finally:
         # Restore original modules so other tests are not affected
         sys.modules.update(saved)
+
+
+def test_try_import_xarray_returns_module_when_installed():
+    """try_import_xarray returns the xarray module when xarray and xarray-sql are installed."""
+    xr = pytest.importorskip("xarray")
+    pytest.importorskip("xarray_sql")
+    from lumen.util import try_import_xarray
+    assert try_import_xarray() is xr
+
+
+def test_try_import_xarray_none_when_missing():
+    """try_import_xarray returns None (not raises) when xarray-sql is absent."""
+    from lumen.util import try_import_xarray
+
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "xarray_sql" or name.startswith("xarray_sql."):
+            raise ImportError("No module named 'xarray_sql'")
+        return real_import(name, *args, **kwargs)
+
+    saved = {
+        key: sys.modules.pop(key)
+        for key in [k for k in sys.modules if k == "xarray_sql" or k.startswith("xarray_sql.")]
+    }
+    try:
+        with patch("builtins.__import__", side_effect=mock_import):
+            assert try_import_xarray() is None
+    finally:
+        sys.modules.update(saved)

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -493,11 +493,16 @@ def normalize_table_name(name: str) -> str:
     return re.sub(r'\W+', '_', name).strip('_').lower()
 
 
+def try_import_xarray():
+    """Import and return xarray, or None if xarray or xarray-sql is unavailable."""
+    try:
+        import xarray
+        import xarray_sql  # noqa
+        return xarray
+    except ImportError:
+        return None
+
+
 def check_xarray_available():
     """Check if xarray and xarray-sql are installed."""
-    try:
-        import xarray  # noqa
-        import xarray_sql  # noqa
-        return True
-    except ImportError:
-        return False
+    return try_import_xarray() is not None

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -501,8 +501,3 @@ def try_import_xarray():
         return xarray
     except ImportError:
         return None
-
-
-def check_xarray_available():
-    """Check if xarray and xarray-sql are installed."""
-    return try_import_xarray() is not None


### PR DESCRIPTION
## Overview

Fixes #1907. Mirrors the `try_import_geopandas()` helper from #1903: adds `try_import_xarray()` (returns the xarray module or `None`), reimplements `check_xarray_available()` on top of it, and uses it at the xarray import in `XArraySQLSource`. Requested in review on #1903 as a separate PR.
