### PR TITLE
fix: allow polygons and paths kinds on hvPlot views

### DIFF
--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -929,7 +929,8 @@ class hvPlotBaseView(View):
         objects=[
             'area', 'bar', 'barh', 'bivariate', 'box', 'contour', 'contourf',
             'errorbars', 'hist', 'image', 'kde', 'labels',
-            'line', 'scatter', 'heatmap', 'hexbin', 'ohlc', 'points', 'step', 'violin'
+            'line', 'scatter', 'heatmap', 'hexbin', 'ohlc', 'paths', 'points',
+            'polygons', 'step', 'violin'
         ]
     )
 


### PR DESCRIPTION
The hvPlotAgent prompt picks `kind` from a geometry column's `geometry_type`, using `polygons` for Polygon/MultiPolygon and `paths` for LineString/MultiLineString. Neither was in the `kind` Selector, so the model could not emit them (Selector objects become a `Literal` in the response model) and validation rejected them if set directly.

This adds both. Checked they render through hvplot:

```
kind=polygons  -> Polygons  rendered OK
kind=paths     -> Path      rendered OK
```

Fixes #1930
