### PR TITLE
fix: blank choropleth when the lookup names an unregistered dataset

### DIFF
--- a/lumen/ai/agents/deck_gl.py
+++ b/lumen/ai/agents/deck_gl.py
@@ -98,7 +98,7 @@ class DeckGLAgent(BaseCodeAgent):
             "Use for large-scale geospatial data with latitude/longitude coordinates",
             "Use for hexbin aggregations, heatmaps, or 3D extruded visualizations on maps",
             "Can render a geometry column (GeoDataFrame polygons/lines/points) on a basemap, suited to 3D/extruded maps or geometry whose schema is 'geographic' (a lat/lon CRS) so the basemap gives real-world context",
-            "NOT when the table only names places (a state or country column) without geometry or lat/lon, since deck.gl has nothing to draw and cannot fetch boundaries; that choropleth belongs to VegaLiteAgent",
+            "NOT when the table only names places (a state or country column) without geometry or lat/lon, since deck.gl has nothing to draw and cannot fetch boundaries",
         ]
     )
 

--- a/lumen/ai/agents/deck_gl.py
+++ b/lumen/ai/agents/deck_gl.py
@@ -98,6 +98,7 @@ class DeckGLAgent(BaseCodeAgent):
             "Use for large-scale geospatial data with latitude/longitude coordinates",
             "Use for hexbin aggregations, heatmaps, or 3D extruded visualizations on maps",
             "Can render a geometry column (GeoDataFrame polygons/lines/points) on a basemap, suited to 3D/extruded maps or geometry whose schema is 'geographic' (a lat/lon CRS) so the basemap gives real-world context",
+            "NOT when the table only names places (a state or country column) without geometry or lat/lon, since deck.gl has nothing to draw and cannot fetch boundaries; that choropleth belongs to VegaLiteAgent",
         ]
     )
 

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -132,6 +132,7 @@ class VegaLiteAgent(BaseCodeAgent):
         default=[
             "Use for publication-ready visualizations or when user specifically requests Vega-Lite charts",
             "Use for polished charts intended for presentation or sharing",
+            "Use for a choropleth whose table names places (states, countries) but holds no geometry or coordinates, since the boundaries can be looked up and joined by name",
         ]
     )
 

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -356,22 +356,44 @@ class VegaLiteEditor(LumenEditor):
     _geometry_formats = frozenset({"topojson", "geojson"})
 
     @classmethod
-    def _draws_geoshape(cls, node) -> bool:
-        """Whether any mark in the spec is a geoshape."""
-        if isinstance(node, list):
-            return any(cls._draws_geoshape(item) for item in node)
-        if not isinstance(node, dict):
-            return False
-        mark = node.get("mark")
-        if mark == "geoshape" or (isinstance(mark, dict) and mark.get("type") == "geoshape"):
-            return True
-        return any(cls._draws_geoshape(value) for value in node.values())
-
-    @classmethod
     def _supplies_geometry(cls, data: dict) -> bool:
         """Whether a data definition yields features a geoshape can draw."""
         fmt = data.get("format") or {}
         return fmt.get("type") in cls._geometry_formats or fmt.get("property") == "features"
+
+    @classmethod
+    def _check_geoshape_data(cls, node: Any, inherited: dict | None = None) -> None:
+        """Raise if any geoshape mark resolves to data that carries no geometry.
+
+        Such a spec compiles cleanly and then draws nothing at all, so the only
+        symptom is an empty canvas; raising turns that silence into an error the
+        agent can retry against. Layers inherit their parent's ``data`` when they
+        declare none, so the check follows the same scoping rather than looking
+        only at the top level. A spec with no ``data`` anywhere is the valid case
+        where the table's own geometry is injected at render time.
+        """
+        if isinstance(node, list):
+            for item in node:
+                cls._check_geoshape_data(item, inherited)
+            return
+        if not isinstance(node, dict):
+            return
+
+        data = node.get("data", inherited)
+        mark = node.get("mark")
+        mark_type = mark.get("type") if isinstance(mark, dict) else mark
+        if mark_type == "geoshape" and isinstance(data, dict) and not cls._supplies_geometry(data):
+            raise RuntimeError(
+                "A geoshape mark draws the geometry found in `data`, but `data` here is the "
+                "table, which carries no geometry, so the map renders empty. Either set `data` "
+                "to the boundary topojson/geojson and pull the table's columns in with a "
+                "`transform.lookup` whose `from.data` names the table, or omit `data` entirely "
+                "when the table has its own geometry column."
+            )
+
+        for key, value in node.items():
+            if key != "data":
+                cls._check_geoshape_data(value, data)
 
     @classmethod
     def validate_spec(cls, spec):
@@ -386,19 +408,7 @@ class VegaLiteEditor(LumenEditor):
                 msg = msg[:msg.index('\n    at Nc.')]
             raise RuntimeError(msg) from e
 
-        # A geoshape over a table with no geometry compiles cleanly and then draws
-        # nothing at all, so the only symptom is an empty canvas. Rejecting it here
-        # turns that silence into an error the agent can retry against. A spec with
-        # no `data` is the valid case where the table's own geometry is injected.
-        data = spec.get("data")
-        if isinstance(data, dict) and cls._draws_geoshape(spec) and not cls._supplies_geometry(data):
-            raise RuntimeError(
-                "A geoshape mark draws the geometry found in `data`, but `data` here is the "
-                "table, which carries no geometry, so the map renders empty. Either set `data` "
-                "to the boundary topojson/geojson and pull the table's columns in with a "
-                "`transform.lookup` whose `from.data` names the table, or omit `data` entirely "
-                "when the table has its own geometry column."
-            )
+        cls._check_geoshape_data(spec)
         return super().validate_spec(spec)
 
     def __str__(self):

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -352,14 +352,11 @@ class VegaLiteEditor(LumenEditor):
             spec_dict.pop('pipeline')
         return type(component).from_spec(spec_dict, pipeline=pipeline)
 
-    # Data formats whose features carry geometry a geoshape mark can draw.
-    _geometry_formats = frozenset({"topojson", "geojson"})
-
-    @classmethod
-    def _supplies_geometry(cls, data: dict) -> bool:
+    @staticmethod
+    def _supplies_geometry(data: dict) -> bool:
         """Whether a data definition yields features a geoshape can draw."""
         fmt = data.get("format") or {}
-        return fmt.get("type") in cls._geometry_formats or fmt.get("property") == "features"
+        return fmt.get("type") in ("topojson", "geojson") or fmt.get("property") == "features"
 
     @classmethod
     def _check_geoshape_data(cls, node: Any, inherited: dict | None = None) -> None:

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -352,6 +352,27 @@ class VegaLiteEditor(LumenEditor):
             spec_dict.pop('pipeline')
         return type(component).from_spec(spec_dict, pipeline=pipeline)
 
+    # Data formats whose features carry geometry a geoshape mark can draw.
+    _geometry_formats = frozenset({"topojson", "geojson"})
+
+    @classmethod
+    def _draws_geoshape(cls, node) -> bool:
+        """Whether any mark in the spec is a geoshape."""
+        if isinstance(node, list):
+            return any(cls._draws_geoshape(item) for item in node)
+        if not isinstance(node, dict):
+            return False
+        mark = node.get("mark")
+        if mark == "geoshape" or (isinstance(mark, dict) and mark.get("type") == "geoshape"):
+            return True
+        return any(cls._draws_geoshape(value) for value in node.values())
+
+    @classmethod
+    def _supplies_geometry(cls, data: dict) -> bool:
+        """Whether a data definition yields features a geoshape can draw."""
+        fmt = data.get("format") or {}
+        return fmt.get("type") in cls._geometry_formats or fmt.get("property") == "features"
+
     @classmethod
     def validate_spec(cls, spec):
         if "spec" in spec:
@@ -364,6 +385,20 @@ class VegaLiteEditor(LumenEditor):
             if '\n    at Nc.' in msg:
                 msg = msg[:msg.index('\n    at Nc.')]
             raise RuntimeError(msg) from e
+
+        # A geoshape over a table with no geometry compiles cleanly and then draws
+        # nothing at all, so the only symptom is an empty canvas. Rejecting it here
+        # turns that silence into an error the agent can retry against. A spec with
+        # no `data` is the valid case where the table's own geometry is injected.
+        data = spec.get("data")
+        if isinstance(data, dict) and cls._draws_geoshape(spec) and not cls._supplies_geometry(data):
+            raise RuntimeError(
+                "A geoshape mark draws the geometry found in `data`, but `data` here is the "
+                "table, which carries no geometry, so the map renders empty. Either set `data` "
+                "to the boundary topojson/geojson and pull the table's columns in with a "
+                "`transform.lookup` whose `from.data` names the table, or omit `data` entirely "
+                "when the table has its own geometry column."
+            )
         return super().validate_spec(spec)
 
     def __str__(self):

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -6,7 +6,10 @@ Generate complete, effective Vega-Lite visualizations clearly communicating data
 ## Essential Structure
 
 Every visualization must:
-- Use `data: {name: {{ memory['table'] }}}` with exact column names from source
+- Use `data: {name: {{ memory['table'] }}}` with exact column names from source. The one
+  exception is a choropleth joined to external boundaries, where `data` must be the
+  boundary file and the table is named inside `transform.lookup.from` instead; see the
+  choropleth example below.
 - Wrap all marks in `layer` array, each with own `mark` and `encoding`
 - Focus on ONE primary metric or relationship per chart
 - If a categorical column separates the rows into more than one series, split on it with `color` (or `detail` when no legend is wanted). A `line` or `area` mark with no split joins points across series and produces a zigzag: two products sharing the same months, drawn as one line, alternate between them.
@@ -268,23 +271,31 @@ encoding:
     - {field: properties.<VALUE_COLUMN>, type: quantitative, format: ".2f"}
 ```
 
-Choropleth map, when the table has no geometry and must be joined to external boundaries:
+Choropleth map, when the table has no geometry and must be joined to external boundaries.
+A geoshape mark draws whatever geometry is in `data`, so here `data` is the boundary file
+rather than the table; this is the one chart where `data: {name: ...}` is wrong, because a
+table has no geometry and the map would render empty. The table is named inside
+`transform.lookup.from.data`, and the join reads the boundaries first, so `lookup` is the
+field on the boundaries and `key` is the matching column in the table.
 ```yaml
 data:
   url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
   format: {type: topojson, feature: states}
 transform:
-  - lookup: "properties.name"
+  - lookup: "properties.name"        # field on the boundaries
     from:
-      data: {name: {{ memory['table'] }}}  # the table name, exactly as given above
-      key: State
-      fields: [Total_Students]
+      data: {name: {{ memory['table'] }}}  # the table, exactly as named above
+      key: <TABLE_COLUMN_HOLDING_THE_STATE_NAME>   # must match a real column
+      fields: [<VALUE_COLUMN>, <TOOLTIP_COLUMN>]   # columns to pull in, real names
 mark: geoshape
 projection: {type: albersUsa}
 encoding:
-  color: {field: Total_Students, type: quantitative, scale: {scheme: blues}, legend: {title: "Total Students"}}
+  color: {field: <VALUE_COLUMN>, type: quantitative, scale: {scheme: blues}, legend: {title: "<VALUE_COLUMN>"}}
   tooltip:
     - {field: "properties.name", type: nominal, title: "State"}
-    - {field: Total_Students, type: quantitative, format: ",", title: "Total Students"}
+    - {field: <VALUE_COLUMN>, type: quantitative, format: ","}
+    - {field: <TOOLTIP_COLUMN>, type: quantitative, format: ","}
 ```
+Only the columns listed in `fields` exist after the join, so every `field` in `encoding`
+must be one of them (or `properties.<something>` from the boundaries).
 {% endblock %}

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -277,24 +277,35 @@ rather than the table; this is the one chart where `data: {name: ...}` is wrong,
 table has no geometry and the map would render empty. The table is named inside
 `transform.lookup.from.data`, and the join reads the boundaries first, so `lookup` is the
 field on the boundaries and `key` is the matching column in the table.
+
+Draw the boundaries twice: an unfilled base layer so regions the table does not cover
+still appear, then the joined layer on top. Without the base layer a region with no
+matching row is dropped rather than drawn, and a table covering 15 states leaves the
+other 35 as holes in the map. The base layer is outlined rather than filled so it reads
+on either a light or a dark theme.
 ```yaml
-data:
-  url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
-  format: {type: topojson, feature: states}
-transform:
-  - lookup: "properties.name"        # field on the boundaries
-    from:
-      data: {name: {{ memory['table'] }}}  # the table, exactly as named above
-      key: <TABLE_COLUMN_HOLDING_THE_STATE_NAME>   # must match a real column
-      fields: [<VALUE_COLUMN>, <TOOLTIP_COLUMN>]   # columns to pull in, real names
-mark: geoshape
 projection: {type: albersUsa}
-encoding:
-  color: {field: <VALUE_COLUMN>, type: quantitative, scale: {scheme: blues}, legend: {title: "<VALUE_COLUMN>"}}
-  tooltip:
-    - {field: "properties.name", type: nominal, title: "State"}
-    - {field: <VALUE_COLUMN>, type: quantitative, format: ","}
-    - {field: <TOOLTIP_COLUMN>, type: quantitative, format: ","}
+layer:
+  - data:
+      url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
+      format: {type: topojson, feature: states}
+    mark: {type: geoshape, fill: null, stroke: "#888888", strokeWidth: 0.5}
+  - data:
+      url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
+      format: {type: topojson, feature: states}
+    transform:
+      - lookup: "properties.name"        # field on the boundaries
+        from:
+          data: {name: {{ memory['table'] }}}  # the table, exactly as named above
+          key: <TABLE_COLUMN_HOLDING_THE_STATE_NAME>   # must match a real column
+          fields: [<VALUE_COLUMN>, <TOOLTIP_COLUMN>]   # columns to pull in, real names
+    mark: {type: geoshape, stroke: "white", strokeWidth: 0.5}
+    encoding:
+      color: {field: <VALUE_COLUMN>, type: quantitative, scale: {scheme: blues}, legend: {title: "<VALUE_COLUMN>"}}
+      tooltip:
+        - {field: "properties.name", type: nominal, title: "State"}
+        - {field: <VALUE_COLUMN>, type: quantitative, format: ","}
+        - {field: <TOOLTIP_COLUMN>, type: quantitative, format: ","}
 ```
 Only the columns listed in `fields` exist after the join, so every `field` in `encoding`
 must be one of them (or `properties.<something>` from the boundaries).

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -60,7 +60,9 @@ Legends appear when mapping data to `color`, `size`, or `shape` in encoding.
 
 **Stack order**: A stacked mark orders its segments alphabetically unless told otherwise. Add a numeric field via `calculate` and map it to the `order` channel to get a deliberate sequence.
 
-**Diverging colormaps**: When values straddle meaningful center (anomalies, deviations, above/below threshold) or diverging requested, pick diverging scheme and anchor center with `domainMid`: `scale: {scheme: redblue, domainMid: 0}`. Without it, neutral color sits at data midpoint and one side dominates. Schemes: `redblue`, `blueorange`, `redyellowblue`, `purplegreen`. Only when the values actually cross that center: a column running 6 to 15 never reaches a `domainMid` of 0, so half the ramp goes unused and every value collapses into a narrow band of near-identical color. Values all on one side of zero want a sequential scheme instead.
+**Diverging colormaps**: When values straddle meaningful center (anomalies, deviations, above/below threshold) or diverging requested, pick diverging scheme and anchor center with `domainMid`: `scale: {scheme: redblue, domainMid: 0}`. Without it, neutral color sits at data midpoint and one side dominates. Schemes: `redblue`, `blueorange`, `redyellowblue`, `purplegreen`. Only when the values actually cross that center: when they all sit on one side of the `domainMid`, half the ramp goes unused and the column collapses into a narrow band of near-identical color, so reach for a sequential scheme instead.
+
+**Choropleth layering**: A geoshape draws the geometry in its own `data`, so a table joined to external boundaries puts the boundary file in `data` and names the table inside `transform.lookup.from.data` — the one chart where `data: {name: ...}` is wrong. Layer the boundaries twice: an unfilled base layer, then the joined layer above it. A region with no matching row is dropped rather than drawn, so without the base layer it becomes a hole. Leave the base layer unencoded, since the joined columns do not exist in it.
 
 **Encoding follows intent**: sorted bars for a ranking, line for a trend, slope or dumbbell for before/after, binned bars or `mark: rect` for a distribution. Keep the one mark that makes the point and drop the rest.
 
@@ -271,18 +273,9 @@ encoding:
     - {field: properties.<VALUE_COLUMN>, type: quantitative, format: ".2f"}
 ```
 
-Choropleth map, when the table has no geometry and must be joined to external boundaries.
-A geoshape mark draws whatever geometry is in `data`, so here `data` is the boundary file
-rather than the table; this is the one chart where `data: {name: ...}` is wrong, because a
-table has no geometry and the map would render empty. The table is named inside
-`transform.lookup.from.data`, and the join reads the boundaries first, so `lookup` is the
-field on the boundaries and `key` is the matching column in the table.
-
-Draw the boundaries twice: an unfilled base layer so regions the table does not cover
-still appear, then the joined layer on top. Without the base layer a region with no
-matching row is dropped rather than drawn, and a table covering 15 states leaves the
-other 35 as holes in the map. The base layer is outlined rather than filled so it reads
-on either a light or a dark theme.
+Choropleth map, when the table has no geometry and must be joined to external boundaries
+(see **Choropleth layering** above). The join reads the boundaries first, so `lookup` is
+the field on the boundaries and `key` is the matching column in the table.
 ```yaml
 projection: {type: albersUsa}
 layer:
@@ -290,8 +283,6 @@ layer:
       url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
       format: {type: topojson, feature: states}
     mark: {type: geoshape, fill: null, stroke: "#888888", strokeWidth: 0.5}
-    # no encoding: the joined columns do not exist in this layer, so a tooltip
-    # naming them would show blanks over every region the table does not cover
   - data:
       url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
       format: {type: topojson, feature: states}
@@ -299,7 +290,7 @@ layer:
       - lookup: "properties.name"        # field on the boundaries
         from:
           data: {name: {{ memory['table'] }}}  # the table, exactly as named above
-          key: <TABLE_COLUMN_HOLDING_THE_STATE_NAME>   # must match a real column
+          key: <TABLE_JOIN_COLUMN>                     # must match a real column
           fields: [<VALUE_COLUMN>, <TOOLTIP_COLUMN>]   # columns to pull in, real names
     mark: {type: geoshape, stroke: "white", strokeWidth: 0.5}
     encoding:

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -276,7 +276,7 @@ data:
 transform:
   - lookup: "properties.name"
     from:
-      data: {name: <TABLE_NAME>}
+      data: {name: {{ memory['table'] }}}  # the table name, exactly as given above
       key: State
       fields: [Total_Students]
 mark: geoshape

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -60,7 +60,7 @@ Legends appear when mapping data to `color`, `size`, or `shape` in encoding.
 
 **Stack order**: A stacked mark orders its segments alphabetically unless told otherwise. Add a numeric field via `calculate` and map it to the `order` channel to get a deliberate sequence.
 
-**Diverging colormaps**: When values straddle meaningful center (anomalies, deviations, above/below threshold) or diverging requested, pick diverging scheme and anchor center with `domainMid`: `scale: {scheme: redblue, domainMid: 0}`. Without it, neutral color sits at data midpoint and one side dominates. Schemes: `redblue`, `blueorange`, `redyellowblue`, `purplegreen`.
+**Diverging colormaps**: When values straddle meaningful center (anomalies, deviations, above/below threshold) or diverging requested, pick diverging scheme and anchor center with `domainMid`: `scale: {scheme: redblue, domainMid: 0}`. Without it, neutral color sits at data midpoint and one side dominates. Schemes: `redblue`, `blueorange`, `redyellowblue`, `purplegreen`. Only when the values actually cross that center: a column running 6 to 15 never reaches a `domainMid` of 0, so half the ramp goes unused and every value collapses into a narrow band of near-identical color. Values all on one side of zero want a sequential scheme instead.
 
 **Encoding follows intent**: sorted bars for a ranking, line for a trend, slope or dumbbell for before/after, binned bars or `mark: rect` for a distribution. Keep the one mark that makes the point and drop the rest.
 
@@ -264,7 +264,7 @@ encoding:
   color:
     field: properties.<VALUE_COLUMN>
     type: quantitative
-    scale: {scheme: redblue, reverse: true}
+    scale: {scheme: blues}   # sequential; swap for a diverging scheme only if the values cross a meaningful center
     legend: {title: "<VALUE_COLUMN>"}
   tooltip:
     - {field: properties.<NAME_COLUMN>, type: nominal}
@@ -290,6 +290,8 @@ layer:
       url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
       format: {type: topojson, feature: states}
     mark: {type: geoshape, fill: null, stroke: "#888888", strokeWidth: 0.5}
+    # no encoding: the joined columns do not exist in this layer, so a tooltip
+    # naming them would show blanks over every region the table does not cover
   - data:
       url: "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
       format: {type: topojson, feature: states}

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -6,10 +6,7 @@ Generate complete, effective Vega-Lite visualizations clearly communicating data
 ## Essential Structure
 
 Every visualization must:
-- Use `data: {name: {{ memory['table'] }}}` with exact column names from source. The one
-  exception is a choropleth joined to external boundaries, where `data` must be the
-  boundary file and the table is named inside `transform.lookup.from` instead; see the
-  choropleth example below.
+- Use `data: {name: {{ memory['table'] }}}` with exact column names from source; a choropleth joined to external boundaries is the one exception (see Key Patterns)
 - Wrap all marks in `layer` array, each with own `mark` and `encoding`
 - Focus on ONE primary metric or relationship per chart
 - If a categorical column separates the rows into more than one series, split on it with `color` (or `detail` when no legend is wanted). A `line` or `area` mark with no split joins points across series and produces a zigzag: two products sharing the same months, drawn as one line, alternate between them.
@@ -62,7 +59,7 @@ Legends appear when mapping data to `color`, `size`, or `shape` in encoding.
 
 **Diverging colormaps**: When values straddle meaningful center (anomalies, deviations, above/below threshold) or diverging requested, pick diverging scheme and anchor center with `domainMid`: `scale: {scheme: redblue, domainMid: 0}`. Without it, neutral color sits at data midpoint and one side dominates. Schemes: `redblue`, `blueorange`, `redyellowblue`, `purplegreen`. Only when the values actually cross that center: when they all sit on one side of the `domainMid`, half the ramp goes unused and the column collapses into a narrow band of near-identical color, so reach for a sequential scheme instead.
 
-**Choropleth layering**: A geoshape draws the geometry in its own `data`, so a table joined to external boundaries puts the boundary file in `data` and names the table inside `transform.lookup.from.data` — the one chart where `data: {name: ...}` is wrong. Layer the boundaries twice: an unfilled base layer, then the joined layer above it. A region with no matching row is dropped rather than drawn, so without the base layer it becomes a hole. Leave the base layer unencoded, since the joined columns do not exist in it.
+**Choropleth layering**: A geoshape draws the geometry in its own `data`, so a table joined to external boundaries puts the boundary file in `data` and names the table inside `transform.lookup.from.data`. A region with no matching row is dropped rather than drawn, so draw the boundaries twice: an unencoded base layer, then the joined layer above it.
 
 **Encoding follows intent**: sorted bars for a ranking, line for a trend, slope or dumbbell for before/after, binned bars or `mark: rect` for a distribution. Keep the one mark that makes the point and drop the rest.
 
@@ -266,16 +263,14 @@ encoding:
   color:
     field: properties.<VALUE_COLUMN>
     type: quantitative
-    scale: {scheme: blues}   # sequential; swap for a diverging scheme only if the values cross a meaningful center
+    scale: {scheme: blues}
     legend: {title: "<VALUE_COLUMN>"}
   tooltip:
     - {field: properties.<NAME_COLUMN>, type: nominal}
     - {field: properties.<VALUE_COLUMN>, type: quantitative, format: ".2f"}
 ```
 
-Choropleth map, when the table has no geometry and must be joined to external boundaries
-(see **Choropleth layering** above). The join reads the boundaries first, so `lookup` is
-the field on the boundaries and `key` is the matching column in the table.
+Choropleth map, when the table has no geometry and must be joined to external boundaries:
 ```yaml
 projection: {type: albersUsa}
 layer:
@@ -289,17 +284,14 @@ layer:
     transform:
       - lookup: "properties.name"        # field on the boundaries
         from:
-          data: {name: {{ memory['table'] }}}  # the table, exactly as named above
-          key: <TABLE_JOIN_COLUMN>                     # must match a real column
-          fields: [<VALUE_COLUMN>, <TOOLTIP_COLUMN>]   # columns to pull in, real names
+          data: {name: {{ memory['table'] }}}          # the table, named exactly
+          key: <TABLE_JOIN_COLUMN>                     # matching column in the table
+          fields: [<VALUE_COLUMN>]                     # only these exist after the join
     mark: {type: geoshape, stroke: "white", strokeWidth: 0.5}
     encoding:
       color: {field: <VALUE_COLUMN>, type: quantitative, scale: {scheme: blues}, legend: {title: "<VALUE_COLUMN>"}}
       tooltip:
         - {field: "properties.name", type: nominal, title: "State"}
         - {field: <VALUE_COLUMN>, type: quantitative, format: ","}
-        - {field: <TOOLTIP_COLUMN>, type: quantitative, format: ","}
 ```
-Only the columns listed in `fields` exist after the join, so every `field` in `encoding`
-must be one of them (or `properties.<something>` from the boundaries).
 {% endblock %}

--- a/lumen/tests/ai/test_vega_lite.py
+++ b/lumen/tests/ai/test_vega_lite.py
@@ -149,3 +149,63 @@ def test_palette_reaches_the_compiled_vega_scale():
     compiled = vl_convert.vegalite_to_vega(spec)
 
     assert compiled["config"]["range"]["category"] == category_palette()
+
+
+class TestGeoshapeGeometryValidation:
+    """A geoshape over a table with no geometry compiles cleanly and draws nothing,
+    so validation has to reject it or the only symptom is an empty canvas."""
+
+    BOUNDARIES = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json"
+
+    def test_rejects_geoshape_bound_to_the_table(self):
+        spec = {
+            "data": {"name": "avg_pm25_by_state"},
+            "projection": {"type": "albersUsa"},
+            "layer": [{
+                "mark": {"type": "geoshape", "stroke": "white"},
+                "encoding": {"color": {"field": "avg_pm25", "type": "quantitative"}},
+            }],
+            "transform": [{
+                "lookup": "properties.name",
+                "from": {
+                    "data": {"url": self.BOUNDARIES, "format": {"type": "topojson", "feature": "states"}},
+                    "key": "properties.name",
+                    "fields": ["state"],
+                },
+            }],
+        }
+        with pytest.raises(RuntimeError, match="carries no geometry"):
+            VegaLiteEditor.validate_spec(spec)
+
+    def test_accepts_boundaries_as_primary_data(self):
+        spec = {
+            "data": {"url": self.BOUNDARIES, "format": {"type": "topojson", "feature": "states"}},
+            "transform": [{
+                "lookup": "properties.name",
+                "from": {"data": {"name": "t"}, "key": "state", "fields": ["avg_pm25"]},
+            }],
+            "mark": "geoshape",
+            "projection": {"type": "albersUsa"},
+            "encoding": {"color": {"field": "avg_pm25", "type": "quantitative"}},
+        }
+        VegaLiteEditor.validate_spec(spec)
+
+    def test_accepts_omitted_data_for_own_geometry(self):
+        """The table's own geometry is injected at render time, so the spec has no data."""
+        spec = {
+            "mark": "geoshape",
+            "projection": {"type": "naturalEarth1"},
+            "encoding": {"color": {"field": "properties.avg_pm25", "type": "quantitative"}},
+        }
+        VegaLiteEditor.validate_spec(spec)
+
+    def test_leaves_non_geographic_charts_alone(self):
+        spec = {
+            "data": {"name": "t"},
+            "mark": "bar",
+            "encoding": {
+                "x": {"field": "state", "type": "nominal"},
+                "y": {"field": "avg_pm25", "type": "quantitative"},
+            },
+        }
+        VegaLiteEditor.validate_spec(spec)

--- a/lumen/tests/ai/test_vega_lite.py
+++ b/lumen/tests/ai/test_vega_lite.py
@@ -199,6 +199,50 @@ class TestGeoshapeGeometryValidation:
         }
         VegaLiteEditor.validate_spec(spec)
 
+    def test_accepts_the_two_layer_base_plus_join_pattern(self):
+        """The base layer keeps regions the table does not cover on the map."""
+        boundaries = {"url": self.BOUNDARIES, "format": {"type": "topojson", "feature": "states"}}
+        spec = {
+            "projection": {"type": "albersUsa"},
+            "layer": [
+                {"data": boundaries, "mark": {"type": "geoshape", "fill": "#eeeeee"}},
+                {
+                    "data": boundaries,
+                    "transform": [{
+                        "lookup": "properties.name",
+                        "from": {"data": {"name": "t"}, "key": "state", "fields": ["avg_pm25"]},
+                    }],
+                    "mark": "geoshape",
+                    "encoding": {"color": {"field": "avg_pm25", "type": "quantitative"}},
+                },
+            ],
+        }
+        VegaLiteEditor.validate_spec(spec)
+
+    def test_rejects_a_layer_bound_to_the_table(self):
+        spec = {
+            "projection": {"type": "albersUsa"},
+            "layer": [{
+                "data": {"name": "t"},
+                "mark": "geoshape",
+                "encoding": {"color": {"field": "avg_pm25", "type": "quantitative"}},
+            }],
+        }
+        with pytest.raises(RuntimeError, match="carries no geometry"):
+            VegaLiteEditor.validate_spec(spec)
+
+    def test_rejects_a_layer_inheriting_table_bound_data(self):
+        """A layer with no data of its own uses its parent's, so the check follows it."""
+        spec = {
+            "data": {"name": "t"},
+            "layer": [{
+                "mark": "geoshape",
+                "encoding": {"color": {"field": "avg_pm25", "type": "quantitative"}},
+            }],
+        }
+        with pytest.raises(RuntimeError, match="carries no geometry"):
+            VegaLiteEditor.validate_spec(spec)
+
     def test_leaves_non_geographic_charts_alone(self):
         spec = {
             "data": {"name": "t"},

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -384,6 +384,71 @@ def test_vega_datasets(set_root):
     pd.testing.assert_frame_equal(final_spec["datasets"]["test"], pipeline.data)
 
 
+def _choropleth_spec(dataset_name):
+    """A choropleth joining the table onto US state outlines via a lookup."""
+    return {
+        "data": {
+            "url": "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json",
+            "format": {"type": "topojson", "feature": "states"},
+        },
+        "transform": [{
+            "lookup": "properties.name",
+            "from": {"data": {"name": dataset_name}, "key": "A", "fields": ["B"]},
+        }],
+        "mark": "geoshape",
+        "projection": {"type": "albersUsa"},
+        "encoding": {"color": {"field": "B", "type": "quantitative"}},
+    }
+
+
+def test_vega_lookup_dataset_name_is_preserved_when_correct(set_root):
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+
+    final_spec = VegaLiteView(spec=_choropleth_spec("test"), pipeline=pipeline).get_panel().object
+
+    assert final_spec["transform"][0]["from"]["data"]["name"] == "test"
+
+
+def test_vega_lookup_dataset_name_is_repointed_when_wrong(set_root):
+    """A lookup naming a dataset that was never registered renders an empty map
+    and raises nothing, so the only correct table name is substituted in."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    spec = _choropleth_spec("some_table_that_was_never_registered")
+
+    final_spec = VegaLiteView(spec=spec, pipeline=pipeline).get_panel().object
+
+    assert final_spec["transform"][0]["from"]["data"]["name"] == "test"
+    assert "test" in final_spec["datasets"]
+    # the caller's spec must not be edited underneath them
+    assert spec["transform"][0]["from"]["data"]["name"] == "some_table_that_was_never_registered"
+
+
+def test_vega_lookup_with_its_own_data_is_left_alone(set_root):
+    """A lookup carrying inline values is self-contained and must not be repointed."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    spec = _choropleth_spec("irrelevant")
+    spec["transform"][0]["from"]["data"] = {"values": [{"A": 1, "B": 2}]}
+
+    final_spec = VegaLiteView(spec=spec, pipeline=pipeline).get_panel().object
+
+    assert final_spec["transform"][0]["from"]["data"] == {"values": [{"A": 1, "B": 2}]}
+
+
+def test_vega_datasets_are_not_accumulated_across_renders(set_root):
+    """self.spec is reused between renders, so registering into it would leak frames."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    view = VegaLiteView(spec=_choropleth_spec("test"), pipeline=pipeline)
+
+    view.get_panel()
+    view.get_panel()
+
+    assert "datasets" not in view.spec
+
+
 def test_vega_defaults_schema(set_root):
     set_root(str(Path(__file__).parent.parent))
     source = FileSource(tables={'test': 'sources/test.csv'})

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -629,3 +629,45 @@ def test_deckgl_view_geometry_with_datetime_column():
     data = DeckGLView._layer_data(gdf)
     assert data['features'][0]['properties']['date'].startswith('2026-06-15')
     json.dumps(data)  # must be serializable
+
+
+def test_deckgl_geojson_layer_without_geometry_raises(set_root):
+    """A GeoJsonLayer handed plain records draws an empty basemap and reports
+    nothing, so the mismatch has to surface as an error instead."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    spec = {
+        "layers": [{"@@type": "GeoJsonLayer", "id": "choropleth"}],
+        "initialViewState": {"latitude": 39.5, "longitude": -98.35, "zoom": 3},
+    }
+
+    with pytest.raises(ValueError, match="needs geometry"):
+        DeckGLView(pipeline=pipeline, spec=spec)._get_params()
+
+
+def test_deckgl_non_geojson_layers_still_receive_records(set_root):
+    """Only GeoJsonLayer needs geometry; other layers take records as before."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    spec = {
+        "layers": [{"@@type": "ScatterplotLayer", "id": "points"}],
+        "initialViewState": {"latitude": 39.5, "longitude": -98.35, "zoom": 3},
+    }
+
+    params = DeckGLView(pipeline=pipeline, spec=spec)._get_params()
+
+    assert params["object"]["layers"][0]["data"] == pipeline.data.to_dict(orient="records")
+
+
+def test_deckgl_geojson_layer_with_its_own_data_is_left_alone(set_root):
+    """A layer that already carries data is not the injection path."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    spec = {
+        "layers": [{"@@type": "GeoJsonLayer", "id": "boundaries", "data": "https://example.com/x.json"}],
+        "initialViewState": {"latitude": 39.5, "longitude": -98.35, "zoom": 3},
+    }
+
+    params = DeckGLView(pipeline=pipeline, spec=spec)._get_params()
+
+    assert params["object"]["layers"][0]["data"] == "https://example.com/x.json"

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -466,6 +466,38 @@ def test_vega_datasets_are_not_accumulated_across_renders(set_root):
     assert set(view.spec["datasets"]) == {"populations"}
 
 
+def test_vega_layered_choropleth_registers_the_named_dataset(set_root):
+    """A layered choropleth carries the boundary url on each layer, not at the top
+    level, so registration has to look deeper or the lookup joins nothing."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    boundaries = {
+        "url": "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json",
+        "format": {"type": "topojson", "feature": "states"},
+    }
+    spec = {
+        "projection": {"type": "albersUsa"},
+        "layer": [
+            {"data": boundaries, "mark": {"type": "geoshape", "fill": None}},
+            {
+                "data": boundaries,
+                "transform": [{
+                    "lookup": "properties.name",
+                    "from": {"data": {"name": "test"}, "key": "A", "fields": ["B"]},
+                }],
+                "mark": "geoshape",
+                "encoding": {"color": {"field": "B", "type": "quantitative"}},
+            },
+        ],
+    }
+
+    final_spec = VegaLiteView(spec=spec, pipeline=pipeline).get_panel().object
+
+    assert "test" in final_spec["datasets"]
+    # the table must not also replace the boundaries as primary data
+    assert "data" not in final_spec
+
+
 def test_vega_defaults_schema(set_root):
     set_root(str(Path(__file__).parent.parent))
     source = FileSource(tables={'test': 'sources/test.csv'})

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -410,6 +410,20 @@ def test_vega_lookup_dataset_name_is_preserved_when_correct(set_root):
     assert final_spec["transform"][0]["from"]["data"]["name"] == "test"
 
 
+def test_vega_lookup_naming_another_registered_dataset_is_left_alone(set_root):
+    """A spec may declare its own datasets; a lookup resolving to one of those is
+    already correct and must not be dragged onto the pipeline table."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    spec = _choropleth_spec("populations")
+    spec["datasets"] = {"populations": [{"A": "a", "B": 1}]}
+
+    final_spec = VegaLiteView(spec=spec, pipeline=pipeline).get_panel().object
+
+    assert final_spec["transform"][0]["from"]["data"]["name"] == "populations"
+    assert set(final_spec["datasets"]) == {"populations", "test"}
+
+
 def test_vega_lookup_dataset_name_is_repointed_when_wrong(set_root):
     """A lookup naming a dataset that was never registered renders an empty map
     and raises nothing, so the only correct table name is substituted in."""
@@ -438,15 +452,18 @@ def test_vega_lookup_with_its_own_data_is_left_alone(set_root):
 
 
 def test_vega_datasets_are_not_accumulated_across_renders(set_root):
-    """self.spec is reused between renders, so registering into it would leak frames."""
+    """self.spec is reused between renders, so registering into its own datasets
+    dict would leave a DataFrame behind on the caller's spec."""
     set_root(str(Path(__file__).parent.parent))
     pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
-    view = VegaLiteView(spec=_choropleth_spec("test"), pipeline=pipeline)
+    spec = _choropleth_spec("test")
+    spec["datasets"] = {"populations": [{"A": "a", "B": 1}]}
+    view = VegaLiteView(spec=spec, pipeline=pipeline)
 
     view.get_panel()
     view.get_panel()
 
-    assert "datasets" not in view.spec
+    assert set(view.spec["datasets"]) == {"populations"}
 
 
 def test_vega_defaults_schema(set_root):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1462,6 +1462,39 @@ class VegaLiteView(View):
 
     _extension = 'vega'
 
+    @classmethod
+    def _retarget_lookup_datasets(cls, node: Any, known: set[str], table: str) -> None:
+        """
+        Point every ``lookup`` transform at a dataset that actually exists, in place.
+
+        A choropleth joins the table onto map outlines, so the table travels as a
+        named dataset and the lookup has to name it exactly. Nothing validates
+        that name: Vega-Lite's schema only checks structure, so a spec naming a
+        dataset that was never registered passes every server-side check and then
+        renders an empty canvas with no error at all. Only one table is ever
+        registered per view, so an unresolvable name has exactly one correct value.
+
+        Lookups carrying their own ``values`` or ``url`` are self-contained and
+        left alone; only a dangling ``name`` is repointed.
+        """
+        if isinstance(node, list):
+            for item in node:
+                cls._retarget_lookup_datasets(item, known, table)
+            return
+        if not isinstance(node, dict):
+            return
+
+        source = node.get("from") if "lookup" in node else None
+        data = source.get("data") if isinstance(source, dict) else None
+        if (
+            isinstance(data, dict) and not {"values", "url"} & data.keys()
+            and data.get("name") not in known
+        ):
+            data["name"] = table
+
+        for value in node.values():
+            cls._retarget_lookup_datasets(value, known, table)
+
     def _get_params(self) -> dict[str, Any]:
         df = self.get_data()
         spec_data = self.spec.get('data', {})
@@ -1471,9 +1504,13 @@ class VegaLiteView(View):
 
         if 'url' in spec_data or 'inline' in spec_data:
             # If data already has url/inline data, make pipeline data available as named dataset
-            # Don't inject into primary data, use datasets instead
-            datasets = self.spec.get('datasets', {})
+            # Don't inject into primary data, use datasets instead.
+            # Copied rather than mutated in place: self.spec is reused across
+            # renders, and growing its datasets dict would leak frames.
+            datasets = dict(self.spec.get('datasets', {}))
             datasets[self.pipeline.table] = df
+            spec = copy.deepcopy({k: v for k, v in spec.items() if k != 'datasets'})
+            self._retarget_lookup_datasets(spec, set(datasets), self.pipeline.table)
             encoded = dict(spec, datasets=datasets)
         elif is_geodataframe(df):
             # geoshape consumes a FeatureCollection, so fields then live under

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1463,6 +1463,24 @@ class VegaLiteView(View):
     _extension = 'vega'
 
     @classmethod
+    def _declares_own_data(cls, node: Any) -> bool:
+        """Whether the spec supplies its own data (a url or inline values) anywhere.
+
+        A layered choropleth carries the boundary url on each layer rather than at
+        the top level, so looking only at ``spec['data']`` would miss it, inject
+        the table as primary data, and leave the lookup's named dataset
+        unregistered -- which renders the boundaries with every value null.
+        """
+        if isinstance(node, list):
+            return any(cls._declares_own_data(item) for item in node)
+        if not isinstance(node, dict):
+            return False
+        data = node.get("data")
+        if isinstance(data, dict) and ("url" in data or "inline" in data):
+            return True
+        return any(cls._declares_own_data(value) for value in node.values())
+
+    @classmethod
     def _retarget_lookup_datasets(cls, node: Any, known: set[str], table: str) -> None:
         """
         Point every ``lookup`` transform at a dataset that actually exists, in place.
@@ -1502,9 +1520,10 @@ class VegaLiteView(View):
         if "$schema" not in spec:
             spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
 
-        if 'url' in spec_data or 'inline' in spec_data:
-            # If data already has url/inline data, make pipeline data available as named dataset
-            # Don't inject into primary data, use datasets instead.
+        if self._declares_own_data(spec):
+            # The spec brings its own data (e.g. map boundaries), so the pipeline
+            # travels as a named dataset for lookups to join against rather than
+            # replacing it.
             # Copied rather than mutated in place: self.spec is reused across
             # renders, and growing its datasets dict would leak frames.
             datasets = dict(self.spec.get('datasets', {}))

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1576,12 +1576,25 @@ class DeckGLView(View):
         # Deep copy to avoid modifying self.spec when injecting data
         spec = copy.deepcopy(self.spec)
 
-        # Inject data into layers
-        if 'layers' in spec:
+        # Inject data into layers that do not carry their own
+        pending = [layer for layer in spec.get('layers', []) if 'data' not in layer]
+        if pending:
+            # A GeoJsonLayer draws the geometry in its data. Handed plain records
+            # it renders an empty basemap and reports nothing, so the only symptom
+            # is a blank map; deck.gl cannot join boundaries by name, which is what
+            # a table of place names would need. Checked before serializing, so a
+            # rejected spec does not pay to convert the frame first.
+            if not is_geodataframe(df) and any(
+                layer.get('@@type') == 'GeoJsonLayer' for layer in pending
+            ):
+                raise ValueError(
+                    "A GeoJsonLayer needs geometry to draw, but this table has none. "
+                    "Either supply a table with a geometry column, or render place "
+                    "names as a Vega-Lite choropleth, which joins boundaries by name."
+                )
             data = self._layer_data(df)
-            for layer in spec['layers']:
-                if 'data' not in layer:
-                    layer['data'] = data
+            for layer in pending:
+                layer['data'] = data
 
         return dict(object=spec, tooltips=self.tooltips, **self.kwargs)
 


### PR DESCRIPTION
A choropleth joins the table onto map outlines, so the table travels as a named dataset and the `lookup` transform has to name it exactly; nothing validates that name, so a spec naming a dataset that was never registered passes every server-side check and then renders a blank map with no error anywhere. `VegaLiteView` now repoints a dangling lookup at the one dataset it actually registered, and the choropleth example in the prompt shows the real table name instead of a `<TABLE_NAME>` placeholder.

Also copies the spec's `datasets` dict before writing to it, which was leaving a DataFrame on the caller's spec on every render.
