### PR TITLE
fix: load geojson uploads end to end

### DIFF
--- a/lumen/ai/controls/ingest/file.py
+++ b/lumen/ai/controls/ingest/file.py
@@ -142,7 +142,7 @@ class FileSourceControls(BaseSourceControls):
         filename = f"{card.filename}.{extension}"
 
         try:
-            if extension.endswith("json"):
+            if extension == "json":
                 # Use the more robust JSON parser on this class
                 df = self._read_json_file(file, filename)
                 result = FileReadResult(tables={alias: df})

--- a/lumen/ai/controls/ingest/utils.py
+++ b/lumen/ai/controls/ingest/utils.py
@@ -319,8 +319,10 @@ def read_geo_file(
     df["geometry"] = geo_df["geometry"].to_wkb()
 
     cols = ", ".join(f'"{c}"' for c in df.columns if c != "geometry")
+    # A TEMP table is scoped to the creating connection, so it would be
+    # invisible to the cursors DuckDBSource opens when querying.
     conversion = (
-        f"CREATE TEMP TABLE {alias} AS SELECT {cols}, "
+        f"CREATE TABLE {alias} AS SELECT {cols}, "
         f"ST_GeomFromWKB(geometry) as geometry FROM {alias}_temp"
     )
 

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -25,6 +25,9 @@ from .base import BaseSQLSource, Source, cached
 if TYPE_CHECKING:
     import pandas as pd
 
+# DuckDB reports a geometry column carrying a CRS as GEOMETRY('EPSG:4326')
+GEOMETRY_CRS = re.compile(r"GEOMETRY\('(.+)'\)")
+
 
 class DuckDBSource(BaseSQLSource):
     """
@@ -68,8 +71,9 @@ class DuckDBSource(BaseSQLSource):
 
     geometry_crs = param.String(default=None, allow_None=True, doc="""
         CRS to reapply to geometry columns after the WKB roundtrip through
-        DuckDB, which stores geometry without a CRS. Populated from the source
-        data at ingest; may also be set explicitly for a known dataset.""")
+        DuckDB, used as a fallback when the column type carries no CRS of its
+        own. Populated from the source data at ingest; may also be set
+        explicitly for a known dataset.""")
 
     read_only = param.Boolean(default=None, doc="""
         Whether to open the DuckDB database in read-only mode.""")
@@ -521,7 +525,11 @@ class DuckDBSource(BaseSQLSource):
         a GeoDataFrame when geopandas is available (WKB bytes otherwise).
         """
         rel = cursor.execute(sql_expr, params) if params else cursor.execute(sql_expr)
-        geom_cols = [d[0] for d in rel.description if str(d[1]) == 'GEOMETRY']
+        geom_crs = {
+            d[0]: (m.group(1) if (m := GEOMETRY_CRS.search(str(d[1]))) else self.geometry_crs)
+            for d in rel.description if str(d[1]).startswith('GEOMETRY')
+        }
+        geom_cols = list(geom_crs)
         if not geom_cols:
             return rel.fetch_df(date_as_object=date_as_object)
 
@@ -536,7 +544,7 @@ class DuckDBSource(BaseSQLSource):
         if gpd := try_import("geopandas"):
             for col in geom_cols:
                 df[col] = gpd.GeoSeries.from_wkb(
-                    df[col].apply(bytes), crs=self.geometry_crs
+                    df[col].apply(bytes), crs=geom_crs[col]
                 )
             df = gpd.GeoDataFrame(df, geometry=geom_cols[0])
         return df

--- a/lumen/tests/ai/test_controls/test_upload.py
+++ b/lumen/tests/ai/test_controls/test_upload.py
@@ -377,3 +377,18 @@ def test_read_geo_file_captures_crs():
     buf = io.BytesIO(gdf.to_json().encode())
     result = read_geo_file(buf, "geojson", "geo")
     assert result.source_params["geometry_crs"] == "EPSG:4326"
+
+
+@requires_geopandas
+def test_add_table_reads_geojson_as_geospatial(upload_controls):
+    """A .geojson upload is parsed by the geospatial reader, not the JSON reader,
+    which rejects a FeatureCollection as non-tabular."""
+    gdf = gpd.GeoDataFrame(
+        {"name": ["a"]}, geometry=[Polygon([(0, 0), (1, 0), (1, 1)])], crs="EPSG:4326"
+    )
+    buf = io.BytesIO(gdf.to_json().encode())
+    source = DuckDBSource(uri=":memory:", tables={})
+    card = UploadedFileRow(file_obj=buf, filename="shapes.geojson", alias="shapes")
+
+    assert upload_controls._add_table(source, buf, card) == 1
+    assert "geometry" in source.get("shapes").columns

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -1401,6 +1401,31 @@ def test_duckdb_geometry_returns_geodataframe():
     assert str(result.geometry.dtype) == 'geometry'
 
 
+def test_duckdb_geometry_crs_read_from_column_type(tmp_path):
+    """ST_Read reports a CRS-carrying column as GEOMETRY('EPSG:4326'), so the
+    type must be matched by prefix and the CRS taken from it."""
+    if gpd is None:
+        pytest.skip("geopandas is not installed")
+    path = tmp_path / 'shapes.geojson'
+    gpd.GeoDataFrame(
+        {'name': ['a']},
+        geometry=[Polygon([(0, 0), (1, 0), (1, 1)])],
+        crs='EPSG:4326',
+    ).to_file(path, driver='GeoJSON')
+    try:
+        source = DuckDBSource(
+            uri=':memory:',
+            initializers=["INSTALL spatial;", "LOAD spatial;"],
+            tables={'geo': f"SELECT * FROM ST_Read('{path}')"},
+        )
+    except Exception as e:  # pragma: no cover - environment dependent
+        pytest.skip(f"duckdb spatial extension unavailable: {e}")
+
+    result = source.get('geo')
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert result.crs.to_epsg() == 4326
+
+
 def test_duckdb_geometry_crs_none_by_default():
     """Without geometry_crs set the CRS stays None (WKB carries none); no regression."""
     source, gpd = _spatial_source()


### PR DESCRIPTION
Uploading a `.geojson` failed with `JSON structure is not tabular`, and the table it created could not be queried afterwards. Three causes on the same path: the upload dispatched on `extension.endswith("json")` so geojson never reached `read_geo_file`; that reader created a TEMP table, invisible to the cursors `DuckDBSource` opens; and `ST_Read` reports a CRS-carrying column as `GEOMETRY('EPSG:4326')`, which the exact `GEOMETRY` match missed, skipping the WKB roundtrip.

Since that type carries the CRS, it is now read from there with `geometry_crs` as the fallback, so a loaded GeoDataFrame keeps its CRS instead of `None`.

