### PR TITLE
Add opt-in model routing (#2004)

### DIFF
--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -143,11 +143,14 @@ class Llm(param.Parameterized):
         'default', 'reasoning' and 'sql'. Agents may pick which model to
         invoke for different reasons.
 
-        An entry may declare a 'routing' key to opt in to model routing for
-        that type: the routing model is invoked first to pick which entry to
-        actually use for each call, e.g.
+        An entry may declare an optional 'description' (shown to the routing
+        model so it can reason about what each option is for) and an optional
+        'routing' key to opt in to model routing for that type: the routing
+        model is invoked first to pick which entry to actually use for each
+        call, e.g.
         {"default": {"model": "gpt-5.4-mini"},
          "edit": {"model": "gpt-5.2",
+                  "description": "Best for editing tables and visualizations",
                   "routing": {"model": "nemotron-switchyard"}}}""")
 
     tools = param.List(default=[], doc="""
@@ -226,6 +229,17 @@ class Llm(param.Parameterized):
                 f"Please specify a 'default' model in the model_kwargs "
                 f"parameter for {self.__class__.__name__}."
             )
+        for spec_name, config in self.model_kwargs.items():
+            if (
+                isinstance(config, dict)
+                and "routing" in config
+                and not isinstance(config["routing"], dict)
+            ):
+                raise ValueError(
+                    f"Invalid 'routing' entry for model spec {spec_name!r} in "
+                    f"model_kwargs: expected a dict, got "
+                    f"{type(config['routing']).__name__}."
+                )
 
     @param.depends("logfire_tags", watch=True)
     def _update_logfire_tags(self):
@@ -240,12 +254,20 @@ class Llm(param.Parameterized):
         """
         Can specify model kwargs as a dict or as a string that is a key in the model_kwargs
         or as a string that is a model type; else the actual name of the model.
+
+        The ``routing`` and ``description`` keys are routing-only directives and are
+        stripped here so they can never reach a provider's ``get_client`` and from
+        there the SDK constructor. ``_get_model_kwargs`` is the single place every
+        provider resolves its model config, so stripping here protects them all.
         """
         if isinstance(model_spec, dict):
-            return model_spec
-
-        model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
-        return dict(model_kwargs)
+            model_kwargs = dict(model_spec)
+        else:
+            model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
+            model_kwargs = dict(model_kwargs)
+        model_kwargs.pop("routing", None)
+        model_kwargs.pop("description", None)
+        return model_kwargs
 
     def _get_create_kwargs(self, response_model: type[BaseModel] | None) -> dict[str, Any]:
         kwargs = dict(self.create_kwargs)
@@ -412,6 +434,26 @@ class Llm(param.Parameterized):
             model_spec=(Literal[*tuple(self.model_kwargs)], ...),
         )
 
+    def _routing_system_prompt(self) -> str:
+        """Build the dedicated system prompt for the routing call.
+
+        The router is told it is choosing between the configured ``model_kwargs``
+        entries and is given each entry's optional ``description`` so it can
+        reason about what each option is for, rather than bare key names.
+        """
+        options = "\n".join(
+            f"- {key}: {config.get('description', 'No description provided.')}"
+            for key, config in self.model_kwargs.items()
+            if isinstance(config, dict)
+        )
+        return (
+            "You are a routing model. Based on the user's request, choose the "
+            "configured model type that is best suited to handle it.\n"
+            "Available model types:\n"
+            f"{options}\n"
+            "Reply with exactly one of the option names above."
+        )
+
     async def _resolve_routing(
         self,
         model_spec: str | dict,
@@ -419,27 +461,35 @@ class Llm(param.Parameterized):
     ) -> str | dict:
         """
         Pick which ``model_kwargs`` entry to use via a routing model when the
-        resolved config for ``model_spec`` declares one.
+        entry named by ``model_spec`` declares a ``routing`` config.
 
-        Only string ``model_spec`` values are routed. A dict ``model_spec``
-        bypasses the ``model_kwargs`` lookup entirely in ``_get_model_kwargs``,
-        which is exactly what the routing call below relies on: it always uses
-        a dict spec, so a routing call can never trigger routing for itself
-        (no recursion guard is needed).
+        Only string ``model_spec`` values that name a key in ``model_kwargs`` are
+        routed: dict specs bypass the ``model_kwargs`` lookup entirely and
+        repo-id strings (e.g. LlamaCpp) are not keys, so both are never routed.
+
+        The routing call itself uses a dict spec and ``tools=[]``, so it can
+        never trigger routing for itself nor run the real tool loop. When
+        routing picks an entry, that entry's resolved config is returned as a
+        dict: dict specs bypass ``_resolve_routing`` downstream, so a routed
+        spec threads through the tool loop and ``stream()`` recursion without
+        being re-resolved (and without paying another routing call per round).
         """
         if isinstance(model_spec, dict):
             return model_spec
 
-        config = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
-        routing_spec = config.get("routing")
+        routing_spec = self.model_kwargs.get(model_spec, {}).get("routing")
         if not routing_spec:
             return model_spec
 
+        routing_spec = dict(routing_spec)
+        routing_prompt = self._routing_system_prompt()
         try:
             route = await self.invoke(
-                messages=messages,
-                model_spec=dict(routing_spec),
+                messages=[m for m in messages if m.get("role") != "system"],
+                system=routing_prompt,
+                model_spec=routing_spec,
                 response_model=self._route_spec_model(),
+                tools=[],
             )
         except Exception:
             log_debug(
@@ -452,7 +502,7 @@ class Llm(param.Parameterized):
             )
             return model_spec
         log_debug(f"Routing {model_spec!r} -> {route.model_spec!r}", prefix="[LLM routing]")
-        return route.model_spec
+        return dict(self._get_model_kwargs(route.model_spec))
 
     async def invoke(
         self,
@@ -609,12 +659,19 @@ class Llm(param.Parameterized):
         self,
         tools: list[dict[str, Any] | FunctionTool | MCPTool] | None,
     ) -> list[dict[str, Any] | FunctionTool | MCPTool] | None:
-        """Combine instance-level ``self.tools`` with per-call *tools*."""
-        if self.tools and tools:
+        """Combine instance-level ``self.tools`` with per-call *tools*.
+
+        ``tools=None`` means "use instance tools"; an explicit empty list opts
+        out of instance tools entirely (used by the routing call so the routing
+        model never runs the real tool loop).
+        """
+        if tools is None:
+            return list(self.tools) if self.tools else None
+        if not tools:
+            return []
+        if self.tools:
             return list(self.tools) + list(tools)
-        elif self.tools:
-            return list(self.tools)
-        return tools
+        return list(tools)
 
     @classmethod
     def _normalize_tools(
@@ -925,6 +982,7 @@ class Llm(param.Parameterized):
         """
         combined_tools = self._combine_tools(tools)
         _, tool_instances, tool_contexts = self._normalize_tools(combined_tools)
+        model_spec = await self._resolve_routing(model_spec, messages)
         messages, contains_image = self._check_for_image(messages)
         if self.logfire_tags is not None or contains_image:
             output = await self.invoke(
@@ -1115,14 +1173,13 @@ class LlamaCpp(Llm, LlamaCppMixin):
     _instructor_wrapper = None
 
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
-        if isinstance(model_spec, dict):
-            return model_spec
-
-        if model_spec in self.model_kwargs or "/" not in model_spec:
+        if isinstance(model_spec, dict) or model_spec in self.model_kwargs or "/" not in model_spec:
             model_kwargs = super()._get_model_kwargs(model_spec)
         else:
             base_kwargs = self.model_kwargs["default"]
             model_kwargs = self.resolve_model_spec(model_spec, base_kwargs)
+            model_kwargs.pop("routing", None)
+            model_kwargs.pop("description", None)
 
         if "n_ctx" not in model_kwargs:
             model_kwargs["n_ctx"] = 0
@@ -2618,10 +2675,7 @@ class MLX(Llm):
             self._instructor_wrapper = "openai"
 
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
-        if isinstance(model_spec, dict):
-            return model_spec
-        model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
-        return dict(model_kwargs)
+        return super()._get_model_kwargs(model_spec)
 
     def _load_mlx_model(self, model_id: str) -> tuple:
         """Load and cache an MLX model. Duplicate loads are harmless but wasteful."""

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -153,6 +153,12 @@ class Llm(param.Parameterized):
                   "description": "Best for editing tables and visualizations",
                   "routing": {"model": "nemotron-switchyard"}}}""")
 
+    spec_descriptions = param.Dict(default={}, doc="""
+        Mapping of spec key to human-readable description, used as a
+        fallback in the routing prompt when ``model_kwargs`` entries
+        do not declare their own ``description``.  Populated externally
+        (e.g. by the UI layer) from agent class metadata.""")
+
     tools = param.List(default=[], doc="""
         Default tools that are always available to this LLM instance.
         These are combined with any tools passed directly to invoke()
@@ -438,11 +444,16 @@ class Llm(param.Parameterized):
         """Build the dedicated system prompt for the routing call.
 
         The router is told it is choosing between the configured ``model_kwargs``
-        entries and is given each entry's optional ``description`` so it can
-        reason about what each option is for, rather than bare key names.
+        entries and is given each entry's description so it can reason about
+        what each option is for, rather than bare key names.
+
+        Descriptions are resolved in order: an explicit ``description`` key in
+        the ``model_kwargs`` entry wins first; then ``spec_descriptions``
+        (populated externally from agent metadata) is consulted as a fallback;
+        finally the literal ``"No description provided."`` is used.
         """
         options = "\n".join(
-            f"- {key}: {config.get('description', 'No description provided.')}"
+            f"- {key}: {config.get('description', self.spec_descriptions.get(key, 'No description provided.'))}"
             for key, config in self.model_kwargs.items()
             if isinstance(config, dict)
         )
@@ -453,6 +464,22 @@ class Llm(param.Parameterized):
             f"{options}\n"
             "Reply with exactly one of the option names above."
         )
+
+    def _strip_for_routing(self, messages: list[Message]) -> list[Message]:
+        """Prepare messages for the routing call: last user message only, images removed."""
+        user_msgs = [m for m in messages if m.get("role") == "user"]
+        if not user_msgs:
+            return []
+        last = dict(user_msgs[-1])
+        content = last.get("content")
+        if isinstance(content, list):
+            last["content"] = [
+                item for item in content
+                if not (isinstance(item, dict) and item.get("type") == "image_url")
+            ]
+        elif isinstance(content, (bytes, Image)):
+            last["content"] = ""
+        return [last]
 
     async def _resolve_routing(
         self,
@@ -483,9 +510,10 @@ class Llm(param.Parameterized):
 
         routing_spec = dict(routing_spec)
         routing_prompt = self._routing_system_prompt()
+        routing_messages = self._strip_for_routing(messages)
         try:
             route = await self.invoke(
-                messages=[m for m in messages if m.get("role") != "system"],
+                messages=routing_messages,
                 system=routing_prompt,
                 model_spec=routing_spec,
                 response_model=self._route_spec_model(),
@@ -542,6 +570,7 @@ class Llm(param.Parameterized):
         """
         system = system.strip().replace("\n\n", "\n")
         messages, input_kwargs = self._add_system_message(messages, system, input_kwargs)
+        messages, contains_image = self._check_for_image(messages)
         model_spec = await self._resolve_routing(model_spec, messages)
         max_tool_rounds = int(input_kwargs.pop("max_tool_rounds", 16))
 
@@ -552,7 +581,6 @@ class Llm(param.Parameterized):
         if tool_specs is not None:
             kwargs["tools"] = tool_specs
 
-        messages, contains_image = self._check_for_image(messages)
         if contains_image:
             # Currently instructor does not support streaming with multimodal
             # https://github.com/567-labs/instructor/issues/1872
@@ -982,8 +1010,8 @@ class Llm(param.Parameterized):
         """
         combined_tools = self._combine_tools(tools)
         _, tool_instances, tool_contexts = self._normalize_tools(combined_tools)
-        model_spec = await self._resolve_routing(model_spec, messages)
         messages, contains_image = self._check_for_image(messages)
+        model_spec = await self._resolve_routing(model_spec, messages)
         if self.logfire_tags is not None or contains_image:
             output = await self.invoke(
                 messages,

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -468,11 +468,11 @@ class Llm(param.Parameterized):
         repo-id strings (e.g. LlamaCpp) are not keys, so both are never routed.
 
         The routing call itself uses a dict spec and ``tools=[]``, so it can
-        never trigger routing for itself nor run the real tool loop. When
-        routing picks an entry, that entry's resolved config is returned as a
-        dict: dict specs bypass ``_resolve_routing`` downstream, so a routed
-        spec threads through the tool loop and ``stream()`` recursion without
-        being re-resolved (and without paying another routing call per round).
+        never trigger routing for itself nor run the real tool loop. Both
+        the success and fallback paths return a dict config: dict specs
+        bypass ``_resolve_routing`` downstream, so a resolved spec threads
+        through the tool loop and ``stream()`` recursion without being
+        re-resolved (and without paying another routing call per round).
         """
         if isinstance(model_spec, dict):
             return model_spec
@@ -500,7 +500,7 @@ class Llm(param.Parameterized):
                 prefix="[LLM routing]",
                 show_sep="above",
             )
-            return model_spec
+            return dict(self._get_model_kwargs(model_spec))
         log_debug(f"Routing {model_spec!r} -> {route.model_spec!r}", prefix="[LLM routing]")
         return dict(self._get_model_kwargs(route.model_spec))
 
@@ -680,7 +680,7 @@ class Llm(param.Parameterized):
     ) -> tuple[list[dict[str, Any]] | None, dict[str, FunctionTool | MCPTool], dict[str, Any]]:
         tool_instances: dict[str, FunctionTool | MCPTool] = {}
         tool_contexts: dict[str, Any] = {}
-        if tools is None:
+        if not tools:
             return None, tool_instances, tool_contexts
         tool_specs: list[dict[str, Any]] = []
         for tool in tools:
@@ -2673,9 +2673,6 @@ class MLX(Llm):
         if self._use_endpoint:
             # Override to use OpenAI-compatible wrapper
             self._instructor_wrapper = "openai"
-
-    def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
-        return super()._get_model_kwargs(model_spec)
 
     def _load_mlx_model(self, model_id: str) -> tuple:
         """Load and cache an MLX model. Duplicate loads are harmless but wasteful."""

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -7,7 +7,7 @@ import os
 import traceback
 
 from collections.abc import Callable
-from functools import partial
+from functools import lru_cache, partial
 from pathlib import Path
 from typing import (
     TYPE_CHECKING, Any, Literal, NotRequired, TypedDict,
@@ -84,6 +84,34 @@ ADAPTIVE_KWARGS = {
     "reasoning_effort": "none",
 }
 
+# Every content shape a message may carry an image in, before and after
+# _check_for_image normalises it.
+IMAGE_TYPES = (bytes, Image, pn.pane.image.ImageBase)
+
+# model_kwargs entries that configure routing rather than the provider client,
+# and so must never reach an SDK constructor.
+ROUTING_KEYS = ("routing", "description")
+
+# The spec keys every provider shares, described for the routing prompt. Agent
+# specs are added on top by the UI layer, which can reach agent metadata.
+SPEC_DESCRIPTIONS = {
+    "default": "General purpose model for most tasks",
+    "edit": "Advanced model for retry & edit tasks",
+    "ui": "Lightweight model for UI interactions",
+}
+
+
+@lru_cache
+def build_route_spec_model(spec_keys: tuple[str, ...]) -> type[BaseModel]:
+    """Build the pydantic model constraining the routing model's output.
+
+    The ``model_spec`` field is constrained via a ``Literal`` to the keys
+    present in ``model_kwargs``, so a hallucinated key cannot silently fall
+    back to ``'default'`` unnoticed. Cached on the keys because instructor
+    re-derives the JSON schema per class, and routing runs on every call.
+    """
+    return create_model("RouteSpec", model_spec=(Literal[*spec_keys], ...))
+
 
 def find_bad_request(error: BaseException | None) -> openai.BadRequestError | None:
     """Find a provider 400 on an exception's cause chain, if there is one."""
@@ -153,11 +181,12 @@ class Llm(param.Parameterized):
                   "description": "Best for editing tables and visualizations",
                   "routing": {"model": "nemotron-switchyard"}}}""")
 
-    spec_descriptions = param.Dict(default={}, doc="""
+    spec_descriptions = param.Dict(default=SPEC_DESCRIPTIONS, doc="""
         Mapping of spec key to human-readable description, used as a
         fallback in the routing prompt when ``model_kwargs`` entries
-        do not declare their own ``description``.  Populated externally
-        (e.g. by the UI layer) from agent class metadata.""")
+        do not declare their own ``description``. Seeded with the spec
+        keys every provider shares and enriched by the UI layer from
+        agent class metadata.""")
 
     tools = param.List(default=[], doc="""
         Default tools that are always available to this LLM instance.
@@ -236,15 +265,11 @@ class Llm(param.Parameterized):
                 f"parameter for {self.__class__.__name__}."
             )
         for spec_name, config in self.model_kwargs.items():
-            if (
-                isinstance(config, dict)
-                and "routing" in config
-                and not isinstance(config["routing"], dict)
-            ):
+            routing = config.get("routing") if isinstance(config, dict) else None
+            if routing is not None and not isinstance(routing, dict):
                 raise ValueError(
                     f"Invalid 'routing' entry for model spec {spec_name!r} in "
-                    f"model_kwargs: expected a dict, got "
-                    f"{type(config['routing']).__name__}."
+                    f"model_kwargs: expected a dict, got {type(routing).__name__}."
                 )
 
     @param.depends("logfire_tags", watch=True)
@@ -269,10 +294,9 @@ class Llm(param.Parameterized):
         if isinstance(model_spec, dict):
             model_kwargs = dict(model_spec)
         else:
-            model_kwargs = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
-            model_kwargs = dict(model_kwargs)
-        model_kwargs.pop("routing", None)
-        model_kwargs.pop("description", None)
+            model_kwargs = dict(self.model_kwargs.get(model_spec) or self.model_kwargs["default"])
+        for key in ROUTING_KEYS:
+            model_kwargs.pop(key, None)
         return model_kwargs
 
     def _get_create_kwargs(self, response_model: type[BaseModel] | None) -> dict[str, Any]:
@@ -429,44 +453,54 @@ class Llm(param.Parameterized):
         """
 
     def _route_spec_model(self) -> type[BaseModel]:
-        """Build the pydantic model constraining the routing model's output.
+        """The routing response model for the current ``model_kwargs`` keys."""
+        return build_route_spec_model(tuple(self.model_kwargs))
 
-        The ``model_spec`` field is constrained via a ``Literal`` to the keys
-        actually present in ``model_kwargs`` at call time, so a hallucinated
-        key cannot silently fall back to ``'default'`` unnoticed.
+    def _spec_description(self, model_spec: str) -> str | None:
+        """How *model_spec* describes itself to the routing model, if at all.
+
+        An explicit ``description`` on the ``model_kwargs`` entry wins over
+        ``spec_descriptions``, so per-provider config beats the generic
+        agent metadata the UI layer supplies.
         """
-        return create_model(
-            "RouteSpec",
-            model_spec=(Literal[*tuple(self.model_kwargs)], ...),
-        )
+        config = self.model_kwargs.get(model_spec)
+        if isinstance(config, dict) and "description" in config:
+            return config["description"]
+        return self.spec_descriptions.get(model_spec)
 
-    def _routing_system_prompt(self) -> str:
+    def _routing_system_prompt(self, model_spec: str) -> str:
         """Build the dedicated system prompt for the routing call.
 
-        The router is told it is choosing between the configured ``model_kwargs``
-        entries and is given each entry's description so it can reason about
-        what each option is for, rather than bare key names.
+        The router is told which task was requested and is given each
+        ``model_kwargs`` entry's description, so it chooses between documented
+        options for a named task rather than guessing from bare key names.
 
-        Descriptions are resolved in order: an explicit ``description`` key in
-        the ``model_kwargs`` entry wins first; then ``spec_descriptions``
-        (populated externally from agent metadata) is consulted as a fallback;
-        finally the literal ``"No description provided."`` is used.
+        See ``_spec_description`` for how each option describes itself.
         """
         options = "\n".join(
-            f"- {key}: {config.get('description', self.spec_descriptions.get(key, 'No description provided.'))}"
+            f"- {key}: {self._spec_description(key) or 'No description provided.'}"
             for key, config in self.model_kwargs.items()
             if isinstance(config, dict)
         )
+        described = self._spec_description(model_spec)
+        task = f"{model_spec!r} ({described})" if described else repr(model_spec)
         return (
-            "You are a routing model. Based on the user's request, choose the "
-            "configured model type that is best suited to handle it.\n"
+            "You are a routing model. Choose the configured model type best "
+            f"suited to handle the request below, which was made for the {task} "
+            "task. Weigh how much capability the request actually needs, so "
+            "simple requests go to cheaper models.\n"
             "Available model types:\n"
             f"{options}\n"
             "Reply with exactly one of the option names above."
         )
 
     def _strip_for_routing(self, messages: list[Message]) -> list[Message]:
-        """Prepare messages for the routing call: last user message only, images removed."""
+        """Prepare messages for the routing call: last user message only, images removed.
+
+        Routing models are chosen for being small and cheap and are typically
+        text-only, so every image shape ``_check_for_image`` can produce has to
+        be dropped here, not just the OpenAI-native content-part dicts.
+        """
         user_msgs = [m for m in messages if m.get("role") == "user"]
         if not user_msgs:
             return []
@@ -475,11 +509,23 @@ class Llm(param.Parameterized):
         if isinstance(content, list):
             last["content"] = [
                 item for item in content
-                if not (isinstance(item, dict) and item.get("type") == "image_url")
+                if not isinstance(item, IMAGE_TYPES)
+                and not (isinstance(item, dict) and item.get("type") == "image_url")
             ]
-        elif isinstance(content, (bytes, Image)):
+        elif isinstance(content, IMAGE_TYPES):
             last["content"] = ""
         return [last]
+
+    def _routing_config(self, model_spec: str) -> dict | None:
+        """The ``routing`` config governing *model_spec*, or None if it is not routed.
+
+        Resolution mirrors ``_get_model_kwargs``: a spec that names no entry
+        falls back to ``'default'``. Actors derive their spec from their class
+        name (``sql``, ``chat``, ``vega_lite``, ...) and providers enumerate
+        only a handful of entries, so without the fallback routing would never
+        fire for the calls Lumen actually makes.
+        """
+        return (self.model_kwargs.get(model_spec) or self.model_kwargs["default"]).get("routing")
 
     async def _resolve_routing(
         self,
@@ -490,9 +536,10 @@ class Llm(param.Parameterized):
         Pick which ``model_kwargs`` entry to use via a routing model when the
         entry named by ``model_spec`` declares a ``routing`` config.
 
-        Only string ``model_spec`` values that name a key in ``model_kwargs`` are
-        routed: dict specs bypass the ``model_kwargs`` lookup entirely and
-        repo-id strings (e.g. LlamaCpp) are not keys, so both are never routed.
+        Only string ``model_spec`` values are routed, and only when the entry
+        they resolve to declares ``routing`` (see ``_routing_config``). Dict
+        specs bypass the ``model_kwargs`` lookup entirely, so they are never
+        routed.
 
         The routing call itself uses a dict spec and ``tools=[]``, so it can
         never trigger routing for itself nor run the real tool loop. Both
@@ -504,12 +551,12 @@ class Llm(param.Parameterized):
         if isinstance(model_spec, dict):
             return model_spec
 
-        routing_spec = self.model_kwargs.get(model_spec, {}).get("routing")
+        routing_spec = self._routing_config(model_spec)
         if not routing_spec:
             return model_spec
 
         routing_spec = dict(routing_spec)
-        routing_prompt = self._routing_system_prompt()
+        routing_prompt = self._routing_system_prompt(model_spec)
         routing_messages = self._strip_for_routing(messages)
         try:
             route = await self.invoke(
@@ -528,9 +575,9 @@ class Llm(param.Parameterized):
                 prefix="[LLM routing]",
                 show_sep="above",
             )
-            return dict(self._get_model_kwargs(model_spec))
+            return self._get_model_kwargs(model_spec)
         log_debug(f"Routing {model_spec!r} -> {route.model_spec!r}", prefix="[LLM routing]")
-        return dict(self._get_model_kwargs(route.model_spec))
+        return self._get_model_kwargs(route.model_spec)
 
     async def invoke(
         self,
@@ -1200,14 +1247,21 @@ class LlamaCpp(Llm, LlamaCppMixin):
     # LlamaCpp doesn't use from_* wrapper - uses patch(create=...)
     _instructor_wrapper = None
 
+    def _routing_config(self, model_spec: str) -> dict | None:
+        # A repo id names a model directly rather than resolving to an entry,
+        # so routing must not override a model the caller asked for by name.
+        if model_spec not in self.model_kwargs and "/" in model_spec:
+            return None
+        return super()._routing_config(model_spec)
+
     def _get_model_kwargs(self, model_spec: str | dict) -> dict[str, Any]:
         if isinstance(model_spec, dict) or model_spec in self.model_kwargs or "/" not in model_spec:
             model_kwargs = super()._get_model_kwargs(model_spec)
         else:
-            base_kwargs = self.model_kwargs["default"]
+            # super() strips the routing keys, so the resolved repo id inherits
+            # a base config that is already safe to hand to the SDK.
+            base_kwargs = super()._get_model_kwargs("default")
             model_kwargs = self.resolve_model_spec(model_spec, base_kwargs)
-            model_kwargs.pop("routing", None)
-            model_kwargs.pop("description", None)
 
         if "n_ctx" not in model_kwargs:
             model_kwargs["n_ctx"] = 0

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -23,7 +23,7 @@ from instructor import Mode, patch
 from instructor.dsl.partial import Partial
 from instructor.processing.multimodal import Image
 from openai import OpenAI as OpenAIClient
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 from .interceptor import Interceptor
 from .services import (
@@ -141,7 +141,14 @@ class Llm(param.Parameterized):
     model_kwargs = param.Dict(default={}, doc="""
         LLM model definitions indexed by type. Supported types include
         'default', 'reasoning' and 'sql'. Agents may pick which model to
-        invoke for different reasons.""")
+        invoke for different reasons.
+
+        An entry may declare a 'routing' key to opt in to model routing for
+        that type: the routing model is invoked first to pick which entry to
+        actually use for each call, e.g.
+        {"default": {"model": "gpt-5.4-mini"},
+         "edit": {"model": "gpt-5.2",
+                  "routing": {"model": "nemotron-switchyard"}}}""")
 
     tools = param.List(default=[], doc="""
         Default tools that are always available to this LLM instance.
@@ -393,6 +400,60 @@ class Llm(param.Parameterized):
         files.
         """
 
+    def _route_spec_model(self) -> type[BaseModel]:
+        """Build the pydantic model constraining the routing model's output.
+
+        The ``model_spec`` field is constrained via a ``Literal`` to the keys
+        actually present in ``model_kwargs`` at call time, so a hallucinated
+        key cannot silently fall back to ``'default'`` unnoticed.
+        """
+        return create_model(
+            "RouteSpec",
+            model_spec=(Literal[*tuple(self.model_kwargs)], ...),
+        )
+
+    async def _resolve_routing(
+        self,
+        model_spec: str | dict,
+        messages: list[Message],
+    ) -> str | dict:
+        """
+        Pick which ``model_kwargs`` entry to use via a routing model when the
+        resolved config for ``model_spec`` declares one.
+
+        Only string ``model_spec`` values are routed. A dict ``model_spec``
+        bypasses the ``model_kwargs`` lookup entirely in ``_get_model_kwargs``,
+        which is exactly what the routing call below relies on: it always uses
+        a dict spec, so a routing call can never trigger routing for itself
+        (no recursion guard is needed).
+        """
+        if isinstance(model_spec, dict):
+            return model_spec
+
+        config = self.model_kwargs.get(model_spec) or self.model_kwargs["default"]
+        routing_spec = config.get("routing")
+        if not routing_spec:
+            return model_spec
+
+        try:
+            route = await self.invoke(
+                messages=messages,
+                model_spec=dict(routing_spec),
+                response_model=self._route_spec_model(),
+            )
+        except Exception:
+            log_debug(
+                [
+                    f"Routing for {model_spec!r} failed; falling back to {model_spec!r}",
+                    traceback.format_exc(),
+                ],
+                prefix="[LLM routing]",
+                show_sep="above",
+            )
+            return model_spec
+        log_debug(f"Routing {model_spec!r} -> {route.model_spec!r}", prefix="[LLM routing]")
+        return route.model_spec
+
     async def invoke(
         self,
         messages: list[Message],
@@ -431,6 +492,7 @@ class Llm(param.Parameterized):
         """
         system = system.strip().replace("\n\n", "\n")
         messages, input_kwargs = self._add_system_message(messages, system, input_kwargs)
+        model_spec = await self._resolve_routing(model_spec, messages)
         max_tool_rounds = int(input_kwargs.pop("max_tool_rounds", 16))
 
         kwargs = dict(self._client_kwargs)

--- a/lumen/ai/llm_dialog.py
+++ b/lumen/ai/llm_dialog.py
@@ -239,6 +239,10 @@ class LLMConfigDialog(Viewer):
         # Initialize model cards
         self._refresh_model_cards()
 
+        # Expose agent descriptions to the LLM so the routing prompt
+        # can use them even when model_kwargs entries lack a 'description' key.
+        self.llm.spec_descriptions = self._get_all_agent_types()
+
         # Flag to prevent update loops during provider changes
         self._updating_provider = False
 

--- a/lumen/ai/llm_dialog.py
+++ b/lumen/ai/llm_dialog.py
@@ -16,7 +16,7 @@ from panel_material_ui import (
 )
 
 from .agents import Agent
-from .llm import Llm
+from .llm import SPEC_DESCRIPTIONS, Llm
 from .utils import class_name_to_llm_spec_key
 
 LLM_CONFIG_HELP = """
@@ -89,15 +89,12 @@ class LLMModelCard(Viewer):
         self.model_select.param.watch(self._on_model_change, "value")
 
     def _get_default_models(self):
-        """Get models for the select dropdown from the LLM class."""
-        llm_type = type(self.llm)
+        """Get models for the select dropdown from the LLM.
 
-        # Check if the LLM class has a select_models attribute (now a param)
-        if hasattr(llm_type, 'select_models'):
-            available = list(llm_type.select_models)
-        else:
-            # Fallback to empty list
-            available = []
+        Read from the instance, not the class, so a ``select_models`` list
+        passed at construction is what the dropdown offers.
+        """
+        available = list(self.llm.select_models)
 
         # Get current model to ensure it's included
         current_config = self.llm.model_kwargs.get(self.model_type, {})
@@ -239,9 +236,10 @@ class LLMConfigDialog(Viewer):
         # Initialize model cards
         self._refresh_model_cards()
 
-        # Expose agent descriptions to the LLM so the routing prompt
-        # can use them even when model_kwargs entries lack a 'description' key.
-        self.llm.spec_descriptions = self._get_all_agent_types()
+        # Expose agent descriptions to the LLM so the routing prompt can use
+        # them even when model_kwargs entries lack a 'description' key.
+        # Descriptions set on the LLM win, so explicit config is not clobbered.
+        self.llm.spec_descriptions = {**self._get_all_agent_types(), **self.llm.spec_descriptions}
 
         # Flag to prevent update loops during provider changes
         self._updating_provider = False
@@ -313,15 +311,9 @@ class LLMConfigDialog(Viewer):
         Get all possible agent types by using param.concrete_descendents to find all Agent classes.
         Returns a dict mapping llm_spec_key to description.
         """
-        agent_types = {}
-
-        # Add common predefined types first (only non-duplicate ones)
-        predefined_types = {
-            "default": "General purpose model for most tasks",
-            "edit": "Advanced model for retry & edit tasks",
-            "ui": "Lightweight model for UI interactions"
-        }
-        agent_types.update(predefined_types)
+        # The universal spec keys are described alongside the routing prompt
+        # that also consumes them, so the two cannot drift apart.
+        agent_types = dict(SPEC_DESCRIPTIONS)
 
         # Get all concrete descendant classes of Agent
         agent_classes = []
@@ -381,7 +373,7 @@ class LLMConfigDialog(Viewer):
             if model_type not in self.llm.model_kwargs:
                 # Use the default model from model_kwargs if available, otherwise use first select_models
                 default_model_config = self.llm.model_kwargs.get("default", {}).copy()
-                if not default_model_config and hasattr(self.llm, 'select_models') and self.llm.select_models:
+                if not default_model_config and self.llm.select_models:
                     default_model_config = {"model": self.llm.select_models[0]}
                 self.llm.model_kwargs[model_type] = default_model_config
 

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -18,6 +18,7 @@ try:
         MLX, Anthropic, AnthropicBedrock, AzureOpenAI, Bedrock, Google, Groq,
         LiteLLM, LlamaCpp, Llm, Message, MistralAI, Ollama, OpenAI, WebLLM,
     )
+    from lumen.ai.tools import FunctionTool
 
 except ModuleNotFoundError:
     pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
@@ -884,7 +885,9 @@ ROUTED_MODEL_KWARGS = {
 
 
 def _routing_llm():
-    return Llm(model_kwargs={k: dict(v) for k, v in ROUTED_MODEL_KWARGS.items()})
+    llm = _make(OpenAI, {})
+    llm.model_kwargs = {k: dict(v) for k, v in ROUTED_MODEL_KWARGS.items()}
+    return llm
 
 
 def test_route_spec_model_constrains_to_current_model_kwargs_keys():
@@ -913,7 +916,8 @@ async def test_no_routing_key_passes_through(monkeypatch):
 
 async def test_routing_invoked_with_dict_spec_and_decision_used(monkeypatch):
     """When a 'routing' key is present, the routing model is invoked with a dict
-    spec and the messages, and its decision is returned as the resolved model_spec."""
+    spec, a dedicated system prompt and no tools, and its decision resolves to
+    the chosen entry's config dict."""
     llm = _routing_llm()
     calls = []
 
@@ -923,12 +927,43 @@ async def test_routing_invoked_with_dict_spec_and_decision_used(monkeypatch):
 
     monkeypatch.setattr(llm, "invoke", fake_invoke)
     messages = [{"role": "user", "content": "hi"}]
-    assert await llm._resolve_routing("edit", messages) == "sql"
+    resolved = await llm._resolve_routing("edit", messages)
+    assert resolved["model"] == "sql-model"
+    assert "routing" not in resolved
 
     routed_messages, routed_kwargs = calls[0]
     assert routed_messages == messages
     assert routed_kwargs["model_spec"] == {"model": "router-model"}
+    assert routed_kwargs["tools"] == []
+    assert routed_kwargs["system"] == llm._routing_system_prompt()
     assert issubclass(routed_kwargs["response_model"], BaseModel)
+
+
+async def test_routing_prompt_lists_options_with_descriptions(monkeypatch):
+    """The routing call gets a dedicated system prompt listing every configured
+    option with its optional description, and does not inherit the caller's
+    system prompt."""
+    llm = _routing_llm()
+    llm.model_kwargs["edit"]["description"] = "Best for editing tasks"
+    llm.model_kwargs["sql"]["description"] = "Best for SQL tasks"
+    calls = []
+
+    async def fake_invoke(messages, **kwargs):
+        calls.append((messages, kwargs))
+        return SimpleNamespace(model_spec="sql")
+
+    monkeypatch.setattr(llm, "invoke", fake_invoke)
+    messages = [
+        {"role": "system", "content": "You are a data analyst."},
+        {"role": "user", "content": "hi"},
+    ]
+    await llm._resolve_routing("edit", messages)
+
+    routed_messages, routed_kwargs = calls[0]
+    assert routed_kwargs["system"] == llm._routing_system_prompt()
+    assert "Best for editing tasks" in routed_kwargs["system"]
+    assert "Best for SQL tasks" in routed_kwargs["system"]
+    assert routed_messages == [{"role": "user", "content": "hi"}]
 
 
 async def test_routing_exception_falls_back(monkeypatch):
@@ -958,22 +993,112 @@ async def test_dict_model_spec_never_routed(monkeypatch):
     assert await llm._resolve_routing(spec, messages) == spec
 
 
+def test_combine_tools_empty_list_opts_out_of_instance_tools():
+    """tools=[] opts out of instance tools, while None uses them and a non-empty
+    list merges them."""
+    llm = _make(OpenAI, {})
+    llm.tools = ["instance-tool"]
+    assert llm._combine_tools(None) == ["instance-tool"]
+    assert llm._combine_tools([]) == []
+    assert llm._combine_tools(["per-call"]) == ["instance-tool", "per-call"]
+
+
+def test_invalid_routing_config_rejected_at_construction():
+    """A non-dict 'routing' entry fails loudly at construction time, not silently
+    at call time."""
+    with pytest.raises(ValueError, match="routing"):
+        OpenAI(api_key="sk-test", model_kwargs={
+            "default": {"model": "base"},
+            "edit": {"model": "edit-model", "routing": "router-model"},
+        })
+
+
+async def test_get_client_strips_routing_key(monkeypatch):
+    """The 'routing' key must never reach the SDK constructor (reviewer repro:
+    AsyncOpenAI.__init__ must not receive an unexpected 'routing' kwarg)."""
+    fake = MagicMock()
+    monkeypatch.setattr(openai, "AsyncOpenAI", fake)
+    llm = OpenAI(
+        api_key="sk-test",
+        model_kwargs={k: dict(v) for k, v in ROUTED_MODEL_KWARGS.items()},
+    )
+    client = await llm.get_client("edit")
+    assert client is not None
+    assert "routing" not in fake.call_args.kwargs
+
+
 async def test_invoke_uses_routed_model_spec(monkeypatch):
-    """invoke() resolves routing before running the tool loop, so the routed
-    model_spec reaches run_client."""
+    """invoke() resolves routing through the real path: the routing model runs
+    first (with a dedicated prompt and no tools), then the resolved config
+    reaches run_client with no 'routing' key."""
     llm = _routing_llm()
     run_client_specs = []
 
-    async def fake_route(model_spec, messages):
-        return "sql"
-
     async def fake_run_client(model_spec, messages, **kwargs):
-        run_client_specs.append(model_spec)
+        run_client_specs.append(dict(model_spec))
+        if kwargs.get("response_model") is not None:
+            return kwargs["response_model"](model_spec="sql")
         return "done"
 
-    monkeypatch.setattr(llm, "_resolve_routing", fake_route)
     monkeypatch.setattr(llm, "run_client", fake_run_client)
 
     output = await llm.invoke([{"role": "user", "content": "hi"}], model_spec="edit")
     assert output == "done"
-    assert run_client_specs == ["sql"]
+    assert [spec["model"] for spec in run_client_specs] == ["router-model", "sql-model"]
+    assert all("routing" not in spec for spec in run_client_specs)
+
+
+def _stream_chunks(text: str = "", tool_calls: list[dict] | None = None):
+    async def gen():
+        if tool_calls:
+            for call in tool_calls:
+                yield SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content="", tool_calls=[call]))]
+                )
+        else:
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content=text, tool_calls=None))]
+            )
+
+    return gen()
+
+
+async def test_stream_resolves_routing_once_across_tool_rounds(monkeypatch):
+    """Routing is resolved once for a whole stream: the routing model is invoked
+    a single time and follow-up tool-loop rounds reuse the resolved spec instead
+    of re-invoking the router (and paying another blocking network call)."""
+    llm = _routing_llm()
+    router_invocations = []
+    stream_specs = []
+
+    def add(a: int, b: int) -> int:
+        """Adds two integers."""
+        return a + b
+
+    tool = FunctionTool(add)
+
+    async def fake_run_client(model_spec, messages, **kwargs):
+        spec = dict(model_spec) if isinstance(model_spec, dict) else model_spec
+        if kwargs.get("response_model") is not None:
+            router_invocations.append(spec)
+            return kwargs["response_model"](model_spec="sql")
+        stream_specs.append(spec)
+        if kwargs.get("stream"):
+            if len(stream_specs) == 1:
+                return _stream_chunks(tool_calls=[
+                    {"index": 0, "id": "call_1", "type": "function",
+                     "function": {"name": "add", "arguments": ""}},
+                    {"index": 0, "id": "call_1", "type": "function",
+                     "function": {"name": None, "arguments": '{"a": 1, "b": 2}'}},
+                ])
+            return _stream_chunks(text="final answer")
+        return "done"
+
+    monkeypatch.setattr(llm, "run_client", fake_run_client)
+    messages = [{"role": "user", "content": "hi"}]
+    outputs = [out async for out in llm.stream(messages, model_spec="edit", tools=[tool])]
+
+    assert len(router_invocations) == 1
+    assert [spec["model"] for spec in router_invocations] == ["router-model"]
+    assert [spec["model"] for spec in stream_specs] == ["sql-model", "sql-model"]
+    assert "final answer" in outputs

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -981,6 +981,7 @@ async def test_routing_exception_falls_back(monkeypatch):
     assert isinstance(result, dict)
     assert result["model"] == "edit-model"
     assert "routing" not in result
+    assert "description" not in result
 
 
 async def test_dict_model_spec_never_routed(monkeypatch):
@@ -1144,3 +1145,45 @@ async def test_stream_router_down_single_timeout(monkeypatch):
     # used directly, so invoke() never tries routing a second time.
     assert len(routing_calls) == 1
     assert routing_calls[0] == {"model": "router-model"}
+
+
+async def test_stream_router_down_no_reroute_across_rounds(monkeypatch):
+    """When routing fails during stream(), the fallback dict prevents
+    re-routing on tool-loop recursion — stream rounds use the resolved
+    model directly without paying another routing timeout."""
+    llm = _routing_llm()
+    routing_attempts = []
+    stream_specs = []
+
+    def add(a: int, b: int) -> int:
+        """Adds two integers."""
+        return a + b
+
+    tool = FunctionTool(add)
+
+    async def fake_run_client(model_spec, messages, **kwargs):
+        spec = dict(model_spec) if isinstance(model_spec, dict) else model_spec
+        if kwargs.get("response_model") is not None:
+            routing_attempts.append(spec)
+            raise RuntimeError("router down")
+        stream_specs.append(spec)
+        if kwargs.get("stream"):
+            if len(stream_specs) == 1:
+                return _stream_chunks(tool_calls=[
+                    {"index": 0, "id": "call_1", "type": "function",
+                     "function": {"name": "add", "arguments": ""}},
+                    {"index": 0, "id": "call_1", "type": "function",
+                     "function": {"name": None, "arguments": '{"a": 1, "b": 2}'}},
+                ])
+            return _stream_chunks(text="fallback answer")
+        return "done"
+
+    monkeypatch.setattr(llm, "run_client", fake_run_client)
+    messages = [{"role": "user", "content": "hi"}]
+    outputs = [out async for out in llm.stream(messages, model_spec="edit", tools=[tool])]
+
+    assert len(routing_attempts) == 1
+    assert routing_attempts[0] == {"model": "router-model"}
+    assert all(spec["model"] == "edit-model" for spec in stream_specs)
+    assert all("routing" not in spec for spec in stream_specs)
+    assert "fallback answer" in outputs

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -932,7 +932,7 @@ async def test_routing_invoked_with_dict_spec_and_decision_used(monkeypatch):
     assert "routing" not in resolved
 
     routed_messages, routed_kwargs = calls[0]
-    assert routed_messages == messages
+    assert routed_messages == [{"role": "user", "content": "hi"}]
     assert routed_kwargs["model_spec"] == {"model": "router-model"}
     assert routed_kwargs["tools"] == []
     assert routed_kwargs["system"] == llm._routing_system_prompt()
@@ -1187,3 +1187,92 @@ async def test_stream_router_down_no_reroute_across_rounds(monkeypatch):
     assert all(spec["model"] == "edit-model" for spec in stream_specs)
     assert all("routing" not in spec for spec in stream_specs)
     assert "fallback answer" in outputs
+
+
+async def test_routing_receives_only_last_user_message(monkeypatch):
+    """The routing call receives only the last user message, not the full
+    conversation history (which could be thousands of chars)."""
+    llm = _routing_llm()
+    calls = []
+
+    async def fake_invoke(messages, **kwargs):
+        calls.append(messages)
+        return SimpleNamespace(model_spec="sql")
+
+    monkeypatch.setattr(llm, "invoke", fake_invoke)
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {"role": "user", "content": "second question"},
+    ]
+    await llm._resolve_routing("edit", messages)
+    assert calls[0] == [{"role": "user", "content": "second question"}]
+
+
+async def test_routing_strips_images_from_messages(monkeypatch):
+    """The routing call never receives raw image data — image content parts
+    are stripped so a small text-only router model is not sent base64 blobs."""
+    llm = _routing_llm()
+    calls = []
+
+    async def fake_invoke(messages, **kwargs):
+        calls.append(messages)
+        return SimpleNamespace(model_spec="sql")
+
+    monkeypatch.setattr(llm, "invoke", fake_invoke)
+    messages = [
+        {"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            {"type": "text", "text": "describe this chart"},
+        ]},
+    ]
+    await llm._resolve_routing("edit", messages)
+    assert calls[0] == [{"role": "user", "content": [{"type": "text", "text": "describe this chart"}]}]
+
+
+async def test_routing_strips_binary_image_content(monkeypatch):
+    """Binary image content in the last user message is replaced with empty
+    string so the router does not receive raw bytes."""
+    llm = _routing_llm()
+    calls = []
+
+    async def fake_invoke(messages, **kwargs):
+        calls.append(messages)
+        return SimpleNamespace(model_spec="sql")
+
+    monkeypatch.setattr(llm, "invoke", fake_invoke)
+    image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    messages = [
+        {"role": "user", "content": image_bytes},
+    ]
+    await llm._resolve_routing("edit", messages)
+    assert calls[0] == [{"role": "user", "content": ""}]
+
+
+def test_spec_descriptions_used_as_fallback_in_routing_prompt():
+    """When model_kwargs entries lack a 'description' key, spec_descriptions
+    is consulted as fallback so the routing prompt is not full of
+    'No description provided.' lines."""
+    llm = _routing_llm()
+    llm.spec_descriptions = {
+        "default": "General purpose model",
+        "sql": "For SQL queries",
+    }
+    prompt = llm._routing_system_prompt()
+    assert "General purpose model" in prompt
+    # edit already has an explicit description in ROUTED_MODEL_KWARGS
+    assert "Best for editing tables and visualizations" in prompt
+    assert "For SQL queries" in prompt
+    assert "No description provided" not in prompt
+
+
+def test_explicit_description_overrides_spec_descriptions():
+    """An explicit 'description' key in model_kwargs takes priority over
+    spec_descriptions."""
+    llm = _routing_llm()
+    llm.model_kwargs["sql"]["description"] = "Custom SQL description"
+    llm.spec_descriptions = {"sql": "Fallback SQL description"}
+    prompt = llm._routing_system_prompt()
+    assert "Custom SQL description" in prompt
+    assert "Fallback SQL description" not in prompt

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -904,7 +904,7 @@ async def test_no_routing_key_passes_through(monkeypatch):
     llm = _routing_llm()
 
     async def fail_invoke(*args, **kwargs):
-        raise AssertionError("routing model must not be invoked")
+        raise AssertionError("routing model must not be invoked")  # pragma: no cover
 
     monkeypatch.setattr(llm, "invoke", fail_invoke)
     messages = [{"role": "user", "content": "hi"}]
@@ -950,7 +950,7 @@ async def test_dict_model_spec_never_routed(monkeypatch):
     llm = _routing_llm()
 
     async def fail_invoke(*args, **kwargs):
-        raise AssertionError("dict model_spec must not be routed")
+        raise AssertionError("dict model_spec must not be routed")  # pragma: no cover
 
     monkeypatch.setattr(llm, "invoke", fail_invoke)
     messages = [{"role": "user", "content": "hi"}]

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -23,7 +23,7 @@ except ModuleNotFoundError:
     pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
 
 from instructor.processing.multimodal import Image
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -870,3 +870,110 @@ def test_api_key_env_var_does_not_clobber_provider_default(monkeypatch):
 
     monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
     assert OpenAI().api_key == "sk-from-env"
+
+
+# ---------------------------------------------------------------------------
+# Model routing
+# ---------------------------------------------------------------------------
+
+ROUTED_MODEL_KWARGS = {
+    "default": {"model": "base-model"},
+    "edit": {"model": "edit-model", "routing": {"model": "router-model"}},
+    "sql": {"model": "sql-model"},
+}
+
+
+def _routing_llm():
+    return Llm(model_kwargs={k: dict(v) for k, v in ROUTED_MODEL_KWARGS.items()})
+
+
+def test_route_spec_model_constrains_to_current_model_kwargs_keys():
+    """The Literal is rebuilt from model_kwargs at call time and rejects unknown keys."""
+    llm = _routing_llm()
+    route_spec_model = llm._route_spec_model()
+    schema = route_spec_model.model_json_schema()["properties"]["model_spec"]
+    assert set(schema["enum"]) == set(ROUTED_MODEL_KWARGS)
+    assert route_spec_model(model_spec="sql").model_spec == "sql"
+    with pytest.raises(ValidationError):
+        route_spec_model(model_spec="bogus")
+
+
+async def test_no_routing_key_passes_through(monkeypatch):
+    """Without a 'routing' key the model_spec passes through unchanged and the
+    routing model is never invoked."""
+    llm = _routing_llm()
+
+    async def fail_invoke(*args, **kwargs):
+        raise AssertionError("routing model must not be invoked")
+
+    monkeypatch.setattr(llm, "invoke", fail_invoke)
+    messages = [{"role": "user", "content": "hi"}]
+    assert await llm._resolve_routing("sql", messages) == "sql"
+
+
+async def test_routing_invoked_with_dict_spec_and_decision_used(monkeypatch):
+    """When a 'routing' key is present, the routing model is invoked with a dict
+    spec and the messages, and its decision is returned as the resolved model_spec."""
+    llm = _routing_llm()
+    calls = []
+
+    async def fake_invoke(messages, **kwargs):
+        calls.append((messages, kwargs))
+        return SimpleNamespace(model_spec="sql")
+
+    monkeypatch.setattr(llm, "invoke", fake_invoke)
+    messages = [{"role": "user", "content": "hi"}]
+    assert await llm._resolve_routing("edit", messages) == "sql"
+
+    routed_messages, routed_kwargs = calls[0]
+    assert routed_messages == messages
+    assert routed_kwargs["model_spec"] == {"model": "router-model"}
+    assert issubclass(routed_kwargs["response_model"], BaseModel)
+
+
+async def test_routing_exception_falls_back(monkeypatch):
+    """If the routing call raises, the original string model_spec is used and no
+    exception propagates."""
+    llm = _routing_llm()
+
+    async def fail_invoke(*args, **kwargs):
+        raise RuntimeError("router down")
+
+    monkeypatch.setattr(llm, "invoke", fail_invoke)
+    messages = [{"role": "user", "content": "hi"}]
+    assert await llm._resolve_routing("edit", messages) == "edit"
+
+
+async def test_dict_model_spec_never_routed(monkeypatch):
+    """A dict model_spec is never routed, even when its contents match keys used
+    elsewhere in the config."""
+    llm = _routing_llm()
+
+    async def fail_invoke(*args, **kwargs):
+        raise AssertionError("dict model_spec must not be routed")
+
+    monkeypatch.setattr(llm, "invoke", fail_invoke)
+    messages = [{"role": "user", "content": "hi"}]
+    spec = {"model": "router-model", "routing": {"model": "other"}}
+    assert await llm._resolve_routing(spec, messages) == spec
+
+
+async def test_invoke_uses_routed_model_spec(monkeypatch):
+    """invoke() resolves routing before running the tool loop, so the routed
+    model_spec reaches run_client."""
+    llm = _routing_llm()
+    run_client_specs = []
+
+    async def fake_route(model_spec, messages):
+        return "sql"
+
+    async def fake_run_client(model_spec, messages, **kwargs):
+        run_client_specs.append(model_spec)
+        return "done"
+
+    monkeypatch.setattr(llm, "_resolve_routing", fake_route)
+    monkeypatch.setattr(llm, "run_client", fake_run_client)
+
+    output = await llm.invoke([{"role": "user", "content": "hi"}], model_spec="edit")
+    assert output == "done"
+    assert run_client_specs == ["sql"]

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -43,6 +43,12 @@ PROVIDER_SPECS = [
     pytest.param(Ollama, {"api_key": "ollama"}, set(), 0.25, id="ollama"),
 ]
 
+ROUTED_MODEL_KWARGS = {
+    "default": {"model": "base-model"},
+    "edit": {"model": "edit-model", "routing": {"model": "router-model"}, "description": "Best for editing tables and visualizations"},
+    "sql": {"model": "sql-model"},
+}
+
 def _make_test_image() -> Image:
     """Create a tiny 1x1 PNG encoded as an instructor Image."""
     pixel = base64.b64encode(
@@ -877,22 +883,16 @@ def test_api_key_env_var_does_not_clobber_provider_default(monkeypatch):
 # Model routing
 # ---------------------------------------------------------------------------
 
-ROUTED_MODEL_KWARGS = {
-    "default": {"model": "base-model"},
-    "edit": {"model": "edit-model", "routing": {"model": "router-model"}, "description": "Best for editing tables and visualizations"},
-    "sql": {"model": "sql-model"},
-}
-
-
-def _routing_llm():
+@pytest.fixture
+def routing_llm():
     llm = _make(OpenAI, {})
     llm.model_kwargs = {k: dict(v) for k, v in ROUTED_MODEL_KWARGS.items()}
     return llm
 
 
-def test_route_spec_model_constrains_to_current_model_kwargs_keys():
+def test_route_spec_model_constrains_to_current_model_kwargs_keys(routing_llm):
     """The Literal is rebuilt from model_kwargs at call time and rejects unknown keys."""
-    llm = _routing_llm()
+    llm = routing_llm
     route_spec_model = llm._route_spec_model()
     schema = route_spec_model.model_json_schema()["properties"]["model_spec"]
     assert set(schema["enum"]) == set(ROUTED_MODEL_KWARGS)
@@ -901,10 +901,10 @@ def test_route_spec_model_constrains_to_current_model_kwargs_keys():
         route_spec_model(model_spec="bogus")
 
 
-async def test_no_routing_key_passes_through(monkeypatch):
+async def test_no_routing_key_passes_through(monkeypatch, routing_llm):
     """Without a 'routing' key the model_spec passes through unchanged and the
     routing model is never invoked."""
-    llm = _routing_llm()
+    llm = routing_llm
 
     async def fail_invoke(*args, **kwargs):
         raise AssertionError("routing model must not be invoked")  # pragma: no cover
@@ -914,11 +914,11 @@ async def test_no_routing_key_passes_through(monkeypatch):
     assert await llm._resolve_routing("sql", messages) == "sql"
 
 
-async def test_routing_invoked_with_dict_spec_and_decision_used(monkeypatch):
+async def test_routing_invoked_with_dict_spec_and_decision_used(monkeypatch, routing_llm):
     """When a 'routing' key is present, the routing model is invoked with a dict
     spec, a dedicated system prompt and no tools, and its decision resolves to
     the chosen entry's config dict."""
-    llm = _routing_llm()
+    llm = routing_llm
     calls = []
 
     async def fake_invoke(messages, **kwargs):
@@ -939,11 +939,11 @@ async def test_routing_invoked_with_dict_spec_and_decision_used(monkeypatch):
     assert issubclass(routed_kwargs["response_model"], BaseModel)
 
 
-async def test_routing_prompt_lists_options_with_descriptions(monkeypatch):
+async def test_routing_prompt_lists_options_with_descriptions(monkeypatch, routing_llm):
     """The routing call gets a dedicated system prompt listing every configured
     option with its optional description, and does not inherit the caller's
     system prompt."""
-    llm = _routing_llm()
+    llm = routing_llm
     llm.model_kwargs["edit"]["description"] = "Best for editing tasks"
     llm.model_kwargs["sql"]["description"] = "Best for SQL tasks"
     calls = []
@@ -966,11 +966,11 @@ async def test_routing_prompt_lists_options_with_descriptions(monkeypatch):
     assert routed_messages == [{"role": "user", "content": "hi"}]
 
 
-async def test_routing_exception_falls_back(monkeypatch):
+async def test_routing_exception_falls_back(monkeypatch, routing_llm):
     """If the routing call raises, the fallback returns the original entry's
     config dict (not the bare string) so the dict-bypass prevents
     re-routing downstream."""
-    llm = _routing_llm()
+    llm = routing_llm
 
     async def fail_invoke(*args, **kwargs):
         raise RuntimeError("router down")
@@ -984,10 +984,10 @@ async def test_routing_exception_falls_back(monkeypatch):
     assert "description" not in result
 
 
-async def test_dict_model_spec_never_routed(monkeypatch):
+async def test_dict_model_spec_never_routed(monkeypatch, routing_llm):
     """A dict model_spec is never routed, even when its contents match keys used
     elsewhere in the config."""
-    llm = _routing_llm()
+    llm = routing_llm
 
     async def fail_invoke(*args, **kwargs):
         raise AssertionError("dict model_spec must not be routed")  # pragma: no cover
@@ -1046,11 +1046,11 @@ async def test_get_client_strips_description_key(monkeypatch):
     assert "description" not in fake.call_args.kwargs
 
 
-async def test_invoke_uses_routed_model_spec(monkeypatch):
+async def test_invoke_uses_routed_model_spec(monkeypatch, routing_llm):
     """invoke() resolves routing through the real path: the routing model runs
     first (with a dedicated prompt and no tools), then the resolved config
     reaches run_client with no 'routing' key."""
-    llm = _routing_llm()
+    llm = routing_llm
     run_client_specs = []
 
     async def fake_run_client(model_spec, messages, **kwargs):
@@ -1082,11 +1082,11 @@ def _stream_chunks(text: str = "", tool_calls: list[dict] | None = None):
     return gen()
 
 
-async def test_stream_resolves_routing_per_invoke_not_per_stream(monkeypatch):
+async def test_stream_resolves_routing_per_invoke_not_per_stream(monkeypatch, routing_llm):
     """Routing is resolved inside invoke(), not stream(). Both success and
     fallback paths return a dict, so the dict-bypass mechanism prevents
     re-routing across tool-loop rounds."""
-    llm = _routing_llm()
+    llm = routing_llm
     router_invocations = []
     stream_specs = []
 
@@ -1123,12 +1123,12 @@ async def test_stream_resolves_routing_per_invoke_not_per_stream(monkeypatch):
     assert "final answer" in outputs
 
 
-async def test_stream_router_down_single_timeout(monkeypatch):
+async def test_stream_router_down_single_timeout(monkeypatch, routing_llm):
     """When the router is unreachable, _resolve_routing returns a dict
     (the fallback config) so the dict-bypass prevents re-routing on
     every subsequent call — router-down pays exactly one routing attempt
     per turn, not one per stream+invoke pair nor one per tool round."""
-    llm = _routing_llm()
+    llm = routing_llm
     routing_calls = []
 
     async def fake_run_client(model_spec, messages, **kwargs):
@@ -1147,11 +1147,11 @@ async def test_stream_router_down_single_timeout(monkeypatch):
     assert routing_calls[0] == {"model": "router-model"}
 
 
-async def test_stream_router_down_no_reroute_across_rounds(monkeypatch):
+async def test_stream_router_down_no_reroute_across_rounds(monkeypatch, routing_llm):
     """When routing fails during stream(), the fallback dict prevents
     re-routing on tool-loop recursion — stream rounds use the resolved
     model directly without paying another routing timeout."""
-    llm = _routing_llm()
+    llm = routing_llm
     routing_attempts = []
     stream_specs = []
 
@@ -1189,10 +1189,10 @@ async def test_stream_router_down_no_reroute_across_rounds(monkeypatch):
     assert "fallback answer" in outputs
 
 
-async def test_routing_receives_only_last_user_message(monkeypatch):
+async def test_routing_receives_only_last_user_message(monkeypatch, routing_llm):
     """The routing call receives only the last user message, not the full
     conversation history (which could be thousands of chars)."""
-    llm = _routing_llm()
+    llm = routing_llm
     calls = []
 
     async def fake_invoke(messages, **kwargs):
@@ -1210,10 +1210,10 @@ async def test_routing_receives_only_last_user_message(monkeypatch):
     assert calls[0] == [{"role": "user", "content": "second question"}]
 
 
-async def test_routing_strips_images_from_messages(monkeypatch):
+async def test_routing_strips_images_from_messages(monkeypatch, routing_llm):
     """The routing call never receives raw image data — image content parts
     are stripped so a small text-only router model is not sent base64 blobs."""
-    llm = _routing_llm()
+    llm = routing_llm
     calls = []
 
     async def fake_invoke(messages, **kwargs):
@@ -1231,10 +1231,10 @@ async def test_routing_strips_images_from_messages(monkeypatch):
     assert calls[0] == [{"role": "user", "content": [{"type": "text", "text": "describe this chart"}]}]
 
 
-async def test_routing_strips_binary_image_content(monkeypatch):
+async def test_routing_strips_binary_image_content(monkeypatch, routing_llm):
     """Binary image content in the last user message is replaced with empty
     string so the router does not receive raw bytes."""
-    llm = _routing_llm()
+    llm = routing_llm
     calls = []
 
     async def fake_invoke(messages, **kwargs):
@@ -1250,11 +1250,11 @@ async def test_routing_strips_binary_image_content(monkeypatch):
     assert calls[0] == [{"role": "user", "content": ""}]
 
 
-def test_spec_descriptions_used_as_fallback_in_routing_prompt():
+def test_spec_descriptions_used_as_fallback_in_routing_prompt(routing_llm):
     """When model_kwargs entries lack a 'description' key, spec_descriptions
     is consulted as fallback so the routing prompt is not full of
     'No description provided.' lines."""
-    llm = _routing_llm()
+    llm = routing_llm
     llm.spec_descriptions = {
         "default": "General purpose model",
         "sql": "For SQL queries",
@@ -1267,10 +1267,10 @@ def test_spec_descriptions_used_as_fallback_in_routing_prompt():
     assert "No description provided" not in prompt
 
 
-def test_explicit_description_overrides_spec_descriptions():
+def test_explicit_description_overrides_spec_descriptions(routing_llm):
     """An explicit 'description' key in model_kwargs takes priority over
     spec_descriptions."""
-    llm = _routing_llm()
+    llm = routing_llm
     llm.model_kwargs["sql"]["description"] = "Custom SQL description"
     llm.spec_descriptions = {"sql": "Fallback SQL description"}
     prompt = llm._routing_system_prompt("edit")
@@ -1372,10 +1372,10 @@ def test_spec_descriptions_documented_by_default():
     assert "No description provided." not in prompt
 
 
-def test_routing_prompt_names_the_requested_spec():
+def test_routing_prompt_names_the_requested_spec(routing_llm):
     """The router picks a model for a task, so it is told which task was asked
     for rather than inferring it from the user message alone."""
-    llm = _routing_llm()
+    llm = routing_llm
     assert "sql" in llm._routing_system_prompt("sql")
 
 

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -879,7 +879,7 @@ def test_api_key_env_var_does_not_clobber_provider_default(monkeypatch):
 
 ROUTED_MODEL_KWARGS = {
     "default": {"model": "base-model"},
-    "edit": {"model": "edit-model", "routing": {"model": "router-model"}},
+    "edit": {"model": "edit-model", "routing": {"model": "router-model"}, "description": "Best for editing tables and visualizations"},
     "sql": {"model": "sql-model"},
 }
 
@@ -967,8 +967,9 @@ async def test_routing_prompt_lists_options_with_descriptions(monkeypatch):
 
 
 async def test_routing_exception_falls_back(monkeypatch):
-    """If the routing call raises, the original string model_spec is used and no
-    exception propagates."""
+    """If the routing call raises, the fallback returns the original entry's
+    config dict (not the bare string) so the dict-bypass prevents
+    re-routing downstream."""
     llm = _routing_llm()
 
     async def fail_invoke(*args, **kwargs):
@@ -976,7 +977,10 @@ async def test_routing_exception_falls_back(monkeypatch):
 
     monkeypatch.setattr(llm, "invoke", fail_invoke)
     messages = [{"role": "user", "content": "hi"}]
-    assert await llm._resolve_routing("edit", messages) == "edit"
+    result = await llm._resolve_routing("edit", messages)
+    assert isinstance(result, dict)
+    assert result["model"] == "edit-model"
+    assert "routing" not in result
 
 
 async def test_dict_model_spec_never_routed(monkeypatch):
@@ -1027,6 +1031,20 @@ async def test_get_client_strips_routing_key(monkeypatch):
     assert "routing" not in fake.call_args.kwargs
 
 
+async def test_get_client_strips_description_key(monkeypatch):
+    """The 'description' key must never reach the SDK constructor — it is
+    routing metadata only."""
+    fake = MagicMock()
+    monkeypatch.setattr(openai, "AsyncOpenAI", fake)
+    llm = OpenAI(
+        api_key="sk-test",
+        model_kwargs={k: dict(v) for k, v in ROUTED_MODEL_KWARGS.items()},
+    )
+    client = await llm.get_client("edit")
+    assert client is not None
+    assert "description" not in fake.call_args.kwargs
+
+
 async def test_invoke_uses_routed_model_spec(monkeypatch):
     """invoke() resolves routing through the real path: the routing model runs
     first (with a dedicated prompt and no tools), then the resolved config
@@ -1063,10 +1081,10 @@ def _stream_chunks(text: str = "", tool_calls: list[dict] | None = None):
     return gen()
 
 
-async def test_stream_resolves_routing_once_across_tool_rounds(monkeypatch):
-    """Routing is resolved once for a whole stream: the routing model is invoked
-    a single time and follow-up tool-loop rounds reuse the resolved spec instead
-    of re-invoking the router (and paying another blocking network call)."""
+async def test_stream_resolves_routing_per_invoke_not_per_stream(monkeypatch):
+    """Routing is resolved inside invoke(), not stream(). Both success and
+    fallback paths return a dict, so the dict-bypass mechanism prevents
+    re-routing across tool-loop rounds."""
     llm = _routing_llm()
     router_invocations = []
     stream_specs = []
@@ -1102,3 +1120,27 @@ async def test_stream_resolves_routing_once_across_tool_rounds(monkeypatch):
     assert [spec["model"] for spec in router_invocations] == ["router-model"]
     assert [spec["model"] for spec in stream_specs] == ["sql-model", "sql-model"]
     assert "final answer" in outputs
+
+
+async def test_stream_router_down_single_timeout(monkeypatch):
+    """When the router is unreachable, _resolve_routing returns a dict
+    (the fallback config) so the dict-bypass prevents re-routing on
+    every subsequent call — router-down pays exactly one routing attempt
+    per turn, not one per stream+invoke pair nor one per tool round."""
+    llm = _routing_llm()
+    routing_calls = []
+
+    async def fake_run_client(model_spec, messages, **kwargs):
+        if kwargs.get("response_model") is not None:
+            routing_calls.append(model_spec)
+            raise RuntimeError("router down")
+        return "done"
+
+    monkeypatch.setattr(llm, "run_client", fake_run_client)
+    messages = [{"role": "user", "content": "hi"}]
+    output = await llm.invoke(messages, model_spec="edit")
+    assert output == "done"
+    # Exactly one routing attempt — the fallback dict is returned and
+    # used directly, so invoke() never tries routing a second time.
+    assert len(routing_calls) == 1
+    assert routing_calls[0] == {"model": "router-model"}

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -935,7 +935,7 @@ async def test_routing_invoked_with_dict_spec_and_decision_used(monkeypatch):
     assert routed_messages == [{"role": "user", "content": "hi"}]
     assert routed_kwargs["model_spec"] == {"model": "router-model"}
     assert routed_kwargs["tools"] == []
-    assert routed_kwargs["system"] == llm._routing_system_prompt()
+    assert routed_kwargs["system"] == llm._routing_system_prompt("edit")
     assert issubclass(routed_kwargs["response_model"], BaseModel)
 
 
@@ -960,7 +960,7 @@ async def test_routing_prompt_lists_options_with_descriptions(monkeypatch):
     await llm._resolve_routing("edit", messages)
 
     routed_messages, routed_kwargs = calls[0]
-    assert routed_kwargs["system"] == llm._routing_system_prompt()
+    assert routed_kwargs["system"] == llm._routing_system_prompt("edit")
     assert "Best for editing tasks" in routed_kwargs["system"]
     assert "Best for SQL tasks" in routed_kwargs["system"]
     assert routed_messages == [{"role": "user", "content": "hi"}]
@@ -1259,7 +1259,7 @@ def test_spec_descriptions_used_as_fallback_in_routing_prompt():
         "default": "General purpose model",
         "sql": "For SQL queries",
     }
-    prompt = llm._routing_system_prompt()
+    prompt = llm._routing_system_prompt("edit")
     assert "General purpose model" in prompt
     # edit already has an explicit description in ROUTED_MODEL_KWARGS
     assert "Best for editing tables and visualizations" in prompt
@@ -1273,6 +1273,117 @@ def test_explicit_description_overrides_spec_descriptions():
     llm = _routing_llm()
     llm.model_kwargs["sql"]["description"] = "Custom SQL description"
     llm.spec_descriptions = {"sql": "Fallback SQL description"}
-    prompt = llm._routing_system_prompt()
+    prompt = llm._routing_system_prompt("edit")
     assert "Custom SQL description" in prompt
     assert "Fallback SQL description" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Routing resolution through the model_kwargs fallback
+# ---------------------------------------------------------------------------
+
+async def _route_and_record(llm, model_spec, decision="sql"):
+    """Invoke through the real routing path, returning the models actually called."""
+    models = []
+
+    async def fake_run_client(spec, messages, **kwargs):
+        model = llm._get_model_kwargs(spec).get("model")
+        models.append(model)
+        if kwargs.get("response_model") is not None:
+            return SimpleNamespace(model_spec=decision)
+        return "done"
+
+    llm.run_client = fake_run_client
+    await llm.invoke([{"role": "user", "content": "hi"}], model_spec=model_spec)
+    return models
+
+
+@pytest.mark.parametrize("model_spec", ["sql", "chat", "vega_lite", "default"])
+async def test_routing_applies_to_specs_resolved_from_default(model_spec):
+    """Actors derive model_spec from their class name (sql, chat, vega_lite, ...),
+    which providers do not enumerate in model_kwargs. Those specs resolve to the
+    'default' entry, so 'default' declaring routing must route them too."""
+    llm = _make(OpenAI, {})
+    llm.model_kwargs = {
+        "default": {"model": "base-model", "routing": {"model": "router-model"}},
+        "ui": {"model": "ui-model"},
+    }
+    models = await _route_and_record(llm, model_spec, decision="ui")
+    assert models == ["router-model", "ui-model"]
+
+
+async def test_routing_skipped_when_resolved_entry_declares_none():
+    """An explicitly configured entry without routing is used as-is, even when
+    the 'default' entry declares routing."""
+    llm = _make(OpenAI, {})
+    llm.model_kwargs = {
+        "default": {"model": "base-model", "routing": {"model": "router-model"}},
+        "ui": {"model": "ui-model"},
+    }
+    assert await _route_and_record(llm, "ui") == ["ui-model"]
+
+
+async def test_llamacpp_repo_id_spec_never_routed():
+    """LlamaCpp resolves a '/' repo id to that model directly, so routing must
+    not override a model the caller named explicitly."""
+    llm = LlamaCpp(model_kwargs={
+        "default": {"repo_id": "unsloth/Qwen3-32B-GGUF", "routing": {"model": "router-model"}},
+    })
+    assert await llm._resolve_routing("unsloth/Qwen3-Coder-32B-A3B-Instruct-GGUF", []) == (
+        "unsloth/Qwen3-Coder-32B-A3B-Instruct-GGUF"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routing context stripping
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("content", [
+    pytest.param(_make_test_image(), id="bare-image"),
+    pytest.param(["describe this", _make_test_image()], id="list-image"),
+    pytest.param([{"type": "text", "text": "hi"},
+                  {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}],
+                 id="list-image-url-dict"),
+])
+def test_strip_for_routing_removes_every_image_shape(content):
+    """The routing model is small and usually text-only, so no image payload may
+    reach it in any of the content shapes _check_for_image produces."""
+    llm = _make(OpenAI, {})
+    stripped = llm._strip_for_routing([{"role": "user", "content": content}])
+    remaining = stripped[0]["content"]
+    items = remaining if isinstance(remaining, list) else [remaining]
+    assert not any(isinstance(item, Image) for item in items)
+    assert not any(isinstance(item, dict) and item.get("type") == "image_url" for item in items)
+
+
+# ---------------------------------------------------------------------------
+# Routing prompt content
+# ---------------------------------------------------------------------------
+
+def test_spec_descriptions_documented_by_default():
+    """The universal spec keys describe themselves without the UI layer having
+    been constructed, so headless routing is not left with bare key names."""
+    llm = _make(OpenAI, {})
+    llm.model_kwargs = {
+        "default": {"model": "base-model", "routing": {"model": "router-model"}},
+        "ui": {"model": "ui-model"},
+    }
+    prompt = llm._routing_system_prompt("default")
+    assert "No description provided." not in prompt
+
+
+def test_routing_prompt_names_the_requested_spec():
+    """The router picks a model for a task, so it is told which task was asked
+    for rather than inferring it from the user message alone."""
+    llm = _routing_llm()
+    assert "sql" in llm._routing_system_prompt("sql")
+
+
+def test_model_card_offers_user_supplied_select_models():
+    """select_models is user-settable at construction, so the dialog dropdown has
+    to read the instance rather than the provider class default."""
+    from lumen.ai.llm_dialog import LLMModelCard
+
+    llm = OpenAI(model_kwargs={"default": {"model": "m"}}, select_models=["my-model", "other"])
+    card = LLMModelCard(llm=llm, model_type="default", llm_choices=[], description="")
+    assert card._get_default_models() == ["m", "my-model", "other"]


### PR DESCRIPTION
## Description

I added opt-in model routing to `Llm.invoke()`, so a task type whose `model_kwargs` entry declares a `"routing"` key now invokes a routing model first to pick which entry to use for that call based on task complexity, instead of always resolving to the fixed config. Routing is opt-in per entry and resolved at a single hook point, so entries without a `"routing"` key behave byte-for-byte as before and `stream()` is covered automatically since every code path in it delegates to `invoke()`.

Relates to #2004. Draft pending design sign-off from @ahuang11 and @ghostiee-11, not ready to merge.

```python
model_kwargs = {
    "default": {"model": "gpt-5.4-mini"},
    "edit": {"model": "gpt-5.2", "routing": {"model": "nemotron-switchyard"}},
}
```

Changes:

- Routing is opt-in per `model_kwargs` entry and resolved once at the top of `Llm.invoke()` right after `_add_system_message`, so a `"routing"` key is the only signal that changes behavior.
- The routing model is always invoked with a dict `model_spec`, which `_get_model_kwargs()` returns as-is, so the routing call bypasses the `model_kwargs` lookup and can never route itself, which removes the need for a recursion guard.
- The routing response is a pydantic model whose `model_spec` field is a `Literal` rebuilt at call time from the current `model_kwargs` keys via `pydantic.create_model`, so a hallucinated key fails validation instead of silently falling back to `"default"`.
- The routing call is wrapped in try/except and logs through `log_debug(..., prefix="[LLM routing]")`, falling back to the original `model_spec` unchanged if the router raises.

No breaking change, new dependency, or migration needed. Tests added in `lumen/tests/ai/test_llm.py`: `test_route_spec_model_constrains_to_current_model_kwargs_keys`, `test_no_routing_key_passes_through`, `test_routing_invoked_with_dict_spec_and_decision_used`, `test_routing_exception_falls_back`, `test_dict_model_spec_never_routed`, and `test_invoke_uses_routed_model_spec`.

## AI Disclosure

Tool & Model: opencode (big-pickle model)

Usage: Drafted the implementation and unit tests for the routing feature, and wrote this description.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
- [x] Added documentation
