### PR TITLE
Scope the revise prompt's schema context to the current table

### DIFF
--- a/lumen/ai/agents/base_lumen.py
+++ b/lumen/ai/agents/base_lumen.py
@@ -1,6 +1,8 @@
 import param
 
 from ...config import dump_yaml, load_yaml
+from ...pipeline import Pipeline
+from ...views import View
 from ..config import PROMPTS_DIR
 from ..context import TContext
 from ..editors import LumenEditor
@@ -38,23 +40,23 @@ class BaseLumenAgent(Agent):
         when it cannot be determined (e.g. SQL generation before a pipeline
         exists), in which case the prompt falls back to the broader context.
         """
-        metaset = context.get("metaset") if isinstance(context, dict) else None
+        metaset = context.get("metaset")
         if metaset is None:
             return None
-        # Prefer the component being revised (unambiguous), then the context.
-        # Table-first: a Pipeline component exposes its own .table, while a View
-        # component has no .table so we fall back to its .pipeline.table. A
-        # chained Pipeline also has a .pipeline (its parent), whose table is NOT
-        # the one being revised, so .table must win over .pipeline.
-        candidate = None
-        component = getattr(view, "component", None)
-        if component is not None:
-            candidate = getattr(component, "table", None)
-            if candidate is None:
-                pipeline = getattr(component, "pipeline", None)
-                candidate = getattr(pipeline, "table", None) if pipeline is not None else None
+        # Prefer the component being revised, since it is unambiguous. A
+        # Pipeline names its own table; a View reaches one through the pipeline
+        # it renders. A chained Pipeline also has a .pipeline, but that is its
+        # parent and not the table being revised, hence Pipeline first.
+        component = view.component if view else None
+        if isinstance(component, Pipeline):
+            candidate = component.table
+        elif isinstance(component, View) and component.pipeline:
+            candidate = component.pipeline.table
+        else:
+            candidate = None
         if candidate is None:
-            candidate = getattr(context.get("pipeline"), "table", None) or context.get("table")
+            pipeline = context.get("pipeline")
+            candidate = (pipeline.table if pipeline else None) or context.get("table")
         slug = metaset._resolve_table_slug(candidate)
         if slug is None:
             return None

--- a/lumen/ai/agents/base_lumen.py
+++ b/lumen/ai/agents/base_lumen.py
@@ -6,6 +6,7 @@ from ..context import TContext
 from ..editors import LumenEditor
 from ..llm import Message
 from ..models import RetrySpec
+from ..schemas import slug_to_table_name
 from ..utils import apply_changes, retry_llm_output
 from .base import Agent
 
@@ -31,6 +32,40 @@ class BaseLumenAgent(Agent):
     _max_width = None
     _editor_type = LumenEditor
 
+    def _resolve_revise_table(self, context: TContext, view: LumenEditor | None) -> str | None:
+        """Slug of the table the output being revised uses, so the revise
+        prompt can scope its schema context to just that table. Returns None
+        when it cannot be determined (e.g. SQL generation before a pipeline
+        exists), in which case the prompt falls back to the broader context.
+        """
+        metaset = context.get("metaset") if isinstance(context, dict) else None
+        if metaset is None:
+            return None
+        # Prefer the component being revised (unambiguous), then the context.
+        # Table-first: a Pipeline component exposes its own .table, while a View
+        # component has no .table so we fall back to its .pipeline.table. A
+        # chained Pipeline also has a .pipeline (its parent), whose table is NOT
+        # the one being revised, so .table must win over .pipeline.
+        candidate = None
+        component = getattr(view, "component", None)
+        if component is not None:
+            candidate = getattr(component, "table", None)
+            if candidate is None:
+                pipeline = getattr(component, "pipeline", None)
+                candidate = getattr(pipeline, "table", None) if pipeline is not None else None
+        if candidate is None:
+            candidate = getattr(context.get("pipeline"), "table", None) or context.get("table")
+        slug = metaset._resolve_table_slug(candidate)
+        if slug is None:
+            return None
+        # Prefer the active (newest) generation so _generate_context's
+        # active-slug filter does not empty the scoped context.
+        active = set(metaset._deduplicated_slugs())
+        if slug not in active:
+            name = slug_to_table_name(slug)
+            slug = next((s for s in active if slug_to_table_name(s) == name), slug)
+        return slug
+
     @retry_llm_output()
     async def revise(
         self,
@@ -53,6 +88,7 @@ class BaseLumenAgent(Agent):
             raise ValueError("Must provide previous spec to revise.")
         lines = spec.splitlines()
         numbered_text = "\n".join(f"{i:2d}: {line}" for i, line in enumerate(lines, 1))
+        revise_table = kwargs.pop("revise_table", None) or self._resolve_revise_table(context, view)
         result = await self._invoke_prompt(
             "revise_output",
             messages,
@@ -62,6 +98,7 @@ class BaseLumenAgent(Agent):
             language=language,
             feedback=instruction,
             errors=errors,
+            revise_table=revise_table,
             **kwargs
         )
         new_spec_raw = apply_changes(lines, result.edits)

--- a/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
+++ b/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
@@ -20,8 +20,11 @@ Critical Requirements:
 {%- block context %}
 {% if memory.get("metaset") %}
 Available schema context:
-{# TODO: THIS SHOULD ONLY SUBSET THE PIPELINE TABLE #}
+{% if revise_table is defined and revise_table and revise_table in memory["metaset"].catalog %}
+{{ memory["metaset"].compact_context(schema_tables=[revise_table], include_sql=True, truncate=False, n_others=0) }}
+{% else %}
 {{ memory["metaset"].compact_context(3) }}
+{% endif %}
 {% endif %}
 
 {% if language %}

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -271,15 +271,22 @@ class Metaset:
         offset: int = 0,
         show_source: bool | None = None,
         n_others: int = 0,
+        schema_tables: list[str] | None = None,
     ) -> str:
         # Deduplicate catalog slugs — keep only the newest entry per
         # table name so stale materialization generations don't appear.
         active_slugs = set(self._deduplicated_slugs())
 
-        # Determine which tables to show with full details
-        if self.schema_tables is not None:
+        # Determine which tables to show with full details. A per-call
+        # schema_tables scopes this render without mutating the shared
+        # instance; None means "not provided" so an explicit [] can still
+        # scope to zero primary tables.
+        effective_schema_tables = (
+            self.schema_tables if schema_tables is None else schema_tables
+        )
+        if effective_schema_tables is not None:
             # Use explicitly set schema_tables, filtered to active slugs
-            primary_slugs = [s for s in self.schema_tables if s in self.catalog and s in active_slugs]
+            primary_slugs = [s for s in effective_schema_tables if s in self.catalog and s in active_slugs]
         else:
             # Fall back to top n by similarity, filtered to active slugs
             primary_slugs = [s for s in self.get_top_tables(n, offset) if s in active_slugs]

--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -273,7 +273,7 @@ class Metaset:
         n_others: int = 0,
         schema_tables: list[str] | None = None,
     ) -> str:
-        # Deduplicate catalog slugs — keep only the newest entry per
+        # Deduplicate catalog slugs, keeping only the newest entry per
         # table name so stale materialization generations don't appear.
         active_slugs = set(self._deduplicated_slugs())
 

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -33,7 +33,7 @@ from lumen.ai.schemas import (
 from lumen.config import SOURCE_TABLE_SEPARATOR, dump_yaml
 from lumen.pipeline import Pipeline
 from lumen.sources.duckdb import DuckDBSource
-from lumen.views import Panel
+from lumen.views import Panel, Table
 
 root = str(Path(__file__).parent.parent / "sources")
 
@@ -296,37 +296,56 @@ def _revise_ms(*slugs):
     return Metaset(query=None, catalog=catalog)
 
 
-def test_resolve_revise_table_from_pipeline_component(llm):
-    """A Pipeline editor component exposes its own .table."""
-    agent = SQLAgent(llm=llm)
-    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1", f"S{SOURCE_TABLE_SEPARATOR}t2")
-    view = SimpleNamespace(component=SimpleNamespace(table="t1", pipeline=None))
-    assert agent._resolve_revise_table({"metaset": ms}, view) == f"S{SOURCE_TABLE_SEPARATOR}t1"
+def _editor(component):
+    """Minimal stand-in for the editor, which only needs to carry .component."""
+    return SimpleNamespace(component=component)
 
 
-def test_resolve_revise_table_from_view_component(llm):
-    """A View editor component has no .table, so fall back to .pipeline.table."""
+def test_resolve_revise_table_from_pipeline_component(llm, tiny_source):
+    """A Pipeline names its own table."""
     agent = SQLAgent(llm=llm)
-    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1")
-    view = SimpleNamespace(component=SimpleNamespace(pipeline=SimpleNamespace(table="t1")))
-    assert agent._resolve_revise_table({"metaset": ms}, view) == f"S{SOURCE_TABLE_SEPARATOR}t1"
+    ms = _revise_ms(f"{tiny_source.name}{SOURCE_TABLE_SEPARATOR}tiny")
+    pipeline = Pipeline(source=tiny_source, table="tiny")
+    assert agent._resolve_revise_table({"metaset": ms}, _editor(pipeline)) == (
+        f"{tiny_source.name}{SOURCE_TABLE_SEPARATOR}tiny"
+    )
+
+
+def test_resolve_revise_table_from_view_component(llm, tiny_source):
+    """A View has no table of its own, so it reaches one through its pipeline."""
+    agent = SQLAgent(llm=llm)
+    ms = _revise_ms(f"{tiny_source.name}{SOURCE_TABLE_SEPARATOR}tiny")
+    view = Table(pipeline=Pipeline(source=tiny_source, table="tiny"))
+    assert agent._resolve_revise_table({"metaset": ms}, _editor(view)) == (
+        f"{tiny_source.name}{SOURCE_TABLE_SEPARATOR}tiny"
+    )
 
 
 def test_resolve_revise_table_prefers_own_table_over_chained_parent(llm):
-    """A chained Pipeline exposes .table (its own) and .pipeline (its parent);
-    the component's own table must win."""
+    """A chained Pipeline also has a parent pipeline; the child's own table wins."""
     agent = SQLAgent(llm=llm)
-    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}child", f"S{SOURCE_TABLE_SEPARATOR}parent")
-    view = SimpleNamespace(component=SimpleNamespace(
-        table="child", pipeline=SimpleNamespace(table="parent")))
-    assert agent._resolve_revise_table({"metaset": ms}, view) == f"S{SOURCE_TABLE_SEPARATOR}child"
+    source = DuckDBSource(tables={
+        "parent": "SELECT 1 AS id",
+        "child": "SELECT 2 AS id",
+    })
+    parent = Pipeline(source=source, table="parent")
+    child = Pipeline(source=source, table="child", pipeline=parent)
+    ms = _revise_ms(
+        f"{source.name}{SOURCE_TABLE_SEPARATOR}parent",
+        f"{source.name}{SOURCE_TABLE_SEPARATOR}child",
+    )
+    assert agent._resolve_revise_table({"metaset": ms}, _editor(child)) == (
+        f"{source.name}{SOURCE_TABLE_SEPARATOR}child"
+    )
 
 
-def test_resolve_revise_table_from_context_pipeline(llm):
+def test_resolve_revise_table_from_context_pipeline(llm, tiny_source):
     agent = SQLAgent(llm=llm)
-    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1")
-    ctx = {"metaset": ms, "pipeline": SimpleNamespace(table="t1")}
-    assert agent._resolve_revise_table(ctx, None) == f"S{SOURCE_TABLE_SEPARATOR}t1"
+    ms = _revise_ms(f"{tiny_source.name}{SOURCE_TABLE_SEPARATOR}tiny")
+    ctx = {"metaset": ms, "pipeline": Pipeline(source=tiny_source, table="tiny")}
+    assert agent._resolve_revise_table(ctx, None) == (
+        f"{tiny_source.name}{SOURCE_TABLE_SEPARATOR}tiny"
+    )
 
 
 def test_resolve_revise_table_from_context_table(llm):
@@ -335,17 +354,13 @@ def test_resolve_revise_table_from_context_table(llm):
     assert agent._resolve_revise_table({"metaset": ms, "table": "t1"}, None) == f"S{SOURCE_TABLE_SEPARATOR}t1"
 
 
-def test_resolve_revise_table_non_dict_context_returns_none(llm):
-    """The base_view auto-retry path passes a string context/view; must not crash."""
+def test_resolve_revise_table_unknown_name_returns_none(llm, tiny_source):
+    """A table the metaset has never heard of resolves to nothing, so the
+    prompt falls back to the broader context rather than an empty scope."""
     agent = SQLAgent(llm=llm)
-    assert agent._resolve_revise_table("```yaml\nfoo\n```", "some string") is None
-
-
-def test_resolve_revise_table_unknown_name_returns_none(llm):
-    agent = SQLAgent(llm=llm)
-    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1")
-    view = SimpleNamespace(component=SimpleNamespace(table="nonexistent", pipeline=None))
-    assert agent._resolve_revise_table({"metaset": ms}, view) is None
+    ms = _revise_ms(f"other{SOURCE_TABLE_SEPARATOR}elsewhere")
+    pipeline = Pipeline(source=tiny_source, table="tiny")
+    assert agent._resolve_revise_table({"metaset": ms}, _editor(pipeline)) is None
 
 
 def _revise_ms_cols(entries):

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -27,8 +27,10 @@ from lumen.ai.agents.vega_lite import VegaLiteSpec, VegaLiteSpecUpdate
 from lumen.ai.analysis import Analysis
 from lumen.ai.editors import AnalysisOutput, SQLEditor, VegaLiteEditor
 from lumen.ai.llm import Llm
-from lumen.ai.schemas import Metaset, get_metaset
-from lumen.config import dump_yaml
+from lumen.ai.schemas import (
+    Column, Metaset, TableCatalogEntry, get_metaset,
+)
+from lumen.config import SOURCE_TABLE_SEPARATOR, dump_yaml
 from lumen.pipeline import Pipeline
 from lumen.sources.duckdb import DuckDBSource
 from lumen.views import Panel
@@ -284,6 +286,151 @@ def test_map_agents_route_geometry_columns():
     coordinator routes GeoDataFrame data to a map-capable view."""
     assert any("geometry" in c.lower() for c in hvPlotAgent.conditions)
     assert any("geometry" in c.lower() for c in DeckGLAgent.conditions)
+
+
+def _revise_ms(*slugs):
+    catalog = {
+        s: TableCatalogEntry(table_slug=s, similarity=1.0, columns=[])
+        for s in slugs
+    }
+    return Metaset(query=None, catalog=catalog)
+
+
+def test_resolve_revise_table_from_pipeline_component(llm):
+    """A Pipeline editor component exposes its own .table."""
+    agent = SQLAgent(llm=llm)
+    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1", f"S{SOURCE_TABLE_SEPARATOR}t2")
+    view = SimpleNamespace(component=SimpleNamespace(table="t1", pipeline=None))
+    assert agent._resolve_revise_table({"metaset": ms}, view) == f"S{SOURCE_TABLE_SEPARATOR}t1"
+
+
+def test_resolve_revise_table_from_view_component(llm):
+    """A View editor component has no .table, so fall back to .pipeline.table."""
+    agent = SQLAgent(llm=llm)
+    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1")
+    view = SimpleNamespace(component=SimpleNamespace(pipeline=SimpleNamespace(table="t1")))
+    assert agent._resolve_revise_table({"metaset": ms}, view) == f"S{SOURCE_TABLE_SEPARATOR}t1"
+
+
+def test_resolve_revise_table_prefers_own_table_over_chained_parent(llm):
+    """A chained Pipeline exposes .table (its own) and .pipeline (its parent);
+    the component's own table must win."""
+    agent = SQLAgent(llm=llm)
+    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}child", f"S{SOURCE_TABLE_SEPARATOR}parent")
+    view = SimpleNamespace(component=SimpleNamespace(
+        table="child", pipeline=SimpleNamespace(table="parent")))
+    assert agent._resolve_revise_table({"metaset": ms}, view) == f"S{SOURCE_TABLE_SEPARATOR}child"
+
+
+def test_resolve_revise_table_from_context_pipeline(llm):
+    agent = SQLAgent(llm=llm)
+    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1")
+    ctx = {"metaset": ms, "pipeline": SimpleNamespace(table="t1")}
+    assert agent._resolve_revise_table(ctx, None) == f"S{SOURCE_TABLE_SEPARATOR}t1"
+
+
+def test_resolve_revise_table_from_context_table(llm):
+    agent = SQLAgent(llm=llm)
+    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1")
+    assert agent._resolve_revise_table({"metaset": ms, "table": "t1"}, None) == f"S{SOURCE_TABLE_SEPARATOR}t1"
+
+
+def test_resolve_revise_table_non_dict_context_returns_none(llm):
+    """The base_view auto-retry path passes a string context/view; must not crash."""
+    agent = SQLAgent(llm=llm)
+    assert agent._resolve_revise_table("```yaml\nfoo\n```", "some string") is None
+
+
+def test_resolve_revise_table_unknown_name_returns_none(llm):
+    agent = SQLAgent(llm=llm)
+    ms = _revise_ms(f"S{SOURCE_TABLE_SEPARATOR}t1")
+    view = SimpleNamespace(component=SimpleNamespace(table="nonexistent", pipeline=None))
+    assert agent._resolve_revise_table({"metaset": ms}, view) is None
+
+
+def _revise_ms_cols(entries):
+    """Build a Metaset from {slug: (column_name, sql_expr)}."""
+    catalog = {
+        slug: TableCatalogEntry(
+            table_slug=slug, similarity=1.0,
+            columns=[Column(name=col)], sql_expr=sql,
+        )
+        for slug, (col, sql) in entries.items()
+    }
+    return Metaset(query=None, catalog=catalog)
+
+
+@pytest.mark.parametrize("agent_cls", [SQLAgent, VegaLiteAgent, DeckGLAgent])
+async def test_revise_output_prompt_scopes_to_revise_table(llm, agent_cls):
+    """With revise_table set, only that table's schema + derived SQL appears.
+    Parametrized to prove every child revise_output template inherits the fix."""
+    agent = agent_cls(llm=llm)
+    t1 = f"S{SOURCE_TABLE_SEPARATOR}orders"
+    t2 = f"S{SOURCE_TABLE_SEPARATOR}customers"
+    ms = _revise_ms_cols({t1: ("order_id", "SELECT * FROM raw_orders"),
+                          t2: ("customer_id", None)})
+    prompt = await agent._render_prompt(
+        "revise_output", [{"role": "user", "content": "fix"}], {"metaset": ms},
+        numbered_text="1: SELECT 1", language="sql", feedback="fix",
+        errors=None, revise_table=t1,
+    )
+    assert "order_id" in prompt
+    assert "raw_orders" in prompt          # derived SQL (read_with) of the scoped table
+    assert "customer_id" not in prompt     # unrelated table's columns excluded
+    assert "customers" not in prompt
+
+
+async def test_revise_output_prompt_fallback_without_revise_table(llm):
+    """Without revise_table (or None), both tables appear (prior behaviour) and
+    the StrictUndefined template does not raise."""
+    agent = SQLAgent(llm=llm)
+    t1 = f"S{SOURCE_TABLE_SEPARATOR}orders"
+    t2 = f"S{SOURCE_TABLE_SEPARATOR}customers"
+    ms = _revise_ms_cols({t1: ("order_id", None), t2: ("customer_id", None)})
+    base_kwargs = dict(
+        numbered_text="1: SELECT 1", language="sql", feedback="fix", errors=None,
+    )
+    for extra in ({}, {"revise_table": None}):
+        prompt = await agent._render_prompt(
+            "revise_output", [{"role": "user", "content": "fix"}], {"metaset": ms},
+            **base_kwargs, **extra,
+        )
+        assert "order_id" in prompt
+        assert "customer_id" in prompt
+
+
+async def test_revise_output_prompt_unknown_slug_falls_back(llm):
+    """A revise_table not in the catalog falls back to the broader context."""
+    agent = SQLAgent(llm=llm)
+    t1 = f"S{SOURCE_TABLE_SEPARATOR}orders"
+    t2 = f"S{SOURCE_TABLE_SEPARATOR}customers"
+    ms = _revise_ms_cols({t1: ("order_id", None), t2: ("customer_id", None)})
+    prompt = await agent._render_prompt(
+        "revise_output", [{"role": "user", "content": "fix"}], {"metaset": ms},
+        numbered_text="1: SELECT 1", language="sql", feedback="fix",
+        errors=None, revise_table=f"S{SOURCE_TABLE_SEPARATOR}does_not_exist",
+    )
+    assert "order_id" in prompt
+    assert "customer_id" in prompt
+
+
+async def test_revise_forwards_resolved_table_to_prompt(llm):
+    """revise() resolves the current table and forwards it to the prompt render."""
+    agent = SQLAgent(llm=llm)
+    t1 = f"S{SOURCE_TABLE_SEPARATOR}orders"
+    ms = _revise_ms(t1, f"S{SOURCE_TABLE_SEPARATOR}customers")
+    captured = {}
+
+    async def fake_invoke(prompt_name, messages, context, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(edits=[])
+
+    with patch.object(agent, "_invoke_prompt", side_effect=fake_invoke):
+        await agent.revise(
+            "fix it", [{"role": "user", "content": "fix"}],
+            {"metaset": ms, "table": "orders"}, spec="SELECT 1", language="sql",
+        )
+    assert captured.get("revise_table") == t1
 
 
 def test_sqlagent_active_filters_describes_conditions():

--- a/lumen/tests/ai/test_schemas.py
+++ b/lumen/tests/ai/test_schemas.py
@@ -151,6 +151,59 @@ class TestSchemaTables:
         assert "Others available:" in output
         assert "tbl" in output
 
+    def test_schema_tables_param_scopes_primary(self):
+        a = _entry(f"S{SEP}shown", columns=[_col("alpha")])
+        b = _entry(f"S{SEP}hidden", columns=[_col("omega")])
+        ms = _metaset([a, b])
+        output = ms.compact_context(schema_tables=[f"S{SEP}shown"], n_others=0)
+        assert "alpha" in output
+        assert "shown" in output
+        # the unrelated table and its columns are absent
+        assert "omega" not in output
+        assert "hidden" not in output
+
+    def test_schema_tables_param_non_mutating(self):
+        a = _entry(f"S{SEP}shown", columns=[_col("alpha")])
+        b = _entry(f"S{SEP}hidden", columns=[_col("omega")])
+        ms = _metaset([a, b])
+        ms.compact_context(schema_tables=[f"S{SEP}shown"])
+        assert ms.schema_tables is None
+        ms2 = _metaset([a, b], schema_tables=[f"S{SEP}hidden"])
+        ms2.compact_context(schema_tables=[f"S{SEP}shown"])
+        assert ms2.schema_tables == [f"S{SEP}hidden"]
+
+    def test_schema_tables_param_none_falls_back_to_instance(self):
+        high = _entry(f"S{SEP}high", similarity=1.0, columns=[_col("highcol")])
+        low = _entry(f"S{SEP}low", similarity=0.1, columns=[_col("lowcol")])
+        ms = _metaset([high, low], schema_tables=[f"S{SEP}low"])
+        # param omitted -> uses instance schema_tables ([low]), not top-n similarity
+        output = ms.compact_context(n=1, n_others=0)
+        assert "lowcol" in output
+        assert "highcol" not in output
+
+    def test_schema_tables_param_empty_list_distinct_from_none(self):
+        a = _entry(f"S{SEP}tbl", columns=[_col("alpha")])
+        ms = _metaset([a])
+        # explicit [] scopes to zero primary tables (does not fall back to top-n)
+        scoped = ms.compact_context(schema_tables=[], n_others=5)
+        assert "alpha" not in scoped
+        assert "Others available:" in scoped
+        assert "tbl" in scoped
+        # omitting the param falls back to top-n, so the table IS primary
+        default = ms.compact_context(n_others=0)
+        assert "alpha" in default
+
+    def test_compact_context_include_sql_surfaces_read_with(self):
+        slug = f"S{SEP}derived"
+        e = _entry(slug, columns=[_col("alpha")], sql_expr="SELECT * FROM raw_source")
+        ms = _metaset([e])
+        with_sql = ms.compact_context(schema_tables=[slug], include_sql=True)
+        assert "read_with" in with_sql
+        assert "raw_source" in with_sql
+        # compact_context defaults to include_sql=False, so no SQL by default
+        without_sql = ms.compact_context(schema_tables=[slug])
+        assert "read_with" not in without_sql
+
 
 # ---------------------------------------------------------------
 # Column rendering


### PR DESCRIPTION
The retry/revise prompt rendered `compact_context(3)`, so on multi-table datasets the model saw unrelated tables while editing a SQL or Vega-Lite output. It now scopes to the table the output being revised uses (plus its derived SQL) and falls back to the previous behaviour when that table cannot be determined.

Fixes #1829.
