### PR TITLE
Document table discovery in embeddings guide

### DIFF
--- a/docs/configuration/coordinators.md
+++ b/docs/configuration/coordinators.md
@@ -122,7 +122,7 @@ The DependencyResolver picks the final agent first, then figures out what it nee
 
 ``` mermaid
 graph BT
-    A[TableLookup] --> B[SQLAgent]
+    A[MetadataLookup] --> B[SQLAgent]
     B --> C[VegaLiteAgent]
     C --> D[Goal Achieved]
 ```
@@ -133,9 +133,9 @@ DependencyResolver thinks:
 ```
 Goal: VegaLiteAgent (needs pipeline)
   ↑ SQLAgent (needs metaset)
-    ↑ TableLookup (no dependencies)
+    ↑ MetadataLookup (no dependencies)
 
-Execution: TableLookup → SQLAgent → VegaLiteAgent
+Execution: MetadataLookup → SQLAgent → VegaLiteAgent
 ```
 
 No planning phase, just direct execution.

--- a/docs/configuration/embeddings.md
+++ b/docs/configuration/embeddings.md
@@ -154,6 +154,16 @@ results = await vector_store.query('authentication setup')
 
 See [Vector Stores - Searching](vector_stores.md#searching) for query examples.
 
+**Table discovery** - Agents find relevant tables using vector search:
+
+``` py
+from lumen.ai.tools import MetadataLookup
+
+tool = MetadataLookup()
+```
+
+See [Tools - Built-in tools](tools.md#built-in-tools) for details on `MetadataLookup`.
+
 **Contextual augmentation** - Chunks get context descriptions:
 
 ``` py

--- a/docs/configuration/tools.md
+++ b/docs/configuration/tools.md
@@ -8,13 +8,15 @@ Most users don't need custom tools. Built-in tools handle common needs.
 
 ## Built-in tools
 
-Lumen includes tools automatically:
+Lumen adds these tools automatically:
 
-- **TableLookup** - Finds relevant tables in your data (see [Vector Stores](vector_stores.md#table-discovery))
-- **DocumentLookup** - Searches uploaded documents (see [Vector Stores](vector_stores.md#document-search))
-- **DbtslLookup** - Queries dbt Semantic Layer metrics
+- **MetadataLookup** - Finds relevant tables in your data (see [Vector Stores](vector_stores.md#table-discovery))
+- **SourceLookup** - Finds relevant external data source actions, added when a `SourceAgent` is present
+- **`list_indexed_documents` and `search_document_chunks`** - Search uploaded documents, added when a document vector store holds documents (see [Vector Stores](vector_stores.md#document-search))
 
 You don't need to configure these. Agents use them when needed.
+
+**DbtslLookup** queries dbt Semantic Layer metrics and is not automatic; pass it via `tools=` to enable it.
 
 ## Create a simple tool
 
@@ -249,7 +251,7 @@ Combine tools for complex workflows:
 === "With built-in tools"
 
     ``` py title="Mix custom and built-in tools"
-    from lumen.ai.tools import DocumentLookup
+    from lumen.ai.tools import MetadataLookup
 
     def get_stats(table) -> dict:
         """Calculate summary statistics."""
@@ -269,7 +271,7 @@ Combine tools for complex workflows:
 
     ui = lmai.ExplorerUI(
         data='penguins.csv',
-        tools=[get_stats, filter_species, DocumentLookup()]
+        tools=[get_stats, filter_species, MetadataLookup(include_columns=False)]
     )
     ui.servable()
     ```

--- a/docs/configuration/vector_stores.md
+++ b/docs/configuration/vector_stores.md
@@ -181,7 +181,7 @@ Requires an LLM to generate context - see [LLM Providers](llm_providers.md) for 
 
 ### Table discovery
 
-Lumen embeds the metadata of every table it knows about, then searches those embeddings to pick the tables relevant to a question. This runs by default through the `MetadataLookup` tool, so a session with hundreds of tables only sends a handful of them to the agents.
+Lumen embeds the metadata of every table in your sources, then searches those embeddings to pick the tables relevant to a question. This runs by default through the `MetadataLookup` tool, which returns the 20 closest matches, so a session with hundreds of tables only sends those to the agents.
 
 ``` py title="Reuse a store for table metadata"
 import lumen.ai as lmai

--- a/docs/configuration/vector_stores.md
+++ b/docs/configuration/vector_stores.md
@@ -179,6 +179,24 @@ Requires an LLM to generate context - see [LLM Providers](llm_providers.md) for 
 
 ## Integration with Lumen AI
 
+### Table discovery
+
+Lumen embeds the metadata of every table it knows about, then searches those embeddings to pick the tables relevant to a question. This runs by default through the `MetadataLookup` tool, so a session with hundreds of tables only sends a handful of them to the agents.
+
+``` py title="Reuse a store for table metadata"
+import lumen.ai as lmai
+
+vector_store = DuckDBVectorStore(uri='tables.db')
+
+ui = lmai.ExplorerUI(
+    data=['penguins.csv', 'earthquakes.parquet'],
+    vector_store=vector_store
+)
+ui.servable()
+```
+
+See [Tools - Built-in tools](tools.md#built-in-tools) for the tools that use these embeddings.
+
 ### Document search
 
 ``` py title="Enable document search"
@@ -194,7 +212,7 @@ ui = lmai.ExplorerUI(
 ui.servable()
 ```
 
-Users can now ask questions about uploaded documents. See [Tools - DocumentLookup](tools.md#built-in-tools) for how this works.
+Users can now ask questions about uploaded documents. See [Tools - Built-in tools](tools.md#built-in-tools) for how this works.
 
 ## Configuration
 


### PR DESCRIPTION
Fixes #1942

Adds the missing table discovery section so the guide lists all three embeddings-powered features. The example uses the current MetadataLookup API and links to the built-in tools documentation.

Tests:
- pre-commit run --files docs/configuration/embeddings.md
- pixi run -e docs docs-build