### PR TITLE
fix: guide VegaLiteAgent toward diverging schemes with domainMid

### DIFF
--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -39,6 +39,8 @@ Legends appear when you map data to `color`, `size`, or `shape` in encoding.
 
 **Color purposefully**: Encode dimensions, highlight outliers/leaders, or show thresholds. Keep color in `mark` for text labels that shouldn't appear in legends. When encoding quantitative values with color, consider setting an appropriate `domain` if data doesn't start at 0 (e.g., `scale: {scheme: blues, domain: [min, max]}`).
 
+**Diverging colormaps**: When values straddle a meaningful center (anomalies, deviations, above/below a threshold) or diverging is requested, pick a diverging scheme and anchor the center with `domainMid`: `scale: {scheme: redblue, domainMid: 0}`. Without it the neutral color sits at the data midpoint and one side dominates. Schemes: `redblue`, `blueorange`, `redyellowblue`, `purplegreen`.
+
 **Informative titles**: Title tells a story (what happened, not what's shown). See examples.
 
 **Data types**: Match type to your data - quantitative for continuous, ordinal for ordered categories, nominal for unordered, temporal for dates


### PR DESCRIPTION
Asking for a diverging colormap centered on 1013 hPa gave me a near uniform blue field. The prompt covers sequential schemes but never mentions diverging ones or `domainMid`, so the neutral color lands on the data midpoint instead of the value that matters and one side of the scale takes over the plot.

This adds a short pattern note next to the existing color guidance: pick a diverging scheme, and anchor the center with `domainMid`.

The two renders below use the same data, mark and encoding. The only difference is the scheme and `domainMid`.
### Without domainMid
<img width="1138" height="546" alt="1-diverging-before" src="https://github.com/user-attachments/assets/7b15939f-f39c-4e8d-83b5-6a6fd5370515" />
<!-- drag 1-diverging-before.png here -->

### With domainMid
<img width="1138" height="546" alt="1-diverging-after" src="https://github.com/user-attachments/assets/08219d3c-a6ef-4a81-84b4-5a37ec6bfb0e" />

<!-- drag 1-diverging-after.png here -->

Fixes #1888