### PR TITLE
Add kilo as a provider

### DIFF
--- a/docs/configuration/llm_providers.md
+++ b/docs/configuration/llm_providers.md
@@ -23,7 +23,7 @@ To use a specific provider, pass the `--provider` flag:
 ``` bash
 lumen-ai serve penguins.csv --provider anthropic
 lumen-ai serve penguins.csv --provider google --model 'gemini-2.5-flash'
-lumen-ai serve penguins.csv --provider openrouter --model 'openai/gpt-4o-mini'
+lumen-ai serve penguins.csv --provider kilo --model 'openai/gpt-4o-mini'
 lumen-ai serve penguins.csv --provider ollama --model 'qwen3:32b'
 lumen-ai serve penguins.csv --provider mlx
 ```
@@ -124,6 +124,7 @@ For installation and API key setup instructions, see the [Installation guide](..
 
 | Provider | Default Model | Description |
 |----------|---------------|-------------|
+| **Kilo** | `kilo-auto/free` | OpenAI-compatible gateway providing access to models from OpenAI, Anthropic, Google, Meta, Mistral, and more through a single API key. |
 | **OpenRouter** | `openai/gpt-4o-mini` | OpenAI-compatible gateway providing access to models from OpenAI, Anthropic, Google, Meta, Mistral, and more through a single API key. |
 | **AWS Bedrock** | `us.anthropic.claude-sonnet-4-6-20250929-v1:0` | Enterprise gateway providing access to models from Anthropic, Meta, Mistral, and more. |
 | **LiteLLM** | `gpt-5.4-mini` | Unified router to access 100+ models across all supported LLM providers. |
@@ -133,6 +134,25 @@ For installation and API key setup instructions, see the [Installation guide](..
 
 - **AnthropicBedrock** - Optimized for Claude models using Anthropic's SDK
 - **Bedrock** - Universal access to all Bedrock models (Claude, Llama, Mistral, Titan, etc.)
+
+### Kilo
+
+Kilo provides an OpenAI-compatible API for routing requests to models from multiple providers.
+
+``` py title="Kilo configuration"
+import lumen.ai as lmai
+
+llm = lmai.llm.Kilo(
+    model_kwargs={
+        "default": {"model": "kilo-auto/free"},
+        "sql": {"model": "anthropic/claude-sonnet-4.6"},
+        "vega_lite": {"model": "openai/gpt-5.4-mini"},
+    }
+)
+
+ui = lmai.ExplorerUI(data='penguins.csv', llm=llm)
+ui.servable()
+```
 
 ### OpenRouter
 
@@ -151,6 +171,7 @@ llm = lmai.llm.OpenRouter(
 
 ui = lmai.ExplorerUI(data='penguins.csv', llm=llm)
 ui.servable()
+```
 
 ## Advanced configuration
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ Lumen works with any LLM provider. Choose the approach that fits your needs:
 
 - ☁️ **Cloud providers** — OpenAI, Anthropic, Google, Mistral, Azure (easiest to get started)
 - 🖥️ **Locally hosted** — Ollama, Llama.cpp (free, runs on your machine, no API keys)
-- 🔀 **Router/Multi-provider** — OpenRouter, LiteLLM (unified interface, many providers and models)
+- 🔀 **Router/Multi-provider** — Kilo, OpenRouter, LiteLLM (unified interface, many providers and models)
 
 ---
 
@@ -267,6 +267,49 @@ Run open-source LLMs on your own machine. No API keys required, full privacy, fr
 ## Router / Multi-Provider
 
 Use a unified interface to access multiple LLM providers and models.
+
+=== "Kilo"
+
+    ```bash
+    pip install 'lumen[ai]'
+    export KILO_API_KEY=...
+    ```
+
+    [Kilo](https://kilo.ai/) provides an OpenAI-compatible API for accessing models from multiple providers through a single API key or its free tier.
+
+    **Get your API key:**
+    
+    1. Visit [app.kilo.ai/profile](https://app.kilo.ai/profile)
+    2. Scroll down and click copy API key
+    3. Set environment variable:
+    
+    ```bash
+    # macOS/Linux
+    export KILO_API_KEY='your-key-here'
+    
+    # Windows PowerShell
+    $env:KILO_API_KEY='your-key-here'
+    
+    # Windows CMD
+    set KILO_API_KEY=your-key-here
+    ```
+
+    Then use Kilo with any supported model:
+
+    ```python
+    import lumen.ai as lmai
+
+    llm = lmai.llm.Kilo(
+        model_kwargs={
+            "default": {"model": "kilo-auto/free"},
+            "sql": {"model": "anthropic/claude-sonnet-4.6"},
+            "vega_lite": {"model": "openai/gpt-5.4-mini"},
+        }
+    )
+
+    ui = lmai.ExplorerUI(data='data.csv', llm=llm)
+    ui.servable()
+    ```
 
 === "OpenRouter"
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -72,7 +72,8 @@ LLM_PROVIDERS = {
     'llama-cpp': 'LlamaCpp',
     'mlx': 'MLX',
     'litellm': 'LiteLLM',
-    'openrouter': 'OpenRouter'
+    'openrouter': 'OpenRouter',
+    'kilo': 'Kilo',
 }
 
 
@@ -2979,3 +2980,40 @@ class OpenRouter(OpenAI):
             for model in response.json().get("data", [])
             if model.get("id")
         }
+
+
+class Kilo(OpenAI):
+    """
+    An LLM implementation using the Kilo API.
+
+    Kilo provides an OpenAI-compatible endpoint that routes requests to
+    models from multiple providers. Kilo has a free tier, but for other models,
+    optionally set the ``Kilo_API_KEY`` environment variable or pass ``api_key``
+    directly. The provider is auto-detected when
+    ``Kilo_API_KEY`` is present, or can be selected explicitly with
+    ``--provider kilo``.
+    """
+
+    api_key_env_var: str = PROVIDER_ENV_VARS["kilo"]
+
+    display_name = param.String(
+        default="Kilo",
+        constant=True,
+        doc="Display name for UI",
+    )
+
+    endpoint = param.String(
+        default="https://api.kilo.ai/api/gateway",
+        doc="The Kilo API endpoint.",
+    )
+
+    model_kwargs = param.Dict(default={
+        "default": {"model": "kilo-auto/free"},
+    })
+
+    select_models = param.List(default=[
+        "kilo-auto/free",
+        "kilo-auto/balanced",
+        "kilo-auto/efficient",
+        "kilo-auto/frontier",
+    ], constant=True, doc="Available Kilo models for selection dropdowns.")

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -803,7 +803,7 @@ class Llm(param.Parameterized):
         try:
             self._ready = False
             await self.invoke(
-                messages=[{'role': 'user', 'content': 'Ready? "Y" or "N"'}],
+                messages=[{'role': 'user', 'content': 'Ready? Just "Y" or "N"'}],
                 model_spec="ui",
             )
             self._ready = True
@@ -2783,7 +2783,7 @@ class WebLLM(Llm):
         self._status.name = pn.rx('Loading LLM {:.1f}%').format(progress)
         try:
             await self.invoke(
-                messages=[{'role': 'user', 'content': 'Ready? "Y" or "N"'}],
+                messages=[{'role': 'user', 'content': 'Ready? Just "Y" or "N"'}],
                 model_spec="ui",
             )
         except Exception as e:
@@ -2988,9 +2988,9 @@ class Kilo(OpenAI):
 
     Kilo provides an OpenAI-compatible endpoint that routes requests to
     models from multiple providers. Kilo has a free tier, but for other models,
-    optionally set the ``Kilo_API_KEY`` environment variable or pass ``api_key``
+    optionally set the ``KILO_API_KEY`` environment variable or pass ``api_key``
     directly. The provider is auto-detected when
-    ``Kilo_API_KEY`` is present, or can be selected explicitly with
+    ``KILO_API_KEY`` is present, or can be selected explicitly with
     ``--provider kilo``.
     """
 
@@ -3017,3 +3017,7 @@ class Kilo(OpenAI):
         "kilo-auto/efficient",
         "kilo-auto/frontier",
     ], constant=True, doc="Available Kilo models for selection dropdowns.")
+
+    def models(self) -> set[str]:
+        """Return the set of available model identifiers from Kilo."""
+        return {model_json["id"] for model_json in requests.get("https://api.kilo.ai/api/gateway/models").json()["data"]}

--- a/lumen/ai/services.py
+++ b/lumen/ai/services.py
@@ -19,6 +19,7 @@ PROVIDER_ENV_VARS = {
     "groq": "GROQ_API_KEY",
     "ai-catalyst": "AI_CATALYST_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "kilo": "KILO_API_KEY",
 }
 
 


### PR DESCRIPTION
Adds https://kilo.ai as an LLM provider

`lumen-ai serve data/olympic* --provider kilo --model nvidia/nemotron-3-super-120b-a12b:free --log-level debug --logfire-tags kilo`
