### PR TITLE
Fix broken link to views documentation in analyses.md

### DIFF
--- a/docs/configuration/analyses.md
+++ b/docs/configuration/analyses.md
@@ -4,7 +4,7 @@
 
 Like tools or hooks, analyses give you control over specific calculations. Use them when you need reliable, repeatable results—financial metrics, scientific formulas, or statistical tests that must be calculated exactly the same way every time.
 
-**Difference from Views:** [Views](../../configuration/spec/views.md) are interactive visualizations that display data. Analyses are computational functions that calculate new insights from data. You can think of views as "how it looks" and analyses as "what it means."
+**Difference from Views:** [Views](configuration/spec/views.md) are interactive visualizations that display data. Analyses are computational functions that calculate new insights from data. You can think of views as "how it looks" and analyses as "what it means."
 
 ## Quick example
 

--- a/docs/configuration/analyses.md
+++ b/docs/configuration/analyses.md
@@ -4,7 +4,7 @@
 
 Like tools or hooks, analyses give you control over specific calculations. Use them when you need reliable, repeatable results—financial metrics, scientific formulas, or statistical tests that must be calculated exactly the same way every time.
 
-**Difference from Views:** [Views](../spec/views.md) are interactive visualizations that display data. Analyses are computational functions that calculate new insights from data. You can think of views as "how it looks" and analyses as "what it means."
+**Difference from Views:** [Views](../../configuration/spec/views.md) are interactive visualizations that display data. Analyses are computational functions that calculate new insights from data. You can think of views as "how it looks" and analyses as "what it means."
 
 ## Quick example
 


### PR DESCRIPTION
See #1948 item 15.

Updated link to:

`[Views](../../configuration/spec/views.md)
`
But in other docs I have seen this style, so without relative paths:

`[Text](configuration/spec/views.md)
`
Which is the correct one?
