### PR TITLE
fix: teach the DeckGL prompt GeoJsonLayer and data-driven colours

### DIFF
--- a/lumen/ai/prompts/DeckGLAgent/main.jinja2
+++ b/lumen/ai/prompts/DeckGLAgent/main.jinja2
@@ -6,7 +6,8 @@ Generate DeckGL JSON spec. Do NOT include `data` in layers (injected automatical
 Use `@@=` prefix for every column-based accessor:
 - Position: `"getPosition": "@@=[longitude, latitude]"` (NOT `["longitude", "latitude"]`)
 - Elevation: `"getElevation": "@@=value"` or `"getElevation": "@@=value * 100"`
-- Static values (no @@=): `"getFillColor": [255, 140, 0, 200]`
+- Colour by value: `"getFillColor": "@@=[value * 25, 40, 255 - value * 25, 200]"`
+- A fixed colour needs no `@@=`: `"getFillColor": [255, 140, 0, 200]`
 
 Column names: spaces→underscores, non-alphanumeric removed (e.g., "Plant latitude"→"Plant_latitude")
 
@@ -29,6 +30,9 @@ Column names: spaces→underscores, non-alphanumeric removed (e.g., "Plant latit
 **For connections:**
 6. **ArcLayer** - Origin-destination arcs
 
+**For a geometry column** (schema `format: geometry`, polygons/lines/points):
+7. **GeoJsonLayer** - Draws the geometry itself; the only choice for a choropleth
+
 ## Key Layer Properties
 
 | Layer | Key Props |
@@ -37,12 +41,21 @@ Column names: spaces→underscores, non-alphanumeric removed (e.g., "Plant latit
 | ColumnLayer | `getElevation`, `radius`, `elevationScale`, `diskResolution`, `extruded: true` |
 | ScatterplotLayer | `radiusMinPixels`, `radiusMaxPixels`, `getFillColor` |
 | ArcLayer | `getSourcePosition`, `getTargetPosition`, `getWidth` |
+| GeoJsonLayer | `filled`, `stroked`, `getFillColor`, `getLineColor`, `lineWidthMinPixels` |
+
+**GeoJsonLayer accessors receive the whole GeoJSON Feature, not a row**, so
+address columns as `properties.<column>`: `"getFillColor": "@@=[properties.value * 25, 40, 255 - properties.value * 25, 200]"`.
+A bare `value` there resolves to undefined and the colour becomes NaN.
 
 ## Styling
 - `pickable: true` for tooltips
 - `autoHighlight: true` for hover effect
-- **Colors:** Use static RGBA arrays: `"getFillColor": [255, 140, 0, 200]` (no `@@=` prefix, no Math functions)
+- **Colors:** a fixed colour is a plain RGBA array: `"getFillColor": [255, 140, 0, 200]`.
+  To colour by a value, use `@@=` with arithmetic or a ternary:
+  `"@@=[value * 25, 40, 255 - value * 25, 200]"` or `"@@=value > 10 ? [255, 0, 0] : [0, 255, 200]"`
 - **Elevation/Radius:** Use simple math only: `"@@=value"` or `"@@=value * 100"` (NO Math.min, Math.max, etc.)
+- **No legend:** deck.gl has no legend property; a `legend` key is silently
+  dropped. When the chart needs a colour legend, prefer Vega-Lite over deck.gl.
 - Zoom levels: 1-3 continent, 4-6 country, 7-10 city, 11+ street
 - Pitch: 45-60 for good 3D perspective
 {%- if gridded is defined and gridded %}

--- a/lumen/ai/prompts/DeckGLAgent/main.jinja2
+++ b/lumen/ai/prompts/DeckGLAgent/main.jinja2
@@ -127,6 +127,27 @@ ScatterplotLayer (simple points):
 }
 ```
 
+GeoJsonLayer (choropleth from a geometry column — note every column is read off
+`properties`, because each datum is a GeoJSON Feature rather than a row):
+```json
+{
+  "initialViewState": {"latitude": 20, "longitude": 0, "zoom": 1.5, "pitch": 0, "bearing": 0},
+  "layers": [{
+    "@@type": "GeoJsonLayer",
+    "id": "choropleth",
+    "filled": true,
+    "stroked": true,
+    "getFillColor": "@@=[properties.value * 25, 40, 255 - properties.value * 25, 200]",
+    "getLineColor": [255, 255, 255, 80],
+    "lineWidthMinPixels": 0.5,
+    "pickable": true,
+    "autoHighlight": true
+  }],
+  "views": [{"@@type": "MapView", "controller": true}],
+  "mapStyle": "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+}
+```
+
 ArcLayer (connections):
 ```json
 {

--- a/lumen/tests/ai/test_deckgl_gridded.py
+++ b/lumen/tests/ai/test_deckgl_gridded.py
@@ -136,6 +136,10 @@ def test_deckgl_prompt_covers_geojsonlayer():
     assert "GeoJsonLayer" in rendered
     assert "properties.<column>" in rendered
     assert "no legend property" in rendered
+    # a worked example matters more than the prose: every other layer has one,
+    # and without it the model copies their bare column names
+    assert '"@@type": "GeoJsonLayer"' in rendered
+    assert '"@@=[properties.value * 25, 40, 255 - properties.value * 25, 200]"' in rendered
 
 
 def test_deckgl_prompt_allows_data_driven_colors():

--- a/lumen/tests/ai/test_deckgl_gridded.py
+++ b/lumen/tests/ai/test_deckgl_gridded.py
@@ -124,3 +124,27 @@ def test_deckglview_row_limit_passes_under_threshold():
         {"lon": 0.0, "lat": 0.0, "value": 1.0},
         {"lon": 1.0, "lat": 1.0, "value": 2.0},
     ]
+
+
+def test_deckgl_prompt_covers_geojsonlayer():
+    """Geometry data needs GeoJsonLayer guidance: accessors receive the Feature,
+    so columns are addressed via properties, and deck.gl has no legend."""
+    rendered = render_template(
+        PROMPTS_DIR / "DeckGLAgent" / "main.jinja2",
+        **_base_context(),
+    )
+    assert "GeoJsonLayer" in rendered
+    assert "properties.<column>" in rendered
+    assert "no legend property" in rendered
+
+
+def test_deckgl_prompt_allows_data_driven_colors():
+    """deck.gl documents @@= colour accessors, so the prompt must not forbid
+    them; only Math.* is genuinely unavailable."""
+    rendered = render_template(
+        PROMPTS_DIR / "DeckGLAgent" / "main.jinja2",
+        **_base_context(),
+    )
+    assert "no `@@=` prefix" not in rendered
+    assert "To colour by a value" in rendered
+    assert "NO Math.min" in rendered


### PR DESCRIPTION
Asking for a choropleth over a geometry column gave me a map where every country was the same flat orange, then one whose colours were `NaN`. The prompt never mentioned `GeoJsonLayer`, so the model improvised: bare column names in accessors that actually receive a whole GeoJSON Feature, plus an invented `legend` prop that deck.gl silently drops.

It also required colours to be static RGBA arrays, `(no @@= prefix, no Math functions)`, which rules out a choropleth entirely. deck.gl's [conversion reference](https://deck.gl/docs/api-reference/json/conversion-reference) documents `"@@=[color / 255, 200, 20]"` as a colour accessor and `"@@=value > 10 ? [255, 0, 0] : [0, 255, 200]"` as a ternary, so only the `Math.*` half was right and I kept it.

Adds `GeoJsonLayer` to the layer list and property table, notes that its accessors need `properties.<column>`, allows `@@=` colour expressions, and says to prefer Vega-Lite when a legend is wanted. Prompt-only, with two `render_template`.
