### PR TITLE
Add single-chart export formats to the multichart "All" tab

### DIFF
--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -745,6 +745,10 @@ class MultiChartEditor(LumenEditor):
         The editors of the individual charts, whose specs are exposed as
         sub-tabs.""")
 
+    export_formats = ("yaml", "png", "jpeg", "pdf", "webp", "tiff", "eps")
+
+    _raster_formats = ("png", "jpeg", "webp", "tiff", "eps")
+
     _label = "Charts"
 
     def __init__(self, **params):
@@ -764,14 +768,43 @@ class MultiChartEditor(LumenEditor):
             dynamic=True, sizing_mode="stretch_both", margin=0
         )
 
-    def export(self, fmt: str) -> StringIO:
-        if fmt != "yaml":
+    def export(self, fmt: str) -> StringIO | BytesIO:
+        if fmt not in self.export_formats:
             raise ValueError(f"Unknown export format {fmt!r} for {self.__class__.__name__}")
         # A chart that could not be serialized has no spec; skip it rather than
         # failing the export of the ones that did.
-        return StringIO("---\n".join(
-            editor.spec for editor in self.chart_editors if editor.spec
-        ))
+        editors = [editor for editor in self.chart_editors if editor.spec]
+        if fmt == "yaml":
+            return StringIO("---\n".join(editor.spec for editor in editors))
+        if not editors:
+            return StringIO("")
+        # Every other format combines the individual chart renders. Each chart is
+        # rendered to PNG first (reusing VegaLiteEditor.export, so scale and the
+        # default sizing come for free), then stacked or paginated with Pillow.
+        images = [Image.open(editor.export("png")) for editor in editors]
+        if fmt == "pdf":
+            pages = [img.convert("RGB") for img in images]
+            buf = BytesIO()
+            pages[0].save(buf, "PDF", save_all=True, append_images=pages[1:])
+            buf.seek(0)
+            return buf
+        return self._stack_images(images, fmt)
+
+    def _stack_images(self, images: list, fmt: str) -> BytesIO:
+        """Vertically stack the chart images into a single image saved as fmt."""
+        mode = "RGB" if fmt in ("jpeg", "eps") else "RGBA"
+        background = (255, 255, 255) if mode == "RGB" else (255, 255, 255, 0)
+        width = max(img.width for img in images)
+        height = sum(img.height for img in images)
+        canvas = Image.new(mode, (width, height), background)
+        offset = 0
+        for img in images:
+            canvas.paste(img.convert(mode), (0, offset))
+            offset += img.height
+        buf = BytesIO()
+        canvas.save(buf, format=fmt.upper())
+        buf.seek(0)
+        return buf
 
 
 class DocumentEditor(LumenEditor):

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -745,7 +745,9 @@ class MultiChartEditor(LumenEditor):
         The editors of the individual charts, whose specs are exposed as
         sub-tabs.""")
 
-    export_formats = ("yaml", "png", "jpeg", "pdf", "webp", "tiff", "eps")
+    # The "All" tab is only ever built from VegaLiteEditors, so it offers the
+    # same formats; referencing the tuple keeps the two in sync.
+    export_formats = VegaLiteEditor.export_formats
 
     _raster_formats = ("png", "jpeg", "webp", "tiff", "eps")
 
@@ -776,11 +778,19 @@ class MultiChartEditor(LumenEditor):
         editors = [editor for editor in self.chart_editors if editor.spec]
         if fmt == "yaml":
             return StringIO("---\n".join(editor.spec for editor in editors))
+        if fmt == "html":
+            # Save the live stacked composite as one standalone, offline page.
+            buf = StringIO()
+            self.component.get_panel().save(buf)
+            buf.seek(0)
+            return buf
         if not editors:
             return StringIO("")
-        # Every other format combines the individual chart renders. Each chart is
-        # rendered to PNG first (reusing VegaLiteEditor.export, so scale and the
-        # default sizing come for free), then stacked or paginated with Pillow.
+        if fmt == "svg":
+            return self._combine_svg([editor.export("svg").getvalue() for editor in editors])
+        # The remaining formats combine the individual chart renders. Each chart
+        # is rendered to PNG first (reusing VegaLiteEditor.export, so scale and
+        # the default sizing come for free), then stacked or paginated with Pillow.
         images = [Image.open(editor.export("png")) for editor in editors]
         if fmt == "pdf":
             pages = [img.convert("RGB") for img in images]
@@ -789,6 +799,25 @@ class MultiChartEditor(LumenEditor):
             buf.seek(0)
             return buf
         return self._stack_images(images, fmt)
+
+    def _combine_svg(self, svgs: list[str]) -> StringIO:
+        """Stack child SVGs vertically inside one outer SVG via nested tags."""
+        parts, offset, max_width = [], 0.0, 0.0
+        for svg in svgs:
+            svg = re.sub(r"^\s*<\?xml[^>]*\?>\s*", "", svg)
+            width_match = re.search(r'<svg\b[^>]*\bwidth="([\d.]+)"', svg)
+            height_match = re.search(r'<svg\b[^>]*\bheight="([\d.]+)"', svg)
+            width = float(width_match.group(1)) if width_match else 800.0
+            height = float(height_match.group(1)) if height_match else 400.0
+            # Nest each child as a positioned inner <svg> by injecting a y offset.
+            parts.append(re.sub(r"<svg\b", f'<svg y="{offset:g}"', svg, count=1))
+            offset += height
+            max_width = max(max_width, width)
+        inner = "\n".join(parts)
+        return StringIO(
+            f'<svg xmlns="http://www.w3.org/2000/svg" '
+            f'width="{max_width:g}" height="{offset:g}">\n{inner}\n</svg>'
+        )
 
     def _stack_images(self, images: list, fmt: str) -> BytesIO:
         """Vertically stack the chart images into a single image saved as fmt."""

--- a/lumen/tests/ai/test_editors.py
+++ b/lumen/tests/ai/test_editors.py
@@ -321,6 +321,73 @@ def test_multichart_survives_an_unserializable_spec(make_multi_chart_editor):
     assert multi.export("yaml").getvalue().count("line0") == 2
 
 
+@pytest.fixture
+def make_multi_vegalite_editor(monkeypatch):
+    """Build an "All" tab whose children are real VegaLiteEditors with a fake
+    Vega pane, so the combined image/pdf/svg/html exports can be exercised."""
+    monkeypatch.setattr(editors_module, 'ParamMethod', lambda *args, **kwargs: None)
+    monkeypatch.setattr(VegaLiteEditor, '_update_component', lambda self, *a, **kw: None)
+
+    class FakePanel:
+        def export(self, fmt, **kwargs):
+            if fmt == "svg":
+                return '<svg width="20" height="30"><rect/></svg>'
+            return _make_png_bytes()
+
+    def factory(n_charts, unserializable=()):
+        charts = [
+            VegaLiteEditor(
+                component=MockVegaComponent(_mock_panel=FakePanel()),
+                spec=None if c in unserializable else _MINIMAL_VEGALITE_SPEC,
+                title=f"Chart {c}",
+            )
+            for c in range(n_charts)
+        ]
+        return MultiChartEditor(
+            component=MockComponent(), title="All", chart_editors=charts
+        )
+
+    return factory
+
+
+def test_multichart_export_png_stacks_every_chart(make_multi_vegalite_editor):
+    result = make_multi_vegalite_editor(3).export("png")
+    assert isinstance(result, BytesIO)
+    img = Image.open(result)
+    assert img.format == "PNG"
+    # Three 10x10 child renders stacked vertically -> one 10x30 image.
+    assert img.size == (10, 30)
+
+
+@pytest.mark.parametrize("fmt,pil_format", [
+    ("jpeg", "JPEG"), ("webp", "WEBP"), ("tiff", "TIFF"),
+])
+def test_multichart_export_raster_formats(make_multi_vegalite_editor, fmt, pil_format):
+    result = make_multi_vegalite_editor(2).export(fmt)
+    img = Image.open(result)
+    assert img.format == pil_format
+    assert img.size == (10, 20)
+
+
+def test_multichart_export_eps(make_multi_vegalite_editor):
+    result = make_multi_vegalite_editor(2).export("eps")
+    assert result.read().startswith(b"%!PS")
+
+
+def test_multichart_export_pdf_is_one_page_per_chart(make_multi_vegalite_editor):
+    result = make_multi_vegalite_editor(3).export("pdf")
+    data = result.getvalue()
+    assert data.startswith(b"%PDF")
+    pypdf = pytest.importorskip("pypdf")
+    assert len(pypdf.PdfReader(BytesIO(data)).pages) == 3
+
+
+def test_multichart_export_skips_unserializable_for_images(make_multi_vegalite_editor):
+    # Chart 0 has spec=None; it is skipped, leaving two 10x10 renders -> 10x20.
+    result = make_multi_vegalite_editor(3, unserializable=(0,)).export("png")
+    assert Image.open(result).size == (10, 20)
+
+
 def test_multichart_export_concatenates_every_chart_spec(make_multi_chart_editor):
     """The overview has no spec of its own; exporting yields all of them."""
     multi = make_multi_chart_editor(3, spec_lines=2)

--- a/lumen/tests/ai/test_editors.py
+++ b/lumen/tests/ai/test_editors.py
@@ -4,6 +4,7 @@ import json
 from io import BytesIO
 
 import pandas as pd
+import panel as pn
 import param
 import pytest
 
@@ -343,8 +344,13 @@ def make_multi_vegalite_editor(monkeypatch):
             )
             for c in range(n_charts)
         ]
+        # The composite's own component supplies the live stacked view that the
+        # html export saves; a plain Column stands in for it here.
+        composite = MockVegaComponent(_mock_panel=pn.Column(*(
+            pn.pane.Markdown(f"Chart {c}") for c in range(n_charts)
+        )))
         return MultiChartEditor(
-            component=MockComponent(), title="All", chart_editors=charts
+            component=composite, title="All", chart_editors=charts
         )
 
     return factory
@@ -375,11 +381,11 @@ def test_multichart_export_eps(make_multi_vegalite_editor):
 
 
 def test_multichart_export_pdf_is_one_page_per_chart(make_multi_vegalite_editor):
-    result = make_multi_vegalite_editor(3).export("pdf")
-    data = result.getvalue()
+    data = make_multi_vegalite_editor(3).export("pdf").getvalue()
     assert data.startswith(b"%PDF")
-    pypdf = pytest.importorskip("pypdf")
-    assert len(pypdf.PdfReader(BytesIO(data)).pages) == 3
+    # Pillow writes one "/Type /Page" per page plus a single "/Type /Pages" tree
+    # node, so page count is the difference.
+    assert data.count(b"/Type /Page") - data.count(b"/Type /Pages") == 3
 
 
 def test_multichart_export_skips_unserializable_for_images(make_multi_vegalite_editor):
@@ -388,9 +394,26 @@ def test_multichart_export_skips_unserializable_for_images(make_multi_vegalite_e
     assert Image.open(result).size == (10, 20)
 
 
+def test_multichart_export_svg_stacks_children(make_multi_vegalite_editor):
+    content = make_multi_vegalite_editor(3).export("svg").getvalue()
+    # One outer <svg> wrapping three nested child <svg> blocks.
+    assert content.count("<svg") == 4
+    # Child mock is 30 tall; three stacked -> outer height 90.
+    assert 'height="90"' in content
+    # Second and third children carry a non-zero y offset.
+    assert 'y="30"' in content and 'y="60"' in content
+
+
+def test_multichart_export_html_is_one_offline_page(make_multi_vegalite_editor):
+    content = make_multi_vegalite_editor(2).export("html").getvalue()
+    assert content.lstrip().startswith("<!DOCTYPE html>")
+    assert "Chart 0" in content and "Chart 1" in content
+
+
 def test_multichart_export_concatenates_every_chart_spec(make_multi_chart_editor):
-    """The overview has no spec of its own; exporting yields all of them."""
+    """The overview has no spec of its own; exporting yaml yields all of them,
+    and a format it does not support still raises."""
     multi = make_multi_chart_editor(3, spec_lines=2)
     assert multi.export("yaml").getvalue().count("line0") == 3
     with pytest.raises(ValueError, match="Unknown export format"):
-        multi.export("png")
+        multi.export("csv")


### PR DESCRIPTION
The multichart "All" tab only offered YAML export while a single chart offers png/jpeg/pdf/svg/html/webp/tiff/eps. This brings it to parity by combining each chart's render into one file: a vertically stacked image for the raster formats, a page-per-chart multipage PDF, a nested-`<svg>` stack, and one standalone HTML page.

<img width="1466" height="796" alt="Screenshot 2026-07-25 at 1 21 58 PM" src="https://github.com/user-attachments/assets/f0df1e18-b716-428c-9dd3-52d8f2ec3d2a" />
Fixes #1966


