### PR TITLE
Batch SQL in one call

### DIFF
--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -38,8 +38,8 @@ from ..filters.base import Filter
 from ..state import state
 from ..transforms.base import Filter as FilterTransform, Transform
 from ..transforms.sql import (
-    SQLCount, SQLDistinct, SQLFilter, SQLLimit, SQLMinMax, SQLSample,
-    SQLSelectFrom, SQLTransform,
+    ARRAY_AGG_DISTINCT_DIALECTS, SQLCount, SQLDistinct, SQLFilter, SQLLimit,
+    SQLMinMax, SQLSample, SQLSchemaStats, SQLSelectFrom, SQLTransform,
 )
 from ..util import get_dataframe_schema, is_ref, merge_schemas
 from ..validation import ValidationError, match_suggestion_message
@@ -59,6 +59,44 @@ if TYPE_CHECKING:
         dd = None  # type: ignore
         DataFrameTypes = (pd.DataFrame,)
 
+
+def _to_enum_list(values: Any, has_nulls: bool) -> list:
+    """
+    Normalizes an array aggregate result into a list of distinct values.
+
+    Arguments
+    ---------
+    values: Any
+        The aggregate as the driver returned it: a list, an array, a JSON
+        string (snowflake) or NULL if the table was empty.
+    has_nulls: bool
+        Whether the column contained NULL. Dialects disagree on whether an
+        array aggregate retains NULLs, so it is reinstated here rather than
+        relied on, to match what SELECT DISTINCT would have returned.
+    """
+    if values is None:
+        values = []
+    elif isinstance(values, np.ndarray):
+        values = values.tolist()
+    elif isinstance(values, str):
+        # snowflake returns ARRAY columns as JSON strings
+        values = json.loads(values)
+    elif isinstance(values, (list, tuple, set)):
+        values = list(values)
+    elif pd.isna(values):
+        # an aggregate over zero rows yields NULL rather than an array
+        values = []
+    else:
+        values = list(values)
+
+    if has_nulls and not any(
+        value is None or (
+            not isinstance(value, (str, bytes, list, dict, tuple, np.ndarray))
+            and pd.isna(value)
+        ) for value in values
+    ):
+        values.append(None)
+    return values
 
 
 def cached(method, locks=None):
@@ -1146,20 +1184,16 @@ class BaseSQLSource(Source):
                 schemas[entry] = {}
                 continue
             sql_expr = self.get_sql_expr(entry)
+            params = self.table_params.get(entry, [])
             data_sql_expr = sql_expr
             for sql_transform in sql_transforms:
                 data_sql_expr = sql_transform.apply(data_sql_expr)
-            data = self.execute(data_sql_expr, self.table_params.get(entry, []))
+            data = self.execute(data_sql_expr, params)
             schemas[entry] = schema = get_dataframe_schema(data)['items']['properties']
 
-            count_expr = SQLCount(read=self.dialect).apply(sql_expr)
-            count_expr = ' '.join(count_expr.splitlines())
-            count_data = self.execute(count_expr, self.table_params.get(entry, []))
-            count_col = 'count' if 'count' in count_data else 'COUNT'
-            count = int(count_data[count_col].iloc[0])
             if limit:
                 # the min/max and enums will be computed on the limited dataset
-                schema['__len__'] = count
+                schema['__len__'] = self._get_count(sql_expr, params)
                 continue
 
             # patch the min/max and enums from the full dataset
@@ -1169,19 +1203,14 @@ class BaseSQLSource(Source):
                     enums.append(name)
                 elif 'inclusiveMinimum' in col_schema:
                     min_maxes.append(name)
-            for col in enums:
-                distinct_expr = SQLDistinct(columns=[col], read=self.dialect).apply(sql_expr)
-                distinct_expr = ' '.join(distinct_expr.splitlines())
-                distinct = self.execute(distinct_expr, self.table_params.get(entry, []))
-                schema[col]['enum'] = distinct[col].tolist()
+
+            count, enum_values, minmax_values = self._get_schema_stats(
+                sql_expr, params, enums, min_maxes
+            )
+            for col, values in enum_values.items():
+                schema[col]['enum'] = values
 
             schema['__len__'] = count
-            if not min_maxes:
-                continue
-
-            minmax_expr = SQLMinMax(columns=min_maxes, read=self.dialect).apply(sql_expr)
-            minmax_expr = ' '.join(minmax_expr.splitlines())
-            minmax_data = self.execute(minmax_expr, self.table_params.get(entry, []))
             for col in min_maxes:
                 kind = data[col].dtype.kind
                 if kind in 'iu':
@@ -1193,16 +1222,110 @@ class BaseSQLSource(Source):
                 else:
                     cast = lambda v: v
 
-                # some dialects, like snowflake output column names to UPPERCASE regardless of input case
-                min_col = f'{col}_min' if f'{col}_min' in minmax_data else f'{col}_MIN'
-                min_data = minmax_data[min_col].iloc[0]
-                max_col = f'{col}_max' if f'{col}_max' in minmax_data else f'{col}_MAX'
-                max_data = minmax_data[max_col].iloc[0]
+                min_data, max_data = minmax_values[col]
                 schema[col]['inclusiveMinimum'] = min_data if pd.isna(min_data) else cast(min_data)
                 schema[col]['inclusiveMaximum'] = max_data if pd.isna(max_data) else cast(max_data)
 
         return schemas if table is None else schemas[table]
 
+    def _get_count(self, sql_expr: str, params: list | dict | None = None) -> int:
+        """
+        Returns the number of rows the given SQL expression yields.
+        """
+        count_expr = SQLCount(read=self.dialect).apply(sql_expr)
+        count_expr = ' '.join(count_expr.splitlines())
+        count_data = self.execute(count_expr, params)
+        # some dialects, like snowflake, output column names in UPPERCASE
+        count_col = 'count' if 'count' in count_data else 'COUNT'
+        return int(count_data[count_col].iloc[0])
+
+    def _get_schema_stats(
+        self, sql_expr: str, params: list | dict | None, enums: list[str],
+        min_maxes: list[str], batch: bool | None = None
+    ) -> tuple[int, dict[str, list], dict[str, tuple[Any, Any]]]:
+        """
+        Computes the row count, distinct values and min/max of a table.
+
+        Uses a single aggregate query where the dialect supports an array
+        aggregate, otherwise one query per statistic.
+
+        Arguments
+        ---------
+        batch: bool | None
+            Force the batched or per-statistic path; by default the dialect
+            decides. Mostly useful for testing that the two agree.
+
+        Returns
+        -------
+        count: int
+            The total number of rows.
+        enum_values: dict[str, list]
+            The distinct values of each column in `enums`.
+        minmax_values: dict[str, tuple]
+            The (min, max) of each column in `min_maxes`.
+        """
+        if batch is None:
+            batch = self.dialect in ARRAY_AGG_DISTINCT_DIALECTS
+        if batch:
+            try:
+                stats_expr = SQLSchemaStats(
+                    enum_columns=enums, minmax_columns=min_maxes, read=self.dialect
+                ).apply(sql_expr)
+                stats_expr = ' '.join(stats_expr.splitlines())
+                stats_data = self.execute(stats_expr, params)
+
+                # Indexed per column rather than via a row-wise .iloc[0] so that
+                # each value keeps its own dtype; some dialects, like snowflake,
+                # also output column names in UPPERCASE.
+                row = {
+                    str(col).lower(): stats_data[col].iloc[0]
+                    for col in stats_data.columns
+                }
+                count = int(row[SQLSchemaStats.count_alias])
+                return (
+                    count,
+                    {
+                        col: _to_enum_list(
+                            row[SQLSchemaStats.enum_alias(i)],
+                            int(row[SQLSchemaStats.nonnull_alias(i)]) < count
+                        )
+                        for i, col in enumerate(enums)
+                    },
+                    {
+                        col: (
+                            row[SQLSchemaStats.min_alias(i)],
+                            row[SQLSchemaStats.max_alias(i)]
+                        )
+                        for i, col in enumerate(min_maxes)
+                    },
+                )
+            except Exception as e:
+                self.param.warning(
+                    f"Batched schema query failed for dialect {self.dialect!r}, "
+                    f"falling back to one query per column: {e}"
+                )
+
+        count = self._get_count(sql_expr, params)
+        enum_values = {}
+        for col in enums:
+            distinct_expr = SQLDistinct(columns=[col], read=self.dialect).apply(sql_expr)
+            distinct_expr = ' '.join(distinct_expr.splitlines())
+            distinct = self.execute(distinct_expr, params)
+            enum_values[col] = distinct[col].tolist()
+
+        minmax_values = {}
+        if min_maxes:
+            minmax_expr = SQLMinMax(columns=min_maxes, read=self.dialect).apply(sql_expr)
+            minmax_expr = ' '.join(minmax_expr.splitlines())
+            minmax_data = self.execute(minmax_expr, params)
+            for col in min_maxes:
+                # some dialects, like snowflake output column names to UPPERCASE regardless of input case
+                min_col = f'{col}_min' if f'{col}_min' in minmax_data else f'{col}_MIN'
+                max_col = f'{col}_max' if f'{col}_max' in minmax_data else f'{col}_MAX'
+                minmax_values[col] = (
+                    minmax_data[min_col].iloc[0], minmax_data[max_col].iloc[0]
+                )
+        return count, enum_values, minmax_values
 
 
 class JSONSource(FileSource):

--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -11,7 +11,7 @@ import lumen as lm
 from lumen.transforms.sql import (
     SQLColumns, SQLCount, SQLDistinct, SQLFilter, SQLFormat, SQLGroupBy,
     SQLLimit, SQLMinMax, SQLOverride, SQLPreFilter, SQLRemoveSourceSeparator,
-    SQLSample, SQLSelectFrom, SQLTransform,
+    SQLSample, SQLSchemaStats, SQLSelectFrom, SQLTransform,
 )
 
 try:
@@ -226,6 +226,36 @@ def test_sql_min_max_nonalphanum_characters():
         'MAX("Period life expectancy at birth - Sex: total - Age: 0") AS "Period life expectancy at birth - Sex: total - Age: 0_max" '
         'FROM (SELECT * FROM TABLE) AS subquery'
     )
+    assert result == expected
+
+
+def test_sql_schema_stats():
+    result = SQLSchemaStats.apply_to(
+        "SELECT * FROM TABLE", enum_columns=["A"], minmax_columns=["B"]
+    )
+    assert result.endswith("FROM (SELECT * FROM TABLE) AS subquery")
+    assert 'COUNT(*) AS "__count"' in result
+    assert 'ARRAY_AGG(DISTINCT "A") AS "__enum_0"' in result
+    # the non-null count is what lets NULL be reinstated afterwards
+    assert 'COUNT("A") AS "__nonnull_0"' in result
+    assert 'MIN("B") AS "__min_0"' in result
+    assert 'MAX("B") AS "__max_0"' in result
+
+
+def test_sql_schema_stats_aliases_are_positional():
+    """Aliases must not be derived from column names, which may be long or
+    contain characters a dialect would mangle."""
+    long_col = "Period life expectancy at birth - Sex: total - Age: 0"
+    result = SQLSchemaStats.apply_to(
+        "SELECT * FROM TABLE", enum_columns=["A"], minmax_columns=[long_col]
+    )
+    assert f'MIN("{long_col}") AS "__min_0"' in result
+    assert f'{long_col}_min' not in result
+
+
+def test_sql_schema_stats_no_columns():
+    result = SQLSchemaStats.apply_to("SELECT * FROM TABLE")
+    expected = 'SELECT COUNT(*) AS "__count" FROM (SELECT * FROM TABLE) AS subquery'
     assert result == expected
 
 

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -13,9 +13,9 @@ import sqlglot
 from sqlglot import parse
 from sqlglot.dialects.dialect import Dialect
 from sqlglot.expressions import (
-    LT, Alias, Column, Expression, Identifier, Literal as SQLLiteral, Max, Min,
-    Null, ReadCSV, Select, Star, Table, TableSample, and_, func, or_,
-    replace_placeholders, select,
+    LT, Alias, ArrayAgg, Column, Count, Distinct, Expression, Identifier,
+    Literal as SQLLiteral, Max, Min, Null, ReadCSV, Select, Star, Table,
+    TableSample, and_, func, or_, replace_placeholders, select,
 )
 from sqlglot.optimizer import optimize
 
@@ -25,6 +25,24 @@ from .base import Transform
 
 Dialect.classes['postgresql'] = Dialect.get('postgres')
 Dialect.classes['mssql'] = Dialect.get('tsql')
+
+#: Dialects known to support aggregating distinct values into an array, i.e.
+#: `ARRAY_AGG(DISTINCT col)`, which `SQLSchemaStats` depends on.
+#:
+#: Deliberately an allowlist rather than a try/except: sqlglot's default
+#: `unsupported_level` only warns, so an unsupported dialect may emit SQL that
+#: is silently wrong rather than raising. MySQL and SQLite have no array
+#: aggregate at all (only `GROUP_CONCAT`); Redshift has only `LISTAGG` but
+#: sqlglot emits `ARRAY_AGG` for it regardless; and BigQuery's `ARRAY_AGG`
+#: raises at runtime on NULL input unless `IGNORE NULLS` is given.
+ARRAY_AGG_DISTINCT_DIALECTS = frozenset({
+    'duckdb',
+    'postgres',
+    'postgresql',
+    'presto',
+    'snowflake',
+    'trino',
+})
 
 
 class SQLTransform(Transform):
@@ -481,6 +499,81 @@ class SQLMinMax(SQLTransform):
                 )
         expression = select(*minmax).from_(subquery)
         return self.to_sql(expression)
+
+
+class SQLSchemaStats(SQLTransform):
+    """
+    Computes every statistic required to describe a table in one query.
+
+    `BaseSQLSource.get_schema` otherwise issues one `SELECT DISTINCT` per
+    categorical column plus separate count and min/max queries, so a wide
+    table costs one round trip per column. Folding them into a single
+    aggregate SELECT reduces that to one round trip and one scan, which
+    matters most for remote backends where each query is network latency
+    (and, on metered warehouses, billed separately).
+
+    Aliases are positional (`__enum_0`, `__min_0`, ...) rather than derived
+    from column names, so they can neither collide with a real column nor
+    exceed a dialect's identifier length limit.
+
+    Requires a dialect that supports aggregating distinct values into an
+    array; see `ARRAY_AGG_DISTINCT_DIALECTS`.
+    """
+
+    enum_columns = param.List(default=[], doc="""
+        Columns to collect the distinct values of.""")
+
+    minmax_columns = param.List(default=[], doc="""
+        Columns to compute the minimum and maximum of.""")
+
+    transform_type: ClassVar[str] = 'sql_schema_stats'
+
+    count_alias: ClassVar[str] = '__count'
+
+    def apply(self, sql_in: str) -> str:
+        subquery = self._to_subquery(self.parse_sql(sql_in))
+        aggregates: list[Expression] = [
+            Count(this=Star()).as_(Identifier(this=self.count_alias, quoted=True))
+        ]
+        for i, col in enumerate(self.enum_columns):
+            column = Column(this=Identifier(this=col, quoted=True))
+            aggregates.append(
+                ArrayAgg(this=Distinct(expressions=[column])).as_(
+                    Identifier(this=self.enum_alias(i), quoted=True)
+                )
+            )
+            # Dialects disagree on whether an array aggregate retains NULLs
+            # (and BigQuery rejects them outright), so count the non-null
+            # values instead and reinstate NULL from the row count.
+            aggregates.append(
+                Count(this=column).as_(
+                    Identifier(this=self.nonnull_alias(i), quoted=True)
+                )
+            )
+        for i, col in enumerate(self.minmax_columns):
+            column = Column(this=Identifier(this=col, quoted=True))
+            for agg_func, alias in ((Min, self.min_alias(i)), (Max, self.max_alias(i))):
+                aggregates.append(
+                    agg_func(this=column).as_(Identifier(this=alias, quoted=True))
+                )
+        expression = select(*aggregates).from_(subquery)
+        return self.to_sql(expression)
+
+    @classmethod
+    def enum_alias(cls, index: int) -> str:
+        return f'__enum_{index}'
+
+    @classmethod
+    def nonnull_alias(cls, index: int) -> str:
+        return f'__nonnull_{index}'
+
+    @classmethod
+    def min_alias(cls, index: int) -> str:
+        return f'__min_{index}'
+
+    @classmethod
+    def max_alias(cls, index: int) -> str:
+        return f'__max_{index}'
 
 
 class SQLColumns(SQLTransform):


### PR DESCRIPTION
If there are 41 enum columns, looping through each one of them can take a long while; instead do it in one call.