### PR TITLE
Align pixi dependency floors with pyproject

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,7 @@ lint = ["py312", "lint"]
 [dependencies]
 bokeh = "*"
 holoviews = ">=1.17.0"
-panel-material-ui = ">=0.8.1"
+panel-material-ui = ">=0.14.0"
 hvplot = "*"
 intake = "<2"
 jinja2 = ">3.0"
@@ -60,7 +60,7 @@ semchunk = "*"
 tiktoken = "*"
 tabulate = "*"
 vl-convert-python = "*"
-panel-splitjs = ">=0.3.2"
+panel-splitjs = ">=0.4.0"
 panel-graphic-walker = ">=0.6.4"
 
 [feature.sql.dependencies]


### PR DESCRIPTION
`pixi.toml` allows `panel-splitjs >=0.3.2` and `panel-material-ui >=0.8.1` while `pyproject.toml` requires `>=0.4.0` and `>=0.14.0`, so a fresh pixi env resolves a splitjs without `collapse_threshold` and the AI UI renders blank.

