### PR TITLE
docs: remove stale extra.js reference

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -8,7 +8,6 @@ repo_url = "https://github.com/holoviz/lumen"
 repo_name = "holoviz/lumen"
 edit_uri = "edit/main/docs/"
 extra_css = ["assets/extra.css"]
-extra_javascript = ["assets/extra.js"]
 nav = [
   {"Home" = "index.md"},
   {"Quick Start" = "quick_start.md"},


### PR DESCRIPTION
## Summary

- I removed the stale `extra_javascript` entry from the Zensical configuration.
- Generated documentation pages no longer request the missing `assets/extra.js` file.

## Validation

- `uvx --from 'zensical<0.0.17' --with mkdocstrings-python --with mkdocs-gen-files --with mkdocs-literate-nav zensical build --clean`
- Python 3 asset-existence check for configured JavaScript files
- `git diff --check upstream/main...HEAD`
- Confirmed generated HTML contains no `assets/extra.js` references

Fixes #1968
