### PR TITLE
Fix Filter warning formatting

### DIFF
--- a/lumen/tests/transforms/test_base.py
+++ b/lumen/tests/transforms/test_base.py
@@ -5,7 +5,7 @@ import pandas as pd
 import param  # type: ignore
 
 from lumen.transforms.base import (
-    Count, DropNA, Eval, Sum, Transform, project_lnglat,
+    Count, DropNA, Eval, Filter, Sum, Transform, project_lnglat,
 )
 
 
@@ -87,3 +87,15 @@ def test_project_lnglat_default_params():
     transform = project_lnglat()
     assert transform.longitude == 'longitude'
     assert transform.latitude == 'latitude'
+
+
+def test_filter_invalid_condition_warns(caplog):
+    df = pd.DataFrame({'A': [1, 2]})
+
+    result = Filter(conditions=[('A', {'unexpected': True})]).apply(df)
+
+    pd.testing.assert_frame_equal(result, df)
+    assert (
+        "Condition {'unexpected': True} on 'A' column not understood. "
+        "Filter query will not be applied."
+    ) in caplog.text

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -243,7 +243,7 @@ class Filter(Transform):
                 mask = self._range_filter(column, *val)
             else:
                 self.param.warning(
-                    'Condition {val!r} on {col!r} column not understood. '
+                    f'Condition {val!r} on {k!r} column not understood. '
                     'Filter query will not be applied.'
                 )
                 continue


### PR DESCRIPTION
## Summary

- format invalid `Filter` condition warnings with the actual condition value
- reference the in-scope column key instead of the undefined `col` name
- add a regression test for the warning and unchanged DataFrame

## Testing

- `python -m pytest lumen/tests/transforms/test_base.py -q`

Fixes #2013
