### PR TITLE
Replace sqlglot

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -32,7 +32,6 @@ panel = ">=1.7.5"
 param = ">=2.2.1"
 pip = "*"
 sqlglot = "*"
-sqlglotrs = "*"
 
 [feature.py312.dependencies]
 python = "3.12.*"


### PR DESCRIPTION
It was making tests fail

```

    from .sql import *
lumen/transforms/sql.py:11: in <module>
    import sqlglot
.pixi/envs/test-312/lib/python3.12/site-packages/sqlglot/__init__.py:17: in <module>
    from sqlglot.dialects.dialect import Dialect as Dialect, Dialects as Dialects
.pixi/envs/test-312/lib/python3.12/site-packages/sqlglot/dialects/dialect.py:15: in <module>
    from sqlglot.generator import Generator, unsupported_args
.pixi/envs/test-312/lib/python3.12/site-packages/sqlglot/generator.py:14: in <module>
    from sqlglot.jsonpath import ALL_JSON_PATH_PARTS, JSON_PATH_PART_TRANSFORMS
.pixi/envs/test-312/lib/python3.12/site-packages/sqlglot/jsonpath.py:7: in <module>
    from sqlglot.tokens import Token, Tokenizer, TokenType
.pixi/envs/test-312/lib/python3.12/site-packages/sqlglot/tokens.py:35: in <module>
    warnings.warn(
E   UserWarning: sqlglot[rs] is deprecated and no longer compatible with sqlglot. Please use sqlglotc instead for faster parsing: pip install sqlglot[c]
```