### PR TITLE
feat: add Report.from_views for assembling reports from prebuilt views

### DIFF
--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -888,6 +888,31 @@ class Report(TaskGroup):
         if self.auto_execute:
             pn.state.execute(self.execute)
 
+    @classmethod
+    def from_views(cls, views: list, title: str | None = None) -> Report:
+        """Assemble an exportable Report from prebuilt views without executing tasks.
+
+        Builds a task-less report whose export state is populated directly from
+        already-rendered views, so `to_html` and `to_notebook` can produce a
+        downloadable report without running an agent. The execute path is
+        untouched; only `views`, the `_view` accordion and `status` are set, and
+        the empty task list keeps the export guards satisfied.
+
+        Parameters
+        ----------
+        views : list
+            The prebuilt viewable outputs to include, in order.
+        title : str, optional
+            The report title, used for the exported document.
+        """
+        report = cls(title=title or "")
+        report._view[:] = [
+            (view.title if "title" in view.param else "", view) for view in views
+        ]
+        report.views = list(views)
+        report.status = "success"
+        return report
+
     def _init_view(self):
         self._header_title = Typography(
             self.param.title, variant="h1", margin=(0, 0, 0, 10)

--- a/lumen/tests/ai/test_report.py
+++ b/lumen/tests/ai/test_report.py
@@ -399,6 +399,33 @@ async def test_report_to_html():
     assert "Hello" in html_string
 
 
+def test_report_from_views_assembles_exportable_report():
+    views = [Markdown("# My Title"), Markdown("Some body text")]
+
+    report = Report.from_views(views, title="Prebuilt Report")
+
+    # No tasks were run, but the report is in an exportable state.
+    assert len(report) == 0
+    assert report.status == "success"
+    assert report.views == views
+
+    nb = json.loads(report.to_notebook())
+    sources = ["".join(cell["source"]) for cell in nb["cells"]]
+    assert any("# My Title" in source for source in sources)
+    assert any("Some body text" in source for source in sources)
+
+    html_string = report.to_html()
+    assert "<html" in html_string.lower()
+    assert "Some body text" in html_string
+
+
+def test_report_from_views_without_title():
+    report = Report.from_views([Markdown("Body")])
+
+    assert report.status == "success"
+    assert "<html" in report.to_html().lower()
+
+
 class BlockingAction(Action):
     """Action that waits on a signal before returning, so tests can deterministically cancel mid-execution."""
 


### PR DESCRIPTION
`Report.to_html` and `to_notebook` assume an executed report, so there is no way to build an exportable report from views produced outside the task machinery. This PR adds a `Report.from_views` classmethod that assembles a task-less report from prebuilt views and marks it exportable, so both exporters work without running an agent. It is additive only, the execute path and existing export guards are unchanged. I need this for lumen-mcp, which builds the views itself and wants a one-liner to produce a downloadable report.
