### PR TITLE
Better tool handling

### DIFF
--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -378,7 +378,6 @@ class Planner(Coordinator):
             response_model=plan_model,
             agents=agents,
             tools=tools,
-            llm_tools=llm_tools,
             unmet_dependencies=unmet_dependencies,
             candidates=agent_candidates + tool_candidates,
             previous_actors=previous_actors,

--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -10,7 +10,9 @@ import param
 
 from panel.io.state import state
 from panel_material_ui import ChatStep
-from pydantic import BaseModel, Field, create_model
+from pydantic import (
+    BaseModel, Field, create_model, model_validator,
+)
 from pydantic.fields import FieldInfo
 
 from ..actor import _merge_prompt_tools
@@ -35,7 +37,6 @@ if TYPE_CHECKING:
 
 
 class RawStep(BaseModel):
-    title: str
     actor: str
     instruction: str = Field(
         description="""
@@ -56,6 +57,24 @@ class RawStep(BaseModel):
             "Plot a line chart of sales over time.",
         ],
     )
+    title: str = Field(
+        default="",
+        description="Optional short label for this step; derived from the instruction if omitted.",
+    )
+
+    @model_validator(mode="after")
+    def _default_title(self) -> RawStep:
+        # The per-step title is display-only, and smaller models routinely omit
+        # it — which used to fail plan validation and crash the planner over a
+        # cosmetic field. Fall back to the instruction (trimmed to a reasonable
+        # length) so an otherwise-valid plan is accepted with a readable label.
+        if not self.title.strip():
+            instruction = self.instruction.strip()
+            self.title = (
+                instruction if len(instruction) <= 60
+                else instruction[:59].rstrip() + "…"
+            )
+        return self
 
 
 class RawPlan(BaseModel):
@@ -359,6 +378,7 @@ class Planner(Coordinator):
             response_model=plan_model,
             agents=agents,
             tools=tools,
+            llm_tools=llm_tools,
             unmet_dependencies=unmet_dependencies,
             candidates=agent_candidates + tool_candidates,
             previous_actors=previous_actors,

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -419,7 +419,9 @@ class Llm(param.Parameterized):
         kwargs.update(input_kwargs)
         combined_tools = self._combine_tools(tools)
         tool_specs, tool_instances, tool_contexts = self._normalize_tools(combined_tools)
-        if tool_specs is not None:
+        # Only attach ``tools`` when non-empty; an empty array is rejected by
+        # some OpenAI-compatible endpoints (see run_client for details).
+        if tool_specs:
             kwargs["tools"] = tool_specs
 
         messages, contains_image = self._check_for_image(messages)
@@ -507,6 +509,14 @@ class Llm(param.Parameterized):
             kwargs["response_model"] = structured_model
             if max_retries is not None:
                 kwargs["max_retries"] = max_retries
+            # Exploration is done: the terminal turn only needs to emit the
+            # structured result, not call more tools. Drop the tool specs so
+            # this becomes a tool-free structured request — that lets the
+            # OpenAI wrapper extract it via JSON (see tool_free_structured_mode)
+            # instead of TOOLS mode, which weak endpoints (vLLM/Gemma) answer
+            # with prose and crash instructor's tool-call reask.
+            kwargs.pop("tools", None)
+            kwargs.pop("tool_choice", None)
             output = await self.run_client(model_spec, messages_curr, stream=stream, **kwargs)
         return output
 
@@ -745,6 +755,14 @@ class Llm(param.Parameterized):
                     f"{name!r} (call_id={call_id!r}); registered: {sorted(tool_instances)}",
                     prefix="[LLM tools]",
                 )
+                # Drop the call rather than appending a synthetic tool result.
+                # The strict vLLM/HF router rejects a tool-role message that
+                # references a tool_call the structured re-ask no longer carries
+                # (422 missing tool_call_id). Returning None leaves the loop to
+                # break on empty tool_messages and re-ask cleanly on the
+                # original messages. Weak models commonly emit an actor name
+                # here as if it were a tool; the planning prompt already tells
+                # them not to, and the clean re-ask recovers the structured plan.
                 return None
             tool = tool_instances[name]
             context = tool_contexts.get(name, {})
@@ -993,6 +1011,13 @@ class Llm(param.Parameterized):
         client = await self.get_client(model_spec, **kwargs)
         if not response_model:
             kwargs.pop("max_retries", None)
+        # Omit an empty ``tools`` array entirely: the OpenAI SDK tolerates
+        # ``tools: []``, but some OpenAI-compatible endpoints (e.g. vLLM behind
+        # the HuggingFace router) reject it with a 400. Drop ``tool_choice``
+        # alongside it since it's meaningless without tools.
+        if "tools" in kwargs and not kwargs["tools"]:
+            kwargs.pop("tools")
+            kwargs.pop("tool_choice", None)
         result = await client(messages=messages, **kwargs)
         if response_model:
             log_debug(f"Response model: \033[93m{response_model.__name__!r}\033[0m")
@@ -1110,6 +1135,15 @@ class OpenAI(Llm, OpenAIMixin):
     display_name = param.String(default="OpenAI", constant=True)
 
     mode = param.Selector(default=Mode.TOOLS)
+
+    tool_free_structured_mode = param.ClassSelector(class_=Mode, default=Mode.JSON, allow_None=True, doc="""
+        instructor mode used for a structured (``response_model``) request when
+        NO tools are attached. TOOLS-family structured extraction routes the
+        schema through a synthetic tool call, which some OpenAI-compatible
+        endpoints (e.g. vLLM/Gemma behind the HuggingFace router) answer with
+        prose instead of a tool call, crashing instructor. Extracting tool-free
+        responses via JSON keeps these calls robust and costs fewer tokens. Set
+        to ``None`` to leave ``mode`` unchanged (i.e. keep TOOLS everywhere).""")
 
     model_kwargs = param.Dict(default={
         "default": {"model": "gpt-5.4-mini"},  # Use standard models, not reasoning models (gpt-5, o4-mini)
@@ -1382,6 +1416,20 @@ class OpenAI(Llm, OpenAIMixin):
         model = model_kwargs.pop("model")
         log_debug(f"LLM Model: \033[96m{model!r}\033[0m")
         mode = model_kwargs.pop("mode", self.mode)
+
+        # No tools in play: a tool-call transport for the structured output
+        # buys nothing and is unreliable on some OpenAI-compatible endpoints
+        # (vLLM/Gemma answer with prose, crashing instructor). Extract via JSON
+        # instead. Only the chat_completions path is affected; see
+        # ``tool_free_structured_mode``.
+        if (
+            self.api == "chat_completions"
+            and response_model is not None
+            and self.tool_free_structured_mode is not None
+            and not kwargs.get("tools")
+            and mode is Mode.TOOLS
+        ):
+            mode = self.tool_free_structured_mode
 
         if self.api == "responses":
             if self._base_client is None:

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -102,14 +102,11 @@ Tools the LLM can call directly inside its own generation loop (tool-calling API
 These are available to you right now, as the planner, and to any agent whose
 loop includes them.
 
-{% if llm_tools -%}
-The ONLY names you may emit as a function/tool call are:
-{% for t in llm_tools %}`{{ t.name }}`{% if not loop.last %}, {% endif %}{% endfor %}.
-{%- else -%}
-You have NO callable tools this turn — do not emit any function/tool call.
-{%- endif %}
-Every actor under "Available Actors" is assigned by adding a Step to the plan's
-`steps` field — NEVER by emitting a function/tool call for its name.
+The callable tools (if any) are supplied through the tool-calling API — rely on
+those specs rather than any list here. Do not emit a function/tool call for a
+name that isn't among them; in particular, every actor under "Available Actors"
+is assigned by adding a Step to the plan's `steps` field — NEVER by emitting a
+function/tool call for its name.
 
 - Call an LLM tool yourself **only when planning requires it** — e.g., you
   need the tool's output to decide the shape of the plan.

--- a/lumen/ai/prompts/Planner/main.jinja2
+++ b/lumen/ai/prompts/Planner/main.jinja2
@@ -102,6 +102,15 @@ Tools the LLM can call directly inside its own generation loop (tool-calling API
 These are available to you right now, as the planner, and to any agent whose
 loop includes them.
 
+{% if llm_tools -%}
+The ONLY names you may emit as a function/tool call are:
+{% for t in llm_tools %}`{{ t.name }}`{% if not loop.last %}, {% endif %}{% endfor %}.
+{%- else -%}
+You have NO callable tools this turn — do not emit any function/tool call.
+{%- endif %}
+Every actor under "Available Actors" is assigned by adding a Step to the plan's
+`steps` field — NEVER by emitting a function/tool call for its name.
+
 - Call an LLM tool yourself **only when planning requires it** — e.g., you
   need the tool's output to decide the shape of the plan.
 - Otherwise, delegate: assign the task to an agent whose loop has access to

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -22,7 +22,10 @@ from lumen.ai.agents import (
 from lumen.ai.agents.analysis import make_analysis_model
 from lumen.ai.agents.deck_gl import DeckGLAgent
 from lumen.ai.agents.hvplot import hvPlotAgent
-from lumen.ai.agents.sql import make_sql_model
+from lumen.ai.agents.sql import execute_exploration_sql, make_sql_model
+from lumen.ai.agents.validation import (
+    QueryCompletionValidation, ValidationAgent,
+)
 from lumen.ai.agents.vega_lite import (
     AltairChartSpec, AltairSpec, ChartSpec, VegaLiteSpec, VegaLiteSpecUpdate,
 )
@@ -769,3 +772,45 @@ async def test_view_retry_recovers_using_revised_spec(llm):
     assert seen_specs[0]["kind"] == "line"   # first attempt used the original
     assert seen_specs[1]["kind"] == "bar"    # retry used the REVISED spec
     assert result["kind"] == "bar"
+
+
+async def test_validation_agent_degrades_on_llm_error(llm, test_messages):
+    """A failed validation call must not abort an already-successful plan.
+
+    If the structured validation request raises (e.g. the model won't return
+    parseable structured output after retries), ValidationAgent degrades to
+    "assume complete" rather than propagating and crashing the plan.
+    """
+    agent = ValidationAgent(llm=llm)
+    with patch.object(
+        agent, "_invoke_prompt",
+        new=AsyncMock(side_effect=RuntimeError("structured output failed")),
+    ):
+        out, out_context = await agent.respond(test_messages, {})
+
+    result = out[0]
+    assert isinstance(result, QueryCompletionValidation)
+    assert result.correct is True
+    assert out_context["validation_result"] is result
+
+
+async def test_exploration_sql_resolves_source(duckdb_source):
+    """run_exploration_sql should not fail when the model passes a table name
+    (or the wrong token) instead of the source name."""
+    src = duckdb_source.name
+    sources = {(src, "test_sql"): duckdb_source}
+    query = "SELECT * FROM test_sql LIMIT 1"
+
+    # exact source name works
+    assert "Unknown source" not in await execute_exploration_sql(src, query, sources=sources)
+    # a *table* name in the source slot resolves to its owning source
+    assert "Unknown source" not in await execute_exploration_sql("test_sql", query, sources=sources)
+    # an unrecognized token falls back to the sole source
+    assert "Unknown source" not in await execute_exploration_sql("obs", query, sources=sources)
+
+
+async def test_exploration_sql_unknown_source_with_multiple_sources(duckdb_source):
+    """With multiple sources an unresolvable token still errors (no silent guess)."""
+    sources = {("src_a", "ta"): duckdb_source, ("src_b", "tb"): duckdb_source}
+    res = await execute_exploration_sql("nope", "SELECT 1", sources=sources)
+    assert "Unknown source 'nope'" in res

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -3,6 +3,7 @@
 import base64
 import os
 
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -20,6 +21,7 @@ try:
 except ModuleNotFoundError:
     pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
 
+from instructor import Mode
 from instructor.processing.multimodal import Image
 from pydantic import BaseModel
 
@@ -707,3 +709,89 @@ def test_mlx_make_sampler_handles_none():
     set_llm = MLX(model_kwargs={"default": {"model": "m"}}, temperature=0.5)
     assert callable(none_llm._make_sampler())
     assert callable(set_llm._make_sampler())
+
+
+# ---------------------------------------------------------------------------
+# Tool-free structured extraction resolves to a JSON instructor mode
+# ---------------------------------------------------------------------------
+
+class _StructuredModel(BaseModel):
+    ok: bool
+
+
+async def _resolve_client_mode(llm, **get_client_kwargs):
+    """Return the instructor ``mode`` that ``get_client`` resolves to.
+
+    ``_get_cached_client`` is stubbed so no real client is created; we only
+    capture the ``mode`` it would have been built with.
+    """
+    captured = {}
+
+    def fake_cached(response_model=None, model=None, **kwargs):
+        captured["mode"] = kwargs.get("mode")
+        return partial(lambda **kw: None)
+
+    with patch.object(llm, "_get_cached_client", new=fake_cached):
+        await llm.get_client("default", **get_client_kwargs)
+    return captured["mode"]
+
+
+async def test_openai_tool_free_structured_uses_json():
+    """A structured request with no tools is extracted via JSON, not TOOLS."""
+    llm = OpenAI(api_key="test", model_kwargs={"default": {"model": "m"}})
+    mode = await _resolve_client_mode(llm, response_model=_StructuredModel)
+    assert mode is Mode.JSON
+
+
+async def test_openai_structured_with_tools_keeps_tools_mode():
+    """When tools are attached the exploration loop still uses TOOLS mode."""
+    llm = OpenAI(api_key="test", model_kwargs={"default": {"model": "m"}})
+    tools = [{"type": "function", "function": {"name": "f", "parameters": {}}}]
+    mode = await _resolve_client_mode(llm, response_model=_StructuredModel, tools=tools)
+    assert mode is Mode.TOOLS
+
+
+async def test_openai_tool_free_structured_mode_can_be_disabled():
+    """Setting tool_free_structured_mode=None preserves the wrapper's mode."""
+    llm = OpenAI(
+        api_key="test",
+        model_kwargs={"default": {"model": "m"}},
+        tool_free_structured_mode=None,
+    )
+    mode = await _resolve_client_mode(llm, response_model=_StructuredModel)
+    assert mode is Mode.TOOLS
+
+
+async def test_openai_no_response_model_keeps_tools_mode():
+    """The rule only affects structured (response_model) requests."""
+    llm = OpenAI(api_key="test", model_kwargs={"default": {"model": "m"}})
+    mode = await _resolve_client_mode(llm)
+    assert mode is Mode.TOOLS
+
+
+async def test_tool_loop_terminal_structured_step_drops_tools():
+    """After exploration, the terminal structured turn must be tool-free so it
+    is extracted via JSON rather than a fragile TOOLS-mode tool call."""
+    llm = OpenAI(api_key="test", model_kwargs={"default": {"model": "m"}})
+    calls = []
+
+    async def fake_run_client(model_spec, messages, **kwargs):
+        calls.append(kwargs)
+        return "OUT"
+
+    with patch.object(llm, "run_client", new=fake_run_client), \
+         patch.object(llm, "_extract_tool_calls", return_value=[]):
+        await llm._run_tool_loop(
+            messages=[{"role": "user", "content": "hi"}],
+            structured_model=_StructuredModel,
+            tool_instances={"t": object()},
+            tool_contexts={},
+            model_spec="default",
+            tools=[{"type": "function", "function": {"name": "t", "parameters": {}}}],
+        )
+
+    # exploration call keeps the tools; the terminal structured call drops them
+    assert "tools" in calls[0]
+    assert calls[-1].get("response_model") is _StructuredModel
+    assert "tools" not in calls[-1]
+    assert "tool_choice" not in calls[-1]


### PR DESCRIPTION
1. Small model may not provide title all the time, and it's unnecessary, so default a title if unprovided so it doesn't crash.

2. Some models also tries to call agents as tools; this prompts them what tools are available.

3. Handle:
```

instructor.v2.core.errors.InstructorRetryException: <failed_attempts>
<generation number="1">
<exception>
    No tool calls or function call found in response (mode: TOOLS)
</exception>
<completion>
```

Gracefully