### PR TITLE
Fix the view yaml auto-retry so it can actually recover

### DIFF
--- a/lumen/ai/agents/base_view.py
+++ b/lumen/ai/agents/base_view.py
@@ -113,6 +113,10 @@ class BaseViewAgent(BaseLumenAgent):
             for i in range(3):
                 try:
                     spec = await self._extract_spec(context, spec)
+                    # Clear the earlier failure: the `if error` check after the
+                    # loop would otherwise turn a successful retry into a raise
+                    # (the exhausted case already re-raises above).
+                    error = ""
                     break
                 except Exception as e:
                     e = get_root_exception(e, exceptions=(MissingContextError,))
@@ -121,18 +125,26 @@ class BaseViewAgent(BaseLumenAgent):
 
                     error = str(e)
                     traceback.print_exception(e)
-                    # Keep `context` intact: the next _extract_spec and revise both
-                    # need the TContext, only the error report wants the yaml text.
-                    error_context = f"```\n{dump_yaml(load_yaml(self._last_output['yaml_spec']))}\n```"
+                    # Report the spec we actually have: agents differ in output
+                    # shape (VegaLite emits a yaml_spec field, hvPlot a flat param
+                    # dict), so assuming a yaml_spec key raises KeyError here.
+                    # Keep `context` intact, the next attempt and revise need it.
+                    error_context = f"```\n{dump_yaml(spec)}\n```"
                     report_error(e, step, language="json", context=error_context, status="failed")
                     with self._add_step(
                         title="Re-attempted view generation",
                         steps_layout=self._steps_layout,
                     ) as retry_step:
-                        view = await self.revise(e, messages, context, spec=dump_yaml(spec), language="yaml")
-                        if "yaml_spec: " in view:
-                            view = view.split("yaml_spec: ")[-1].rstrip('"').rstrip("'")
-                        retry_step.stream(f"\n\n```yaml\n{view}\n```")
+                        revised = await self.revise(e, messages, context, spec=dump_yaml(spec), language="yaml")
+                        if "yaml_spec: " in revised:
+                            revised = revised.split("yaml_spec: ")[-1].rstrip('"').rstrip("'")
+                        retry_step.stream(f"\n\n```yaml\n{revised}\n```")
+                        # Feed the revision into the next attempt, otherwise the
+                        # loop re-runs _extract_spec on the identical spec and can
+                        # never recover.
+                        revised_spec = load_yaml(revised)
+                        if isinstance(revised_spec, dict):
+                            spec = revised_spec
                     if i == 2:
                         raise
 

--- a/lumen/ai/agents/base_view.py
+++ b/lumen/ai/agents/base_view.py
@@ -121,13 +121,15 @@ class BaseViewAgent(BaseLumenAgent):
 
                     error = str(e)
                     traceback.print_exception(e)
-                    context = f"```\n{dump_yaml(load_yaml(self._last_output['yaml_spec']))}\n```"
-                    report_error(e, step, language="json", context=context, status="failed")
+                    # Keep `context` intact: the next _extract_spec and revise both
+                    # need the TContext, only the error report wants the yaml text.
+                    error_context = f"```\n{dump_yaml(load_yaml(self._last_output['yaml_spec']))}\n```"
+                    report_error(e, step, language="json", context=error_context, status="failed")
                     with self._add_step(
                         title="Re-attempted view generation",
                         steps_layout=self._steps_layout,
                     ) as retry_step:
-                        view = await self.revise(e, messages, context, dump_yaml(spec), language="yaml")
+                        view = await self.revise(e, messages, context, spec=dump_yaml(spec), language="yaml")
                         if "yaml_spec: " in view:
                             view = view.split("yaml_spec: ")[-1].rstrip('"').rstrip("'")
                         retry_step.stream(f"\n\n```yaml\n{view}\n```")

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -328,3 +328,45 @@ async def test_sqlagent_prompt_surfaces_active_filters(llm):
     assert "Active exploration filters" in prompt
     assert "game_year between 2000 and 2016" in prompt
     assert "game_season in ('Summer')" in prompt
+
+
+async def test_view_retry_keeps_context_and_passes_spec_by_keyword(llm):
+    """The yaml auto-retry must keep the TContext dict (the next _extract_spec and
+    revise both need it) and pass the spec by keyword, otherwise it binds to the
+    `view` parameter and revise() raises AttributeError on `view.spec`."""
+    agent = hvPlotAgent(llm=llm)
+    captured = {}
+
+    class _Out(dict):
+        chain_of_thought = ""
+
+    async def fake_stream_prompt(*args, **kwargs):
+        async def gen():
+            yield _Out(yaml_spec="kind: line")
+        return gen()
+
+    async def fake_extract_spec(context, spec):
+        raise ValueError("bad spec")
+
+    async def fake_revise(instruction, messages, context, view=None, spec=None, **kwargs):
+        captured["context"] = context
+        captured["view"] = view
+        captured["spec"] = spec
+        return "kind: line"
+
+    ctx = {"pipeline": SimpleNamespace(table="t")}
+    with patch.object(agent, "_stream_prompt", side_effect=fake_stream_prompt), \
+         patch.object(agent, "_extract_spec", side_effect=fake_extract_spec), \
+         patch.object(agent, "revise", side_effect=fake_revise):
+        # _extract_spec always fails, so the retry loop exhausts and raises
+        with pytest.raises(Exception):
+            await agent._generate_yaml_spec(
+                [{"role": "user", "content": "x"}], ctx,
+                SimpleNamespace(table="t"), {},
+            )
+
+    # context must still be the TContext dict, not a formatted yaml string
+    assert captured["context"] is ctx
+    # the spec must not have bound to the `view` parameter
+    assert captured["view"] is None
+    assert isinstance(captured["spec"], str)

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -370,3 +370,44 @@ async def test_view_retry_keeps_context_and_passes_spec_by_keyword(llm):
     # the spec must not have bound to the `view` parameter
     assert captured["view"] is None
     assert isinstance(captured["spec"], str)
+
+
+async def test_view_retry_recovers_using_revised_spec(llm):
+    """The retry must not assume a `yaml_spec` field (hvPlot emits a flat param
+    dict) and must feed the revision into the next attempt, otherwise it re-runs
+    _extract_spec on the identical spec and can never recover."""
+    agent = hvPlotAgent(llm=llm)
+    seen_specs = []
+
+    class _Out(dict):
+        chain_of_thought = ""
+
+    async def fake_stream_prompt(*args, **kwargs):
+        async def gen():
+            # realistic hvPlot output shape: view params, no yaml_spec
+            yield _Out(kind="line", x="a", y="b")
+        return gen()
+
+    async def fake_extract_spec(context, spec):
+        seen_specs.append(dict(spec))
+        if len(seen_specs) == 1:
+            raise ValueError("bad spec")
+        return dict(spec)
+
+    async def fake_revise(instruction, messages, context, view=None, spec=None, **kwargs):
+        return "kind: bar\nx: a\ny: b"
+
+    ctx = {"pipeline": SimpleNamespace(table="t")}
+    with patch.object(agent, "_stream_prompt", side_effect=fake_stream_prompt), \
+         patch.object(agent, "_extract_spec", side_effect=fake_extract_spec), \
+         patch.object(agent, "revise", side_effect=fake_revise):
+        result = await agent._generate_yaml_spec(
+            [{"role": "user", "content": "x"}], ctx,
+            SimpleNamespace(table="t"), {},
+        )
+
+    # revise was reached (no KeyError on the missing yaml_spec) and retried once
+    assert len(seen_specs) == 2
+    assert seen_specs[0]["kind"] == "line"   # first attempt used the original
+    assert seen_specs[1]["kind"] == "bar"    # retry used the REVISED spec
+    assert result["kind"] == "bar"


### PR DESCRIPTION
The view yaml auto-retry could never recover. It assumed a `yaml_spec` field that hvPlot (its only user) does not emit, so it raised `KeyError` before `revise` was even reached; it also rebound `context` to a string, passed the spec positionally so it landed on `revise()`'s `view` parameter, discarded the revision instead of retrying with it, and then raised on a stale `error` flag even when a retry had succeeded.

It now reports the spec it actually has, keeps `context` intact, passes `spec=` by keyword, feeds the revision into the next attempt, and clears `error` on recovery. Added regression tests that fail without the change.
