### PR TITLE
Fix three blockers for local and file-based sources

### DIFF
--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -268,6 +268,7 @@ class LLMUser(param.Parameterized):
         model_index: int | None = None,
         model_kwargs: dict | None = None,
         tools: list | None = None,
+        max_retries: int | None = None,
         **prompt_kwargs
     ) -> Any:
         """
@@ -318,6 +319,8 @@ class LLMUser(param.Parameterized):
         merged_tools = _merge_prompt_tools(self.llm_tools, tools, context)
         if merged_tools is not None:
             invoke_kw["tools"] = merged_tools
+        if max_retries is not None:
+            invoke_kw["max_retries"] = max_retries
 
         result = await self.llm.invoke(
             messages=messages,

--- a/lumen/ai/services.py
+++ b/lumen/ai/services.py
@@ -243,7 +243,14 @@ class APIKeyServiceMixin(ServiceMixin):
 
     def __init__(self, **params):
         if "api_key" not in params:
-            params["api_key"] = os.environ.get(self.api_key_env_var)
+            # Only override when the variable is actually set. os.environ.get
+            # returns None otherwise, which overwrote subclass defaults: Ollama
+            # declares api_key="ollama" and does not accept None, so it could
+            # not be constructed at all unless OPENAI_API_KEY happened to be
+            # set, despite needing no key of its own.
+            api_key = os.environ.get(self.api_key_env_var)
+            if api_key:
+                params["api_key"] = api_key
         super().__init__(**params)
 
     def _instantiate_client_kwargs(self, **extra_kwargs) -> dict:

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -108,7 +108,12 @@ class DuckDBSource(BaseSQLSource):
             # First pass: separate file paths from SQL expressions
             for table_name, table_expr in self.tables.items():
                 if isinstance(table_expr, str) and self._is_file_path(table_expr):
-                    table_name = re.sub(r'\W+', '_', table_name)
+                    # Must match normalize_table, which every lookup goes
+                    # through. Substituting non-word characters alone left the
+                    # leading underscore an absolute path produces, so the
+                    # registered key did not survive its own normalization and
+                    # the source could not find its own table.
+                    table_name = normalize_table_name(table_name)
                     self._file_based_tables[table_name] = table_expr
                 else:
                     sql_based_tables[table_name] = table_expr

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -707,3 +707,21 @@ def test_mlx_make_sampler_handles_none():
     set_llm = MLX(model_kwargs={"default": {"model": "m"}}, temperature=0.5)
     assert callable(none_llm._make_sampler())
     assert callable(set_llm._make_sampler())
+
+
+def test_api_key_env_var_does_not_clobber_provider_default(monkeypatch):
+    """An unset env var must leave the provider's own default alone.
+
+    ``APIKeyServiceMixin`` assigned ``os.environ.get(api_key_env_var)``
+    unconditionally, so a missing variable wrote None over the default. Ollama
+    declares ``api_key="ollama"`` and does not accept None, which made
+    ``lumen-ai serve --provider ollama`` fail at startup unless OPENAI_API_KEY
+    happened to be set, despite Ollama needing no key of its own.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert Ollama().api_key == "ollama"
+    assert Ollama(api_key="explicit").api_key == "explicit"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    assert OpenAI().api_key == "sk-from-env"

--- a/lumen/tests/ai/test_tools.py
+++ b/lumen/tests/ai/test_tools.py
@@ -370,3 +370,26 @@ def test_apply_filter_tool_subsets_xarray_like_sel():
     expected = ds.sel(lat=slice(20.0, 30.0)).to_dataframe().reset_index().shape[0]
     assert len(pipeline.data) == expected
     assert set(pipeline.data["lat"].unique()) == {20.0, 30.0}
+
+
+async def test_invoke_prompt_forwards_max_retries(llm, monkeypatch):
+    """``max_retries`` reaches the LLM instead of the Jinja context.
+
+    ``tools/base.py`` and ``tools/mcp.py`` both pass ``max_retries=3``, but
+    ``_invoke_prompt`` had no such parameter, so it fell into ``**prompt_kwargs``
+    and was rendered as template context. Those call sites silently ran with the
+    single attempt from ``Llm.create_kwargs``.
+    """
+    from lumen.ai.actor import Actor
+
+    seen = {}
+
+    async def fake_invoke(**kwargs):
+        seen.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(llm, "invoke", fake_invoke)
+    actor = Actor(llm=llm)
+    await actor._invoke_prompt("main", [{"role": "user", "content": "hi"}], {}, max_retries=3)
+
+    assert seen["max_retries"] == 3

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -1438,3 +1438,24 @@ def test_duckdb_get_schema_geometry_no_distinct():
     # non-geometry columns still summarised as usual
     assert schema['pop']['inclusiveMinimum'] == 1
     assert schema['pop']['inclusiveMaximum'] == 2
+
+
+def test_file_table_key_survives_normalization(tmp_path):
+    """A registered file-based table must be findable by its own name.
+
+    File-based keys were normalized with a bare non-word substitution while
+    every lookup goes through ``normalize_table``, which also strips leading
+    and trailing underscores. An absolute path starts with a separator and so
+    produced a leading underscore, leaving the source unable to resolve the
+    table it had just registered. That broke ``lumen-ai serve /abs/path.csv``
+    for any absolute path.
+    """
+    csv = tmp_path / "sales.csv"
+    pd.DataFrame({"region": ["North", "South"], "revenue": [10, 20]}).to_csv(csv, index=False)
+
+    source = DuckDBSource(tables={str(csv): str(csv)}, uri=":memory:")
+
+    (table,) = source.get_tables()
+    assert not table.startswith("_")
+    assert source.normalize_table(table) in source.tables
+    assert len(source.get(table)) == 2


### PR DESCRIPTION
`lumen-ai serve --provider ollama` can't start, because an unset `OPENAI_API_KEY` overwrites Ollama's own `api_key` default with `None`, and any absolute CSV path registers a table name the source can't look up again.

Also forwards `max_retries` from `_invoke_prompt` to the LLM, where two call sites were passing it into the Jinja context instead.

