### PR TITLE
fix: gridded plotting on real climate netCDF (cftime + bounds)

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -1669,11 +1669,12 @@ def get_gridded_metadata(pipeline: Pipeline) -> dict[str, Any] | None:
         arr = np.asarray(values)
         if arr.ndim != 1 or arr.size < 2:
             return False
-        # datetime64 coords need int64 conversion before allclose
-        if np.issubdtype(arr.dtype, np.datetime64):
-            arr = arr.astype('int64')
         diffs = np.diff(arr)
-        return bool(np.allclose(diffs, diffs[0], rtol=1e-6))
+        # Real-number steps compare with a tolerance; datetime/timedelta/object
+        # steps (e.g. cftime) can't, since allclose adds a float atol to them.
+        if diffs.dtype.kind in 'fiu':
+            return bool(np.allclose(diffs, diffs[0], rtol=1e-6))
+        return bool((diffs == diffs[0]).all())
 
     regular = all(
         _is_regular(ds.coords[d].values) for d in ds.dims if d in ds.coords

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -1730,16 +1730,21 @@ def subset_gridded_to_2d(
     time on a lon/lat map) collapse. Returns the pipeline unchanged when it is
     not gridded or the spec already references every dimension.
     """
-    md = get_gridded_metadata(pipeline)
-    if not md:
+    # The compact gridded dataset (lazy, coords only -- never the long-form
+    # frame) carries just this variable's dims and, crucially, its coords in the
+    # materialized column's dtype (e.g. cftime coords become datetime64 there),
+    # so both the dims to collapse and the pin values come from it. Pinning from
+    # the raw dataset would leave cftime dims uncollapsed (the object value can't
+    # match the datetime64 column).
+    grid = pipeline.get_dataset()
+    if grid is None:
         return pipeline
-    ds = pipeline.source.dataset
     referenced = _spec_field_references(spec, kind)
-    collapse = [dim for dim in ds.dims if dim not in referenced]
+    collapse = [dim for dim in grid.dims if dim not in referenced]
     if not collapse:
         return pipeline
     filters = [
-        ConstantFilter(field=dim, value=ds[dim].values[0]) for dim in collapse
+        ConstantFilter(field=dim, value=grid[dim].values[0]) for dim in collapse
     ]
     return pipeline.chain(filters=filters)
 

--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -284,7 +284,13 @@ class XArraySQLSource(BaseSQLSource):
         on the dataset dims for xarray-sql < 0.3.
         """
         result = self._ctx.sql(self._build_sql(table, **query))
-        dims = list(self._dataset.dims)
+        # A single variable's own dims exclude unrelated dataset dims (e.g. an
+        # nbnds bounds dim from a *_bounds variable) that the query result has
+        # no column for and that would break to_dataset(dims=...).
+        if table in self._dataset.data_vars:
+            dims = list(self._dataset[table].dims)
+        else:
+            dims = list(self._dataset.dims)
         if hasattr(result, 'to_dataset'):
             # Pass dims explicitly: with multiple data variables registered the
             # source cannot infer them unambiguously from the FROM clause.

--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -284,19 +284,17 @@ class XArraySQLSource(BaseSQLSource):
         on the dataset dims for xarray-sql < 0.3.
         """
         result = self._ctx.sql(self._build_sql(table, **query))
-        # A single variable's own dims exclude unrelated dataset dims (e.g. an
-        # nbnds bounds dim from a *_bounds variable) that the query result has
-        # no column for and that would break to_dataset(dims=...).
-        if table in self._dataset.data_vars:
-            dims = list(self._dataset[table].dims)
-        else:
-            dims = list(self._dataset.dims)
         if hasattr(result, 'to_dataset'):
-            # Pass dims explicitly: with multiple data variables registered the
-            # source cannot infer them unambiguously from the FROM clause.
+            # Pass only the dims the result actually has a column for. Multiple
+            # data vars need dims passed explicitly (the FROM clause is
+            # ambiguous), but a bounds dim (e.g. nbnds) or a projecting/
+            # aggregating sql_transform can leave a dataset dim out of the
+            # result, and to_dataset(dims=...) errors on a dim it can't find.
+            names = set(result.schema().names)
+            dims = [d for d in self._dataset.dims if d in names]
             return result.to_dataset(dims=dims)
         df = result.to_pandas()
-        present = [d for d in dims if d in df.columns]
+        present = [d for d in self._dataset.dims if d in df.columns]
         return df.set_index(present).to_xarray() if present else df
 
     def create_sql_expr_source(

--- a/lumen/tests/ai/test_gridded.py
+++ b/lumen/tests/ai/test_gridded.py
@@ -326,6 +326,24 @@ def test_subset_keeps_dims_the_spec_uses(simple_dataset_3d_pipeline):
     assert sub.data["lat"].nunique() == 1
 
 
+def test_subset_collapses_cftime_dim():
+    """A cftime time dim must still collapse: the raw cftime coord value can't
+    match the materialized (datetime64) column, so the pin comes from the data."""
+    cftime = pytest.importorskip("cftime")
+    times = np.array(
+        [cftime.DatetimeGregorian(2026, m, 1) for m in (1, 2, 3)], dtype=object
+    )
+    ds = xr.Dataset(
+        {"air": (["time", "lat", "lon"], np.arange(3 * 3 * 4, dtype=float).reshape(3, 3, 4))},
+        coords={"time": times, "lat": [0.0, 1.0, 2.0], "lon": [10.0, 20.0, 30.0, 40.0]},
+    )
+    pipeline = Pipeline(source=XArraySQLSource(_dataset=ds), table="air")
+    spec = {"encoding": {"x": {"field": "lon"}, "y": {"field": "lat"}}}  # collapse time
+    sub = subset_gridded_to_2d(pipeline, spec, "vega-lite")
+    assert len(sub.data) < len(pipeline.data)
+    assert sub.data["time"].nunique() == 1
+
+
 def test_subset_noop_when_spec_uses_all_dims(xarray_pipeline):
     """When the spec references every dim, the pipeline is returned unchanged."""
     spec = {"encoding": {"x": {"field": "lon"}, "y": {"field": "lat"}}}

--- a/lumen/tests/ai/test_gridded.py
+++ b/lumen/tests/ai/test_gridded.py
@@ -124,6 +124,27 @@ def test_gridded_metadata_handles_datetime_coord():
     assert result["regular"] is True
 
 
+def test_gridded_metadata_handles_cftime_coord():
+    """cftime (non-standard calendar) time coords stay object-dtype and cannot
+    become datetime64, so the regularity check must not crash on them: np.diff
+    yields timedeltas and np.allclose cannot add a float tolerance to one."""
+    cftime = pytest.importorskip("cftime")
+    times = np.array(
+        [cftime.DatetimeNoLeap(2026, m, 1) for m in (1, 2, 3, 4)], dtype=object
+    )
+    lons = np.array([10.0, 20.0, 30.0])
+    temp = np.arange(12, dtype=float).reshape(4, 3)
+    ds = xr.Dataset(
+        {"temp": (["time", "lon"], temp)},
+        coords={"time": times, "lon": lons},
+    )
+    pipeline = Pipeline(source=XArraySQLSource(_dataset=ds), table="temp")
+    result = get_gridded_metadata(pipeline)
+    assert result is not None
+    # month starts are unevenly spaced, so the grid is irregular
+    assert result["regular"] is False
+
+
 # ---- Prompt rendering tests ----
 
 def _base_context(gridded=None):

--- a/lumen/tests/sources/test_xarray_sql.py
+++ b/lumen/tests/sources/test_xarray_sql.py
@@ -676,6 +676,18 @@ class TestToDataset:
         ds = source.to_dataset("temperature", lat=30.0)
         assert ds.sizes["lat"] == 1
 
+    def test_to_dataset_ignores_bounds_dim(self, synthetic_dataset):
+        """A bounds variable adds a dim (e.g. nbnds) the queried variable lacks;
+        to_dataset must use the variable's own dims, not every dataset dim, or
+        the extra dim has no column in the result and to_dataset crashes."""
+        ds = synthetic_dataset.assign(
+            time_bnds=(["time", "nbnds"], np.zeros((10, 2)))
+        )
+        source = XArraySQLSource(_dataset=ds)
+        result = source.to_dataset("temperature")
+        assert "nbnds" not in result.dims
+        assert set(result.dims) >= {"time", "lat", "lon"}
+
     def test_get_still_returns_long_form(self, synthetic_dataset):
         """get() is unchanged: it returns the long-form pandas frame."""
         source = XArraySQLSource(_dataset=synthetic_dataset)

--- a/lumen/tests/sources/test_xarray_sql.py
+++ b/lumen/tests/sources/test_xarray_sql.py
@@ -23,6 +23,7 @@ xr = pytest.importorskip("xarray")
 pytest.importorskip("xarray_sql")
 
 from lumen.sources.xarray_sql import XArraySQLSource
+from lumen.transforms.sql import SQLColumns
 
 # ---- Fixtures ----
 
@@ -687,6 +688,16 @@ class TestToDataset:
         result = source.to_dataset("temperature")
         assert "nbnds" not in result.dims
         assert set(result.dims) >= {"time", "lat", "lon"}
+
+    def test_to_dataset_ignores_projected_away_dim(self, synthetic_dataset):
+        """A projecting sql_transform (e.g. DeckGL keeping only lat/lon/value)
+        drops a dim from the result; to_dataset must pass only the dims the
+        result still has a column for, not every dataset dim."""
+        source = XArraySQLSource(_dataset=synthetic_dataset)
+        transform = SQLColumns(columns=["lat", "lon", "temperature"])  # drops time
+        result = source.to_dataset("temperature", sql_transforms=[transform])
+        assert "time" not in result.dims
+        assert set(result.dims) == {"lat", "lon"}
 
     def test_get_still_returns_long_form(self, synthetic_dataset):
         """get() is unchanged: it returns the long-form pandas frame."""


### PR DESCRIPTION
Testing the new gridded path (#1823) against real 4D climate files surfaced several crashes on cftime calendars and on datasets that carry bounds variables. This scopes them out so a gridded source plots cleanly regardless of calendar or auxiliary variables.

- Regularity check no longer crashes on cftime coords
- The VegaLite/DeckGL 2D subset now collapses cftime dims (pins from the compact grid, whose coords match the materialized column)
- `to_dataset` passes only dims the result has a column for, so a bounds dim (e.g. `nbnds`) or a dim an aggregating transform drops no longer breaks it

Each fix has a regression test that fails without it.

## Before / after

| Case | Before | After |
|---|---|---|
| cftime map (VegaLite) | `TypeError` in regularity check | renders, time collapsed |
| cftime lon/lat map rows | 2.1M (all 12 months) | 10,512 (one slice) |
| `air` file with bounds var | `list.index(x): x not in list` | renders |
| DeckGL map (projection) | `list.index(x): x not in list` | renders |
