### PR TITLE
Fix formatting

### DIFF
--- a/lumen/ai/agents/base_list.py
+++ b/lumen/ai/agents/base_list.py
@@ -96,14 +96,8 @@ class BaseListAgent(Agent):
 
         all_items = [item for source_items in items.values() for item in source_items]
         total = len(all_items)
-        max_shown = 10
-        if total > max_shown:
-            shown = ", ".join(all_items[:max_shown])
-            item_list_str = f"{shown}, ... and {total - max_shown} more"
-        else:
-            item_list_str = ", ".join(all_items)
         listing = (
-            f"Displayed {total} {self._column_name.lower()}(s) to the user: {item_list_str}"
+            f"Displayed {total} {self._column_name.lower()}(s) to the user."
         )
 
         if self.interface is not None:

--- a/lumen/ai/agents/base_list.py
+++ b/lumen/ai/agents/base_list.py
@@ -97,7 +97,7 @@ class BaseListAgent(Agent):
         all_items = [item for source_items in items.values() for item in source_items]
         total = len(all_items)
         listing = (
-            f"Displayed {total} {self._column_name.lower()}(s) to the user."
+            f"Displayed {total} {self._column_name.lower()}(s)"
         )
 
         if self.interface is not None:

--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -40,7 +40,7 @@ from ..tools.document_llm_tools import make_document_vector_llm_tools
 from ..tools.metaset_docs_llm_tools import make_load_metaset_relevant_docs_tool
 from ..utils import (
     describe_data_sync, fuse_messages, get_root_exception, log_debug,
-    mutate_user_message, normalized_name, truncate_iterable, wrap_logfire,
+    mutate_user_message, normalized_name, truncate_to_tokens, wrap_logfire,
 )
 from ..vector_store import NumpyVectorStore
 
@@ -532,7 +532,7 @@ class Coordinator(Viewer, VectorLookupToolUser):
             if len(df.columns) == 1:
                 # Do not waste tokens with a summary if just one column
                 col_name = df.columns[0]
-                return f"{col_name}: {truncate_iterable(df[col_name].tolist())}"
+                return f"{col_name}(s): {truncate_to_tokens('`, `'.join(df[col_name].tolist()), max_tokens=1500)}"
             if df is not None and not df.empty:
                 return describe_data_sync(df)
             return "[Empty table]"


### PR DESCRIPTION
Reduce duplication and fix bug (showing bool)

Before:
```
Assistant: Displayed 4 table(s) to the user: data_olympic_hosts_csv, data_olympic_results_csv, data_olympic_athletes_csv, data_olympic_medals_csv
## ProvidedSource00000
Table: (['data_olympic_hosts_csv', 'data_olympic_results_csv', 'data_olympic_athletes_csv', 'data_olympic_medals_csv'], False)
```

After
```
Assistant: Displayed 4 table(s)
## ProvidedSource00000
Table(s): data_olympic_hosts_csv, data_olympic_results_csv, data_olympic_athletes_csv, data_olympic_medals_csv
<\Chat History>
```