### PR TITLE
fix: quote bare table names that sqlglot mis-parses

### DIFF
--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -831,6 +831,12 @@ def test_sql_select_from_duckdb_path():
     assert result == expected
 
 
+def test_sql_select_from_table_starting_with_digit():
+    result = SQLSelectFrom.apply_to("2014_world_gdp_with_codes")
+    expected = 'SELECT * FROM "2014_world_gdp_with_codes"'
+    assert result == expected
+
+
 def test_sql_select_from_expression():
     result = SQLSelectFrom.apply_to("""
         SELECT

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -310,8 +310,13 @@ class SQLSelectFrom(SQLFormat):
             # e.g. read_parquet("/path/to/file.parquet"); so we need to quote
             expression = Table(this=Identifier(this=sql_in, quoted=True))
 
-        # if 'data/life-expectancy.csv' becomes 'data / life-expectancy.csv'
-        if not list(expression.find_all(Select)) and " / " in expression.sql():
+        # A bare table name that does not round-trip was mis-parsed as an
+        # expression, e.g. 'data/life-expectancy.csv' becomes
+        # 'data / life-expectancy.csv' and '2014_sales' becomes '2014 AS _sales'
+        if (
+            not list(expression.find_all(Select))
+            and expression.sql().strip().lower() != sql_in.strip().lower()
+        ):
             expression = Table(this=Identifier(this=sql_in, quoted=True))
 
         tables = {}


### PR DESCRIPTION
A CSV named `2014_world_gdp_with_codes.csv` broke every query against it, because sqlglot parsed the digit-prefixed table name as a numeric literal plus an alias, generating `SELECT * FROM 2014 AS _world_gdp_with_codes`. I replaced the existing path-specific check with a general one: if a bare table name does not round-trip through sqlglot, it was mis-parsed, so quote it.

**Before**

```python
SQLSelectFrom.apply_to("2014_world_gdp_with_codes")
# 'SELECT * FROM 2014 AS _world_gdp_with_codes'
# _duckdb.ParserException: syntax error at or near "2014"
```

**After**

```python
SQLSelectFrom.apply_to("2014_world_gdp_with_codes")
# 'SELECT * FROM "2014_world_gdp_with_codes"'
```

