### PR TITLE
Fix describe data

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -888,9 +888,7 @@ def describe_data_sync(
         summary["columns_shown"] = len(selected_columns)
         notes.append(
             f"Showing {len(selected_columns)} of {n_cols} columns, chosen by "
-            "relevance (query/filter columns and low-cardinality fields first); "
-            "use the schema tools for the rest."
-        )
+            "relevance (query/filter columns and low-cardinality fields first).")
     if notes:
         summary["note"] = " ".join(notes)
     result = {

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -68,10 +68,10 @@ IMAGE_MIME_TYPES = {
 }
 
 # Column-selection tuning for describe_data_sync.
-DEFAULT_MAX_SUMMARY_COLS = 12
+DEFAULT_MAX_SUMMARY_COLS = 16
 # Columns with at most this many distinct values are treated as
 # human-meaningful "enum"/categorical columns and prioritised.
-LOW_CARDINALITY_MAX = 30
+LOW_CARDINALITY_MAX = 10
 
 
 def deterministic_hash(text: str) -> int:
@@ -783,10 +783,6 @@ def describe_data_sync(
     columns_to_drop = [col for col in columns_to_drop if col in describe_df.columns]
     df_describe_dict = describe_df.drop(columns=columns_to_drop).to_dict()
 
-    # Include category/boolean dtypes here: AnnData (and other) sources
-    # return low-cardinality metadata columns as pandas `category`, and
-    # without this they render as empty `{}` — hiding the very enum values
-    # a model needs to write valid filters.
     for col in df.select_dtypes(include=["object", "string", "category", "boolean", "bool"]).columns:
         if col not in df_describe_dict:
             df_describe_dict[col] = {}

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -642,8 +642,11 @@ def _score_column_relevance(series: pd.Series, n_rows: int) -> float:
     ratio = nunique / n_rows if n_rows else 0.0
 
     # Low-cardinality categorical/enum (incl. bool and small int codes):
-    # cheap to summarise and usually the most query-relevant.
-    if nunique <= LOW_CARDINALITY_MAX and ratio < 0.5:
+    # cheap to summarise and usually the most query-relevant. nunique is
+    # already capped, so no additional ratio gate is needed here — on small
+    # frames a low-card column can have a high ratio (e.g. 8/12) and should
+    # still be surfaced.
+    if nunique <= LOW_CARDINALITY_MAX:
         return 3.0
 
     # Continuous numerics: informative ranges/distributions.

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -67,6 +67,12 @@ IMAGE_MIME_TYPES = {
     '.bmp': 'image/bmp',
 }
 
+# Column-selection tuning for describe_data_sync.
+DEFAULT_MAX_SUMMARY_COLS = 12
+# Columns with at most this many distinct values are treated as
+# human-meaningful "enum"/categorical columns and prioritised.
+LOW_CARDINALITY_MAX = 30
+
 
 def deterministic_hash(text: str) -> int:
     """Stable hash using MD5, consistent across Python sessions."""
@@ -600,11 +606,116 @@ async def get_data(pipeline):
     return await asyncio.to_thread(get_data_sync)
 
 
+def _score_column_relevance(series: pd.Series, n_rows: int) -> float:
+    """
+    Cheap, dataset-agnostic relevance score used to pick which columns
+    to include in a summary. Higher is more informative.
+
+    The ordering favours low-cardinality categoricals (the columns a
+    model most often filters/groups on) and numerics with actual spread,
+    while penalising constant columns and near-unique id/free-text
+    columns. It deliberately relies only on dtype and cardinality so it
+    generalises across datasets rather than matching specific names.
+
+    Parameters
+    ----------
+    series : pd.Series
+        The (already row-sampled) column to score.
+    n_rows : int
+        Number of rows in the sample, used for the cardinality ratio.
+
+    Returns
+    -------
+    float
+        Relevance score; larger values are kept first.
+    """
+    try:
+        nunique = int(series.nunique(dropna=True))
+    except TypeError:
+        # Unhashable values (e.g. lists/dicts) — treat as uninformative.
+        return 0.5
+
+    if nunique <= 1:
+        # Constant (or all-null) column carries no signal.
+        return 0.0
+
+    ratio = nunique / n_rows if n_rows else 0.0
+
+    # Low-cardinality categorical/enum (incl. bool and small int codes):
+    # cheap to summarise and usually the most query-relevant.
+    if nunique <= LOW_CARDINALITY_MAX and ratio < 0.5:
+        return 3.0
+
+    # Continuous numerics: informative ranges/distributions.
+    if pd.api.types.is_numeric_dtype(series):
+        return 2.0
+
+    # Near-unique non-numeric column: likely an id or free text.
+    if ratio > 0.9:
+        return 0.5
+
+    # Moderate-cardinality text.
+    return 1.5
+
+
+def _select_relevant_columns(
+    df: pd.DataFrame,
+    max_cols: int,
+    priority_columns: list[str] | None = None,
+) -> tuple[list[str], bool]:
+    """
+    Choose up to *max_cols* columns to summarise, ordered by relevance.
+
+    Any caller-supplied *priority_columns* (e.g. columns referenced in
+    the query or in active exploration filters) are always kept and
+    placed first; the remaining budget is filled by intrinsic relevance
+    score. Columns are returned relevance-first so that if the rendered
+    summary is later truncated to a character/token budget, the most
+    useful columns survive.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The (already row-sampled) frame to select columns from.
+    max_cols : int
+        Soft cap on the number of columns to keep. Priority columns are
+        always kept even if they exceed this.
+    priority_columns : list[str] | None
+        Columns to force-include, in order of importance.
+
+    Returns
+    -------
+    tuple[list[str], bool]
+        The selected column names and whether any columns were dropped.
+    """
+    columns = list(df.columns)
+    if len(columns) <= max_cols and not priority_columns:
+        return columns, False
+
+    priority = [c for c in (priority_columns or []) if c in df.columns]
+    priority_set = set(priority)
+
+    n_rows = len(df)
+    scored = [
+        (_score_column_relevance(df[col], n_rows), idx, col)
+        for idx, col in enumerate(columns)
+        if col not in priority_set
+    ]
+    # Highest score first; ties fall back to original column order.
+    scored.sort(key=lambda t: (-t[0], t[1]))
+
+    remaining = max(0, max_cols - len(priority))
+    selected = priority + [col for _, _, col in scored[:remaining]]
+    return selected, len(selected) < len(columns)
+
+
 def describe_data_sync(
     df: pd.DataFrame,
     enum_limit: int = 3,
     reduce_enums: bool = True,
     row_limit: int | None = None,
+    max_cols: int = DEFAULT_MAX_SUMMARY_COLS,
+    priority_columns: list[str] | None = None,
 ) -> str:
     """
     Synchronous version of describe_data that generates a YAML summary of a DataFrame.
@@ -622,6 +733,14 @@ def describe_data_sync(
         returned frame reaches this many rows the result was truncated, so
         the summary flags it instead of presenting the capped count as the
         table's true size.
+    max_cols : int
+        Soft cap on how many columns to include. When the frame is wider,
+        columns are selected by relevance (see _select_relevant_columns)
+        rather than by position, so informative fields aren't dropped just
+        for appearing late in the table.
+    priority_columns : list[str] | None
+        Columns to always include (e.g. columns referenced in the query
+        or active filters), placed first.
 
     Returns
     -------
@@ -646,21 +765,29 @@ def describe_data_sync(
 
     df = df.sort_index()
 
+    # Select the most informative columns before the (more expensive)
+    # per-column stats below, so wide tables don't crowd out or truncate
+    # the columns a model actually needs.
+    selected_columns, sampled_columns = _select_relevant_columns(
+        df, max_cols=max_cols, priority_columns=priority_columns
+    )
+    if sampled_columns:
+        df = df[selected_columns]
+
     for col in df.columns:
         if isinstance(df[col].iloc[0], pd.Timestamp):
             df[col] = pd.to_datetime(df[col])
-
-    sampled_columns = False
-    if len(df.columns) > 10:
-        df = df[df.columns[:10]]
-        sampled_columns = True
 
     describe_df = df.describe(percentiles=[])
     columns_to_drop = ["min", "max", "count", "top", "freq"] # present if any numeric or object
     columns_to_drop = [col for col in columns_to_drop if col in describe_df.columns]
     df_describe_dict = describe_df.drop(columns=columns_to_drop).to_dict()
 
-    for col in df.select_dtypes(include=["object", "string"]).columns:
+    # Include category/boolean dtypes here: AnnData (and other) sources
+    # return low-cardinality metadata columns as pandas `category`, and
+    # without this they render as empty `{}` — hiding the very enum values
+    # a model needs to write valid filters.
+    for col in df.select_dtypes(include=["object", "string", "category", "boolean", "bool"]).columns:
         if col not in df_describe_dict:
             df_describe_dict[col] = {}
         try:
@@ -733,6 +860,15 @@ def describe_data_sync(
     for col in df.select_dtypes(include=["float64"]).columns:
         df[col] = df[col].apply(format_float)
 
+    # Emit stats in the (relevance-first) column order so that if the
+    # rendered summary is later truncated to a character/token budget by
+    # a caller, the most informative columns are the ones that survive.
+    ordered_describe = {c: df_describe_dict[c] for c in df.columns if c in df_describe_dict}
+    for key, value in df_describe_dict.items():
+        if key not in ordered_describe:
+            ordered_describe[key] = value
+    df_describe_dict = ordered_describe
+
     n_rows, n_cols = shape
 
     # Add head and tail samples (2 rows each); deduplicate if identical
@@ -745,12 +881,22 @@ def describe_data_sync(
         "sampled_cols": sampled_columns,
         "is_sampled": is_sampled,
     }
+    notes = []
     if row_limit is not None and n_rows >= row_limit:
         summary["rows_capped_at_limit"] = row_limit
-        summary["note"] = (
+        notes.append(
             f"Result capped at the {row_limit}-row display limit; "
             "the full table may contain more rows."
         )
+    if sampled_columns:
+        summary["columns_shown"] = len(selected_columns)
+        notes.append(
+            f"Showing {len(selected_columns)} of {n_cols} columns, chosen by "
+            "relevance (query/filter columns and low-cardinality fields first); "
+            "use the schema tools for the rest."
+        )
+    if notes:
+        summary["note"] = " ".join(notes)
     result = {
         "summary": summary,
         "stats": df_describe_dict,
@@ -769,6 +915,8 @@ async def describe_data(
     enum_limit: int = 3,
     reduce_enums: bool = True,
     row_limit: int | None = None,
+    max_cols: int = DEFAULT_MAX_SUMMARY_COLS,
+    priority_columns: list[str] | None = None,
 ) -> str:
     """
     Async wrapper for describe_data_sync that generates a YAML summary of a DataFrame.
@@ -781,6 +929,15 @@ async def describe_data(
         Maximum number of enum values to show per column
     reduce_enums : bool
         Whether to reduce enum values for readability
+    row_limit : int | None
+        The row cap applied to the result; used to flag truncation.
+    max_cols : int
+        Soft cap on how many columns to include in the summary. When the
+        frame is wider, columns are chosen by relevance rather than
+        position.
+    priority_columns : list[str] | None
+        Columns to always include (e.g. columns referenced in the query
+        or active filters), placed first.
 
     Returns
     -------
@@ -788,7 +945,8 @@ async def describe_data(
         YAML-formatted summary of the DataFrame
     """
     return await asyncio.to_thread(
-        describe_data_sync, df, enum_limit, reduce_enums, row_limit
+        describe_data_sync, df, enum_limit, reduce_enums, row_limit,
+        max_cols, priority_columns,
     )
 
 

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -295,7 +295,7 @@ class TestDescribeData:
         df = pd.DataFrame(data)
         result = yaml.load(await describe_data(df), yaml.SafeLoader)
         assert result["summary"]["sampled_cols"] is True
-        assert result["summary"]["columns_shown"] == 12
+        assert result["summary"]["columns_shown"] == 16
         # Low-cardinality categorical kept even though it is the last column.
         assert "category" in result["stats"]
         # Near-unique id column dropped in favour of more informative columns.

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -284,6 +284,56 @@ class TestDescribeData:
         assert "col1: 1" in result
         assert "col2: 3" in result
 
+    async def test_describe_selects_relevant_columns(self):
+        # Wide frame: many numerics, one low-cardinality categorical placed
+        # last, and one near-unique id column. Relevance selection should
+        # keep the categorical (despite its position) and drop the id.
+        n = 200
+        data = {f"num_{i}": np.arange(n) + i for i in range(15)}
+        data["uid"] = [f"id_{i}" for i in range(n)]
+        data["category"] = (["a", "b", "c"] * n)[:n]
+        df = pd.DataFrame(data)
+        result = yaml.load(await describe_data(df), yaml.SafeLoader)
+        assert result["summary"]["sampled_cols"] is True
+        assert result["summary"]["columns_shown"] == 12
+        # Low-cardinality categorical kept even though it is the last column.
+        assert "category" in result["stats"]
+        # Near-unique id column dropped in favour of more informative columns.
+        assert "uid" not in result["stats"]
+
+    async def test_describe_priority_columns_forced_in(self):
+        n = 200
+        data = {f"num_{i}": np.arange(n) + i for i in range(15)}
+        data["uid"] = [f"id_{i}" for i in range(n)]
+        df = pd.DataFrame(data)
+        result = yaml.load(
+            await describe_data(df, priority_columns=["uid"]), yaml.SafeLoader
+        )
+        # Explicitly requested column is included despite low relevance.
+        assert "uid" in result["stats"]
+
+    async def test_describe_narrow_data_not_sampled(self):
+        df = pd.DataFrame({f"col_{i}": np.arange(0, 200) for i in range(5)})
+        result = yaml.load(await describe_data(df), yaml.SafeLoader)
+        assert result["summary"]["sampled_cols"] is False
+        assert "columns_shown" not in result["summary"]
+
+    async def test_describe_categorical_dtype_emits_enum(self):
+        # AnnData and similar sources return low-cardinality columns as
+        # pandas `category`; their enum values must still surface.
+        n = 300
+        df = pd.DataFrame({
+            "smoking": pd.Categorical((["Former", "Current", "Never"] * n)[:n]),
+            "flag": pd.array(([True, False] * n)[:n], dtype="boolean"),
+            "value": np.random.rand(n),
+        })
+        result = yaml.load(await describe_data(df), yaml.SafeLoader)
+        assert set(result["stats"]["smoking"]["enum"]) <= {
+            "Former", "Current", "Never", "...",
+        }
+        assert result["stats"]["smoking"]["nunique"] == 3
+        assert "enum" in result["stats"]["flag"]
+
 
 def test_clean_sql_removes_backticks():
     sql_expr = "```sql SELECT * FROM `table`; ```"

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -319,8 +319,8 @@ class TestDescribeData:
         assert "columns_shown" not in result["summary"]
 
     async def test_describe_categorical_dtype_emits_enum(self):
-        # AnnData and similar sources return low-cardinality columns as
-        # pandas `category`; their enum values must still surface.
+        # Sources that return low-cardinality columns as
+        # pandas `category` must still surface their enum values.
         n = 300
         df = pd.DataFrame({
             "smoking": pd.Categorical((["Former", "Current", "Never"] * n)[:n]),


### PR DESCRIPTION
Rank which columns to show enums. I noticed wide dataframes wasted cols with many string values, but there were cols with limited enums that is very useful for filtering.