### PR TITLE
Allow Analysis to provide context dynamically

### DIFF
--- a/lumen/ai/analysis.py
+++ b/lumen/ai/analysis.py
@@ -40,6 +40,14 @@ class Analysis(param.ParameterizedFunction):
 
     _run_button = param.Parameter(default=None)
 
+    _dynamic_provides = param.Dict(default={}, instantiate=True, doc="""
+        Context values the analysis publishes reactively after it has rendered,
+        e.g. following an interactive selection. AnalysisOutput watches this and
+        merges it into its render_context, so updates reach the out-context
+        without mutating the (snapshot) input context. Unlike Tool.provides (a
+        static list of context key names), this is a live map of values that can
+        change on each interaction.""")
+
      # Whether to allow the analysis to be called multiple times in a row
     _consecutive_calls = False
 

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -58,6 +58,11 @@ class LumenEditor(Viewer):
 
     title = param.String(allow_None=True)
 
+    _context_updated = param.Event(doc="""
+        Triggered when the output's context changes after render (e.g. an
+        interactive selection) so watchers can refresh the out-context without
+        going through the spec/deserialize path.""")
+
     export_formats = ("yaml",)
 
     language = "yaml"
@@ -182,6 +187,10 @@ class LumenEditor(Viewer):
 
     @param.depends("spec", watch=True)
     def _update_component(self):
+        # spec is None for outputs that couldn't be serialized (e.g. an
+        # interactive analysis view); there is nothing to deserialize.
+        if self.spec is None:
+            return
         if self.spec in self._last_output and self.component is None:
             return
         pipeline = getattr(self.component, 'pipeline', None)
@@ -466,6 +475,14 @@ class AnalysisOutput(LumenEditor):
         if 'title' not in params or params['title'] is None:
             params['title'] = type(params['analysis']).__name__
         super().__init__(**params)
+        if self.analysis is not None:
+            self.analysis.param.watch(self._on_dynamic_provides, '_dynamic_provides')
+
+    def _on_dynamic_provides(self, event):
+        # The analysis published context after rendering (e.g. an interactive
+        # selection). Signal watchers to re-run render_context and merge it into
+        # out_context, without touching spec (which would try to re-deserialize).
+        self.param.trigger('_context_updated')
 
     def _render_editor(self):
         controls = self.analysis.controls(self.context)
@@ -485,6 +502,8 @@ class AnalysisOutput(LumenEditor):
     async def render_context(self):
         out_context = await super().render_context()
         out_context["analysis"] = self.analysis
+        if self.analysis is not None and self.analysis._dynamic_provides:
+            out_context.update(self.analysis._dynamic_provides)
         return out_context
 
     async def _rerun(self, event):

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -1277,8 +1277,11 @@ class ActorTask(ExecutableTask):
     def output_schema(self):
         return self.actor.output_schema
 
-    async def _update_spec(self, event: param.parameterized.Event):
-        self.out_context = dict(self.out_context, **(await event.obj.render_context()))
+    async def _update_spec(self, *events: param.parameterized.Event):
+        # Watches both `spec` and `_context_updated`; a batched update can
+        # deliver several events, all from the same editor.
+        editor = events[0].obj
+        self.out_context = dict(self.out_context, **(await editor.render_context()))
 
     def _add_outputs(self, views: list, context: TContext):
         # Handle Tool specific behaviors
@@ -1304,7 +1307,7 @@ class ActorTask(ExecutableTask):
         for view in views:
             if not isinstance(view, LumenEditor):
                 continue
-            view.param.watch(self._update_spec, "spec")
+            view.param.watch(self._update_spec, ["spec", "_context_updated"])
 
         self.views = self._header + views
         rendered = []


### PR DESCRIPTION
Analysis returns a view and its out-context is captured once, meaning interactive analyses (e.g. a manifold-map lasso) had no supported way to push updated `source`/`pipeline`/`data` to later steps.

This PR adds dynamic provides, where AnalysisOutput watches it and merges into render context, triggering context_updated so out_context is updated, without affecting spec.

Lastly, `_update_component` guards against a `None` spec.