### PR TITLE
Collapse repeated column names

### DIFF
--- a/lumen/ai/schemas.py
+++ b/lumen/ai/schemas.py
@@ -9,7 +9,8 @@ import yaml
 
 from .config import SOURCE_TABLE_SEPARATOR
 from .utils import (
-    get_schema, log_debug, slug_to_table_name, truncate_string,
+    collapse_indexed_columns, get_schema, log_debug, slug_to_table_name,
+    truncate_string,
 )
 
 if TYPE_CHECKING:
@@ -190,8 +191,14 @@ class Metaset:
         data['columns'] = cols = self._build_columns_data(
             table_slug, catalog_entry.columns, include_schema, truncate
         )
-        if isinstance(cols, dict) and not any(info for info in cols.values()):
-            data['columns'] = list(cols)
+        # Collapse large numbered column series (e.g. embedding/PCA matrices)
+        # wherever columns render as a bare name list: either schema was
+        # excluded (list), or no per-column schema was available and the dict
+        # degenerates to names. A dict with real per-column info stays a mapping.
+        if isinstance(cols, list):
+            data['columns'] = collapse_indexed_columns(cols)
+        elif not any(info for info in cols.values()):
+            data['columns'] = collapse_indexed_columns(list(cols))
         return data
 
     def _build_columns_data(
@@ -201,7 +208,9 @@ class Metaset:
         include_schema: bool,
         truncate: bool
     ) -> dict | list:
-        # If include_schema is False, just return column names as a list
+        # If include_schema is False, just return column names as a list.
+        # (Numbered-series collapsing happens in the caller, which also handles
+        # the case where a schema dict degenerates to a bare name list.)
         if not include_schema:
             return [col.name for col in columns]
 

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -77,6 +77,11 @@ DEFAULT_MAX_SUMMARY_COLS = 16
 # human-meaningful "enum"/categorical columns and prioritised.
 LOW_CARDINALITY_MAX = 10
 
+# Matches a column name ending in a stem + integer index, with an optional
+# separator so all common series conventions are caught: "X_pca_12", "PC1",
+# "dim-1", "emb.2". Used to collapse machine-generated numbered column series.
+INDEXED_COLUMN_RE = re.compile(r"^(?P<stem>.+?)[_.\-]?(?P<idx>\d+)$")
+
 
 def deterministic_hash(text: str) -> int:
     """Stable hash using MD5, consistent across Python sessions."""
@@ -1233,6 +1238,96 @@ def truncate_string(s, max_length=30, ellipsis="..."):
         return s
     part_length = (max_length - len(ellipsis)) // 2
     return f"{s[:part_length]}{ellipsis}{s[-part_length:]}"
+
+
+def collapse_indexed_columns(
+    names: list[str], min_series: int = 8, max_gaps: int = 5
+) -> list[str]:
+    """
+    Collapse machine-generated numbered column series into a single entry.
+
+    A *series* is a group of columns that share a stem and differ only by a
+    trailing integer index (e.g. ``X_pca_0 … X_pca_99`` or ``PCs_0 … PCs_99``),
+    such as embedding/PCA matrices or one-hot expansions. Individually the names
+    carry no meaning, so listing every one wastes prompt budget without adding
+    signal. A run of at least *min_series* members collapses; a near-complete
+    run is still collapsed and its missing indices are named. Genuinely distinct
+    names, short runs, and sparse/heavily-gapped runs (which includes any
+    step > 1 series) are returned unchanged and in their original position.
+
+    Parameters
+    ----------
+    names : list[str]
+        Column names in their original order.
+    min_series : int
+        Minimum present members before a stem is collapsed. Smaller runs stay
+        expanded since the token savings don't justify hiding the columns.
+    max_gaps : int
+        Most missing indices tolerated within a run's span. A run with more
+        holes than this stays expanded, since the gaps are likely meaningful
+        (and too numerous to name compactly). This also excludes step > 1
+        series, whose "gaps" exceed the budget.
+
+    Returns
+    -------
+    list[str]
+        Column names with each qualifying series replaced by a single
+        ``"{first}..{last} ({n} cols)"`` entry — with ``", missing <indices>"``
+        appended when the run has holes. The real first/last column names are
+        used, so the original separator and any zero-padding are preserved. The
+        entry sits where the series first appeared.
+
+    Examples
+    --------
+    >>> collapse_indexed_columns(["obs_id", "PCs_0", "PCs_1", "PCs_2"], min_series=2)
+    ['obs_id', 'PCs_0..PCs_2 (3 cols)']
+    >>> collapse_indexed_columns(["x_0", "x_1", "x_3"], min_series=2)
+    ['x_0..x_3 (3 cols, missing 2)']
+    >>> collapse_indexed_columns(["gender", "age", "smoking_status"])
+    ['gender', 'age', 'smoking_status']
+    """
+    stem_members: dict[str, list[tuple[int, str]]] = {}
+    name_stem: dict[str, str] = {}
+    for name in names:
+        match = INDEXED_COLUMN_RE.match(name)
+        if match:
+            stem = match.group("stem")
+            stem_members.setdefault(stem, []).append((int(match.group("idx")), name))
+            name_stem[name] = stem
+
+    collapsible: dict[str, str] = {}
+    for stem, members in stem_members.items():
+        indices = [idx for idx, _ in members]
+        # Skip small runs, and any with duplicate indices (not a clean series).
+        if len(indices) < min_series or len(set(indices)) != len(indices):
+            continue
+        lo, hi = min(indices), max(indices)
+        # Collapse a contiguous run, or a near-complete one whose few holes we
+        # can name. A sparse or heavily-gapped run (including any step > 1
+        # series) exceeds max_gaps and stays expanded — its holes may matter.
+        missing = sorted(set(range(lo, hi + 1)) - set(indices))
+        if len(missing) > max_gaps:
+            continue
+        # Label from the real endpoint names so the source's separator and any
+        # zero-padding (``_``, ``-``, ``.`` or none) are preserved.
+        lo_name = next(name for idx, name in members if idx == lo)
+        hi_name = next(name for idx, name in members if idx == hi)
+        label = f"{lo_name}..{hi_name} ({len(indices)} cols"
+        if missing:
+            label += f", missing {', '.join(map(str, missing))}"
+        collapsible[stem] = label + ")"
+
+    result: list[str] = []
+    emitted: set[str] = set()
+    for name in names:
+        stem = name_stem.get(name)
+        if stem in collapsible:
+            if stem not in emitted:
+                result.append(collapsible[stem])
+                emitted.add(stem)
+        else:
+            result.append(name)
+    return result
 
 
 def truncate_iterable(iterable, max_length=150) -> tuple[list, list, bool]:

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -20,12 +20,91 @@ from lumen.ai.config import PROMPTS_DIR
 from lumen.ai.models import DeleteLine, InsertLine, ReplaceLine
 from lumen.ai.utils import (
     IMAGE_MIME_TYPES, UNRECOVERABLE_ERRORS, apply_changes, clean_sql,
-    content_to_text, describe_data, find_slug_by_table_name,
-    format_msg_content, fuse_messages, get_schema, mutate_user_message,
-    parse_huggingface_url, render_template, report_error, retry_llm_output,
-    serialize_image_content, set_content_text, slug_to_table_name,
+    collapse_indexed_columns, content_to_text, describe_data,
+    find_slug_by_table_name, format_msg_content, fuse_messages, get_schema,
+    mutate_user_message, parse_huggingface_url, render_template, report_error,
+    retry_llm_output, serialize_image_content, set_content_text,
+    slug_to_table_name,
 )
 from lumen.config import SOURCE_TABLE_SEPARATOR as SEP
+
+
+def test_collapse_indexed_columns_collapses_large_series():
+    """A dense numbered series (e.g. an embedding matrix) collapses to one entry."""
+    names = ["obs_id"] + [f"X_pca_{i}" for i in range(100)]
+    assert collapse_indexed_columns(names) == ["obs_id", "X_pca_0..X_pca_99 (100 cols)"]
+
+
+def test_collapse_indexed_columns_leaves_unique_names():
+    """Genuinely distinct columns are never collapsed."""
+    names = ["gender", "age", "smoking_status", "tissue_site"]
+    assert collapse_indexed_columns(names) == names
+
+
+def test_collapse_indexed_columns_short_series_untouched():
+    """Runs below the threshold stay expanded (e.g. tSNE/UMAP 2-D embeddings)."""
+    names = ["X_tsne_0", "X_tsne_1", "obs_id"]
+    assert collapse_indexed_columns(names) == names
+
+
+def test_collapse_indexed_columns_preserves_position_and_interleaving():
+    """Each series collapses at its first occurrence, even when interleaved."""
+    names = []
+    for i in range(10):
+        names.extend([f"a_{i}", f"b_{i}"])
+    result = collapse_indexed_columns(names)
+    assert result == ["a_0..a_9 (10 cols)", "b_0..b_9 (10 cols)"]
+
+
+def test_collapse_indexed_columns_near_complete_gap_named():
+    """A near-complete run collapses and names its missing index."""
+    names = [f"X_pca_{i}" for i in range(100) if i != 50]
+    assert collapse_indexed_columns(names) == ["X_pca_0..X_pca_99 (99 cols, missing 50)"]
+
+
+def test_collapse_indexed_columns_multiple_gaps_listed():
+    """Several holes (within budget) are all named, in order."""
+    names = [f"x_{i}" for i in range(100) if i not in (50, 73)]
+    assert collapse_indexed_columns(names) == ["x_0..x_99 (98 cols, missing 50, 73)"]
+
+
+def test_collapse_indexed_columns_too_many_gaps_expanded():
+    """More holes than max_gaps: left expanded, since the gaps likely matter."""
+    drop = {1, 3, 5, 7, 9, 11}  # 6 gaps > default max_gaps of 5
+    names = [f"x_{i}" for i in range(20) if i not in drop]
+    assert collapse_indexed_columns(names) == names
+
+
+def test_collapse_indexed_columns_step_series_expanded():
+    """A step-2 series is too gappy to be a run and stays expanded."""
+    names = [f"x_{2 * i}" for i in range(10)]  # span 19, 9 holes
+    assert collapse_indexed_columns(names) == names
+
+
+def test_collapse_indexed_columns_nonzero_start():
+    """Contiguous runs that don't start at zero collapse honestly."""
+    names = [f"p_{i}" for i in range(5, 21)]  # p_5..p_20, 16 members
+    assert collapse_indexed_columns(names) == ["p_5..p_20 (16 cols)"]
+
+
+def test_collapse_indexed_columns_non_numeric_suffix_ignored():
+    """Names whose suffix isn't a bare integer don't match the series pattern."""
+    names = ["total_counts", "total_counts_mt", "n_genes_by_counts"]
+    assert collapse_indexed_columns(names) == names
+
+
+def test_collapse_indexed_columns_no_separator():
+    """The classic PCA convention (no separator, e.g. PC1..PC50) collapses too."""
+    names = [f"PC{i}" for i in range(1, 51)]
+    assert collapse_indexed_columns(names) == ["PC1..PC50 (50 cols)"]
+
+
+def test_collapse_indexed_columns_alternate_separators():
+    """Hyphen- and dot-separated series are recognised, not just underscores."""
+    hyphen = [f"dim-{i}" for i in range(8)]
+    dot = [f"emb.{i}" for i in range(8)]
+    assert collapse_indexed_columns(hyphen) == ["dim-0..dim-7 (8 cols)"]
+    assert collapse_indexed_columns(dot) == ["emb.0..emb.7 (8 cols)"]
 
 
 def test_render_template_with_valid_template():


### PR DESCRIPTION
Collapses column names that are like PCs_0 and PCs_1, PCs_2, etc to just one line to save context
  - PCs_0..PCs_99 (100 cols)