### PR TITLE
feat: add a reusable normalize_vegalite_spec function

### DIFF
--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -30,6 +30,109 @@ from ..vector_store import DuckDBVectorStore
 from .base_code import BaseCodeAgent
 
 
+def normalize_vegalite_spec(
+    vega_spec: dict[str, Any], *, editor_type: type[VegaLiteEditor] = VegaLiteEditor
+) -> dict[str, Any]:
+    """Normalize and validate a parsed Vega-Lite spec without an agent instance.
+
+    Injects ``$schema``, defaults ``width``/``height`` to ``"container"``
+    (skipping compound charts such as ``hconcat``/``vconcat``/``concat``/
+    ``facet``/``repeat``), validates the spec via ``editor_type.validate_spec``
+    and adds geographic pan/zoom interactivity for maps. The spec dict is
+    mutated in place and returned wrapped in the view metadata Lumen expects.
+
+    Pure helper: no LLM, no UI and no agent instance are required.
+    """
+    # Remove wrapper properties that aren't part of Vega-Lite spec
+    for key in ['sizing_mode', 'min_height', 'type']:
+        vega_spec.pop(key, None)
+
+    if "$schema" not in vega_spec:
+        vega_spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
+
+    # Check if this is a compound chart (hconcat, vconcat, concat, facet, repeat)
+    is_compound = any(key in vega_spec for key in ['hconcat', 'vconcat', 'concat', 'facet', 'repeat'])
+
+    if is_compound:
+        # Remove invalid top-level width/height for compound charts
+        # Altair's config.view.continuousWidth/Height handles sub-chart sizing
+        vega_spec.pop('width', None)
+        vega_spec.pop('height', None)
+    else:
+        if "width" not in vega_spec:
+            vega_spec["width"] = "container"
+        if "height" not in vega_spec:
+            vega_spec["height"] = "container"
+
+    editor_type.validate_spec(vega_spec)
+
+    # using string comparison because these keys could be in different nested levels
+    vega_spec_str = dump_yaml(vega_spec)
+    # Handle different types of interactive controls based on chart type
+    if "latitude:" in vega_spec_str or "longitude:" in vega_spec_str:
+        vega_spec = _add_geographic_items(vega_spec, vega_spec_str)
+    # elif ("point: true" not in vega_spec_str or "params" not in vega_spec) and vega_spec_str.count("encoding:") == 1:
+    #     # add pan/zoom controls to all plots except geographic ones and points overlaid on line plots
+    #     # because those result in an blank plot without error
+    #     vega_spec["params"] = [{"bind": "scales", "name": "grid", "select": "interval"}]
+    return {"spec": vega_spec, "sizing_mode": "stretch_both", "min_height": 200}
+
+
+def _add_zoom_params(vega_spec: dict) -> None:
+    """Add zoom parameters to vega spec."""
+    if "params" not in vega_spec:
+        vega_spec["params"] = []
+
+    existing_param_names = {
+        p.get("name") for p in vega_spec["params"]
+        if isinstance(p, dict) and "name" in p
+    }
+
+    for p in VEGA_ZOOMABLE_MAP_ITEMS["params"]:
+        if p.get("name") not in existing_param_names:
+            vega_spec["params"].append(p)
+
+
+def _setup_projection(vega_spec: dict) -> None:
+    """Setup map projection settings."""
+    if "projection" not in vega_spec:
+        vega_spec["projection"] = {"type": "mercator"}
+    vega_spec["projection"].update(VEGA_ZOOMABLE_MAP_ITEMS["projection"])
+
+
+def _handle_map_compatibility(vega_spec: dict, vega_spec_str: str) -> None:
+    """Handle map projection compatibility and add geographic outlines."""
+    has_world_map = "world-110m.json" in vega_spec_str
+    uses_albers_usa = vega_spec["projection"]["type"] == "albersUsa"
+
+    if has_world_map and uses_albers_usa:
+        # albersUsa incompatible with world map
+        vega_spec["projection"] = "mercator"
+    elif not has_world_map and not uses_albers_usa:
+        # Add world map outlines if needed
+        if "layer" not in vega_spec:
+            vega_spec["layer"] = [{
+                "mark": vega_spec.pop("mark", {})
+            }]
+        vega_spec["layer"].insert(0, VEGA_MAP_LAYER["world"])
+
+
+def _add_geographic_items(vega_spec: dict, vega_spec_str: str) -> dict:
+    """Add geographic visualization items to vega spec."""
+    _add_zoom_params(vega_spec)
+    _setup_projection(vega_spec)
+
+    # Remove projection from individual layers to prevent conflicts
+    # All layers must inherit the top-level projection for zoom/pan to work correctly
+    if "layer" in vega_spec:
+        for layer in vega_spec["layer"]:
+            if isinstance(layer, dict) and "projection" in layer:
+                del layer["projection"]
+
+    _handle_map_compatibility(vega_spec, vega_spec_str)
+    return vega_spec
+
+
 class VegaLiteSpec(EscapeBaseModel):
 
     chain_of_thought: str = Field(
@@ -371,57 +474,6 @@ class VegaLiteAgent(BaseCodeAgent):
             update_dict = load_yaml(result.yaml_update)
         return step_name, update_dict
 
-    def _add_zoom_params(self, vega_spec: dict) -> None:
-        """Add zoom parameters to vega spec."""
-        if "params" not in vega_spec:
-            vega_spec["params"] = []
-
-        existing_param_names = {
-            p.get("name") for p in vega_spec["params"]
-            if isinstance(p, dict) and "name" in p
-        }
-
-        for p in VEGA_ZOOMABLE_MAP_ITEMS["params"]:
-            if p.get("name") not in existing_param_names:
-                vega_spec["params"].append(p)
-
-    def _setup_projection(self, vega_spec: dict) -> None:
-        """Setup map projection settings."""
-        if "projection" not in vega_spec:
-            vega_spec["projection"] = {"type": "mercator"}
-        vega_spec["projection"].update(VEGA_ZOOMABLE_MAP_ITEMS["projection"])
-
-    def _handle_map_compatibility(self, vega_spec: dict, vega_spec_str: str) -> None:
-        """Handle map projection compatibility and add geographic outlines."""
-        has_world_map = "world-110m.json" in vega_spec_str
-        uses_albers_usa = vega_spec["projection"]["type"] == "albersUsa"
-
-        if has_world_map and uses_albers_usa:
-            # albersUsa incompatible with world map
-            vega_spec["projection"] = "mercator"
-        elif not has_world_map and not uses_albers_usa:
-            # Add world map outlines if needed
-            if "layer" not in vega_spec:
-                vega_spec["layer"] = [{
-                    "mark": vega_spec.pop("mark", {})
-                }]
-            vega_spec["layer"].insert(0, VEGA_MAP_LAYER["world"])
-
-    def _add_geographic_items(self, vega_spec: dict, vega_spec_str: str) -> dict:
-        """Add geographic visualization items to vega spec."""
-        self._add_zoom_params(vega_spec)
-        self._setup_projection(vega_spec)
-
-        # Remove projection from individual layers to prevent conflicts
-        # All layers must inherit the top-level projection for zoom/pan to work correctly
-        if "layer" in vega_spec:
-            for layer in vega_spec["layer"]:
-                if isinstance(layer, dict) and "projection" in layer:
-                    del layer["projection"]
-
-        self._handle_map_compatibility(vega_spec, vega_spec_str)
-        return vega_spec
-
     @classmethod
     def _extract_as_keys(cls, transforms: list[dict]) -> list[str]:
         """
@@ -542,40 +594,7 @@ class VegaLiteAgent(BaseCodeAgent):
             vega_spec = load_yaml(yaml_spec)
         elif json_spec := spec.get("json_spec"):
             vega_spec = load_json(json_spec)
-
-        # Remove wrapper properties that aren't part of Vega-Lite spec
-        for key in ['sizing_mode', 'min_height', 'type']:
-            vega_spec.pop(key, None)
-
-        if "$schema" not in vega_spec:
-            vega_spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
-
-        # Check if this is a compound chart (hconcat, vconcat, concat, facet, repeat)
-        is_compound = any(key in vega_spec for key in ['hconcat', 'vconcat', 'concat', 'facet', 'repeat'])
-
-        if is_compound:
-            # Remove invalid top-level width/height for compound charts
-            # Altair's config.view.continuousWidth/Height handles sub-chart sizing
-            vega_spec.pop('width', None)
-            vega_spec.pop('height', None)
-        else:
-            if "width" not in vega_spec:
-                vega_spec["width"] = "container"
-            if "height" not in vega_spec:
-                vega_spec["height"] = "container"
-
-        self._editor_type.validate_spec(vega_spec)
-
-        # using string comparison because these keys could be in different nested levels
-        vega_spec_str = dump_yaml(vega_spec)
-        # Handle different types of interactive controls based on chart type
-        if "latitude:" in vega_spec_str or "longitude:" in vega_spec_str:
-            vega_spec = self._add_geographic_items(vega_spec, vega_spec_str)
-        # elif ("point: true" not in vega_spec_str or "params" not in vega_spec) and vega_spec_str.count("encoding:") == 1:
-        #     # add pan/zoom controls to all plots except geographic ones and points overlaid on line plots
-        #     # because those result in an blank plot without error
-        #     vega_spec["params"] = [{"bind": "scales", "name": "grid", "select": "interval"}]
-        return {"spec": vega_spec, "sizing_mode": "stretch_both", "min_height": 200}
+        return normalize_vegalite_spec(vega_spec, editor_type=self._editor_type)
 
     async def _get_doc_examples(self, user_query: str) -> list[str]:
         # Query vector store for relevant examples

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -17,120 +17,18 @@ from ..code_executor import AltairExecutor, CodeSafetyCheck
 from ..config import (
     LUMEN_CACHE_DIR, PROMPTS_DIR, VECTOR_STORE_ASSETS_URL,
     VEGA_LITE_EXAMPLES_NUMPY_DB_FILE, VEGA_LITE_EXAMPLES_OPENAI_DB_FILE,
-    VEGA_MAP_LAYER, VEGA_ZOOMABLE_MAP_ITEMS, UserCancelledError,
+    UserCancelledError,
 )
 from ..context import TContext
 from ..editors import LumenEditor, VegaLiteEditor
 from ..llm import Message, OpenAI
 from ..models import EscapeBaseModel, RetrySpec
 from ..utils import (
-    get_data, get_schema, load_json, log_debug, retry_llm_output,
+    get_data, get_schema, load_json, log_debug, normalize_vegalite_spec,
+    retry_llm_output,
 )
 from ..vector_store import DuckDBVectorStore
 from .base_code import BaseCodeAgent
-
-
-def normalize_vegalite_spec(
-    vega_spec: dict[str, Any], *, editor_type: type[VegaLiteEditor] = VegaLiteEditor
-) -> dict[str, Any]:
-    """Normalize and validate a parsed Vega-Lite spec without an agent instance.
-
-    Injects ``$schema``, defaults ``width``/``height`` to ``"container"``
-    (skipping compound charts such as ``hconcat``/``vconcat``/``concat``/
-    ``facet``/``repeat``), validates the spec via ``editor_type.validate_spec``
-    and adds geographic pan/zoom interactivity for maps. The spec dict is
-    mutated in place and returned wrapped in the view metadata Lumen expects.
-
-    Pure helper: no LLM, no UI and no agent instance are required.
-    """
-    # Remove wrapper properties that aren't part of Vega-Lite spec
-    for key in ['sizing_mode', 'min_height', 'type']:
-        vega_spec.pop(key, None)
-
-    if "$schema" not in vega_spec:
-        vega_spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
-
-    # Check if this is a compound chart (hconcat, vconcat, concat, facet, repeat)
-    is_compound = any(key in vega_spec for key in ['hconcat', 'vconcat', 'concat', 'facet', 'repeat'])
-
-    if is_compound:
-        # Remove invalid top-level width/height for compound charts
-        # Altair's config.view.continuousWidth/Height handles sub-chart sizing
-        vega_spec.pop('width', None)
-        vega_spec.pop('height', None)
-    else:
-        if "width" not in vega_spec:
-            vega_spec["width"] = "container"
-        if "height" not in vega_spec:
-            vega_spec["height"] = "container"
-
-    editor_type.validate_spec(vega_spec)
-
-    # using string comparison because these keys could be in different nested levels
-    vega_spec_str = dump_yaml(vega_spec)
-    # Handle different types of interactive controls based on chart type
-    if "latitude:" in vega_spec_str or "longitude:" in vega_spec_str:
-        vega_spec = _add_geographic_items(vega_spec, vega_spec_str)
-    # elif ("point: true" not in vega_spec_str or "params" not in vega_spec) and vega_spec_str.count("encoding:") == 1:
-    #     # add pan/zoom controls to all plots except geographic ones and points overlaid on line plots
-    #     # because those result in an blank plot without error
-    #     vega_spec["params"] = [{"bind": "scales", "name": "grid", "select": "interval"}]
-    return {"spec": vega_spec, "sizing_mode": "stretch_both", "min_height": 200}
-
-
-def _add_zoom_params(vega_spec: dict) -> None:
-    """Add zoom parameters to vega spec."""
-    if "params" not in vega_spec:
-        vega_spec["params"] = []
-
-    existing_param_names = {
-        p.get("name") for p in vega_spec["params"]
-        if isinstance(p, dict) and "name" in p
-    }
-
-    for p in VEGA_ZOOMABLE_MAP_ITEMS["params"]:
-        if p.get("name") not in existing_param_names:
-            vega_spec["params"].append(p)
-
-
-def _setup_projection(vega_spec: dict) -> None:
-    """Setup map projection settings."""
-    if "projection" not in vega_spec:
-        vega_spec["projection"] = {"type": "mercator"}
-    vega_spec["projection"].update(VEGA_ZOOMABLE_MAP_ITEMS["projection"])
-
-
-def _handle_map_compatibility(vega_spec: dict, vega_spec_str: str) -> None:
-    """Handle map projection compatibility and add geographic outlines."""
-    has_world_map = "world-110m.json" in vega_spec_str
-    uses_albers_usa = vega_spec["projection"]["type"] == "albersUsa"
-
-    if has_world_map and uses_albers_usa:
-        # albersUsa incompatible with world map
-        vega_spec["projection"] = "mercator"
-    elif not has_world_map and not uses_albers_usa:
-        # Add world map outlines if needed
-        if "layer" not in vega_spec:
-            vega_spec["layer"] = [{
-                "mark": vega_spec.pop("mark", {})
-            }]
-        vega_spec["layer"].insert(0, VEGA_MAP_LAYER["world"])
-
-
-def _add_geographic_items(vega_spec: dict, vega_spec_str: str) -> dict:
-    """Add geographic visualization items to vega spec."""
-    _add_zoom_params(vega_spec)
-    _setup_projection(vega_spec)
-
-    # Remove projection from individual layers to prevent conflicts
-    # All layers must inherit the top-level projection for zoom/pan to work correctly
-    if "layer" in vega_spec:
-        for layer in vega_spec["layer"]:
-            if isinstance(layer, dict) and "projection" in layer:
-                del layer["projection"]
-
-    _handle_map_compatibility(vega_spec, vega_spec_str)
-    return vega_spec
 
 
 class VegaLiteSpec(EscapeBaseModel):

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -38,18 +38,20 @@ from jsonschema import ValidationError
 from markupsafe import escape
 from panel_material_ui import Details
 
+from ..config import dump_yaml
 from ..pipeline import Pipeline
 from ..sources.base import Source
 from ..transforms import SQLRemoveSourceSeparator
 from ..util import log
 from .config import (
-    PROMPTS_DIR, SOURCE_TABLE_SEPARATOR, UNRECOVERABLE_ERRORS,
-    MissingContextError, RetriesExceededError,
+    PROMPTS_DIR, SOURCE_TABLE_SEPARATOR, UNRECOVERABLE_ERRORS, VEGA_MAP_LAYER,
+    VEGA_ZOOMABLE_MAP_ITEMS, MissingContextError, RetriesExceededError,
 )
 
 if TYPE_CHECKING:
     from panel.chat.step import ChatStep
 
+    from .editors import VegaLiteEditor
     from .models import (
         DeleteLine, InsertLine, LineEdit, ReplaceLine,
     )
@@ -1485,3 +1487,112 @@ def result_to_dataframe(result) -> pd.DataFrame | None:
             return None
 
     return None
+
+
+def normalize_vegalite_spec(
+    vega_spec: dict[str, Any], *, editor_type: type[VegaLiteEditor] | None = None
+) -> dict[str, Any]:
+    """Normalize and validate a parsed Vega-Lite spec without an agent instance.
+
+    Injects ``$schema``, defaults ``width``/``height`` to ``"container"``
+    (skipping compound charts such as ``hconcat``/``vconcat``/``concat``/
+    ``facet``/``repeat``), validates the spec via ``editor_type.validate_spec``
+    and adds geographic pan/zoom interactivity for maps. The spec dict is
+    mutated in place and returned wrapped in the view metadata Lumen expects.
+
+    Pure helper: no LLM, no UI and no agent instance are required. ``editor_type``
+    defaults to ``VegaLiteEditor`` when not provided.
+    """
+    if editor_type is None:
+        # Imported lazily to avoid an editors -> utils import cycle.
+        from .editors import VegaLiteEditor
+        editor_type = VegaLiteEditor
+
+    # Remove wrapper properties that aren't part of Vega-Lite spec
+    for key in ['sizing_mode', 'min_height', 'type']:
+        vega_spec.pop(key, None)
+
+    if "$schema" not in vega_spec:
+        vega_spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
+
+    # Check if this is a compound chart (hconcat, vconcat, concat, facet, repeat)
+    is_compound = any(key in vega_spec for key in ['hconcat', 'vconcat', 'concat', 'facet', 'repeat'])
+
+    if is_compound:
+        # Remove invalid top-level width/height for compound charts
+        # Altair's config.view.continuousWidth/Height handles sub-chart sizing
+        vega_spec.pop('width', None)
+        vega_spec.pop('height', None)
+    else:
+        if "width" not in vega_spec:
+            vega_spec["width"] = "container"
+        if "height" not in vega_spec:
+            vega_spec["height"] = "container"
+
+    editor_type.validate_spec(vega_spec)
+
+    # using string comparison because these keys could be in different nested levels
+    vega_spec_str = dump_yaml(vega_spec)
+    # Handle different types of interactive controls based on chart type
+    if "latitude:" in vega_spec_str or "longitude:" in vega_spec_str:
+        vega_spec = _add_geographic_items(vega_spec, vega_spec_str)
+    # elif ("point: true" not in vega_spec_str or "params" not in vega_spec) and vega_spec_str.count("encoding:") == 1:
+    #     # add pan/zoom controls to all plots except geographic ones and points overlaid on line plots
+    #     # because those result in an blank plot without error
+    #     vega_spec["params"] = [{"bind": "scales", "name": "grid", "select": "interval"}]
+    return {"spec": vega_spec, "sizing_mode": "stretch_both", "min_height": 200}
+
+
+def _add_zoom_params(vega_spec: dict) -> None:
+    """Add zoom parameters to vega spec."""
+    if "params" not in vega_spec:
+        vega_spec["params"] = []
+
+    existing_param_names = {
+        p.get("name") for p in vega_spec["params"]
+        if isinstance(p, dict) and "name" in p
+    }
+
+    for p in VEGA_ZOOMABLE_MAP_ITEMS["params"]:
+        if p.get("name") not in existing_param_names:
+            vega_spec["params"].append(p)
+
+
+def _setup_projection(vega_spec: dict) -> None:
+    """Setup map projection settings."""
+    if "projection" not in vega_spec:
+        vega_spec["projection"] = {"type": "mercator"}
+    vega_spec["projection"].update(VEGA_ZOOMABLE_MAP_ITEMS["projection"])
+
+
+def _handle_map_compatibility(vega_spec: dict, vega_spec_str: str) -> None:
+    """Handle map projection compatibility and add geographic outlines."""
+    has_world_map = "world-110m.json" in vega_spec_str
+    uses_albers_usa = vega_spec["projection"]["type"] == "albersUsa"
+
+    if has_world_map and uses_albers_usa:
+        # albersUsa incompatible with world map
+        vega_spec["projection"] = "mercator"
+    elif not has_world_map and not uses_albers_usa:
+        # Add world map outlines if needed
+        if "layer" not in vega_spec:
+            vega_spec["layer"] = [{
+                "mark": vega_spec.pop("mark", {})
+            }]
+        vega_spec["layer"].insert(0, VEGA_MAP_LAYER["world"])
+
+
+def _add_geographic_items(vega_spec: dict, vega_spec_str: str) -> dict:
+    """Add geographic visualization items to vega spec."""
+    _add_zoom_params(vega_spec)
+    _setup_projection(vega_spec)
+
+    # Remove projection from individual layers to prevent conflicts
+    # All layers must inherit the top-level projection for zoom/pan to work correctly
+    if "layer" in vega_spec:
+        for layer in vega_spec["layer"]:
+            if isinstance(layer, dict) and "projection" in layer:
+                del layer["projection"]
+
+    _handle_map_compatibility(vega_spec, vega_spec_str)
+    return vega_spec

--- a/lumen/tests/ai/test_vega_lite.py
+++ b/lumen/tests/ai/test_vega_lite.py
@@ -1,0 +1,58 @@
+import pytest
+
+try:
+    import lumen.ai  # noqa
+except ModuleNotFoundError:
+    pytest.skip(
+        "lumen.ai could not be imported, skipping tests.",
+        allow_module_level=True,
+    )
+
+from lumen.ai.agents.vega_lite import normalize_vegalite_spec
+from lumen.ai.editors import VegaLiteEditor
+
+
+def test_normalize_vegalite_spec_adds_schema_and_container_sizing():
+    """A bare spec gains $schema and container sizing and stays valid."""
+    raw = {
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "A", "type": "quantitative"},
+            "y": {"field": "B", "type": "quantitative"},
+        },
+    }
+
+    result = normalize_vegalite_spec(raw)
+
+    spec = result["spec"]
+    assert spec["$schema"] == "https://vega.github.io/schema/vega-lite/v5.json"
+    assert spec["width"] == "container"
+    assert spec["height"] == "container"
+    assert result["sizing_mode"] == "stretch_both"
+    assert result["min_height"] == 200
+    # Normalized spec must pass the editor's own validation.
+    VegaLiteEditor.validate_spec(spec)
+
+
+def test_normalize_vegalite_spec_strips_sizing_for_compound_charts():
+    """Compound charts drop top-level width/height (sub-charts size themselves)."""
+    raw = {
+        "hconcat": [
+            {
+                "data": {"values": [{"A": 1, "B": 2}]},
+                "mark": "bar",
+                "encoding": {
+                    "x": {"field": "A", "type": "quantitative"},
+                    "y": {"field": "B", "type": "quantitative"},
+                },
+            }
+        ],
+        "width": 400,
+        "height": 300,
+    }
+
+    spec = normalize_vegalite_spec(raw)["spec"]
+
+    assert "width" not in spec
+    assert "height" not in spec
+    assert spec["$schema"] == "https://vega.github.io/schema/vega-lite/v5.json"

--- a/lumen/tests/ai/test_vega_lite.py
+++ b/lumen/tests/ai/test_vega_lite.py
@@ -8,8 +8,8 @@ except ModuleNotFoundError:
         allow_module_level=True,
     )
 
-from lumen.ai.agents.vega_lite import normalize_vegalite_spec
 from lumen.ai.editors import VegaLiteEditor
+from lumen.ai.utils import normalize_vegalite_spec
 
 
 def test_normalize_vegalite_spec_adds_schema_and_container_sizing():
@@ -56,3 +56,20 @@ def test_normalize_vegalite_spec_strips_sizing_for_compound_charts():
     assert "width" not in spec
     assert "height" not in spec
     assert spec["$schema"] == "https://vega.github.io/schema/vega-lite/v5.json"
+
+
+def test_normalize_vegalite_spec_adds_geographic_interactivity():
+    """Specs with lat/long encodings gain a projection, zoom params and map layer."""
+    raw = {
+        "mark": "circle",
+        "encoding": {
+            "latitude": {"field": "lat", "type": "quantitative"},
+            "longitude": {"field": "lon", "type": "quantitative"},
+        },
+    }
+
+    spec = normalize_vegalite_spec(raw)["spec"]
+
+    assert spec["projection"]["type"] == "mercator"
+    assert "scale" in {p.get("name") for p in spec["params"]}
+    assert "layer" in spec


### PR DESCRIPTION
Lumen's Vega-Lite spec normalization is locked inside the private `VegaLiteAgent._extract_spec`, reachable only by spinning up a full agent. This PR lifts it into a standalone `normalize_vegalite_spec` function so specs can be normalized headlessly; `_extract_spec` keeps its parsing and now delegates to it, so existing behavior is unchanged. I need this for lumen-mcp, which renders host-written Vega-Lite specs without an agent and relies on this step to inject `$schema` (which `pn.pane.Vega` requires).
