### PR TITLE
Fix: specify encoding="utf-8" in test_optional_imports.py

### DIFF
--- a/lumen/tests/sources/test_optional_imports.py
+++ b/lumen/tests/sources/test_optional_imports.py
@@ -34,7 +34,7 @@ OPTIONAL_SOURCES = [
 def test_error_message_contains_pip_install(module_path, class_name, guard_package, pip_extra):
     """Error messages should include the correct pip install command."""
     module_file = module_path.replace(".", "/") + ".py"
-    source_text = Path(module_file).read_text()
+    source_text = Path(module_file).read_text(encoding="utf-8")
     expected = f"pip install lumen[{pip_extra}]"
     assert expected in source_text, (
         f"{module_path} should contain '{expected}' in its error message"
@@ -49,7 +49,7 @@ def test_error_message_contains_pip_install(module_path, class_name, guard_packa
 def test_import_guard_uses_try_except(module_path, class_name, guard_package, pip_extra):
     """Each module should have a try/except guard around the optional import."""
     module_file = module_path.replace(".", "/") + ".py"
-    source_text = Path(module_file).read_text()
+    source_text = Path(module_file).read_text(encoding="utf-8")
     assert "except ImportError" in source_text, (
         f"{module_path} should have 'except ImportError' guard"
     )


### PR DESCRIPTION
Fixes UnicodeDecodeError on Windows with non-UTF-8 locale when reading lumen/sources/snowflake.py, which contains a UTF-8 em-dash character.

## Description

[test_error_message_contains_pip_install](cci:1://file:///d:/1_Codex/111_PR/lumen/lumen/tests/sources/test_optional_imports.py:28:0-40:5) and [test_import_guard_uses_try_except](cci:1://file:///d:/1_Codex/111_PR/lumen/lumen/tests/sources/test_optional_imports.py:43:0-57:5)
in [lumen/tests/sources/test_optional_imports.py](cci:7://file:///d:/1_Codex/111_PR/lumen/lumen/tests/sources/test_optional_imports.py:0:0-0:0) read source files via
`Path(module_file).read_text()` without specifying an encoding, relying on the
platform's default locale encoding.

On Windows with a non-UTF-8 default locale (e.g. `cp936`), this fails to
decode `lumen/sources/snowflake.py`, which contains a UTF-8 em-dash character
(`—`, bytes `\xe2\x80\x94`) in a comment, raising `UnicodeDecodeError` instead
of running the intended assertion.

Fix: explicitly pass `encoding="utf-8"` to both `read_text()` calls, since the
source files are always UTF-8 regardless of host locale.

To reproduce (on a non-UTF-8 locale system):

```python
from pathlib import Path
Path("lumen/sources/snowflake.py").read_text()
# UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 12274: illegal multibyte sequence