### PR TITLE
fix: gridded VegaLite subset corrupts aggregating charts

### DIFF
--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -1717,6 +1717,19 @@ def _spec_field_references(
     return refs
 
 
+def _spec_has_aggregate(spec: Any) -> bool:
+    """True if a Vega-Lite spec aggregates anywhere -- an encoding ``aggregate``
+    (``{"field": "x", "aggregate": "mean"}``) or an ``aggregate`` transform.
+    Such a spec reduces over the dims it does not plot, so those dims must not
+    be pinned to a single slice.
+    """
+    if isinstance(spec, dict):
+        return 'aggregate' in spec or any(_spec_has_aggregate(v) for v in spec.values())
+    if isinstance(spec, list):
+        return any(_spec_has_aggregate(item) for item in spec)
+    return False
+
+
 def subset_gridded_to_2d(
     pipeline: Pipeline, spec: Any, kind: Literal['vega-lite', 'deckgl']
 ) -> Pipeline:
@@ -1736,6 +1749,14 @@ def subset_gridded_to_2d(
     # so both the dims to collapse and the pin values come from it. Pinning from
     # the raw dataset would leave cftime dims uncollapsed (the object value can't
     # match the datetime64 column).
+    # A Vega-Lite spec that aggregates (e.g. mean per latitude, or a heatmap of
+    # a temporal mean) reduces over every dim it does not plot. Pinning those
+    # dims to one slice would make the aggregate run on a single slice and
+    # report wrong values, so leave the grid whole and let Vega-Lite aggregate.
+    # ponytail: sends the full grid to the browser; push the aggregate into SQL
+    # if that row volume becomes a problem.
+    if kind == 'vega-lite' and _spec_has_aggregate(spec):
+        return pipeline
     grid = pipeline.get_dataset()
     if grid is None:
         return pipeline

--- a/lumen/tests/ai/test_gridded.py
+++ b/lumen/tests/ai/test_gridded.py
@@ -326,6 +326,24 @@ def test_subset_keeps_dims_the_spec_uses(simple_dataset_3d_pipeline):
     assert sub.data["lat"].nunique() == 1
 
 
+def test_subset_skips_collapse_when_spec_aggregates(simple_dataset_3d_pipeline):
+    """An aggregating spec (mean per lat) reduces over the dims it does not plot,
+    so the grid must stay whole; pinning lon/time would make Vega-Lite average a
+    single slice and report wrong values."""
+    spec = {
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "lat"},
+            "y": {"field": "air", "aggregate": "mean"},
+        },
+    }
+    full = len(simple_dataset_3d_pipeline.data)
+    sub = subset_gridded_to_2d(simple_dataset_3d_pipeline, spec, "vega-lite")
+    assert len(sub.data) == full  # not collapsed
+    assert sub.data["time"].nunique() > 1
+    assert sub.data["lon"].nunique() > 1
+
+
 def test_subset_collapses_cftime_dim():
     """A cftime time dim must still collapse: the raw cftime coord value can't
     match the materialized (datetime64) column, so the pin comes from the data."""


### PR DESCRIPTION
Follow-up to #1943. The gridded VegaLite subset (`subset_gridded_to_2d`) pins every dim a spec does not plot to a single slice, which is right for a raw 2D map but wrong for an aggregating chart: a spec like "mean 2m temperature per latitude" reduces over the dims it does not plot, so pinning them makes Vega-Lite average a single slice and report incorrect values, with no error.

This skips the collapse when a Vega-Lite spec aggregates (an encoding `aggregate` or an `aggregate` transform) and lets Vega-Lite reduce the full grid instead.

## Before / after

| Case | Before | After |
|---|---|---|
| bar: mean per latitude | 651,744 rows -> 73 (lon+time pinned), wrong means | full grid, means match the true spatial mean |
| heatmap: `color: mean(air)` over time | time pinned to one slice | all times kept, correct temporal mean |
| plain lon/lat map (no aggregate) | collapses to one slice | unchanged (still one slice) |

Regression test added; it fails without the fix.
