### PR TITLE
fix: build hvPlotAgent response model explicitly and add colormap options

### DIFF
--- a/lumen/ai/agents/hvplot.py
+++ b/lumen/ai/agents/hvplot.py
@@ -2,6 +2,7 @@ from typing import Any, Literal
 
 import param
 
+from hvplot.ui import CMAPS, DEFAULT_CMAPS, Colormapping
 from pydantic import BaseModel, Field, create_model
 
 from ...views import hvPlotUIView
@@ -10,19 +11,21 @@ from ..context import TContext
 from ..utils import get_data
 from .base_view import BaseViewAgent
 
+# Taken from hvPlot rather than restated, so the options cannot drift apart.
+CMAP_KINDS = tuple(DEFAULT_CMAPS)
+CNORMS = tuple(Colormapping.param["cnorm"].objects)
+
 
 def resolve_cmap(cmap: str) -> str:
     """
     Map a semantic colormap name onto a concrete one.
 
-    hvPlot understands 'linear', 'diverging', 'categorical' and 'cyclic' in its
-    converter, but `hvplot.ui.Colormapping.cmap` is a Selector over concrete
-    colormap names and rejects them, so they have to be resolved before the
-    spec reaches the view. The categorical default resolves to a list of
-    colours, which the Selector also rejects, hence the named fallback.
+    hvPlot understands these names in its converter, but
+    `hvplot.ui.Colormapping.cmap` is a Selector over concrete colormap names
+    and rejects them, so they have to be resolved before the spec reaches the
+    view. The categorical default resolves to a list of colors, which the
+    Selector also rejects, hence the named fallback.
     """
-    from hvplot.ui import CMAPS, DEFAULT_CMAPS
-
     resolved = DEFAULT_CMAPS.get(cmap, cmap)
     if not isinstance(resolved, str) or resolved not in CMAPS:
         return "glasbey"
@@ -36,19 +39,19 @@ class hvPlotSpec(BaseModel):
         description="Your thought process behind the plot."
     )
 
-    cmap: Literal["linear", "diverging", "categorical", "cyclic"] | None = Field(
+    cmap: Literal[CMAP_KINDS] | None = Field(
         default=None,
         description=(
-            "Colormap to use when a column is mapped to colour. Pick 'diverging' "
+            "Colormap to use when a column is mapped to color. Pick 'diverging' "
             "for values around a meaningful centre such as anomalies or deviations, "
             "'categorical' for unordered categories, 'cyclic' for wrapping values "
             "such as wind direction or hour of day, and 'linear' otherwise."
         ),
     )
 
-    cnorm: Literal["linear", "log", "eq_hist"] | None = Field(
+    cnorm: Literal[CNORMS] | None = Field(
         default=None,
-        description="Colour scale normalization. Use 'log' for values spanning orders of magnitude.",
+        description="Color scale normalization. Use 'log' for values spanning orders of magnitude.",
     )
 
     colorbar: bool | None = Field(
@@ -95,7 +98,7 @@ def make_hvplot_model(view_type: type[hvPlotUIView], schema: dict[str, Any]) -> 
         ),
         color=(
             column | None,
-            Field(default=None, description="Column to map onto colour."),
+            Field(default=None, description="Column to map onto color."),
         ),
         groupby=(
             list[column] | None,
@@ -159,8 +162,8 @@ class hvPlotAgent(BaseViewAgent):
         if "cmap" in spec:
             spec["cmap"] = resolve_cmap(spec["cmap"])
 
-        # Colouring by a non-numeric column makes hvPlot default the colormap to
-        # a list of colours, which the explorer's Selector rejects, so name one.
+        # Coloring by a non-numeric column makes hvPlot default the colormap to
+        # a list of colors, which the explorer's Selector rejects, so name one.
         if (color := spec.get("color")) in data and data[color].dtype.kind in "OSU":
             spec.setdefault("cmap", resolve_cmap("categorical"))
 

--- a/lumen/ai/agents/hvplot.py
+++ b/lumen/ai/agents/hvplot.py
@@ -1,16 +1,120 @@
-from typing import Any
+from typing import Any, Literal
 
 import param
 
-from pydantic import BaseModel
-from pydantic.fields import FieldInfo
+from pydantic import BaseModel, Field, create_model
 
 from ...views import hvPlotUIView
 from ..config import PROMPTS_DIR
 from ..context import TContext
-from ..translate import param_to_pydantic
 from ..utils import get_data
 from .base_view import BaseViewAgent
+
+
+def resolve_cmap(cmap: str) -> str:
+    """
+    Map a semantic colormap name onto a concrete one.
+
+    hvPlot understands 'linear', 'diverging', 'categorical' and 'cyclic' in its
+    converter, but `hvplot.ui.Colormapping.cmap` is a Selector over concrete
+    colormap names and rejects them, so they have to be resolved before the
+    spec reaches the view. The categorical default resolves to a list of
+    colours, which the Selector also rejects, hence the named fallback.
+    """
+    from hvplot.ui import CMAPS, DEFAULT_CMAPS
+
+    resolved = DEFAULT_CMAPS.get(cmap, cmap)
+    if not isinstance(resolved, str) or resolved not in CMAPS:
+        return "glasbey"
+    return resolved
+
+
+class hvPlotSpec(BaseModel):
+    """Fields that do not depend on the data schema."""
+
+    chain_of_thought: str = Field(
+        description="Your thought process behind the plot."
+    )
+
+    cmap: Literal["linear", "diverging", "categorical", "cyclic"] | None = Field(
+        default=None,
+        description=(
+            "Colormap to use when a column is mapped to colour. Pick 'diverging' "
+            "for values around a meaningful centre such as anomalies or deviations, "
+            "'categorical' for unordered categories, 'cyclic' for wrapping values "
+            "such as wind direction or hour of day, and 'linear' otherwise."
+        ),
+    )
+
+    cnorm: Literal["linear", "log", "eq_hist"] | None = Field(
+        default=None,
+        description="Colour scale normalization. Use 'log' for values spanning orders of magnitude.",
+    )
+
+    colorbar: bool | None = Field(
+        default=None,
+        description="Whether to show a colorbar. Leave unset to let hvPlot decide.",
+    )
+
+    geo: bool = Field(
+        default=False,
+        description="Whether the data is geographic and should be plotted on a map.",
+    )
+
+    limit: int | None = Field(
+        default=None,
+        ge=0,
+        description="Maximum number of rows to plot. Leave unset to plot all rows.",
+    )
+
+    title: str | None = Field(
+        default=None,
+        description="Title describing what the plot shows.",
+    )
+
+
+def make_hvplot_model(view_type: type[hvPlotUIView], schema: dict[str, Any]) -> type[BaseModel]:
+    """
+    Build the structured-output model for a given view type and data schema.
+
+    The column fields are restricted to the columns actually present so the
+    model cannot reference a column that does not exist, and `kind` is derived
+    from the view's own Selector so the two cannot drift apart.
+    """
+    kinds = tuple(view_type.param["kind"].objects)
+    columns = tuple(schema)
+    # Literal[()] is not a valid annotation, so fall back to a plain string
+    # when the schema is empty.
+    column = Literal[columns] if columns else str
+
+    return create_model(
+        "hvPlotSpecWithColumns",
+        by=(
+            list[column] | None,
+            Field(default=None, description="Columns to split into separate series."),
+        ),
+        color=(
+            column | None,
+            Field(default=None, description="Column to map onto colour."),
+        ),
+        groupby=(
+            list[column] | None,
+            Field(default=None, description="Columns to group by into widgets."),
+        ),
+        kind=(
+            Literal[kinds],
+            Field(description="The kind of plot to generate."),
+        ),
+        x=(
+            column | None,
+            Field(default=None, description="Column to plot on the x-axis."),
+        ),
+        y=(
+            column | None,
+            Field(default=None, description="Column to plot on the y-axis."),
+        ),
+        __base__=hvPlotSpec,
+    )
 
 
 class hvPlotAgent(BaseViewAgent):
@@ -37,31 +141,13 @@ class hvPlotAgent(BaseViewAgent):
     view_type = hvPlotUIView
 
     def _get_model(self, prompt_name: str, schema: dict[str, Any]) -> type[BaseModel]:
-        # Find parameters
-        excluded = self.view_type._internal_params + [
-            "controls",
-            "type",
-            "source",
-            "pipeline",
-            "transforms",
-            "download",
-            "field",
-            "selection_group",
-        ]
-        model = param_to_pydantic(
-            self.view_type,
-            base_model=BaseModel,
-            excluded=excluded,
-            schema=schema,
-            extra_fields={
-                "chain_of_thought": (str, FieldInfo(description="Your thought process behind the plot.")),
-            },
-        )
-        return model[self.view_type.__name__]
+        return make_hvplot_model(self.view_type, schema)
 
     async def _extract_spec(self, context: TContext, spec: dict[str, Any]):
         pipeline = context["pipeline"]
         spec = {key: val for key, val in spec.items() if val is not None}
+        # Reasoning is streamed to the UI, it is not part of the view spec.
+        spec.pop("chain_of_thought", None)
         spec["type"] = "hvplot_ui"
         self.view_type.validate(spec)
         spec.pop("type", None)
@@ -69,7 +155,17 @@ class hvPlotAgent(BaseViewAgent):
         # Add defaults
         spec["responsive"] = True
         data = await get_data(pipeline)
+
+        if "cmap" in spec:
+            spec["cmap"] = resolve_cmap(spec["cmap"])
+
+        # Colouring by a non-numeric column makes hvPlot default the colormap to
+        # a list of colours, which the explorer's Selector rejects, so name one.
+        if (color := spec.get("color")) in data and data[color].dtype.kind in "OSU":
+            spec.setdefault("cmap", resolve_cmap("categorical"))
+
         if len(data) > 20000 and spec["kind"] in ("line", "scatter", "points"):
             spec["rasterize"] = True
-            spec["cnorm"] = "log"
+            spec.setdefault("cnorm", "log")
+            spec.setdefault("cmap", resolve_cmap("linear"))
         return spec

--- a/lumen/ai/prompts/hvPlotAgent/main.jinja2
+++ b/lumen/ai/prompts/hvPlotAgent/main.jinja2
@@ -7,7 +7,7 @@ histogram is requested, use `y` instead of `x`. If x is categorical or strings, 
 the values. If a column has `format: geometry`, set `kind` from its `geometry_type`: `polygons` for Polygon or
 MultiPolygon, `paths` for LineString or MultiLineString, otherwise `points`.
 
-Only set `color` when a column should drive the colour; `by` already separates series. When you do, pick the
+Only set `color` when a column should drive the color; `by` already separates series. When you do, pick the
 `cmap` that matches the data: `diverging` for values around a meaningful centre such as anomalies or deviations
 from a reference, `categorical` for unordered categories, `cyclic` for values that wrap such as wind direction or
 hour of day, and `linear` otherwise. Set `cnorm` to `log` only when values span orders of magnitude.

--- a/lumen/ai/prompts/hvPlotAgent/main.jinja2
+++ b/lumen/ai/prompts/hvPlotAgent/main.jinja2
@@ -6,4 +6,9 @@ no repeated columns are allowed. Do not arbitrarily set `groupby` and `by` field
 histogram is requested, use `y` instead of `x`. If x is categorical or strings, prefer barh over bar, and use `y` for
 the values. If a column has `format: geometry`, set `kind` from its `geometry_type`: `polygons` for Polygon or
 MultiPolygon, `paths` for LineString or MultiLineString, otherwise `points`.
+
+Only set `color` when a column should drive the colour; `by` already separates series. When you do, pick the
+`cmap` that matches the data: `diverging` for values around a meaningful centre such as anomalies or deviations
+from a reference, `categorical` for unordered categories, `cyclic` for values that wrap such as wind direction or
+hour of day, and `linear` otherwise. Set `cnorm` to `log` only when values span orders of magnitude.
 {% endblock %}

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -327,6 +327,59 @@ def test_resolve_cmap_returns_names_the_explorer_accepts():
         assert resolve_cmap(semantic) in CMAPS
 
 
+async def test_hvplot_agent_resolves_semantic_colormap(llm, tiny_source):
+    """The semantic colormap names exist for the model's benefit;
+    hvplot.ui.Colormapping.cmap is a Selector over concrete colormaps and
+    rejects them, so they have to be resolved before the spec reaches the view.
+    The reasoning field has to go for the same reason."""
+    agent = hvPlotAgent(llm=llm)
+    context = {"pipeline": Pipeline(source=tiny_source, table="tiny")}
+
+    spec = await agent._extract_spec(context, {
+        "chain_of_thought": "why", "kind": "scatter",
+        "x": "id", "y": "value", "cmap": "diverging",
+    })
+
+    assert spec["cmap"] == "coolwarm"
+    assert "chain_of_thought" not in spec
+
+
+async def test_hvplot_agent_names_colormap_for_categorical_colour(llm, tiny_source):
+    """Colouring by a non-numeric column makes hvPlot default the colormap to a
+    list of colours, which the same Selector rejects, so name one instead."""
+    agent = hvPlotAgent(llm=llm)
+    context = {"pipeline": Pipeline(source=tiny_source, table="tiny")}
+    base = {"chain_of_thought": "why", "kind": "scatter", "x": "id", "y": "value"}
+
+    spec = await agent._extract_spec(context, dict(base, color="category"))
+    assert spec["cmap"] == "glasbey"
+
+    # Numeric colour columns are left alone for hvPlot to decide.
+    spec = await agent._extract_spec(context, dict(base, color="value"))
+    assert "cmap" not in spec
+
+
+async def test_hvplot_agent_keeps_explicit_cnorm_on_large_data(llm):
+    """Large datasets get a log colour norm, but not at the cost of one the
+    model asked for."""
+    source = DuckDBSource(tables={
+        "big": "SELECT i AS id, i * 1.0 AS value FROM range(25000) t(i)"
+    })
+    agent = hvPlotAgent(llm=llm)
+    context = {"pipeline": Pipeline(source=source, table="big")}
+    base = {"chain_of_thought": "why", "kind": "scatter", "x": "id", "y": "value"}
+
+    spec = await agent._extract_spec(context, dict(base, cnorm="eq_hist"))
+    assert spec["rasterize"] is True
+    assert spec["cnorm"] == "eq_hist"
+
+    # Without an explicit choice the log norm is applied, with a colormap to
+    # go alongside it rather than a bare norm.
+    spec = await agent._extract_spec(context, dict(base))
+    assert spec["cnorm"] == "log"
+    assert spec["cmap"] == "kbc_r"
+
+
 def test_map_agents_route_geometry_columns():
     """hvPlot and DeckGL agents advertise a geometry-column condition so the
     coordinator routes GeoDataFrame data to a map-capable view."""

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -15,6 +15,7 @@ try:
 except ModuleNotFoundError:
     pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
 
+from hvplot.ui import DEFAULT_CMAPS
 from panel.pane import Markdown
 
 from lumen.ai.agents import (
@@ -314,7 +315,7 @@ def test_hvplot_agent_model_exposes_colormap(llm):
         assert field in model.model_fields
 
     cmap_literal, _none = get_args(model.model_fields["cmap"].annotation)
-    assert set(get_args(cmap_literal)) == {"linear", "diverging", "categorical", "cyclic"}
+    assert set(get_args(cmap_literal)) == set(DEFAULT_CMAPS)
 
 
 def test_resolve_cmap_returns_names_the_explorer_accepts():

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -2,6 +2,7 @@ import json
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import get_args
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -21,7 +22,7 @@ from lumen.ai.agents import (
 )
 from lumen.ai.agents.analysis import make_analysis_model
 from lumen.ai.agents.deck_gl import DeckGLAgent
-from lumen.ai.agents.hvplot import hvPlotAgent
+from lumen.ai.agents.hvplot import hvPlotAgent, resolve_cmap
 from lumen.ai.agents.sql import make_sql_model
 from lumen.ai.agents.vega_lite import VegaLiteSpec, VegaLiteSpecUpdate
 from lumen.ai.analysis import Analysis
@@ -31,7 +32,7 @@ from lumen.ai.schemas import Metaset, get_metaset
 from lumen.config import dump_yaml
 from lumen.pipeline import Pipeline
 from lumen.sources.duckdb import DuckDBSource
-from lumen.views import Panel
+from lumen.views import Panel, hvPlotUIView
 
 root = str(Path(__file__).parent.parent / "sources")
 
@@ -277,6 +278,53 @@ class TestTemplateOverrides:
         messages = [{"role": "user", "content": "test"}]
         prompt = await agent._render_prompt("main", messages, {})
         assert "Footer appended." in prompt
+
+
+def test_hvplot_agent_builds_response_model(llm):
+    """hvPlotAgent must be able to build its structured-output model. The model
+    is requested on every response (Actor._invoke), so a failure here makes the
+    agent unusable rather than degraded."""
+    schema = {
+        "A": {"type": "number"},
+        "B": {"type": "number"},
+        "C": {"type": "string"},
+    }
+    model = hvPlotAgent(llm=llm)._get_model("main", schema=schema)
+
+    assert "chain_of_thought" in model.model_fields
+    for field in ("kind", "x", "y", "by", "groupby"):
+        assert field in model.model_fields
+
+    # x/y are restricted to real columns so the LLM cannot invent one.
+    x_literal, _none = get_args(model.model_fields["x"].annotation)
+    assert set(get_args(x_literal)) == set(schema)
+
+    # kind tracks the view's own Selector rather than a duplicated list.
+    assert set(get_args(model.model_fields["kind"].annotation)) == set(
+        hvPlotUIView.param["kind"].objects
+    )
+
+
+def test_hvplot_agent_model_exposes_colormap(llm):
+    """The model offers semantic colormap names rather than the full list of
+    concrete colormaps, which is far easier for an LLM to choose from."""
+    model = hvPlotAgent(llm=llm)._get_model("main", schema={"A": {"type": "number"}})
+
+    for field in ("cmap", "cnorm", "colorbar", "color"):
+        assert field in model.model_fields
+
+    cmap_literal, _none = get_args(model.model_fields["cmap"].annotation)
+    assert set(get_args(cmap_literal)) == {"linear", "diverging", "categorical", "cyclic"}
+
+
+def test_resolve_cmap_returns_names_the_explorer_accepts():
+    """hvplot.ui.Colormapping.cmap is a Selector over concrete colormap names,
+    so the semantic names have to be resolved before reaching the view. The
+    categorical default resolves to a list of colours, which it rejects."""
+    from hvplot.ui import CMAPS
+
+    for semantic in ("linear", "diverging", "categorical", "cyclic"):
+        assert resolve_cmap(semantic) in CMAPS
 
 
 def test_map_agents_route_geometry_columns():

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -321,7 +321,7 @@ def test_hvplot_agent_model_exposes_colormap(llm):
 def test_resolve_cmap_returns_names_the_explorer_accepts():
     """hvplot.ui.Colormapping.cmap is a Selector over concrete colormap names,
     so the semantic names have to be resolved before reaching the view. The
-    categorical default resolves to a list of colours, which it rejects."""
+    categorical default resolves to a list of colors, which it rejects."""
     from hvplot.ui import CMAPS
 
     for semantic in ("linear", "diverging", "categorical", "cyclic"):
@@ -345,9 +345,9 @@ async def test_hvplot_agent_resolves_semantic_colormap(llm, tiny_source):
     assert "chain_of_thought" not in spec
 
 
-async def test_hvplot_agent_names_colormap_for_categorical_colour(llm, tiny_source):
-    """Colouring by a non-numeric column makes hvPlot default the colormap to a
-    list of colours, which the same Selector rejects, so name one instead."""
+async def test_hvplot_agent_names_colormap_for_categorical_color(llm, tiny_source):
+    """Coloring by a non-numeric column makes hvPlot default the colormap to a
+    list of colors, which the same Selector rejects, so name one instead."""
     agent = hvPlotAgent(llm=llm)
     context = {"pipeline": Pipeline(source=tiny_source, table="tiny")}
     base = {"chain_of_thought": "why", "kind": "scatter", "x": "id", "y": "value"}
@@ -355,13 +355,13 @@ async def test_hvplot_agent_names_colormap_for_categorical_colour(llm, tiny_sour
     spec = await agent._extract_spec(context, dict(base, color="category"))
     assert spec["cmap"] == "glasbey"
 
-    # Numeric colour columns are left alone for hvPlot to decide.
+    # Numeric color columns are left alone for hvPlot to decide.
     spec = await agent._extract_spec(context, dict(base, color="value"))
     assert "cmap" not in spec
 
 
 async def test_hvplot_agent_keeps_explicit_cnorm_on_large_data(llm):
-    """Large datasets get a log colour norm, but not at the cost of one the
+    """Large datasets get a log color norm, but not at the cost of one the
     model asked for."""
     source = DuckDBSource(tables={
         "big": "SELECT i AS id, i * 1.0 AS value FROM range(25000) t(i)"


### PR DESCRIPTION
`hvPlotAgent` could not build its structured-output model at all: `param_to_pydantic` walks parent classes and every subclass transitively, so from `hvPlotUIView` it reached Panel's whole class graph and failed differently on each run. `_get_model` is called on every response, so the agent raised rather than degraded.

This builds the model with `create_model` instead, listing fields explicitly and deriving `kind` from the view's own Selector. Since the model was being rebuilt anyway it also adds `cmap`, `cnorm`, `colorbar` and `color`, with the colormap offered as linear/diverging/categorical/cyclic and resolved to a concrete name before it reaches the view.

Fixes #1931
