### PR TITLE
feat: generate multiple charts per query in VegaLiteAgent

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -23,7 +23,7 @@ Lumen includes eight agents automatically. You don't need to configure anything.
 | Agent | What it does |
 |-------|-------------|
 | **SQLAgent** | Writes and runs SQL queries |
-| **VegaLiteAgent** | Creates charts and visualizations |
+| **VegaLiteAgent** | Creates one or more charts from a single request (each in its own editable tab, with an "All" overview) |
 | **DeckGLAgent** | Creates 3D map visualizations for geographic data |
 | **ChatAgent** | Answers questions and provides guidance |
 | **SourceAgent** | Fetches data from configured source controls |

--- a/docs/getting_started/using_lumen_ai.md
+++ b/docs/getting_started/using_lumen_ai.md
@@ -18,6 +18,9 @@ Here are some ideas to spark your exploration:
 - "Show me a scatter plot of 'flipper_length_mm' vs 'body_mass_g'."
 - "Create a histogram of 'bill_length_mm'."
 - "Show me a bar chart of average values by species."
+- "Create separate charts of average body mass by species and average flipper length by species."
+
+When a request calls for more than one chart, each chart opens in its own tab that you can edit, alongside an "All" tab that shows every chart together.
 
 **Complex queries:**
 

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -8,11 +8,12 @@ import requests
 
 from instructor import Image
 from panel.io import state
+from panel.layout import Column
 from pydantic import BaseModel, Field
 
 from ...config import dump_yaml, load_yaml
 from ...pipeline import Pipeline
-from ...views import VegaLiteView
+from ...views import Panel, VegaLiteView
 from ..code_executor import AltairExecutor, CodeSafetyCheck
 from ..config import (
     LUMEN_CACHE_DIR, PROMPTS_DIR, VECTOR_STORE_ASSETS_URL,
@@ -20,7 +21,7 @@ from ..config import (
     UserCancelledError,
 )
 from ..context import TContext
-from ..editors import LumenEditor, VegaLiteEditor
+from ..editors import LumenEditor, MultiChartEditor, VegaLiteEditor
 from ..llm import Message, OpenAI
 from ..models import EscapeBaseModel, RetrySpec
 from ..utils import (
@@ -29,6 +30,18 @@ from ..utils import (
 )
 from ..vector_store import DuckDBVectorStore
 from .base_code import BaseCodeAgent
+
+
+class ChartSpec(BaseModel):
+    """A single Vega-Lite chart within a (potentially multi-chart) response."""
+
+    title: str = Field(
+        default="",
+        description="Short, human-readable label for this chart, used as its tab or section heading when several charts are returned."
+    )
+    yaml_spec: str = Field(
+        description="A basic vega-lite YAML specification with core plot elements only (mark, basic x/y encoding). Skip $schema and data fields."
+    )
 
 
 class VegaLiteSpec(EscapeBaseModel):
@@ -40,15 +53,16 @@ class VegaLiteSpec(EscapeBaseModel):
         - What additional context adds value without repeating the title (for the subtitle)?
         - Which visual encodings (position, color, size) best reveal patterns?
         - Should color highlight specific insights or remain neutral?
-        - What makes this plot engaging and useful for the user?
+        - When several charts are warranted, why each one earns its place.
         Keep response to 1-2 sentences.""",
         examples=[
             "The data reveals US dominance in Winter Olympic hosting (4 times vs France's 3)—title should emphasize this leadership. Position encoding via horizontal bars sorted descending makes comparison immediate, neutral blue keeps focus on counts rather than categories, and the subtitle can note the 23-country spread to add context without redundancy.",
             "This time series shows a 40% revenue spike in Q3 2024—the key trend for the title. A line chart with position encoding (time→x, revenue→y) reveals the pattern, endpoint labels eliminate need for constant grid reference making it cleaner, and color remains neutral since there's one series; the subtitle should explain what drove the spike (e.g., 'Three offshore projects') to add insight."
         ]
     )
-    yaml_spec: str = Field(
-        description="A basic vega-lite YAML specification with core plot elements only (mark, basic x/y encoding). Skip $schema and data fields."
+    charts: list[ChartSpec] = Field(
+        min_length=1,
+        description="One or more chart specifications. Return several charts only when the request spans distinct metrics or relationships that should not share a single plot; otherwise return exactly one."
     )
 
 
@@ -66,20 +80,12 @@ class VegaLiteSpecUpdate(BaseModel):
     )
 
 
-class AltairSpec(BaseModel):
-    """Response model for Altair code generation."""
+class AltairChartSpec(BaseModel):
+    """A single Altair chart within a (potentially multi-chart) response."""
 
-    chain_of_thought: str = Field(
+    title: str = Field(
         default="",
-        description="""Explain your design choices based on visualization theory:
-        - What story does this data tell?
-        - What's the most compelling insight or trend (for the title)?
-        - Which visual encodings (position, color, size) best reveal patterns?
-        Keep response to 1-2 sentences.""",
-        examples=[
-            "The data reveals US dominance in Winter Olympic hosting—a horizontal bar chart sorted descending makes comparison immediate, with the leader highlighted in a distinct color.",
-            "This time series shows a 40% revenue spike in Q3 2024—a line chart with point markers reveals the trend clearly."
-        ]
+        description="Short, human-readable label for this chart, used as its tab or section heading when several charts are returned."
     )
     code: str = Field(
         description="""Python code that creates an Altair chart.
@@ -93,6 +99,28 @@ class AltairSpec(BaseModel):
     )
 
 
+class AltairSpec(BaseModel):
+    """Response model for Altair code generation."""
+
+    chain_of_thought: str = Field(
+        default="",
+        description="""Explain your design choices based on visualization theory:
+        - What story does this data tell?
+        - What's the most compelling insight or trend (for the title)?
+        - Which visual encodings (position, color, size) best reveal patterns?
+        - When several charts are warranted, why each one earns its place.
+        Keep response to 1-2 sentences.""",
+        examples=[
+            "The data reveals US dominance in Winter Olympic hosting—a horizontal bar chart sorted descending makes comparison immediate, with the leader highlighted in a distinct color.",
+            "This time series shows a 40% revenue spike in Q3 2024—a line chart with point markers reveals the trend clearly."
+        ]
+    )
+    charts: list[AltairChartSpec] = Field(
+        min_length=1,
+        description="One or more chart specifications. Return several charts only when the request spans distinct metrics or relationships that should not share a single plot; otherwise return exactly one."
+    )
+
+
 class VegaLiteAgent(BaseCodeAgent):
 
     conditions = param.List(
@@ -102,7 +130,7 @@ class VegaLiteAgent(BaseCodeAgent):
         ]
     )
 
-    purpose = param.String(default="Generates a vega-lite plot specification from the input data pipeline.")
+    purpose = param.String(default="Generates one or more vega-lite plot specifications from the input data pipeline.")
 
     prompts = param.Dict(
         default={
@@ -413,7 +441,7 @@ class VegaLiteAgent(BaseCodeAgent):
         doc_examples: list | None = None,
         errors: list | None = None
     ) -> dict[str, Any]:
-        """Generate VegaLite spec via YAML (declarative mode)."""
+        """Generate one or more VegaLite specs via YAML (declarative mode)."""
         errors_context = self._build_errors_context(pipeline, context, errors)
         with self._add_step(title="Creating basic plot structure", steps_layout=self._steps_layout) as step:
             response = self._stream_prompt(
@@ -428,9 +456,20 @@ class VegaLiteAgent(BaseCodeAgent):
             async for output in response:
                 step.stream(output.chain_of_thought, replace=True)
 
-            current_spec = await self._extract_spec(context, {"yaml_spec": output.yaml_spec})
+            # Extract each chart independently so one malformed spec does not
+            # discard the charts that did parse.
+            specs, titles = [], []
+            for chart_spec in output.charts:
+                try:
+                    specs.append(await self._extract_spec(context, {"yaml_spec": chart_spec.yaml_spec}))
+                    titles.append(chart_spec.title)
+                except Exception as e:
+                    log_debug(f"Skipping chart {chart_spec.title!r} that failed to parse: {e}")
+            if not specs:
+                # Nothing parsed; let retry_llm_output regenerate with the errors.
+                raise ValueError("None of the generated chart specifications could be parsed.")
             step.success_title = "Complete visualization with titles and colors created"
-        return current_spec
+        return {"specs": specs, "titles": titles}
 
     @retry_llm_output()
     async def _generate_code_spec(
@@ -442,7 +481,7 @@ class VegaLiteAgent(BaseCodeAgent):
         doc_examples: list | None = None,
         errors: list | None = None,
     ) -> dict[str, Any] | None:
-        """Generate spec via Altair code execution."""
+        """Generate one or more specs via Altair code execution."""
         errors_context = self._build_errors_context(pipeline, context, errors)
 
         with self._add_step(title="Generating Altair code", steps_layout=self._steps_layout) as step:
@@ -458,31 +497,38 @@ class VegaLiteAgent(BaseCodeAgent):
             async for output in response:
                 step.stream(output.chain_of_thought, replace=True)
 
-            step.stream(f"\n```python\n{output.code}\n```\n", replace=False)
-
-            # Get LLM system prompt for safety validation if needed
-            system = None
-            if self.code_execution == "llm":
-                system = await self._render_prompt(
-                    "code_safety",
-                    messages,
-                    context,
-                    code=output.code,
-                )
-
-            # Execute code using mixin (handles AST validation, LLM validation, user prompt)
+            # Execute each generated code block into its own chart object
             df = await get_data(pipeline)
-            chart = await self._execute_code(output.code, df, system=system, step=step)
+            chart_objects = []
+            for chart_spec in output.charts:
+                step.stream(f"\n```python\n{chart_spec.code}\n```\n", replace=False)
+                # Get LLM system prompt for safety validation if needed
+                system = None
+                if self.code_execution == "llm":
+                    system = await self._render_prompt(
+                        "code_safety",
+                        messages,
+                        context,
+                        code=chart_spec.code,
+                    )
+                # Execute code using mixin (handles AST validation, LLM validation, user prompt)
+                chart = await self._execute_code(chart_spec.code, df, system=system, step=step)
+                if chart is None:
+                    raise UserCancelledError("Code execution rejected by user.")
+                chart_objects.append(chart)
 
-        if chart is None:
-            raise UserCancelledError("Code execution rejected by user.")
+        specs = []
+        for chart in chart_objects:
+            # Convert to Vega-Lite spec
+            spec = chart.to_dict()
+            spec.pop("datasets", None)  # Remove inline data
+            spec["data"] = {"name": pipeline.table}  # Use named data source
+            specs.append(await self._extract_spec(context, {"yaml_spec": dump_yaml(spec)}))
 
-        # Convert to Vega-Lite spec
-        spec = chart.to_dict()
-        spec.pop("datasets", None)  # Remove inline data
-        spec["data"] = {"name": pipeline.table}  # Use named data source
-
-        return await self._extract_spec(context, {"yaml_spec": dump_yaml(spec)})
+        return {
+            "specs": specs,
+            "titles": [chart_spec.title for chart_spec in output.charts],
+        }
 
     async def _extract_spec(self, context: TContext, spec: dict[str, Any]):
         # .encode().decode('unicode_escape') fixes a JSONDecodeError in Python
@@ -597,7 +643,8 @@ class VegaLiteAgent(BaseCodeAgent):
         step_title: str | None = None,
     ) -> tuple[list[Any], TContext]:
         """
-        Generates a VegaLite visualization using progressive building approach with real-time updates.
+        Generates one or more VegaLite visualizations using a progressive building
+        approach with real-time updates.
         """
         pipeline = context.get("pipeline")
         if not pipeline:
@@ -613,26 +660,47 @@ class VegaLiteAgent(BaseCodeAgent):
         except Exception:
             doc_examples = []
 
-        # Step 1: Generate basic spec
+        # Step 1: Generate one or more specs
         doc = self.view_type.__doc__.split("\n\n")[0] if self.view_type.__doc__ else self.view_type.__name__
-        # Produces {"spec": {$schema: ..., ...}, "sizing_mode": ..., ...}
-        full_dict = await self._generate_spec(
+        # Produces {"specs": [{"spec": {...}, ...}], "titles": [...]}
+        result = await self._generate_spec(
             messages, context, pipeline, doc, doc_examples=doc_examples
         )
-        if full_dict is None:
+        if result is None:
             # User rejected code execution
             return [], {}
 
-        # Step 2: Show complete plot immediately
-        view = self.view_type(pipeline=pipeline, **full_dict)
-        out = self._editor_type(component=view, title=step_title)
+        # Step 2: One editable editor per chart. The UI renders each as its own
+        # tab with a code editor beside the plot.
+        titles = result["titles"]
+        views = [self.view_type(pipeline=pipeline, **spec) for spec in result["specs"]]
+        if len(views) == 1:
+            editors = [self._editor_type(component=views[0], title=step_title)]
+        else:
+            editors = [
+                self._editor_type(component=view, title=titles[i] or f"Chart {i + 1}")
+                for i, view in enumerate(views)
+            ]
 
-        # Step 3: enhancements (LLM-driven creative decisions)
+        # Step 3: For multiple charts, append a view-only "All" tab that stacks
+        # every plot together as an overview (no code editor of its own). It is
+        # added last so the UI opens it by default as the final tab.
+        outs = editors
+        if len(views) > 1:
+            overview = Column(
+                *(view.get_panel() for view in views),
+                sizing_mode="stretch_width",
+                scroll=True,
+            )
+            outs = [*editors, MultiChartEditor(component=Panel(object=overview), title="All")]
+
+        # Step 4: enhancements (LLM-driven creative decisions), per editable chart
         if not self.code_execution_enabled:
-            state.execute(partial(self._polish_plot, out, messages, context, doc))
+            for editor in editors:
+                state.execute(partial(self._polish_plot, editor, messages, context, doc))
 
-        out_context = await out.render_context()
-        return [out], out_context
+        out_context = await editors[-1].render_context()
+        return outs, out_context
 
     async def annotate(
         self,

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -18,9 +18,9 @@ from ...pipeline import Pipeline
 from ...views import Panel, VegaLiteView
 from ..code_executor import AltairExecutor, CodeSafetyCheck
 from ..config import (
-    LUMEN_CACHE_DIR, PROMPTS_DIR, VECTOR_STORE_ASSETS_URL,
-    VEGA_LITE_EXAMPLES_NUMPY_DB_FILE, VEGA_LITE_EXAMPLES_OPENAI_DB_FILE,
-    UserCancelledError,
+    LUMEN_CACHE_DIR, PROMPTS_DIR, UNRECOVERABLE_ERRORS,
+    VECTOR_STORE_ASSETS_URL, VEGA_LITE_EXAMPLES_NUMPY_DB_FILE,
+    VEGA_LITE_EXAMPLES_OPENAI_DB_FILE, UserCancelledError,
 )
 from ..context import TContext
 from ..editors import LumenEditor, MultiChartEditor, VegaLiteEditor
@@ -460,22 +460,31 @@ class VegaLiteAgent(BaseCodeAgent):
 
             # Extract each chart independently so one malformed spec does not
             # discard the charts that did parse.
-            specs, titles = [], []
+            charts, chart_errors = [], []
             for chart_spec in output.charts:
                 try:
-                    specs.append(await self._extract_spec(context, {"yaml_spec": chart_spec.yaml_spec}))
-                    titles.append(chart_spec.title)
+                    spec = await self._extract_spec(context, {"yaml_spec": chart_spec.yaml_spec})
+                except UNRECOVERABLE_ERRORS:
+                    # e.g. missing context or a cancelled run; retrying cannot help.
+                    raise
                 except Exception as e:
                     log_debug(f"Skipping chart {chart_spec.title!r} that failed to parse: {e}")
-            if not specs:
-                # Nothing parsed; let retry_llm_output regenerate with the errors.
-                raise ValueError("None of the generated chart specifications could be parsed.")
-            skipped = len(output.charts) - len(specs)
+                    chart_errors.append(f"{chart_spec.title or 'chart'}: {e}")
+                    continue
+                charts.append((spec, chart_spec.title))
+            if not charts:
+                # Nothing parsed; report every failure so the regenerated specs
+                # from retry_llm_output have something concrete to fix.
+                raise ValueError(
+                    "None of the generated chart specifications could be parsed. "
+                    + "; ".join(chart_errors)
+                )
+            skipped = len(output.charts) - len(charts)
             if skipped:
                 # Surface the drop to the user instead of only logging it.
                 step.stream(f"\n\nSkipped {skipped} chart(s) whose specification could not be parsed.")
             step.success_title = "Complete visualization with titles and colors created"
-        return {"specs": specs, "titles": titles}
+        return {"charts": charts}
 
     @retry_llm_output()
     async def _generate_code_spec(
@@ -521,20 +530,17 @@ class VegaLiteAgent(BaseCodeAgent):
                 chart = await self._execute_code(chart_spec.code, df, system=system, step=step)
                 if chart is None:
                     raise UserCancelledError("Code execution rejected by user.")
-                chart_objects.append(chart)
+                chart_objects.append((chart, chart_spec.title))
 
-        specs = []
-        for chart in chart_objects:
+        charts = []
+        for chart, title in chart_objects:
             # Convert to Vega-Lite spec
             spec = chart.to_dict()
             spec.pop("datasets", None)  # Remove inline data
             spec["data"] = {"name": pipeline.table}  # Use named data source
-            specs.append(await self._extract_spec(context, {"yaml_spec": dump_yaml(spec)}))
+            charts.append((await self._extract_spec(context, {"yaml_spec": dump_yaml(spec)}), title))
 
-        return {
-            "specs": specs,
-            "titles": [chart_spec.title for chart_spec in output.charts],
-        }
+        return {"charts": charts}
 
     async def _extract_spec(self, context: TContext, spec: dict[str, Any]):
         # .encode().decode('unicode_escape') fixes a JSONDecodeError in Python
@@ -681,7 +687,7 @@ class VegaLiteAgent(BaseCodeAgent):
 
         # Step 1: Generate one or more specs
         doc = self.view_type.__doc__.split("\n\n")[0] if self.view_type.__doc__ else self.view_type.__name__
-        # Produces {"specs": [{"spec": {...}, ...}], "titles": [...]}
+        # Produces {"charts": [({"spec": {...}, ...}, title), ...]}
         result = await self._generate_spec(
             messages, context, pipeline, doc, doc_examples=doc_examples
         )
@@ -690,30 +696,35 @@ class VegaLiteAgent(BaseCodeAgent):
             return [], {}
 
         # Step 2: One editable editor per chart. The UI renders each as its own
-        # tab with a code editor beside the plot.
-        titles = result["titles"]
-        views = [self.view_type(pipeline=pipeline, **spec) for spec in result["specs"]]
-        if len(views) == 1:
-            editors = [self._editor_type(component=views[0], title=step_title)]
-        else:
-            editors = [
-                self._editor_type(component=view, title=titles[i] or f"Chart {i + 1}")
-                for i, view in enumerate(views)
-            ]
+        # tab with a code editor beside the plot. A lone chart keeps the task's
+        # own title; several charts are labelled individually so their tabs are
+        # distinguishable.
+        charts = result["charts"]
+        editors = [
+            self._editor_type(
+                component=self.view_type(pipeline=pipeline, **spec),
+                title=step_title if len(charts) == 1 else (title or f"Chart {i}"),
+            )
+            for i, (spec, title) in enumerate(charts, start=1)
+        ]
 
-        # Step 3: For multiple charts, append a view-only "All" tab that stacks
-        # every plot together as an overview (no code editor of its own). It is
+        # Step 3: For multiple charts, append an "All" tab that stacks every plot
+        # together as an overview, with one code editor sub-tab per chart. It is
         # added last so the UI opens it by default as the final tab. Each plot
         # re-renders from its editor's component, so edits (or the polish pass)
         # to a chart tab stay in sync with the overview.
         outs = editors
-        if len(views) > 1:
-            overview = Column(
+        if len(editors) > 1:
+            # Left at its natural height so it overflows the editor's view,
+            # which is what gives that view something to scroll.
+            stacked = Column(
                 *(self._overview_item(editor) for editor in editors),
                 sizing_mode="stretch_width",
-                scroll=True,
             )
-            outs = [*editors, MultiChartEditor(component=Panel(object=overview), title="All")]
+            overview = MultiChartEditor(
+                component=Panel(object=stacked), title="All", chart_editors=editors
+            )
+            outs = [*editors, overview]
 
         # Step 4: enhancements (LLM-driven creative decisions), per editable chart
         if not self.code_execution_enabled:

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -470,6 +470,10 @@ class VegaLiteAgent(BaseCodeAgent):
             if not specs:
                 # Nothing parsed; let retry_llm_output regenerate with the errors.
                 raise ValueError("None of the generated chart specifications could be parsed.")
+            skipped = len(output.charts) - len(specs)
+            if skipped:
+                # Surface the drop to the user instead of only logging it.
+                step.stream(f"\n\nSkipped {skipped} chart(s) whose specification could not be parsed.")
             step.success_title = "Complete visualization with titles and colors created"
         return {"specs": specs, "titles": titles}
 

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -7,8 +7,10 @@ import param
 import requests
 
 from instructor import Image
+from panel import bind
 from panel.io import state
 from panel.layout import Column
+from panel.param import ParamFunction
 from pydantic import BaseModel, Field
 
 from ...config import dump_yaml, load_yaml
@@ -636,6 +638,19 @@ class VegaLiteAgent(BaseCodeAgent):
                 out.spec = dump_yaml(merged_spec)
             log_debug(f"📊 Applied {step_name} updates and refreshed visualization")
 
+    @staticmethod
+    def _overview_item(editor: VegaLiteEditor) -> ParamFunction:
+        """A plot for the "All" overview that tracks an editor's component.
+
+        Binding to the editor's ``component`` means the overview re-renders when
+        the chart is edited or polished, instead of showing a stale snapshot.
+        """
+        render = bind(
+            lambda component: component.get_panel() if component is not None else None,
+            editor.param.component,
+        )
+        return ParamFunction(render, sizing_mode="stretch_width")
+
     async def respond(
         self,
         messages: list[Message],
@@ -684,11 +699,13 @@ class VegaLiteAgent(BaseCodeAgent):
 
         # Step 3: For multiple charts, append a view-only "All" tab that stacks
         # every plot together as an overview (no code editor of its own). It is
-        # added last so the UI opens it by default as the final tab.
+        # added last so the UI opens it by default as the final tab. Each plot
+        # re-renders from its editor's component, so edits (or the polish pass)
+        # to a chart tab stay in sync with the overview.
         outs = editors
         if len(views) > 1:
             overview = Column(
-                *(view.get_panel() for view in views),
+                *(self._overview_item(editor) for editor in editors),
                 sizing_mode="stretch_width",
                 scroll=True,
             )

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -726,6 +726,22 @@ class SQLEditor(LumenEditor):
         return f"{self.__class__.__name__}:\n```sql\n{self.spec}\n```"
 
 
+class MultiChartEditor(LumenEditor):
+    """
+    Display-only editor for a composite of several charts (e.g. an "All" tab
+    that stacks every plot as an overview).
+
+    The composite is not a single editable spec, so no code editor is shown
+    (mirrors DocumentEditor); the charts still render through the base
+    LumenEditor view path.
+    """
+
+    _label = "Charts"
+
+    def _render_editor(self):
+        return None
+
+
 class DocumentEditor(LumenEditor):
     """
     Displays relevant documents in tabs with type-aware rendering.

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -757,9 +757,11 @@ class MultiChartEditor(LumenEditor):
         self.view = Column(self.view, sizing_mode="stretch_both", scroll="y-auto")
 
     def _render_editor(self):
+        # No margin of its own: each sub-tab's CodeEditor already carries the
+        # (0, 10) inset, so a margin here would double the left gap.
         return Tabs(
             *((editor.title, editor._code_editor()) for editor in self.chart_editors),
-            dynamic=True, sizing_mode="stretch_both", margin=(0, 10)
+            dynamic=True, sizing_mode="stretch_both", margin=0
         )
 
     def export(self, fmt: str) -> StringIO:

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -88,8 +88,9 @@ class LumenEditor(Viewer):
         self.view = ParamMethod(self.render, inplace=True, sizing_mode='stretch_width')
         self._last_output = {}
 
-    def _render_editor(self):
-        self._editor = CodeEditor(
+    def _code_editor(self) -> CodeEditor:
+        """A CodeEditor two-way bound to this editor's spec."""
+        editor = CodeEditor(
             value=self.param.spec.rx.or_(f'{self.title} output could not be serialized and may therefore not be edited.'),
             language=self.language,
             theme="github_dark" if config.theme == "dark" else "github_light_default",
@@ -101,7 +102,11 @@ class LumenEditor(Viewer):
             disabled=self.param.spec.rx.is_(None),
             styles={"border": "1px solid var(--border-color)"}
         )
-        self._editor.link(self, bidirectional=True, value='spec')
+        editor.link(self, bidirectional=True, value='spec')
+        return editor
+
+    def _render_editor(self):
+        self._editor = self._code_editor()
         self._icons = Row(
             *self.footer,
             margin=(0, 0, 5, 10)
@@ -728,18 +733,43 @@ class SQLEditor(LumenEditor):
 
 class MultiChartEditor(LumenEditor):
     """
-    Display-only editor for a composite of several charts (e.g. an "All" tab
-    that stacks every plot as an overview).
+    Editor for a composite of several charts, e.g. an "All" tab that stacks
+    every plot as an overview.
 
-    The composite is not a single editable spec, so no code editor is shown
-    (mirrors DocumentEditor); the charts still render through the base
-    LumenEditor view path.
+    The composite has no single spec, so instead of one code editor it shows a
+    sub-tab per chart, each bound to that chart's own spec; edits made here and
+    on the chart's own tab are therefore the same edit.
     """
+
+    chart_editors = param.List(default=[], item_type=LumenEditor, doc="""
+        The editors of the individual charts, whose specs are exposed as
+        sub-tabs.""")
 
     _label = "Charts"
 
+    def __init__(self, **params):
+        super().__init__(**params)
+        # A scrollbar only appears on a height-constrained container, and the
+        # base view is stretch_width, so stacking every plot just grows it past
+        # its pane and the overflow spills. Wrapping it the way
+        # ExplorerUI._render_view wraps the editor puts the scroll container
+        # directly in the split pane, which is what gives it a fixed height.
+        self.view = Column(self.view, sizing_mode="stretch_both", scroll="y-auto")
+
     def _render_editor(self):
-        return None
+        return Tabs(
+            *((editor.title, editor._code_editor()) for editor in self.chart_editors),
+            dynamic=True, sizing_mode="stretch_both", margin=(0, 10)
+        )
+
+    def export(self, fmt: str) -> StringIO:
+        if fmt != "yaml":
+            raise ValueError(f"Unknown export format {fmt!r} for {self.__class__.__name__}")
+        # A chart that could not be serialized has no spec; skip it rather than
+        # failing the export of the ones that did.
+        return StringIO("---\n".join(
+            editor.spec for editor in self.chart_editors if editor.spec
+        ))
 
 
 class DocumentEditor(LumenEditor):

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -16,6 +16,12 @@ Every visualization must:
   - Use aggregation and/or binning either in the encoding fields or as distinct transforms
   - OR enable canvas rendering using `{config: {render: {renderer: "canvas"}}}` (up to 50k rows)
 
+## MULTIPLE CHARTS
+
+Return several charts in `charts` ONLY when the request clearly spans distinct metrics or relationships that should not share one plot (e.g. "sales over time and sales by region"), or when the user explicitly asks for more than one. When a single chart answers the question, return exactly one.
+- Each entry in `charts` is a complete, standalone single-view spec following the rules above; do not pack several plots into one entry with `hconcat`/`vconcat`/`facet`/`repeat`.
+- Give each chart a short, descriptive `title` used as its tab label.
+
 ## MARK vs ENCODING
 
 This is the most common source of errors. See examples for correct placement:

--- a/lumen/ai/prompts/VegaLiteAgent/main_altair.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main_altair.jinja2
@@ -3,6 +3,9 @@
 {% block instructions %}
 Generate Altair code. Data is `df`, assign to `chart`, end with `.interactive()`. Use `width='container'` for single charts only. NO I/O methods.
 
+## MULTIPLE CHARTS
+Return several entries in `charts` ONLY when the request spans distinct metrics or relationships, or the user asks for more than one; otherwise return exactly one. Each entry is an independent code block that assigns its own `chart` (use `alt.hconcat`/`alt.vconcat`/`.facet`/`.repeat` only to compose within a single entry), and give each entry a short `title` used as its tab label.
+
 ## Encodings: `:Q` quantitative | `:N` nominal | `:O` ordinal | `:T` temporal
 
 ## Reference

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -247,7 +247,7 @@ _BLOCK_RE = re.compile(
 
 def get_block_names(template_path: Path | str, relative_to: Path = PROMPTS_DIR):
     env = Environment()
-    parsed = env.parse(Path(template_path).read_text())
+    parsed = env.parse(Path(template_path).read_text(encoding='utf-8'))
     collector = BlockNameCollector()
     collector.visit(parsed)
     return list(collector.blocks)

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -27,6 +27,7 @@ from lumen.ai.agents.vega_lite import (
     AltairChartSpec, AltairSpec, ChartSpec, VegaLiteSpec, VegaLiteSpecUpdate,
 )
 from lumen.ai.analysis import Analysis
+from lumen.ai.config import RetriesExceededError
 from lumen.ai.editors import (
     AnalysisOutput, MultiChartEditor, SQLEditor, VegaLiteEditor,
 )
@@ -202,10 +203,12 @@ async def test_vegalite_agent_multiple(llm, duckdb_source, test_messages):
     assert isinstance(out[1], VegaLiteEditor)
     assert "field: B" in out[0].spec
     assert "field: C" in out[1].spec
-    # ...then the view-only "All" overview as the last tab (no code editor).
+    # ...then the "All" overview as the last tab, editing every chart's spec
+    # through one sub-tab each.
     assert isinstance(out[-1], MultiChartEditor)
     assert out[-1].title == "All"
-    assert out[-1]._render_editor() is None
+    assert out[-1].chart_editors == out[:2]
+    assert out[-1].editor._names == ["A vs B", "A vs C"]
     assert isinstance(out[-1].component, Panel)
     assert len(out[-1].component.object) == 2  # both plots stacked in the overview
 
@@ -249,6 +252,40 @@ async def test_vegalite_agent_skips_unparseable_chart(llm, duckdb_source, test_m
     assert len(out) == 1
     assert isinstance(out[0], VegaLiteEditor)
     assert "field: B" in out[0].spec
+
+
+async def test_vegalite_agent_reports_why_every_chart_failed(llm, duckdb_source, test_messages):
+    """When no chart parses the underlying errors reach the retry, which would
+    otherwise regenerate blind against an identical message."""
+
+    agent = VegaLiteAgent(llm=llm, code_execution="disabled")
+
+    context = {
+        "source": duckdb_source,
+        "pipeline": Pipeline(source=duckdb_source, table="test_sql"),
+        "table": "test_sql",
+        "sources": [duckdb_source],
+        "metaset": await get_metaset([duckdb_source], ["test_sql"]),
+        "data": duckdb_source.get("test_sql")
+    }
+
+    # Unbalanced braces -> YAML parse error, for every chart.
+    malformed = "mark: bar\nencoding:\n  x: {field: A, type: quantitative}}"
+    llm.set_responses([
+        VegaLiteSpec(
+            chain_of_thought="all malformed",
+            charts=[
+                ChartSpec(title="first", yaml_spec=malformed),
+                ChartSpec(title="second", yaml_spec=malformed),
+            ],
+            insufficient_context=False,
+            insufficient_context_reason="none"
+        ),
+    ] * 3)  # one response per retry_llm_output attempt
+    with pytest.raises(RetriesExceededError) as excinfo:
+        await agent.respond(test_messages, context)
+    message = str(excinfo.value.__cause__)
+    assert "first:" in message and "second:" in message
 
 
 async def test_vegalite_agent_altair_multiple(llm, duckdb_source, test_messages):

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -23,9 +23,13 @@ from lumen.ai.agents.analysis import make_analysis_model
 from lumen.ai.agents.deck_gl import DeckGLAgent
 from lumen.ai.agents.hvplot import hvPlotAgent
 from lumen.ai.agents.sql import make_sql_model
-from lumen.ai.agents.vega_lite import VegaLiteSpec, VegaLiteSpecUpdate
+from lumen.ai.agents.vega_lite import (
+    AltairChartSpec, AltairSpec, ChartSpec, VegaLiteSpec, VegaLiteSpecUpdate,
+)
 from lumen.ai.analysis import Analysis
-from lumen.ai.editors import AnalysisOutput, SQLEditor, VegaLiteEditor
+from lumen.ai.editors import (
+    AnalysisOutput, MultiChartEditor, SQLEditor, VegaLiteEditor,
+)
 from lumen.ai.llm import Llm
 from lumen.ai.schemas import Metaset, get_metaset
 from lumen.config import dump_yaml
@@ -134,7 +138,7 @@ async def test_vegalite_agent(llm, duckdb_source, test_messages):
     llm.set_responses([
         VegaLiteSpec(
             chain_of_thought="Test plot",
-            yaml_spec=dump_yaml(spec),
+            charts=[ChartSpec(title="A vs B", yaml_spec=dump_yaml(spec))],
             insufficient_context=False,
             insufficient_context_reason="none"
         ),
@@ -147,6 +151,161 @@ async def test_vegalite_agent(llm, duckdb_source, test_messages):
     assert len(out) == 1
     assert isinstance(out[0], VegaLiteEditor)
     assert out[0].spec == "$schema: https://vega.github.io/schema/vega-lite/v5.json\ndata:\n  values:\n  - A: 1\n    B: 2\n    C: 3\n    D: '2023-01-01T00:00:00Z'\n  - A: 4\n    B: 5\n    C: 6\n    D: '2023-01-02T00:00:00Z'\nencoding:\n  x:\n    field: A\n    type: quantitative\n  y:\n    field: B\n    type: quantitative\nheight: container\nmark: bar\nwidth: container\n"
+
+
+async def test_vegalite_agent_multiple(llm, duckdb_source, test_messages):
+    """Multiple charts: a view-only 'All' overview plus one editable editor per chart."""
+
+    agent = VegaLiteAgent(llm=llm, code_execution="disabled")
+
+    context = {
+        "source": duckdb_source,
+        "pipeline": Pipeline(source=duckdb_source, table="test_sql"),
+        "table": "test_sql",
+        "sources": [duckdb_source],
+        "metaset": await get_metaset([duckdb_source], ["test_sql"]),
+        "data": duckdb_source.get("test_sql")
+    }
+
+    spec_ab = {
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "A", "type": "quantitative"},
+            "y": {"field": "B", "type": "quantitative"},
+        }
+    }
+    spec_ac = {
+        "mark": "line",
+        "encoding": {
+            "x": {"field": "A", "type": "quantitative"},
+            "y": {"field": "C", "type": "quantitative"},
+        }
+    }
+    llm.set_responses([
+        VegaLiteSpec(
+            chain_of_thought="Two distinct relationships",
+            charts=[
+                ChartSpec(title="A vs B", yaml_spec=dump_yaml(spec_ab)),
+                ChartSpec(title="A vs C", yaml_spec=dump_yaml(spec_ac)),
+            ],
+            insufficient_context=False,
+            insufficient_context_reason="none"
+        ),
+        # One polish response per editable editor.
+        VegaLiteSpecUpdate(chain_of_thought="ok", yaml_update=""),
+        VegaLiteSpecUpdate(chain_of_thought="ok", yaml_update=""),
+    ])
+    out, out_context = await agent.respond(test_messages, context)
+    assert len(out) == 3
+    # One editable VegaLiteEditor per chart first...
+    assert isinstance(out[0], VegaLiteEditor)
+    assert isinstance(out[1], VegaLiteEditor)
+    assert "field: B" in out[0].spec
+    assert "field: C" in out[1].spec
+    # ...then the view-only "All" overview as the last tab (no code editor).
+    assert isinstance(out[-1], MultiChartEditor)
+    assert out[-1].title == "All"
+    assert out[-1]._render_editor() is None
+    assert isinstance(out[-1].component, Panel)
+    assert len(out[-1].component.object) == 2  # both plots stacked in the overview
+
+
+async def test_vegalite_agent_skips_unparseable_chart(llm, duckdb_source, test_messages):
+    """A chart whose spec fails to parse is skipped; valid charts still render."""
+
+    agent = VegaLiteAgent(llm=llm, code_execution="disabled")
+
+    context = {
+        "source": duckdb_source,
+        "pipeline": Pipeline(source=duckdb_source, table="test_sql"),
+        "table": "test_sql",
+        "sources": [duckdb_source],
+        "metaset": await get_metaset([duckdb_source], ["test_sql"]),
+        "data": duckdb_source.get("test_sql")
+    }
+
+    good = {
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "A", "type": "quantitative"},
+            "y": {"field": "B", "type": "quantitative"},
+        }
+    }
+    llm.set_responses([
+        VegaLiteSpec(
+            chain_of_thought="one good, one malformed",
+            charts=[
+                ChartSpec(title="good", yaml_spec=dump_yaml(good)),
+                # Unbalanced braces -> YAML parse error.
+                ChartSpec(title="bad", yaml_spec="mark: bar\nencoding:\n  x: {field: A, type: quantitative}}"),
+            ],
+            insufficient_context=False,
+            insufficient_context_reason="none"
+        ),
+        VegaLiteSpecUpdate(chain_of_thought="ok", yaml_update=""),
+    ])
+    out, out_context = await agent.respond(test_messages, context)
+    # Only the valid chart survives -> a single editor, no "All" overview.
+    assert len(out) == 1
+    assert isinstance(out[0], VegaLiteEditor)
+    assert "field: B" in out[0].spec
+
+
+async def test_vegalite_agent_altair_multiple(llm, duckdb_source, test_messages):
+    """VegaLiteAgent Altair (code) mode returns one editor per generated chart."""
+
+    agent = VegaLiteAgent(llm=llm, code_execution="allow")
+
+    context = {
+        "source": duckdb_source,
+        "pipeline": Pipeline(source=duckdb_source, table="test_sql"),
+        "table": "test_sql",
+        "sources": [duckdb_source],
+        "metaset": await get_metaset([duckdb_source], ["test_sql"]),
+        "data": duckdb_source.get("test_sql")
+    }
+
+    chart_ab = SimpleNamespace(to_dict=lambda: {
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "A", "type": "quantitative"},
+            "y": {"field": "B", "type": "quantitative"},
+        },
+    })
+    chart_ac = SimpleNamespace(to_dict=lambda: {
+        "mark": "line",
+        "encoding": {
+            "x": {"field": "A", "type": "quantitative"},
+            "y": {"field": "C", "type": "quantitative"},
+        },
+    })
+    # Bypass real code execution; return a chart object per generated code block.
+    agent._execute_code = AsyncMock(side_effect=[chart_ab, chart_ac])
+
+    llm.set_responses([
+        AltairSpec(
+            chain_of_thought="Two independent charts",
+            charts=[
+                AltairChartSpec(
+                    title="A vs B",
+                    code="chart = alt.Chart(df).mark_bar().encode(x='A:Q', y='B:Q')"
+                ),
+                AltairChartSpec(
+                    title="A vs C",
+                    code="chart = alt.Chart(df).mark_line().encode(x='A:Q', y='C:Q')"
+                ),
+            ],
+        ),
+    ])
+    out, out_context = await agent.respond(test_messages, context)
+    # One editable editor per chart, then a view-only "All" overview last.
+    assert len(out) == 3
+    assert isinstance(out[0], VegaLiteEditor)
+    assert isinstance(out[1], VegaLiteEditor)
+    assert "field: B" in out[0].spec
+    assert "field: C" in out[1].spec
+    assert isinstance(out[-1], MultiChartEditor)
+    assert out[-1].title == "All"
 
 
 async def test_analysis_agent(llm, duckdb_source, test_messages):

--- a/lumen/tests/ai/test_editors.py
+++ b/lumen/tests/ai/test_editors.py
@@ -11,7 +11,9 @@ from PIL import Image
 
 import lumen.ai.editors as editors_module
 
-from lumen.ai.editors import LumenEditor, SQLEditor, VegaLiteEditor
+from lumen.ai.editors import (
+    LumenEditor, MultiChartEditor, SQLEditor, VegaLiteEditor,
+)
 from lumen.base import Component
 from lumen.pipeline import Pipeline
 from lumen.sources.duckdb import DuckDBSource
@@ -272,3 +274,56 @@ def test_class_name_with_numbers():
         pass
 
     assert Editor2D._class_name_to_download_filename("png") == "editor2_d.png"
+
+
+@pytest.fixture
+def make_multi_chart_editor(monkeypatch):
+    monkeypatch.setattr(editors_module, 'ParamMethod', lambda *args, **kwargs: None)
+
+    def factory(n_charts, spec_lines=9, unserializable=()):
+        charts = [
+            LumenEditor(
+                component=MockComponent(),
+                spec=None if c in unserializable else "\n".join(
+                    f"line{i}" for i in range(spec_lines)
+                ),
+                title=f"Chart {c}",
+            )
+            for c in range(n_charts)
+        ]
+        return MultiChartEditor(
+            component=MockComponent(), title="All", chart_editors=charts
+        )
+
+    return factory
+
+
+@pytest.mark.parametrize("n_charts", [2, 3, 5, 9])
+def test_multichart_shows_one_editor_sub_tab_per_chart(make_multi_chart_editor, n_charts):
+    """Every chart's spec is reachable, however many charts there are, and only
+    the active one is mounted."""
+    editor = make_multi_chart_editor(n_charts).editor
+    assert editor._names == [f"Chart {c}" for c in range(n_charts)]
+    assert editor.dynamic
+
+
+def test_multichart_scrolls_its_stacked_plots(make_multi_chart_editor):
+    """The overview stacks every plot, so its view has to scroll rather than
+    grow past the pane and spill."""
+    assert make_multi_chart_editor(5).view.scroll == "y-auto"
+
+
+def test_multichart_survives_an_unserializable_spec(make_multi_chart_editor):
+    """spec is None when a component could not be serialized; the sub-tab still
+    renders and export skips it rather than failing outright."""
+    multi = make_multi_chart_editor(3, unserializable=(0,))
+    assert len(multi.editor) == 3
+    assert multi.export("yaml").getvalue().count("line0") == 2
+
+
+def test_multichart_export_concatenates_every_chart_spec(make_multi_chart_editor):
+    """The overview has no spec of its own; exporting yields all of them."""
+    multi = make_multi_chart_editor(3, spec_lines=2)
+    assert multi.export("yaml").getvalue().count("line0") == 3
+    with pytest.raises(ValueError, match="Unknown export format"):
+        multi.export("png")

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -43,7 +43,7 @@ from lumen.ai.models import ErrorDescription
 from lumen.ai.report import ActorTask
 from lumen.ai.schemas import get_metaset
 from lumen.ai.ui import UI, Exploration, ExplorerUI
-from lumen.config import SOURCE_TABLE_SEPARATOR, dump_yaml
+from lumen.config import SOURCE_TABLE_SEPARATOR, dump_yaml, load_yaml
 from lumen.pipeline import Pipeline
 from lumen.sources.duckdb import DuckDBSource
 from lumen.sources.sqlalchemy import SQLAlchemySource
@@ -395,9 +395,10 @@ async def test_find_view_in_tabs(explorer_ui):
         assert tab_idx >= 0
 
 
-async def test_multichart_all_tab_last_and_view_only(explorer_ui):
-    """A multi-chart response renders one editable tab per chart plus a view-only
-    'All' overview that is placed last and opened by default."""
+async def test_multichart_all_tab_last_and_editable(explorer_ui):
+    """A multi-chart response renders one editable tab per chart plus an 'All'
+    overview that is placed last, opened by default, and exposes every chart's
+    spec as an editor sub-tab."""
     ui = explorer_ui
     test_source = ui.context["source"]
     SQLQueryWithTables = make_sql_model([(test_source.name, "test_table")])
@@ -445,17 +446,36 @@ async def test_multichart_all_tab_last_and_view_only(explorer_ui):
     await ui._execute_plan(plan)
 
     exploration = ui._exploration["view"]
-    # The multi-chart output includes the view-only "All" overview.
-    assert any(isinstance(v, MultiChartEditor) for v in exploration.plan.views)
+    # The multi-chart output includes the "All" overview.
+    overview = next(v for v in exploration.plan.views if isinstance(v, MultiChartEditor))
 
     tabs = exploration.view[0]
     # "All" is the last tab and is opened by default.
     assert tabs._names[-1] == "All"
     assert tabs.active == len(tabs) - 1
 
-    # The "All" tab is view-only (no code-editor VSplit); a chart tab has one.
-    assert not any(isinstance(child, VSplit) for child in tabs[-1])
-    assert any(isinstance(child, VSplit) for child in tabs[-2])
+    # The "All" tab lays out exactly like a chart tab: same editor/plot split,
+    # same proportions, and nothing pinning a pane open (which would stop the
+    # divider being dragged).
+    overview_split = next(child for child in tabs[-1] if isinstance(child, VSplit))
+    chart_split = next(child for child in tabs[-2] if isinstance(child, VSplit))
+    assert overview_split.sizes == chart_split.sizes
+    assert overview_split.min_size == chart_split.min_size
+
+    # The overview's editor pane is one sub-tab per chart, and editing a sub-tab
+    # writes through to that chart's own spec.
+    sub_tabs = overview.editor
+    assert sub_tabs._names == ["By category", "Value line"]
+    edited = dump_yaml({**load_yaml(overview.chart_editors[1].spec), "mark": "point"})
+    sub_tabs[1].value = edited
+    assert overview.chart_editors[1].spec == edited
+    assert overview.chart_editors[1].component.spec["mark"] == "point"
+    # The chart's own tab shows the same edit, not a stale copy.
+    assert overview.chart_editors[1]._editor.value == edited
+
+    # The overview wraps its view to scroll the stacked plots; pop-out and rerun
+    # must still locate it through that wrapper.
+    assert ui._find_view_in_tabs(exploration, overview) == len(tabs) - 1
 
 
 async def test_find_view_in_popped_out(explorer_ui):

--- a/lumen/tests/ai/test_ui.py
+++ b/lumen/tests/ai/test_ui.py
@@ -33,14 +33,17 @@ from panel_splitjs import VSplit
 
 from lumen.ai.agents.chat import ChatAgent
 from lumen.ai.agents.sql import SQLAgent, make_sql_model
+from lumen.ai.agents.vega_lite import (
+    ChartSpec, VegaLiteAgent, VegaLiteSpec, VegaLiteSpecUpdate,
+)
 from lumen.ai.config import PROVIDED_SOURCE_NAME
 from lumen.ai.coordinator import Plan
-from lumen.ai.editors import SQLEditor
+from lumen.ai.editors import MultiChartEditor, SQLEditor
 from lumen.ai.models import ErrorDescription
 from lumen.ai.report import ActorTask
 from lumen.ai.schemas import get_metaset
 from lumen.ai.ui import UI, Exploration, ExplorerUI
-from lumen.config import SOURCE_TABLE_SEPARATOR
+from lumen.config import SOURCE_TABLE_SEPARATOR, dump_yaml
 from lumen.pipeline import Pipeline
 from lumen.sources.duckdb import DuckDBSource
 from lumen.sources.sqlalchemy import SQLAlchemySource
@@ -390,6 +393,69 @@ async def test_find_view_in_tabs(explorer_ui):
     if view in tabs:
         assert tab_idx is not None
         assert tab_idx >= 0
+
+
+async def test_multichart_all_tab_last_and_view_only(explorer_ui):
+    """A multi-chart response renders one editable tab per chart plus a view-only
+    'All' overview that is placed last and opened by default."""
+    ui = explorer_ui
+    test_source = ui.context["source"]
+    SQLQueryWithTables = make_sql_model([(test_source.name, "test_table")])
+
+    spec_bar = {
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "category", "type": "nominal"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    spec_line = {
+        "mark": "line",
+        "encoding": {
+            "x": {"field": "value", "type": "quantitative"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    ui.llm.set_responses([
+        SQLQueryWithTables(
+            query="SELECT category, value FROM test_table",
+            table_slug="cat_vals",
+            tables=["test_table"],
+        ),
+        VegaLiteSpec(
+            chain_of_thought="two charts",
+            charts=[
+                ChartSpec(title="By category", yaml_spec=dump_yaml(spec_bar)),
+                ChartSpec(title="Value line", yaml_spec=dump_yaml(spec_line)),
+            ],
+            insufficient_context=False,
+            insufficient_context_reason="none",
+        ),
+        VegaLiteSpecUpdate(chain_of_thought="ok", yaml_update=""),
+        VegaLiteSpecUpdate(chain_of_thought="ok", yaml_update=""),
+    ])
+
+    plan = Plan(
+        ActorTask(SQLAgent(llm=ui.llm)),
+        ActorTask(VegaLiteAgent(llm=ui.llm, code_execution="disabled")),
+        history=[{"content": "two charts of value", "role": "user"}],
+        title="Two charts",
+        context=ui.context,
+    )
+    await ui._execute_plan(plan)
+
+    exploration = ui._exploration["view"]
+    # The multi-chart output includes the view-only "All" overview.
+    assert any(isinstance(v, MultiChartEditor) for v in exploration.plan.views)
+
+    tabs = exploration.view[0]
+    # "All" is the last tab and is opened by default.
+    assert tabs._names[-1] == "All"
+    assert tabs.active == len(tabs) - 1
+
+    # The "All" tab is view-only (no code-editor VSplit); a chart tab has one.
+    assert not any(isinstance(child, VSplit) for child in tabs[-1])
+    assert any(isinstance(child, VSplit) for child in tabs[-2])
 
 
 async def test_find_view_in_popped_out(explorer_ui):


### PR DESCRIPTION
Fixes #1916.
`VegaLiteAgent` could only ever produce a single plot. It now returns one or more charts from a single request: each chart opens in its own editable tab (vega-lite code beside the plot), plus a view-only **"All"** tab that stacks every  plot when there are several. A chart whose spec fails to parse is skipped, so the others still render.

https://github.com/user-attachments/assets/284f170b-7854-44ff-ac84-4e5384af9929



