### PR TITLE
fix: correct the PyPI package description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "lumen"
 dynamic = ["version"]
-description = "A monitoring solution built on Panel."
+description = "Agent framework for chatting with data and building dashboards."
 readme = "README.md"
 license = { text = "BSD" }
 requires-python = ">=3.11"


### PR DESCRIPTION
The PyPI summary for `lumen` still reads "A monitoring solution built on Panel." That was accurate in 2020, but it is now the description shown on pypi.org, in `pip show lumen`, and in the index mirrors that scrape PyPI, so anyone finding Lumen through a package index is told it is a monitoring tool.

lumen.holoviz.org already describes Lumen as an agent framework for chatting with data. I took the new wording from that meta description so the two stay in sync.

## Before

https://pypi.org/project/lumen/

```
$ pip show lumen
Summary: A monitoring solution built on Panel.
```

## After

```
Summary: Agent framework for chatting with data and building dashboards.
```

I left `keywords` alone deliberately, since none of the sibling HoloViz projects set it and this seemed better as a single-purpose change.
