### PR TITLE
feat: give generated charts a shared categorical palette

### DIFF
--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -581,13 +581,13 @@ class VegaLiteAgent(BaseCodeAgent):
                     step_name, step_desc, out.spec, step_name, messages, context, doc=doc, out=out
                 )
                 try:
-                    # Validate merged spec
+                    # Validate merged spec, and keep what normalization added to it
                     merged_spec = self._deep_merge_dicts(out._spec_dict["spec"], update_dict)
-                    await self._extract_spec(context, {"yaml_spec": dump_yaml(merged_spec)})
+                    normalized = await self._extract_spec(context, {"yaml_spec": dump_yaml(merged_spec)})
                 except Exception as e:
                     log_debug(f"Skipping invalid {step_name} update due to error: {e}")
                     continue
-                out.spec = dump_yaml(merged_spec)
+                out.spec = dump_yaml(normalized["spec"])
             log_debug(f"📊 Applied {step_name} updates and refreshed visualization")
 
     async def respond(

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -3,7 +3,6 @@ import base64
 from functools import partial
 from typing import Any
 
-import colorcet as cc
 import param
 import requests
 
@@ -25,8 +24,8 @@ from ..editors import LumenEditor, VegaLiteEditor
 from ..llm import Message, OpenAI
 from ..models import EscapeBaseModel, RetrySpec
 from ..utils import (
-    get_data, get_schema, load_json, log_debug, normalize_vegalite_spec,
-    retry_llm_output,
+    category_palette, get_data, get_schema, has_categorical_color, load_json,
+    log_debug, normalize_vegalite_spec, retry_llm_output,
 )
 from ..vector_store import DuckDBVectorStore
 from .base_code import BaseCodeAgent
@@ -92,38 +91,6 @@ class AltairSpec(BaseModel):
         - Use 'container' for width to make charts responsive
         """
     )
-
-
-def category_palette(ncolors: int = 20) -> list[str]:
-    """
-    Colours used for categorical encodings the model did not color itself.
-
-    Glasbey seeded on category10, so the first ten entries are visually the same
-    as Vega's own default (largest total RGB difference is 3 out of 765). Charts
-    with ten categories or fewer are unchanged; only the ones that used to
-    recycle colors differ. The b_ prefix is the hex form, since
-    colorcet.glasbey_category10 gives float RGB tuples that cannot be
-    serialized into a spec.
-    """
-    return cc.b_glasbey_category10[:ncolors]
-
-
-def has_categorical_color(spec: Any) -> bool:
-    """
-    Whether anything in the spec maps a field to color by category.
-
-    Only those charts can use the palette, so only they are worth adding it to.
-    Layered, concatenated and faceted specs nest their encodings, hence the
-    walk rather than a single lookup.
-    """
-    if isinstance(spec, dict):
-        color = spec.get("encoding", {}).get("color")
-        if isinstance(color, dict) and "field" in color and color.get("type") in ("nominal", "ordinal"):
-            return True
-        return any(has_categorical_color(value) for value in spec.values())
-    if isinstance(spec, list):
-        return any(has_categorical_color(item) for item in spec)
-    return False
 
 
 class VegaLiteAgent(BaseCodeAgent):

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -93,6 +93,40 @@ class AltairSpec(BaseModel):
     )
 
 
+def category_palette(ncolors: int = 20) -> list[str]:
+    """
+    Colours used for categorical encodings the model did not color itself.
+
+    Glasbey seeded on category10, so the first ten entries are visually the same
+    as Vega's own default (largest total RGB difference is 3 out of 765). Charts
+    with ten categories or fewer are unchanged; only the ones that used to
+    recycle colors differ. The b_ prefix is the hex form, since
+    colorcet.glasbey_category10 gives float RGB tuples that cannot be
+    serialized into a spec.
+    """
+    import colorcet as cc
+
+    return cc.b_glasbey_category10[:ncolors]
+
+
+def has_categorical_color(spec: Any) -> bool:
+    """
+    Whether anything in the spec maps a field to color by category.
+
+    Only those charts can use the palette, so only they are worth adding it to.
+    Layered, concatenated and faceted specs nest their encodings, hence the
+    walk rather than a single lookup.
+    """
+    if isinstance(spec, dict):
+        color = spec.get("encoding", {}).get("color")
+        if isinstance(color, dict) and "field" in color and color.get("type") in ("nominal", "ordinal"):
+            return True
+        return any(has_categorical_color(value) for value in spec.values())
+    if isinstance(spec, list):
+        return any(has_categorical_color(item) for item in spec)
+    return False
+
+
 class VegaLiteAgent(BaseCodeAgent):
 
     conditions = param.List(
@@ -484,7 +518,7 @@ class VegaLiteAgent(BaseCodeAgent):
 
         return await self._extract_spec(context, {"yaml_spec": dump_yaml(spec)})
 
-    async def _extract_spec(self, context: TContext, spec: dict[str, Any]):
+    async def _extract_spec(self, context: TContext, spec: dict[str, Any], apply_defaults: bool = True):
         # .encode().decode('unicode_escape') fixes a JSONDecodeError in Python
         # where it's expecting property names enclosed in double quotes
         # by properly handling the escaped characters in your JSON string
@@ -492,6 +526,14 @@ class VegaLiteAgent(BaseCodeAgent):
             vega_spec = load_yaml(yaml_spec)
         elif json_spec := spec.get("json_spec"):
             vega_spec = load_json(json_spec)
+        # Supply the palette as a default the model can override, so charts in a
+        # single report share colors unless a chart asked for something else.
+        # Only on the way in: re-applying it on a later edit would undo a
+        # palette the user had deliberately removed.
+        if apply_defaults and has_categorical_color(vega_spec):
+            vega_spec = self._deep_merge_dicts(
+                {"config": {"range": {"category": category_palette()}}}, vega_spec
+            )
         return normalize_vegalite_spec(vega_spec, editor_type=self._editor_type)
 
     async def _get_doc_examples(self, user_query: str) -> list[str]:
@@ -583,7 +625,9 @@ class VegaLiteAgent(BaseCodeAgent):
                 try:
                     # Validate merged spec, and keep what normalization added to it
                     merged_spec = self._deep_merge_dicts(out._spec_dict["spec"], update_dict)
-                    normalized = await self._extract_spec(context, {"yaml_spec": dump_yaml(merged_spec)})
+                    normalized = await self._extract_spec(
+                        context, {"yaml_spec": dump_yaml(merged_spec)}, apply_defaults=False
+                    )
                 except Exception as e:
                     log_debug(f"Skipping invalid {step_name} update due to error: {e}")
                     continue
@@ -679,7 +723,9 @@ class VegaLiteAgent(BaseCodeAgent):
 
         try:
             final_dict["spec"] = self._deep_merge_dicts(final_dict["spec"], update_dict)
-            spec = await self._extract_spec(context, {"yaml_spec": dump_yaml(final_dict["spec"])})
+            spec = await self._extract_spec(
+                context, {"yaml_spec": dump_yaml(final_dict["spec"])}, apply_defaults=False
+            )
         except Exception as e:
             log_debug(f"Skipping invalid annotation update due to error: {e}")
             raise e

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -3,6 +3,7 @@ import base64
 from functools import partial
 from typing import Any
 
+import colorcet as cc
 import param
 import requests
 
@@ -104,8 +105,6 @@ def category_palette(ncolors: int = 20) -> list[str]:
     colorcet.glasbey_category10 gives float RGB tuples that cannot be
     serialized into a spec.
     """
-    import colorcet as cc
-
     return cc.b_glasbey_category10[:ncolors]
 
 

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -23,6 +23,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import parse_qs
 
+import colorcet as cc
 import pandas as pd
 import param
 import sqlglot
@@ -1642,6 +1643,39 @@ def result_to_dataframe(result) -> pd.DataFrame | None:
             return None
 
     return None
+
+
+def category_palette(ncolors: int = 20) -> list[str]:
+    """
+    Colors used for categorical encodings a plot did not color itself.
+
+    Glasbey seeded on category10, so the first ten entries are visually the same
+    as Vega's own default (largest total RGB difference is 3 out of 765). Charts
+    with ten categories or fewer are unchanged; only the ones that used to
+    recycle colors differ. hvPlot reaches for the same palette when it picks a
+    colormap itself, so the two agree. The b_ prefix is the hex form, since
+    colorcet.glasbey_category10 gives float RGB tuples that cannot be
+    serialized into a spec.
+    """
+    return cc.b_glasbey_category10[:ncolors]
+
+
+def has_categorical_color(spec: Any) -> bool:
+    """
+    Whether anything in the Vega-Lite spec maps a field to color by category.
+
+    Only those charts can use the palette, so only they are worth adding it to.
+    Layered, concatenated and faceted specs nest their encodings, hence the
+    walk rather than a single lookup.
+    """
+    if isinstance(spec, dict):
+        color = spec.get("encoding", {}).get("color")
+        if isinstance(color, dict) and "field" in color and color.get("type") in ("nominal", "ordinal"):
+            return True
+        return any(has_categorical_color(value) for value in spec.values())
+    if isinstance(spec, list):
+        return any(has_categorical_color(item) for item in spec)
+    return False
 
 
 def normalize_vegalite_spec(

--- a/lumen/tests/ai/test_vega_lite.py
+++ b/lumen/tests/ai/test_vega_lite.py
@@ -8,8 +8,12 @@ except ModuleNotFoundError:
         allow_module_level=True,
     )
 
+import vl_convert
+
+from lumen.ai.agents.vega_lite import VegaLiteAgent, category_palette
 from lumen.ai.editors import VegaLiteEditor
 from lumen.ai.utils import normalize_vegalite_spec
+from lumen.config import dump_yaml
 
 
 def test_normalize_vegalite_spec_adds_schema_and_container_sizing():
@@ -73,3 +77,75 @@ def test_normalize_vegalite_spec_adds_geographic_interactivity():
     assert spec["projection"]["type"] == "mercator"
     assert "scale" in {p.get("name") for p in spec["params"]}
     assert "layer" in spec
+
+
+CATEGORICAL_SPEC = {
+    "mark": "bar",
+    "encoding": {
+        "x": {"field": "c", "type": "nominal"},
+        "y": {"field": "v", "type": "quantitative"},
+        "color": {"field": "c", "type": "nominal"},
+    },
+}
+
+
+async def test_palette_supplied_as_a_default_the_model_can_override(llm):
+    """Charts share a palette so a report does not shift colors between views,
+    but a chart that chose its own colors keeps them."""
+    agent = VegaLiteAgent(llm=llm, code_execution="disabled")
+
+    spec = (await agent._extract_spec({}, {"yaml_spec": dump_yaml(dict(CATEGORICAL_SPEC))}))["spec"]
+    assert spec["config"]["range"]["category"] == category_palette()
+
+    chosen = dict(CATEGORICAL_SPEC, config={"range": {"category": ["#111111"]}, "view": {"stroke": None}})
+    spec = (await agent._extract_spec({}, {"yaml_spec": dump_yaml(chosen)}))["spec"]
+    assert spec["config"]["range"]["category"] == ["#111111"]
+    assert spec["config"]["view"] == {"stroke": None}
+
+
+async def test_palette_only_added_where_it_can_be_used(llm):
+    """A palette is only meaningful for categorical color, so charts that do not
+    use it are left alone rather than carrying twenty unused colors."""
+    agent = VegaLiteAgent(llm=llm, code_execution="disabled")
+    axes = {"x": {"field": "c", "type": "nominal"}, "y": {"field": "v", "type": "quantitative"}}
+
+    for encoding in (axes, dict(axes, color={"field": "v", "type": "quantitative"})):
+        chart = {"mark": "bar", "encoding": encoding}
+        spec = (await agent._extract_spec({}, {"yaml_spec": dump_yaml(chart)}))["spec"]
+        assert "range" not in spec.get("config", {})
+
+    layered = {"layer": [{"mark": "bar", "encoding": CATEGORICAL_SPEC["encoding"]}]}
+    spec = (await agent._extract_spec({}, {"yaml_spec": dump_yaml(layered)}))["spec"]
+    assert spec["config"]["range"]["category"] == category_palette()
+
+
+async def test_palette_not_reapplied_once_the_chart_exists(llm):
+    """Annotating or polishing a chart must not restore a palette the user
+    removed, so the defaults are only supplied on the way in."""
+    agent = VegaLiteAgent(llm=llm, code_execution="disabled")
+
+    spec = (await agent._extract_spec(
+        {}, {"yaml_spec": dump_yaml(dict(CATEGORICAL_SPEC))}, apply_defaults=False
+    ))["spec"]
+
+    assert "range" not in spec.get("config", {})
+
+
+def test_palette_reaches_the_compiled_vega_scale():
+    """The palette is only useful if Vega resolves it, which it does through the
+    named 'category' range rather than by inlining the colors in the scale."""
+    spec = {
+        "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+        "data": {"values": [{"c": "a", "v": 1}, {"c": "b", "v": 2}]},
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "c", "type": "nominal"},
+            "y": {"field": "v", "type": "quantitative"},
+            "color": {"field": "c", "type": "nominal"},
+        },
+        "config": {"range": {"category": category_palette()}},
+    }
+
+    compiled = vl_convert.vegalite_to_vega(spec)
+
+    assert compiled["config"]["range"]["category"] == category_palette()

--- a/lumen/tests/ai/test_vega_lite.py
+++ b/lumen/tests/ai/test_vega_lite.py
@@ -10,9 +10,9 @@ except ModuleNotFoundError:
 
 import vl_convert
 
-from lumen.ai.agents.vega_lite import VegaLiteAgent, category_palette
+from lumen.ai.agents.vega_lite import VegaLiteAgent
 from lumen.ai.editors import VegaLiteEditor
-from lumen.ai.utils import normalize_vegalite_spec
+from lumen.ai.utils import category_palette, normalize_vegalite_spec
 from lumen.config import dump_yaml
 
 


### PR DESCRIPTION
Charts picked their own colors, so two views of the same data in one report could disagree, and anything past ten categories fell off the end of Vega's `category10` default and started repeating.

This supplies a glasbey palette seeded on category10 as a `config` default the model can still override. Its first ten entries are visually identical to category10 (largest total RGB difference is 3 out of 765), so charts with ten categories or fewer render unchanged and only the repeating case differs. It is added only where a chart colors by category, and only on the way in, so annotating or polishing does not restore a palette someone removed.

The first commit is a separate fix: `_polish_plot` used `_extract_spec` purely as a validator and wrote back the un-normalized spec, dropping the projection, basemap layer and zoom params when a polish step introduced a lat/long encoding.

Refs #1932
