### PR TITLE
feat: render a table's own geometry as a Vega-Lite geoshape

### DIFF
--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -251,7 +251,24 @@ config:
   view: {stroke: null}
 ```
 {%- endif %}
-Choropleth map:
+Choropleth map, when the table has its own geometry column (schema `format: geometry`).
+Omit `data`: the geometry is injected as a GeoJSON FeatureCollection, so every
+field is addressed as `properties.<column>` because each datum is a Feature.
+```yaml
+mark: geoshape
+projection: {type: naturalEarth1}
+encoding:
+  color:
+    field: properties.<VALUE_COLUMN>
+    type: quantitative
+    scale: {scheme: redblue, reverse: true}
+    legend: {title: "<VALUE_COLUMN>"}
+  tooltip:
+    - {field: properties.<NAME_COLUMN>, type: nominal}
+    - {field: properties.<VALUE_COLUMN>, type: quantitative, format: ".2f"}
+```
+
+Choropleth map, when the table has no geometry and must be joined to external boundaries:
 ```yaml
 data:
   url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"

--- a/lumen/tests/ai/test_vega_lite_gridded.py
+++ b/lumen/tests/ai/test_vega_lite_gridded.py
@@ -92,3 +92,16 @@ def test_vegalite_altair_prompt_gridded_is_general():
     assert "reduced to single slice" in rendered
     # the old per-dim subset instruction is gone (code handles it now)
     assert "cannot page a dimension with a slider" not in rendered
+
+
+def test_vegalite_prompt_covers_choropleth_from_own_geometry():
+    """A table carrying its own geometry needs a geoshape example that omits
+    data and reads fields off properties, not only the external-TopoJSON join."""
+    rendered = render_template(
+        PROMPTS_DIR / "VegaLiteAgent" / "main.jinja2",
+        **_base_context(),
+    )
+    assert "its own geometry column" in rendered
+    assert "properties.<VALUE_COLUMN>" in rendered
+    # the external boundary join stays available for tables without geometry
+    assert "topojson" in rendered

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -9,7 +9,7 @@ import pytest
 
 from lumen.panel import DownloadButton
 from lumen.pipeline import Pipeline
-from lumen.sources.base import FileSource
+from lumen.sources.base import FileSource, InMemorySource
 from lumen.state import state
 from lumen.tests.utils import Polygon, gpd, requires_geopandas
 from lumen.variables.base import Variables
@@ -499,3 +499,38 @@ def test_deckgl_view_geometry_as_geojson():
     assert len(data['features']) == 2
     assert data['features'][0]['geometry']['type'] == 'Polygon'
     json.dumps(data)  # must be serializable
+
+
+@requires_geopandas
+def test_vegalite_view_geometry_as_geoshape_data():
+    """VegaLiteView emits a GeoDataFrame as a FeatureCollection with the
+    format.property geoshape needs, rather than an unserializable frame."""
+    gdf = gpd.GeoDataFrame(
+        {'pop': [1, 2],
+         'date': [pd.Timestamp('2026-06-15'), pd.Timestamp('2026-06-15')],
+         'geometry': [
+             Polygon([(0, 0), (1, 0), (1, 1)]), Polygon([(2, 0), (3, 0), (3, 1)])]},
+        crs='EPSG:4326',
+    )
+    pipeline = Pipeline(source=InMemorySource(tables={'geo': gdf}), table='geo')
+    spec = {'mark': 'geoshape',
+            'encoding': {'color': {'field': 'properties.pop', 'type': 'quantitative'}}}
+    data = VegaLiteView(pipeline=pipeline, spec=spec)._get_params()['object']['data']
+
+    assert data['format'] == {'type': 'json', 'property': 'features'}
+    assert data['values']['type'] == 'FeatureCollection'
+    assert len(data['values']['features']) == 2
+    assert data['values']['features'][0]['properties']['pop'] == 1
+    json.dumps(data)  # must be serializable
+
+
+@requires_geopandas
+def test_vegalite_view_plain_frame_unchanged():
+    """A non-geometry frame still goes through as data.values records."""
+    df = pd.DataFrame({'x': [1, 2], 'y': [3, 4]})
+    pipeline = Pipeline(source=InMemorySource(tables={'plain': df}), table='plain')
+    spec = {'mark': 'point', 'encoding': {'x': {'field': 'x'}}}
+    data = VegaLiteView(pipeline=pipeline, spec=spec)._get_params()['object']['data']
+
+    assert 'format' not in data
+    assert data['values'].equals(df)

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import importlib
 import io
+import json
 import os
 import re
 import sys
@@ -572,3 +573,14 @@ def geometry_to_wkt(df):
     for col in geom_cols:
         df[col] = gpd.GeoSeries(df[col]).to_wkt()
     return df
+
+
+def geometry_to_geojson(df):
+    """Return a GeoDataFrame as a GeoJSON FeatureCollection dict.
+
+    Shapely geometry cannot be sent to the browser, so views that render
+    geometry emit a FeatureCollection instead. ``default=str`` is required
+    because to_json defers to json.dumps, which cannot encode the Timestamps
+    and Decimals a SQL source yields.
+    """
+    return json.loads(df.to_json(default=str))

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import copy
 import html
-import json
 import sys
 
 from io import BytesIO, StringIO
@@ -44,8 +43,8 @@ from ..state import state
 from ..transforms.base import Transform
 from ..transforms.sql import SQLTransform
 from ..util import (
-    VARIABLE_RE, catch_and_notify, geometry_to_wkt, is_geodataframe, is_ref,
-    resolve_module_reference, try_import_xarray,
+    VARIABLE_RE, catch_and_notify, geometry_to_geojson, geometry_to_wkt,
+    is_geodataframe, is_ref, resolve_module_reference, try_import_xarray,
 )
 from ..validation import ValidationError
 
@@ -1476,6 +1475,14 @@ class VegaLiteView(View):
             datasets = self.spec.get('datasets', {})
             datasets[self.pipeline.table] = df
             encoded = dict(spec, datasets=datasets)
+        elif is_geodataframe(df):
+            # geoshape consumes a FeatureCollection, so fields then live under
+            # properties, e.g. {"field": "properties.value"}.
+            encoded = dict(spec, data={
+                'values': geometry_to_geojson(df),
+                'format': {'type': 'json', 'property': 'features'},
+                **spec_data,
+            })
         else:
             encoded = dict(spec, data={'values': df, **spec_data})
         return dict(object=encoded, **self.kwargs)
@@ -1517,7 +1524,7 @@ class DeckGLView(View):
         usual list-of-records form.
         """
         if is_geodataframe(df):
-            return json.loads(df.to_json())
+            return geometry_to_geojson(df)
         return df.to_dict(orient='records')
 
     def _get_params(self) -> dict[str, Any]:


### PR DESCRIPTION
Asking for a choropleth from a table that already has a geometry column failed with `TypeError: Object of type GeoDataFrame is not JSON serializable`, because `VegaLiteView` passed the frame straight through as `data.values`. It now emits a GeoJSON FeatureCollection with `format: {type: json, property: features}`, so `mark: geoshape` works and fields are read off `properties.<column>`.

The prompt only had one choropleth example, joining a geometryless table to external TopoJSON boundaries from a CDN, so I added one for the case where the table carries its own geometry. The FeatureCollection serialization moved into `geometry_to_geojson` next to `geometry_to_wkt`, shared with `DeckGLView`, which was doing the same thing inline.
