### PR TITLE
chores: lint imports that are not at the top of a file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,9 @@ repos:
     -   id: end-of-file-fixer
         exclude: \.(csv|excalidraw)$
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.4
     hooks:
-      - id: ruff
+      - id: ruff-check
         files: lumen
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/lumen/__main__.py
+++ b/lumen/__main__.py
@@ -1,10 +1,10 @@
 import sys
 
+from lumen.command import main as _main
+
 
 def main():
-    from lumen.command import main as _main  # noqa: PLC0415
-
-   # Main entry point (see setup.py)
+    # Main entry point (see setup.py)
     _main(sys.argv)
 
 if __name__ == "__main__":

--- a/lumen/__main__.py
+++ b/lumen/__main__.py
@@ -2,7 +2,7 @@ import sys
 
 
 def main():
-    from lumen.command import main as _main
+    from lumen.command import main as _main  # noqa: PLC0415
 
    # Main entry point (see setup.py)
     _main(sys.argv)

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -27,7 +27,7 @@ def _expand_llm_tool_entries(entries: list[Any] | None, context: TContext) -> li
     Expand :attr:`LLMUser.llm_tools` entries: keep plain tools; resolve callables
     ``f(context)`` or no-arg ``f()`` to a tool or list of tools.
     """
-    from .tools.base import FunctionTool
+    from .tools.base import FunctionTool  # noqa: PLC0415
 
     if not entries:
         return []

--- a/lumen/ai/actor.py
+++ b/lumen/ai/actor.py
@@ -27,6 +27,7 @@ def _expand_llm_tool_entries(entries: list[Any] | None, context: TContext) -> li
     Expand :attr:`LLMUser.llm_tools` entries: keep plain tools; resolve callables
     ``f(context)`` or no-arg ``f()`` to a tool or list of tools.
     """
+    # Deferred: .tools.base imports Actor from this module.
     from .tools.base import FunctionTool  # noqa: PLC0415
 
     if not entries:

--- a/lumen/ai/agents/source.py
+++ b/lumen/ai/agents/source.py
@@ -29,6 +29,7 @@ from ..controls.ingest.result import SourceResult
 from ..llm import Message
 from ..schemas import Metaset, get_metaset
 from ..tools import FunctionTool
+from ..tools.source_lookup import _control_hash
 from ..translate import doc_descriptions
 from ..utils import (
     describe_data, get_pipeline, log_debug, result_to_dataframe,
@@ -261,9 +262,6 @@ class SourceAgent(Agent):
         ctrl_map: dict[str, BaseSourceControls] = {}
         for c in controls:
             if c._supports_tools:
-                from ..tools.source_lookup import (  # noqa: PLC0415
-                    _control_hash,
-                )
                 ctrl_map[_control_hash(c)] = c
 
         tools: list[FunctionTool] = []

--- a/lumen/ai/agents/source.py
+++ b/lumen/ai/agents/source.py
@@ -261,7 +261,9 @@ class SourceAgent(Agent):
         ctrl_map: dict[str, BaseSourceControls] = {}
         for c in controls:
             if c._supports_tools:
-                from ..tools.source_lookup import _control_hash
+                from ..tools.source_lookup import (  # noqa: PLC0415
+                    _control_hash,
+                )
                 ctrl_map[_control_hash(c)] = c
 
         tools: list[FunctionTool] = []

--- a/lumen/ai/code_executor.py
+++ b/lumen/ai/code_executor.py
@@ -338,7 +338,7 @@ class AltairExecutor(CodeExecutor):
 
     @classmethod
     def _get_injected_modules(cls) -> dict[str, Any]:
-        import altair as alt
+        import altair as alt  # noqa: PLC0415
         return {'alt': alt, 'altair': alt}
 
     @classmethod
@@ -348,7 +348,7 @@ class AltairExecutor(CodeExecutor):
 
     @classmethod
     def _validate_result(cls, result: Any) -> None:
-        import altair as alt
+        import altair as alt  # noqa: PLC0415
         valid_types = (
             alt.Chart, alt.LayerChart, alt.HConcatChart,
             alt.VConcatChart, alt.FacetChart, alt.RepeatChart
@@ -366,11 +366,11 @@ class PyDeckExecutor(CodeExecutor):
 
     @classmethod
     def _get_injected_modules(cls) -> dict[str, Any]:
-        import pydeck as pdk
+        import pydeck as pdk  # noqa: PLC0415
         return {'pdk': pdk, 'pydeck': pdk}
 
     @classmethod
     def _validate_result(cls, result: Any) -> None:
-        import pydeck as pdk
+        import pydeck as pdk  # noqa: PLC0415
         if not isinstance(result, pdk.Deck):
             raise ValueError(f"'deck' must be a pydeck.Deck, got {type(result).__name__}")

--- a/lumen/ai/config.py
+++ b/lumen/ai/config.py
@@ -169,7 +169,7 @@ def get_markitdown():
     Built on first use rather than at import, because markitdown reaches
     pandas through its xlsx converter and costs about 0.7s to import.
     """
-    from markitdown import MarkItDown
+    from markitdown import MarkItDown  # noqa: PLC0415
 
     return MarkItDown()
 

--- a/lumen/ai/context.py
+++ b/lumen/ai/context.py
@@ -55,7 +55,7 @@ def _parse_accumulate_meta(annotation: Any) -> AccumulateSpec | None:
       annotation = get_args(annotation)[0]
   if get_origin(annotation) is not Annotated:
       return None
-  base, *meta = get_args(annotation)
+  _base, *meta = get_args(annotation)
   # accept either a tuple ("accumulate", "source"), a Callabe or an AccumulateSpec
   for m in meta:
       if isinstance(m, AccumulateSpec):

--- a/lumen/ai/controls/explorer.py
+++ b/lumen/ai/controls/explorer.py
@@ -98,6 +98,7 @@ class TableExplorer(Viewer):
         if not self.table_slug:
             return
 
+        # Deferred: .editors imports the controls package, which imports this module.
         from ..editors import SQLEditor  # noqa: PLC0415
 
         source = self.source_map[self.table_slug]

--- a/lumen/ai/controls/explorer.py
+++ b/lumen/ai/controls/explorer.py
@@ -98,7 +98,7 @@ class TableExplorer(Viewer):
         if not self.table_slug:
             return
 
-        from ..editors import SQLEditor
+        from ..editors import SQLEditor  # noqa: PLC0415
 
         source = self.source_map[self.table_slug]
         if SOURCE_TABLE_SEPARATOR in self.table_slug:

--- a/lumen/ai/controls/ingest/download.py
+++ b/lumen/ai/controls/ingest/download.py
@@ -62,7 +62,7 @@ class DownloadSourceControls(FileSourceControls):
     def __init__(self, **params):
         super().__init__(**params)
         try:
-            import kagglehub
+            import kagglehub  # noqa: PLC0415
             self._kagglehub = kagglehub
         except ModuleNotFoundError:
             self._kagglehub = None

--- a/lumen/ai/controls/ingest/file_row.py
+++ b/lumen/ai/controls/ingest/file_row.py
@@ -112,7 +112,7 @@ class UploadedFileRow(Viewer):
         """Load sheet names for xlsx files."""
         if self.extension != "xlsx":
             return
-        import openpyxl
+        import openpyxl  # noqa: PLC0415
         wb = openpyxl.load_workbook(self.file_obj, read_only=True)
         self.param.sheet.objects = wb.sheetnames
         self.sheet = wb.sheetnames[0]

--- a/lumen/ai/controls/ingest/progress.py
+++ b/lumen/ai/controls/ingest/progress.py
@@ -83,7 +83,7 @@ class Progress(Viewer):
         -------
         Typography or similar widget
         """
-        from panel_material_ui import Typography
+        from panel_material_ui import Typography  # noqa: PLC0415
         return Typography(
             styles={"margin-left": "auto", "margin-right": "auto"},
             visible=False

--- a/lumen/ai/controls/ingest/progress.py
+++ b/lumen/ai/controls/ingest/progress.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import param
 
 from panel.viewable import Viewer
-from panel_material_ui import Column, LinearProgress
+from panel_material_ui import Column, LinearProgress, Typography
 
 
 class Progress(Viewer):
@@ -83,7 +83,6 @@ class Progress(Viewer):
         -------
         Typography or similar widget
         """
-        from panel_material_ui import Typography  # noqa: PLC0415
         return Typography(
             styles={"margin-left": "auto", "margin-right": "auto"},
             visible=False

--- a/lumen/ai/controls/ingest/utils.py
+++ b/lumen/ai/controls/ingest/utils.py
@@ -309,7 +309,7 @@ def read_geo_file(
             raise ValueError("ZIP file does not contain a shapefile (.shp)")
         file_obj.seek(0)
 
-    import geopandas as gpd
+    import geopandas as gpd  # noqa: PLC0415
 
     geo_df = gpd.read_file(file_obj)
     if geo_df.empty:

--- a/lumen/ai/coordinator/planner.py
+++ b/lumen/ai/coordinator/planner.py
@@ -286,7 +286,7 @@ class Planner(Coordinator):
                     title=f"Gathering context with {tool_name}",
                     steps_layout=self.steps_layout,
                 )
-                outputs, out_context = await task.execute(context)
+                _outputs, out_context = await task.execute(context)
                 if task.status == "error":
                     step.stream(f"\n\n✗ Failed to gather context from {tool_name}")
                     continue

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -11,6 +11,7 @@ from io import BytesIO, StringIO
 from typing import TYPE_CHECKING, Any
 
 import param
+import vl_convert as vlc
 
 from panel.config import config
 from panel.layout import Column, Row
@@ -398,7 +399,6 @@ class VegaLiteEditor(LumenEditor):
         if "spec" in spec:
             spec = spec["spec"]
         try:
-            import vl_convert as vlc  # noqa: PLC0415
             vlc.vegalite_to_vega(spec)
         except ValueError as e:
             msg = str(e)

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -398,7 +398,7 @@ class VegaLiteEditor(LumenEditor):
         if "spec" in spec:
             spec = spec["spec"]
         try:
-            import vl_convert as vlc
+            import vl_convert as vlc  # noqa: PLC0415
             vlc.vegalite_to_vega(spec)
         except ValueError as e:
             msg = str(e)

--- a/lumen/ai/embeddings.py
+++ b/lumen/ai/embeddings.py
@@ -147,7 +147,7 @@ class HuggingFaceEmbeddings(Embeddings):
 
     def __init__(self, **params):
         super().__init__(**params)
-        from sentence_transformers import SentenceTransformer
+        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
         self._model = SentenceTransformer(self.model, device=self.device)
         self.embedding_dim = self._model.get_sentence_embedding_dimension()
 
@@ -188,7 +188,7 @@ class LlamaCppEmbeddings(Embeddings, LlamaCppMixin):
     })
 
     def __init__(self, **params):
-        import llama_cpp
+        import llama_cpp  # noqa: PLC0415
         super().__init__(**params)
         if "pooling_type" not in self.model_kwargs["default"]:
             self.model_kwargs["default"]["pooling_type"] = llama_cpp.LLAMA_POOLING_TYPE_CLS

--- a/lumen/ai/export.py
+++ b/lumen/ai/export.py
@@ -176,7 +176,7 @@ def docx_add_table(doc, df, max_rows: int = 50):
 
 def docx_add_chart(doc, editor) -> bool:
     """Embed a chart editor as a PNG image; return True if one was added."""
-    from docx.shared import Inches
+    from docx.shared import Inches  # noqa: PLC0415
 
     if 'png' not in editor.export_formats:
         return False

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -765,6 +765,7 @@ class Llm(param.Parameterized):
             else:
                 tool_context = None
             if callable(tool) and hasattr(tool, "__lumen_tool_annotations__"):
+                # Deferred: .tools -> .tools.base -> .actor -> .llm is a cycle.
                 from .tools import FunctionTool  # noqa: PLC0415
                 tool = FunctionTool(tool)
             if hasattr(tool, "_model"):
@@ -941,6 +942,7 @@ class Llm(param.Parameterized):
         tool_contexts: dict[str, Any],
         messages: list[Message],
     ) -> list[Message]:
+        # Deferred: .tools -> .tools.base -> .actor -> .llm is a cycle.
         from .tools import FunctionTool, MCPTool  # noqa: PLC0415
 
         async def run_single_tool_call(call: Any) -> Message | None:

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -275,7 +275,7 @@ class Llm(param.Parameterized):
     @param.depends("logfire_tags", watch=True)
     def _update_logfire_tags(self):
         if self.logfire_tags is not None and self._supports_logfire:
-            import logfire
+            import logfire  # noqa: PLC0415
             logfire.configure(send_to_logfire=True)
             self._logfire = logfire.Logfire(tags=self.logfire_tags)
         else:
@@ -765,7 +765,7 @@ class Llm(param.Parameterized):
             else:
                 tool_context = None
             if callable(tool) and hasattr(tool, "__lumen_tool_annotations__"):
-                from .tools import FunctionTool
+                from .tools import FunctionTool  # noqa: PLC0415
                 tool = FunctionTool(tool)
             if hasattr(tool, "_model"):
                 tool_instances[tool.name] = tool  # type: ignore[assignment]
@@ -941,7 +941,7 @@ class Llm(param.Parameterized):
         tool_contexts: dict[str, Any],
         messages: list[Message],
     ) -> list[Message]:
-        from .tools import FunctionTool, MCPTool
+        from .tools import FunctionTool, MCPTool  # noqa: PLC0415
 
         async def run_single_tool_call(call: Any) -> Message | None:
             name, arguments, call_id = self._parse_tool_call(call)
@@ -1760,7 +1760,7 @@ class MistralAI(Llm, MistralAIMixin):
 
     def models(self) -> set[str]:
         """Return the set of available model identifiers from Mistral."""
-        from mistralai import Mistral
+        from mistralai import Mistral  # noqa: PLC0415
         return {m.id for m in Mistral(api_key=self.api_key).models.list().data}
 
     def _create_base_client(self, **kwargs) -> Any:
@@ -1852,7 +1852,7 @@ class Anthropic(Llm, AnthropicMixin):
 
     def models(self) -> set[str]:
         """Return the set of available model identifiers from Anthropic."""
-        from anthropic import Anthropic as AnthropicClient
+        from anthropic import Anthropic as AnthropicClient  # noqa: PLC0415
         response = AnthropicClient(api_key=self.api_key, timeout=5).models.list()
         # also handle model aliases (claude-sonnet-4-5-20250929) -> (claude-sonnet-4-5)
         return {m.id for m in response.data} | {m.id.rsplit("-", maxsplit=1)[0] for m in response.data}
@@ -2118,7 +2118,9 @@ class AnthropicBedrock(BedrockMixin, Anthropic):  # Keep it before Anthropic so 
     })
 
     def _create_base_client(self, **kwargs) -> Any:
-        from anthropic.lib.bedrock import AsyncAnthropicBedrock
+        from anthropic.lib.bedrock import (  # noqa: PLC0415
+            AsyncAnthropicBedrock,
+        )
         return AsyncAnthropicBedrock(
             aws_access_key=self.aws_access_key_id,
             aws_secret_key=self.api_key,
@@ -2176,7 +2178,7 @@ class Bedrock(Llm, BedrockMixin):
     def _create_base_client(self, **kwargs) -> Any:
         """Create boto3 bedrock-runtime client for inference."""
         try:
-            import boto3
+            import boto3  # noqa: PLC0415
         except ImportError as exc:
             raise ImportError(
                 "Please install boto3 to use AWS Bedrock. "
@@ -2328,7 +2330,7 @@ class Google(Llm, GenAIMixin):
 
     def models(self) -> set[str]:
         """Return the set of available model identifiers from Google AI."""
-        from google import genai
+        from google import genai  # noqa: PLC0415
         available = set()
         for m in genai.Client(api_key=self.api_key).models.list():
             available.add(m.name)
@@ -2512,7 +2514,9 @@ class Google(Llm, GenAIMixin):
         if not tool_specs:
             return
 
-        from google.genai.types import FunctionDeclaration, Tool
+        from google.genai.types import (  # noqa: PLC0415
+            FunctionDeclaration, Tool,
+        )
         declarations = []
         for spec in tool_specs:
             if not isinstance(spec, dict) or spec.get("type") != "function":
@@ -2550,7 +2554,7 @@ class Google(Llm, GenAIMixin):
     async def run_client(self, model_spec: str | dict, messages: list[Message], **kwargs):
         """Override to handle Gemini-specific message format conversion."""
         try:
-            from google.genai.types import (
+            from google.genai.types import (  # noqa: PLC0415
                 GenerateContentConfig, HttpOptions, ThinkingConfig,
             )
         except ImportError as exc:
@@ -2759,7 +2763,7 @@ class MLX(Llm):
     def _load_mlx_model(self, model_id: str) -> tuple:
         """Load and cache an MLX model. Duplicate loads are harmless but wasteful."""
         if model_id not in self._mlx_models:
-            from mlx_lm import load
+            from mlx_lm import load  # noqa: PLC0415
             self._mlx_models[model_id] = load(model_id)
         return self._mlx_models[model_id]
 
@@ -2785,14 +2789,14 @@ class MLX(Llm):
 
     def _make_sampler(self):
         """Create an MLX sampler from the configured temperature."""
-        from mlx_lm.sample_utils import make_sampler
+        from mlx_lm.sample_utils import make_sampler  # noqa: PLC0415
         if self.temperature is None:
             return make_sampler()
         return make_sampler(temp=self.temperature)
 
     def _create_chat_completion(self, messages: list[Message], **kwargs) -> Any:
         """Synchronous chat completion compatible with instructor's patch(create=...)."""
-        from mlx_lm import generate as mlx_generate
+        from mlx_lm import generate as mlx_generate  # noqa: PLC0415
 
         model_spec = kwargs.pop("model", "default")
         model_kwargs = self._get_model_kwargs(model_spec)
@@ -2838,7 +2842,7 @@ class MLX(Llm):
     @classmethod
     def warmup(cls, model_kwargs: dict | None):
         """Pre-download model weights from Hugging Face Hub."""
-        from mlx_lm import load
+        from mlx_lm import load  # noqa: PLC0415
         model_kwargs = model_kwargs or {}
         if "default" not in model_kwargs:
             model_kwargs["default"] = cls.model_kwargs["default"]
@@ -2980,7 +2984,7 @@ class WebLLM(Llm):
         return {}
 
     def __init__(self, **params):
-        from panel_web_llm import WebLLM as pnWebLLM
+        from panel_web_llm import WebLLM as pnWebLLM  # noqa: PLC0415
         self._llm = pnWebLLM()
         super().__init__(**params)
 
@@ -3118,9 +3122,9 @@ class LiteLLM(Llm):
         super().__init__(**params)
         self._router = None  # Lazy init
         if self.enable_caching:
-            import litellm
+            import litellm  # noqa: PLC0415
 
-            from litellm import Cache
+            from litellm import Cache  # noqa: PLC0415
             litellm.cache = Cache()
         if self.logfire_tags:
             self._logfire.instrument_litellm()
@@ -3128,7 +3132,7 @@ class LiteLLM(Llm):
     def _get_router(self):
         """Get or create cached LiteLLM Router."""
         if self._router is None:
-            from litellm import Router
+            from litellm import Router  # noqa: PLC0415
             model_list = [
                 {'model_name': key, 'litellm_params': config}
                 for key, config in self.model_kwargs.items()

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -1237,9 +1237,11 @@ class Report(TaskGroup):
                 "Exporting a report to Word requires python-docx; install it with "
                 "`pip install python-docx`."
             )
-        from docx import Document
+        from docx import Document  # noqa: PLC0415
 
-        from .export import docx_add_chart, docx_add_markdown, docx_add_table
+        from .export import (  # noqa: PLC0415
+            docx_add_chart, docx_add_markdown, docx_add_table,
+        )
 
         doc = Document()
         pending: list[tuple[int, str]] = []

--- a/lumen/ai/report.py
+++ b/lumen/ai/report.py
@@ -40,7 +40,8 @@ from .context import (
 )
 from .editors import LumenEditor
 from .export import (
-    format_output, make_md_cell, make_preamble, write_notebook,
+    docx_add_chart, docx_add_markdown, docx_add_table, format_output,
+    make_md_cell, make_preamble, write_notebook,
 )
 from .llm import Llm, Message
 from .tools import FunctionTool, Tool
@@ -1238,10 +1239,6 @@ class Report(TaskGroup):
                 "`pip install python-docx`."
             )
         from docx import Document  # noqa: PLC0415
-
-        from .export import (  # noqa: PLC0415
-            docx_add_chart, docx_add_markdown, docx_add_table,
-        )
 
         doc = Document()
         pending: list[tuple[int, str]] = []

--- a/lumen/ai/services.py
+++ b/lumen/ai/services.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from abc import abstractmethod
@@ -92,7 +93,7 @@ class DbtslMixin(ServiceMixin):
         """
         Create and return a dbt Semantic Layer client instance.
         """
-        from dbtsl.asyncio import AsyncSemanticLayerClient
+        from dbtsl.asyncio import AsyncSemanticLayerClient  # noqa: PLC0415
 
         kwargs = self._instantiate_client_kwargs(**extra_kwargs)
         return AsyncSemanticLayerClient(**kwargs)
@@ -131,7 +132,7 @@ class LlamaCppMixin(ServiceMixin):
         if 'model_path' in kwargs:
             return kwargs['model_path']
         elif 'repo_id' in kwargs and 'filename' in kwargs:
-            from huggingface_hub import hf_hub_download
+            from huggingface_hub import hf_hub_download  # noqa: PLC0415
             return hf_hub_download(
                 repo_id=kwargs['repo_id'],
                 filename=kwargs['filename'],
@@ -176,7 +177,7 @@ class LlamaCppMixin(ServiceMixin):
         """
         Create and return a Llama instance with the configured parameters.
         """
-        from llama_cpp import Llama
+        from llama_cpp import Llama  # noqa: PLC0415
 
         kwargs = self._instantiate_client_kwargs(model_kwargs=model_kwargs, **extra_kwargs)
         return Llama(**kwargs)
@@ -217,9 +218,7 @@ class LlamaCppMixin(ServiceMixin):
         if not huggingface_models:
             return
 
-        import json
-
-        from huggingface_hub import hf_hub_download
+        from huggingface_hub import hf_hub_download  # noqa: PLC0415
         print(f"{cls.__name__} provider is downloading following models:\n\n{json.dumps(huggingface_models, indent=2)}")  # noqa: T201
         for kwargs in model_kwargs_dict.values():
             repo_id = kwargs.get('repo_id')
@@ -270,7 +269,7 @@ class AnthropicMixin(APIKeyServiceMixin):
     api_key_env_var: str = PROVIDER_ENV_VARS['anthropic']
 
     def _instantiate_client(self, async_client=True, **extra_kwargs):
-        from anthropic import Anthropic, AsyncAnthropic
+        from anthropic import Anthropic, AsyncAnthropic  # noqa: PLC0415
         kwargs = self._instantiate_client_kwargs(**extra_kwargs)
         return AsyncAnthropic(**kwargs) if async_client else Anthropic(**kwargs)
 
@@ -284,7 +283,7 @@ class GenAIMixin(APIKeyServiceMixin):
     api_key_env_var: str = PROVIDER_ENV_VARS['google']
 
     def _instantiate_client(self, **extra_kwargs):
-        from google import genai
+        from google import genai  # noqa: PLC0415
         kwargs = self._instantiate_client_kwargs(**extra_kwargs)
         return genai.Client(**kwargs)
 
@@ -298,7 +297,7 @@ class MistralAIMixin(APIKeyServiceMixin):
     api_key_env_var: str = PROVIDER_ENV_VARS['mistral']
 
     def _instantiate_client(self, **extra_kwargs):
-        from mistralai import Mistral
+        from mistralai import Mistral  # noqa: PLC0415
         kwargs = self._instantiate_client_kwargs(**extra_kwargs)
         return Mistral(**kwargs)
 
@@ -323,7 +322,7 @@ class AzureMistralAIMixin(MistralAIMixin):
         """
         Create and return an Azure Mistral client instance.
         """
-        from mistralai_azure import MistralAzure
+        from mistralai_azure import MistralAzure  # noqa: PLC0415
         kwargs = self._instantiate_client_kwargs(**extra_kwargs)
         return MistralAzure(azure_endpoint=self.endpoint, **kwargs)
 

--- a/lumen/ai/tools/mcp.py
+++ b/lumen/ai/tools/mcp.py
@@ -180,7 +180,7 @@ class MCPTool(Tool):
         list[MCPTool]
             One MCPTool per tool advertised by the server.
         """
-        from fastmcp import Client
+        from fastmcp import Client  # noqa: PLC0415
 
         client = server if isinstance(server, Client) else Client(server)
         async with client:
@@ -228,7 +228,7 @@ class MCPTool(Tool):
             The tool result.  Structured ``.data`` is preferred; falls
             back to concatenated text content blocks.
         """
-        from fastmcp import Client
+        from fastmcp import Client  # noqa: PLC0415
 
         client = self.server if isinstance(self.server, Client) else Client(self.server)
         async with client:

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -4,6 +4,7 @@ import asyncio
 import atexit
 import os
 import tempfile
+import traceback
 
 from contextlib import contextmanager
 from functools import partial
@@ -600,7 +601,9 @@ class UI(Viewer):
                     continue
                 elif src.startswith(('sqlite://', 'postgresql://', 'mysql://', 'mssql://', 'oracle://')):
                     try:
-                        from ..sources.sqlalchemy import SQLAlchemySource
+                        from ..sources.sqlalchemy import (  # noqa: PLC0415
+                            SQLAlchemySource,
+                        )
                     except ImportError as e:
                         raise ImportError(
                             "SQLAlchemy is required for database connection strings. "
@@ -626,7 +629,9 @@ class UI(Viewer):
                         sources.append(source)
                     else:
                         try:
-                            from ..sources.sqlalchemy import SQLAlchemySource
+                            from ..sources.sqlalchemy import (  # noqa: PLC0415
+                                SQLAlchemySource,
+                            )
                         except ImportError as e:
                             raise ImportError(
                                 "SQLAlchemy is required to read .db files. "
@@ -745,7 +750,6 @@ class UI(Viewer):
             self._chat_input.disabled = False
             self.interface.disabled = False
         except Exception as e:
-            import traceback
             traceback.print_exc()
             self._llm_status = str(e)
             if self._error_alert is not None:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -1804,7 +1804,8 @@ def result_to_dataframe(result) -> pd.DataFrame | None:
     if isinstance(result, Source):
         return None
 
-    # SourceResult from controls — extract the DataFrame from the first source
+    # SourceResult from controls — extract the DataFrame from the first source.
+    # Deferred: the controls package reaches .editors, which imports this module.
     from .controls.ingest.result import SourceResult  # noqa: PLC0415
     if isinstance(result, SourceResult):
         if not result.sources or not result.table:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -1278,6 +1278,8 @@ def _get_token_encoder():
     if "encoder" in _TOKEN_ENCODER_CACHE:
         return _TOKEN_ENCODER_CACHE["encoder"]
     try:
+        # Deferred so a missing tiktoken degrades to the character estimate
+        # rather than breaking the import.
         import tiktoken  # noqa: PLC0415
 
         encoder = tiktoken.get_encoding(TOKEN_ENCODING)

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -1278,7 +1278,7 @@ def _get_token_encoder():
     if "encoder" in _TOKEN_ENCODER_CACHE:
         return _TOKEN_ENCODER_CACHE["encoder"]
     try:
-        import tiktoken
+        import tiktoken  # noqa: PLC0415
 
         encoder = tiktoken.get_encoding(TOKEN_ENCODING)
     except Exception as e:
@@ -1805,7 +1805,7 @@ def result_to_dataframe(result) -> pd.DataFrame | None:
         return None
 
     # SourceResult from controls — extract the DataFrame from the first source
-    from .controls.ingest.result import SourceResult
+    from .controls.ingest.result import SourceResult  # noqa: PLC0415
     if isinstance(result, SourceResult):
         if not result.sources or not result.table:
             return None
@@ -2031,7 +2031,7 @@ def normalize_vegalite_spec(
     """
     if editor_type is None:
         # Imported lazily to avoid an editors -> utils import cycle.
-        from .editors import VegaLiteEditor
+        from .editors import VegaLiteEditor  # noqa: PLC0415
         editor_type = VegaLiteEditor
 
     # Remove wrapper properties that aren't part of Vega-Lite spec

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -584,6 +584,8 @@ class VectorStore(LLMUser):
         -------
         List of assigned IDs for the added items.
         """
+        # Deferred for the same reason as get_markitdown: markitdown reaches
+        # pandas through its xlsx converter and costs ~2s to import.
         from markitdown import (  # noqa: PLC0415
             FileConversionException, StreamInfo,
         )

--- a/lumen/ai/vector_store.py
+++ b/lumen/ai/vector_store.py
@@ -584,7 +584,9 @@ class VectorStore(LLMUser):
         -------
         List of assigned IDs for the added items.
         """
-        from markitdown import FileConversionException, StreamInfo
+        from markitdown import (  # noqa: PLC0415
+            FileConversionException, StreamInfo,
+        )
 
         if metadata is None:
             metadata = {}
@@ -1728,7 +1730,7 @@ class ChromaDBVectorStore(VectorStore):
 
     def __init__(self, **params):
         super().__init__(**params)
-        import chromadb
+        import chromadb  # noqa: PLC0415
 
         if self.uri is None:
             self._client = chromadb.Client()

--- a/lumen/base.py
+++ b/lumen/base.py
@@ -79,6 +79,7 @@ class Component(Parameterized):
                     self._update_ref(p, ref)
 
     def _extract_refs(self, params: dict[str, Any], refs: dict[str, Any]):
+        # Deferred: .variables subclasses MultiTypeComponent from this module.
         from .variables import Variable  # noqa: PLC0415
         processed = {}
         for pname, pval in params.items():

--- a/lumen/base.py
+++ b/lumen/base.py
@@ -79,7 +79,7 @@ class Component(Parameterized):
                     self._update_ref(p, ref)
 
     def _extract_refs(self, params: dict[str, Any], refs: dict[str, Any]):
-        from .variables import Variable
+        from .variables import Variable  # noqa: PLC0415
         processed = {}
         for pname, pval in params.items():
             if is_ref(pval):

--- a/lumen/command/precache.py
+++ b/lumen/command/precache.py
@@ -28,7 +28,7 @@ class Precache(Subcommand):
     )
 
     def invoke(self, args: argparse.Namespace):
-        from ..dashboard import load_yaml
+        from ..dashboard import load_yaml  # noqa: PLC0415
         for yaml_file in args.files:
             config.root = str(Path(yaml_file).parent)
             state.spec = load_yaml(Path(yaml_file).read_text())

--- a/lumen/command/precache.py
+++ b/lumen/command/precache.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from bokeh.command.subcommand import Argument, Subcommand  # type: ignore
 
 from lumen.config import config
+from lumen.dashboard import load_yaml
 from lumen.state import state
 from lumen.variables import Variables
 
@@ -28,7 +29,6 @@ class Precache(Subcommand):
     )
 
     def invoke(self, args: argparse.Namespace):
-        from ..dashboard import load_yaml  # noqa: PLC0415
         for yaml_file in args.files:
             config.root = str(Path(yaml_file).parent)
             state.spec = load_yaml(Path(yaml_file).read_text())

--- a/lumen/command/validate.py
+++ b/lumen/command/validate.py
@@ -28,7 +28,7 @@ class Validate(Subcommand):
     )
 
     def invoke(self, args: argparse.Namespace):
-        from ..dashboard import Dashboard, load_yaml
+        from ..dashboard import Dashboard, load_yaml  # noqa: PLC0415
         for yaml_file in args.files:
             spec = load_yaml(Path(yaml_file).read_text())
             try:

--- a/lumen/command/validate.py
+++ b/lumen/command/validate.py
@@ -6,6 +6,7 @@ import yaml  # type: ignore
 
 from bokeh.command.subcommand import Argument, Subcommand
 
+from ..dashboard import Dashboard, load_yaml
 from ..validation import ValidationError
 
 
@@ -28,7 +29,6 @@ class Validate(Subcommand):
     )
 
     def invoke(self, args: argparse.Namespace):
-        from ..dashboard import Dashboard, load_yaml  # noqa: PLC0415
         for yaml_file in args.files:
             spec = load_yaml(Path(yaml_file).read_text())
             try:

--- a/lumen/dashboard.py
+++ b/lumen/dashboard.py
@@ -376,11 +376,11 @@ class Defaults(Component):
         if not isinstance(download_defaults, dict):
             msg = f'Defaults for Download component must be declared as a dictionary, not as a {type(download_defaults)}.'
             raise ValidationError(msg, spec, 'download:')
-        for p in download_defaults:
+        for p, default in download_defaults.items():
             if p in Download.param:
                 pobj = Download.param[p]
                 try:
-                    pobj._validate(download_defaults[p])
+                    pobj._validate(default)
                 except Exception as e:
                     msg = f"The default for Download {p!r} parameter failed validation: {e!s}"
                     raise ValidationError(msg, download_defaults, p) from e

--- a/lumen/panel.py
+++ b/lumen/panel.py
@@ -6,6 +6,7 @@ import param  # type: ignore
 
 from panel import panel
 from panel.custom import JSComponent
+from panel.links import Callback
 from panel.reactive import ReactiveHTML
 from panel.widgets import FileDownload
 
@@ -149,7 +150,6 @@ class IconButton(ReactiveHTML):
         self._callbacks.append(callback)
 
     def js_on_click(self, args=None, code=""):
-        from panel.links import Callback  # noqa: PLC0415
         if args is None:
             args = {}
         return Callback(self, code={'event:'+self._event: code}, args=args)

--- a/lumen/panel.py
+++ b/lumen/panel.py
@@ -149,7 +149,7 @@ class IconButton(ReactiveHTML):
         self._callbacks.append(callback)
 
     def js_on_click(self, args=None, code=""):
-        from panel.links import Callback
+        from panel.links import Callback  # noqa: PLC0415
         if args is None:
             args = {}
         return Callback(self, code={'event:'+self._event: code}, args=args)

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -645,6 +645,8 @@ class Pipeline(Viewer, Component):
         chain_update = kwargs.pop('_chain_update', False)
         if sql_transforms:
             try:
+                # Deferred: .sources.duckdb needs duckdb, which the core
+                # install does not pull in.
                 from .sources.duckdb import DuckDBSource  # noqa: PLC0415
             except Exception as e:
                 raise RuntimeError(

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -335,7 +335,7 @@ class Pipeline(Viewer, Component):
         for filt in self.filters:
             if not isinstance(filt, ParamFilter):
                 continue
-            from holoviews import Dataset  # type: ignore
+            from holoviews import Dataset  # type: ignore  # noqa: PLC0415
             if filt.value is not None:
                 # HoloViews only learned to read narwhals frames in 1.22 and the
                 # floor is lower than that, so hand it pandas.
@@ -645,7 +645,7 @@ class Pipeline(Viewer, Component):
         chain_update = kwargs.pop('_chain_update', False)
         if sql_transforms:
             try:
-                from .sources.duckdb import DuckDBSource
+                from .sources.duckdb import DuckDBSource  # noqa: PLC0415
             except Exception as e:
                 raise RuntimeError(
                     'Cannot chain SQL transforms on a Pipeline without '

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -12,6 +12,7 @@ import panel as pn
 import param  # type: ignore
 import tqdm  # type: ignore
 
+from holoviews import Dataset  # type: ignore
 from panel.io.document import unlocked
 from panel.io.state import state as pn_state
 from panel.layout import Column, Row
@@ -335,7 +336,6 @@ class Pipeline(Viewer, Component):
         for filt in self.filters:
             if not isinstance(filt, ParamFilter):
                 continue
-            from holoviews import Dataset  # type: ignore  # noqa: PLC0415
             if filt.value is not None:
                 # HoloViews only learned to read narwhals frames in 1.22 and the
                 # floor is lower than that, so hand it pandas.

--- a/lumen/rest.py
+++ b/lumen/rest.py
@@ -195,6 +195,8 @@ class SchemaHandler(web.RequestHandler):
 
 
 def lumen_rest_provider(files, endpoint):
+    # Deferred: panel.io.rest loads this module through the panel.io.rest
+    # entry point, so importing it at the top is a circular import.
     from panel.io.rest import _exec_files  # noqa: PLC0415
     _exec_files(files)
     if endpoint:

--- a/lumen/rest.py
+++ b/lumen/rest.py
@@ -195,7 +195,7 @@ class SchemaHandler(web.RequestHandler):
 
 
 def lumen_rest_provider(files, endpoint):
-    from panel.io.rest import _exec_files
+    from panel.io.rest import _exec_files  # noqa: PLC0415
     _exec_files(files)
     if endpoint:
         prefix = rf'^/{endpoint}/'

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -381,7 +381,7 @@ class Source(MultiTypeComponent):
         return source_type(refs=refs, **resolved_spec)
 
     def __init__(self, **params):
-        from ..config import config
+        from ..config import config  # noqa: PLC0415
         params['root'] = Path(params.get('root', config.root))
         super().__init__(**params)
         self.param.watch(self.clear_cache, self._reload_params)
@@ -494,7 +494,7 @@ class Source(MultiTypeComponent):
         elif self.cache_dir:
             if self.cache_with_dask:
                 try:
-                    import dask.dataframe as dd
+                    import dask.dataframe as dd  # noqa: PLC0415
                 except Exception:
                     dd = None
             else:
@@ -541,7 +541,7 @@ class Source(MultiTypeComponent):
         if self.cache_dir and write_to_file:
             if self.cache_with_dask:
                 try:
-                    import dask.dataframe as dd
+                    import dask.dataframe as dd  # noqa: PLC0415
                 except Exception:
                     dd = None
             else:
@@ -914,7 +914,7 @@ class FileSource(Source):
             kwargs.update(self.kwargs)
         if self.use_dask and dask:
             try:
-                import dask.dataframe as dd
+                import dask.dataframe as dd  # noqa: PLC0415
             except Exception:
                 return self._load_fn(ext, dask=False)
             if ext == 'csv':
@@ -998,7 +998,7 @@ class FileSource(Source):
                 if len(dfs) <= 1:
                     df = dfs[0] if dfs else None
                 elif self.use_dask and hasattr(dfs[0], 'compute'):
-                    import dask.dataframe as dd
+                    import dask.dataframe as dd  # noqa: PLC0415
                     df = dd.concat(dfs)
                 else:
                     df = pd.concat(dfs)

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -35,6 +35,7 @@ except ImportError:
 from panel.io.cache import _generate_hash
 
 from ..base import MultiTypeComponent
+from ..config import config
 from ..filters.base import Filter
 from ..state import state
 from ..transforms.base import Filter as FilterTransform, Transform
@@ -381,7 +382,6 @@ class Source(MultiTypeComponent):
         return source_type(refs=refs, **resolved_spec)
 
     def __init__(self, **params):
-        from ..config import config  # noqa: PLC0415
         params['root'] = Path(params.get('root', config.root))
         super().__init__(**params)
         self.param.watch(self.clear_cache, self._reload_params)

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -311,7 +311,7 @@ class DuckDBSource(BaseSQLSource):
         if 'mirrors' not in spec:
             return spec
 
-        from ..pipeline import Pipeline
+        from ..pipeline import Pipeline  # noqa: PLC0415
         mirrors = {}
         for table, mirror in spec['mirrors'].items():
             if isinstance(mirror, pd.DataFrame):
@@ -391,7 +391,7 @@ class DuckDBSource(BaseSQLSource):
                 source = cls.from_spec(src_spec)
                 resolved_mirrors[table] = (source, src_table)
             elif mirror.get('type') == 'pipeline':
-                from ..pipeline import Pipeline
+                from ..pipeline import Pipeline  # noqa: PLC0415
                 resolved_mirrors[table] = Pipeline.from_spec(mirror)
             else:
                 resolved_mirrors[table] = Serializer.deserialize(mirror)

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -14,6 +14,7 @@ import param
 import sqlglot
 
 from ..config import config
+from ..pipeline import Pipeline
 from ..serializers import Serializer
 from ..transforms import Filter
 from ..transforms.sql import (
@@ -311,7 +312,6 @@ class DuckDBSource(BaseSQLSource):
         if 'mirrors' not in spec:
             return spec
 
-        from ..pipeline import Pipeline  # noqa: PLC0415
         mirrors = {}
         for table, mirror in spec['mirrors'].items():
             if isinstance(mirror, pd.DataFrame):
@@ -391,7 +391,6 @@ class DuckDBSource(BaseSQLSource):
                 source = cls.from_spec(src_spec)
                 resolved_mirrors[table] = (source, src_table)
             elif mirror.get('type') == 'pipeline':
-                from ..pipeline import Pipeline  # noqa: PLC0415
                 resolved_mirrors[table] = Pipeline.from_spec(mirror)
             else:
                 resolved_mirrors[table] = Serializer.deserialize(mirror)

--- a/lumen/sources/intake_dremio.py
+++ b/lumen/sources/intake_dremio.py
@@ -70,7 +70,9 @@ class IntakeDremioSource(IntakeBaseDremioSource):
     source_type = 'intake_dremio'
 
     def __init__(self, **params):
-        from intake_dremio.dremio_cat import DremioCatalog  # type: ignore
+        from intake_dremio.dremio_cat import (  # type: ignore  # noqa: PLC0415
+            DremioCatalog,
+        )
         super().__init__(**params)
         self.cat = DremioCatalog(
             self.uri, cert=self.cert, tls=self.tls, username=self.username,
@@ -96,7 +98,7 @@ class IntakeDremioSQLSource(IntakeBaseDremioSource):
     source_type = 'intake_dremio_sql'
 
     def __init__(self, **params):
-        from intake_dremio.intake_dremio import DremioSource
+        from intake_dremio.intake_dremio import DremioSource  # noqa: PLC0415
         super().__init__(**params)
         self.cat = {
             table: DremioSource(

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -468,7 +468,7 @@ class SnowflakeSource(BaseSQLSource):
         def subset_table_slugs(df: pd.DataFrame) -> pd.DataFrame:
             df["TABLE_SLUG"] = df[
                 ["TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME"]
-            ].agg(lambda x: ".".join(x), axis=1).str.upper()
+            ].agg(".".join, axis=1).str.upper()
             df = df[df["TABLE_SLUG"].isin(table_slugs)]
             df = df.drop(
                 columns=["TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME"]

--- a/lumen/sources/sqlalchemy.py
+++ b/lumen/sources/sqlalchemy.py
@@ -140,7 +140,9 @@ class SQLAlchemySource(BaseSQLSource):
             )
 
             if self._driver_is_async:
-                from sqlalchemy.ext.asyncio import create_async_engine
+                from sqlalchemy.ext.asyncio import (  # noqa: PLC0415
+                    create_async_engine,
+                )
                 self._engine = create_async_engine(self._url, **engine_kwargs)
             else:
                 self._engine = create_engine(self._url, **engine_kwargs)

--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -127,7 +127,7 @@ class XArraySQLSource(BaseSQLSource):
             variables=self.variables,
         )
 
-        from xarray_sql import XarrayContext
+        from xarray_sql import XarrayContext  # noqa: PLC0415
         self._ctx = XarrayContext()
         chunk_spec = self._resolve_chunks(self._dataset, self.chunks)
 

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -23,6 +23,10 @@ class _session_state:
     The session_state object holds both global and session specific
     state making it easy to manage access to Sources and Filters
     across components.
+
+    Every ``lumen.*`` import in the method bodies below is deferred on
+    purpose: the components this module hands back all import ``state``
+    themselves, so resolving them at module scope is a cycle.
     """
 
     global_sources: dict[str, Source] = {}

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -119,7 +119,7 @@ class _session_state:
 
     @property
     def variables(self) -> Variables:
-        from .variables import Variables
+        from .variables import Variables  # noqa: PLC0415
         if self._variable is None:
             self._variable = Variables.create_variables()
         doc = pn.state.curdoc
@@ -133,7 +133,7 @@ class _session_state:
 
     @property
     def _global_filters(self):
-        from .filters import Filter
+        from .filters import Filter  # noqa: PLC0415
         return {
             source: {
                 name: Filter.from_spec(spec, schema)
@@ -173,19 +173,19 @@ class _session_state:
         variables = variables or self.variables
         context = {}
         if auth:
-            from .dashboard import AuthSpec
+            from .dashboard import AuthSpec  # noqa: PLC0415
             if isinstance(auth, dict):
                 context['auth'] = AuthSpec.validate(auth)
             else:
                 context['auth'] = auth.to_spec()
         if config:
-            from .dashboard import Config
+            from .dashboard import Config  # noqa: PLC0415
             if isinstance(config, dict):
                 context['config'] = Config.validate(config)
             else:
                 context['config'] = config.to_spec()
         if defaults:
-            from .dashboard import Defaults
+            from .dashboard import Defaults  # noqa: PLC0415
             if isinstance(defaults, dict):
                 context['defaults'] = Defaults.validate(defaults)
             else:
@@ -246,7 +246,7 @@ class _session_state:
         """
         Loads global sources shared across all layouts.
         """
-        from .sources.base import Source
+        from .sources.base import Source  # noqa: PLC0415
         for name, source_spec in self.spec.get('sources', {}).items():
             if not source_spec.get('shared'):
                 continue
@@ -286,7 +286,7 @@ class _session_state:
             }
 
     def load_pipelines(self, **kwargs):
-        from .pipeline import Pipeline
+        from .pipeline import Pipeline  # noqa: PLC0415
         pipelines = self.pipelines
         for name, pipeline_spec in self.spec.get('pipelines', {}).items():
             pipelines[name] = Pipeline.from_spec(
@@ -295,8 +295,8 @@ class _session_state:
         return pipelines
 
     def load_source(self, name: str, source_spec: dict[str, Any]):
-        from .filters.base import Filter
-        from .sources.base import Source
+        from .filters.base import Filter  # noqa: PLC0415
+        from .sources.base import Source  # noqa: PLC0415
         source_spec = dict(source_spec)
         filter_specs = source_spec.pop('filters', None)
         if self.loading_msg:
@@ -322,7 +322,7 @@ class _session_state:
         return source
 
     def resolve_views(self):
-        from .views import View
+        from .views import View  # noqa: PLC0415
         exts = []
         for layout in self.spec.get('layouts', []):
             views = layout.get('views', [])
@@ -346,7 +346,7 @@ class _session_state:
             refs = cast(tuple[str], refs)
             (sourceref,) = refs
 
-        from .sources.base import Source
+        from .sources.base import Source  # noqa: PLC0415
         source = Source.from_spec(sourceref)
         if len(refs) == 1:
             return source
@@ -366,7 +366,7 @@ class _session_state:
     def resolve_reference(self, reference: str, variables: Variables = None):
         if not is_ref(reference):
             raise ValueError('References should be prefixed by $ symbol.')
-        from .variables import Variable
+        from .variables import Variable  # noqa: PLC0415
         refs = tuple(reference[1:].split('.'))
         if len(refs) > 3:
             raise ValueError(

--- a/lumen/state.py
+++ b/lumen/state.py
@@ -23,10 +23,6 @@ class _session_state:
     The session_state object holds both global and session specific
     state making it easy to manage access to Sources and Filters
     across components.
-
-    Every ``lumen.*`` import in the method bodies below is deferred on
-    purpose: the components this module hands back all import ``state``
-    themselves, so resolving them at module scope is a cycle.
     """
 
     global_sources: dict[str, Source] = {}
@@ -123,6 +119,7 @@ class _session_state:
 
     @property
     def variables(self) -> Variables:
+        # Deferred: .variables imports state at module scope.
         from .variables import Variables  # noqa: PLC0415
         if self._variable is None:
             self._variable = Variables.create_variables()
@@ -137,6 +134,7 @@ class _session_state:
 
     @property
     def _global_filters(self):
+        # Deferred: .filters imports state at module scope.
         from .filters import Filter  # noqa: PLC0415
         return {
             source: {
@@ -177,18 +175,21 @@ class _session_state:
         variables = variables or self.variables
         context = {}
         if auth:
+            # Deferred: .dashboard imports state at module scope.
             from .dashboard import AuthSpec  # noqa: PLC0415
             if isinstance(auth, dict):
                 context['auth'] = AuthSpec.validate(auth)
             else:
                 context['auth'] = auth.to_spec()
         if config:
+            # Deferred: .dashboard imports state at module scope.
             from .dashboard import Config  # noqa: PLC0415
             if isinstance(config, dict):
                 context['config'] = Config.validate(config)
             else:
                 context['config'] = config.to_spec()
         if defaults:
+            # Deferred: .dashboard imports state at module scope.
             from .dashboard import Defaults  # noqa: PLC0415
             if isinstance(defaults, dict):
                 context['defaults'] = Defaults.validate(defaults)
@@ -250,6 +251,7 @@ class _session_state:
         """
         Loads global sources shared across all layouts.
         """
+        # Deferred: .sources.base imports state at module scope.
         from .sources.base import Source  # noqa: PLC0415
         for name, source_spec in self.spec.get('sources', {}).items():
             if not source_spec.get('shared'):
@@ -290,6 +292,7 @@ class _session_state:
             }
 
     def load_pipelines(self, **kwargs):
+        # Deferred: .pipeline imports state at module scope.
         from .pipeline import Pipeline  # noqa: PLC0415
         pipelines = self.pipelines
         for name, pipeline_spec in self.spec.get('pipelines', {}).items():
@@ -299,7 +302,9 @@ class _session_state:
         return pipelines
 
     def load_source(self, name: str, source_spec: dict[str, Any]):
+        # Deferred: .filters.base imports state at module scope.
         from .filters.base import Filter  # noqa: PLC0415
+        # Deferred: .sources.base imports state at module scope.
         from .sources.base import Source  # noqa: PLC0415
         source_spec = dict(source_spec)
         filter_specs = source_spec.pop('filters', None)
@@ -326,6 +331,7 @@ class _session_state:
         return source
 
     def resolve_views(self):
+        # Deferred: .views imports state at module scope.
         from .views import View  # noqa: PLC0415
         exts = []
         for layout in self.spec.get('layouts', []):
@@ -350,6 +356,7 @@ class _session_state:
             refs = cast(tuple[str], refs)
             (sourceref,) = refs
 
+        # Deferred: .sources.base imports state at module scope.
         from .sources.base import Source  # noqa: PLC0415
         source = Source.from_spec(sourceref)
         if len(refs) == 1:
@@ -370,6 +377,7 @@ class _session_state:
     def resolve_reference(self, reference: str, variables: Variables = None):
         if not is_ref(reference):
             raise ValueError('References should be prefixed by $ symbol.')
+        # Deferred: .variables imports state at module scope.
         from .variables import Variable  # noqa: PLC0415
         refs = tuple(reference[1:].split('.'))
         if len(refs) > 3:

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -926,7 +926,7 @@ class Melt(Transform):
         if isinstance(table, pd.DataFrame):
             melt = pd.melt
         else:
-            import dask.dataframe as dd
+            import dask.dataframe as dd  # noqa: PLC0415
             melt = dd.melt
         return melt(
             table, id_vars=self.id_vars, value_vars=self.value_vars,

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -810,7 +810,6 @@ class SQLPreFilter(SQLFilterBase):
         Table
             Subquery expression that can replace the original table
         """
-        from sqlglot.expressions import Identifier  # noqa: PLC0415
 
         # Start with SELECT * FROM table_name
         base_table = Table(this=Identifier(this=table_name, quoted=True))

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -810,7 +810,7 @@ class SQLPreFilter(SQLFilterBase):
         Table
             Subquery expression that can replace the original table
         """
-        from sqlglot.expressions import Identifier
+        from sqlglot.expressions import Identifier  # noqa: PLC0415
 
         # Start with SELECT * FROM table_name
         base_table = Table(this=Identifier(this=table_name, quoted=True))

--- a/lumen/ui/base.py
+++ b/lumen/ui/base.py
@@ -5,6 +5,7 @@ from panel.reactive import ReactiveHTML
 from panel.viewable import Viewable
 
 from .fast import FastDivider
+from .state import state
 
 
 class Wizard(ReactiveHTML):
@@ -54,7 +55,6 @@ class Wizard(ReactiveHTML):
             self._next()
 
     def open_modal(self):
-        from .state import state  # noqa: PLC0415
         self.preview.object = dict(state.spec)
         if state.modal.objects == [self.preview]:
             state.template.open_modal()

--- a/lumen/ui/base.py
+++ b/lumen/ui/base.py
@@ -54,7 +54,7 @@ class Wizard(ReactiveHTML):
             self._next()
 
     def open_modal(self):
-        from .state import state
+        from .state import state  # noqa: PLC0415
         self.preview.object = dict(state.spec)
         if state.modal.objects == [self.preview]:
             state.template.open_modal()

--- a/lumen/ui/views.py
+++ b/lumen/ui/views.py
@@ -366,7 +366,9 @@ class hvPlotViewEditor(ViewEditor):
         super().__init__(**params)
 
     def render(self):
-        from hvplot.ui import hvDataFrameExplorer  # type: ignore
+        from hvplot.ui import (  # type: ignore  # noqa: PLC0415
+            hvDataFrameExplorer,
+        )
         kwargs = dict(self.spec)
         del kwargs['type']
         pipeline = lm_state.pipelines[kwargs.pop('pipeline', self.pipeline)]

--- a/lumen/ui/views.py
+++ b/lumen/ui/views.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+import hvplot.pandas  # type: ignore  # noqa: F401
 import panel as pn
 import param  # type: ignore
 
+from hvplot.ui import hvDataFrameExplorer  # type: ignore
 from panel.reactive import ReactiveHTML
 
 from lumen.state import state as lm_state
@@ -361,14 +363,7 @@ class hvPlotViewEditor(ViewEditor):
 
     view_type = param.String(default='hvplot')
 
-    def __init__(self, **params):
-        import hvplot.pandas  # type: ignore # noqa
-        super().__init__(**params)
-
     def render(self):
-        from hvplot.ui import (  # type: ignore  # noqa: PLC0415
-            hvDataFrameExplorer,
-        )
         kwargs = dict(self.spec)
         del kwargs['type']
         pipeline = lm_state.pipelines[kwargs.pop('pipeline', self.pipeline)]

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -259,7 +259,7 @@ def get_dataframe_schema(df, columns=None):
             return _narwhals_dataframe_schema(narwhals_df, columns)
 
     if 'dask.dataframe' in sys.modules:
-        import dask.dataframe as dd
+        import dask.dataframe as dd  # noqa: PLC0415
         is_dask = isinstance(df, dd.DataFrame)
     else:
         is_dask = False
@@ -541,7 +541,7 @@ def catch_and_notify(message=None):
             try:
                 return func(*args, **kwargs)
             except Exception as e:
-                from .state import state as session_state
+                from .state import state as session_state  # noqa: PLC0415
                 if session_state.config and session_state.config.on_error:
                     state.execute(partial(state.config.on_error, e))
                 if pn.config.notifications:
@@ -643,7 +643,7 @@ def detect_file_encoding(file_obj: Path | str | io.BytesIO | io.StringIO | bytes
 
     # Use chardet if available, otherwise fallback
     try:
-        import chardet
+        import chardet  # noqa: PLC0415
         result = chardet.detect(data)
         encoding = result.get('encoding', 'latin-1')
         # Clean up common names
@@ -656,7 +656,7 @@ def detect_file_encoding(file_obj: Path | str | io.BytesIO | io.StringIO | bytes
 
 def _set_backend_opts(element, cur_opts, compat_opts):
     """Utility to make it possible to serialize hvPlot generated plots"""
-    from hvplot.utilities import hvplot_extension
+    from hvplot.utilities import hvplot_extension  # noqa: PLC0415
     element = element.opts(**cur_opts, backend='bokeh')
     if hvplot_extension.compatibility and compat_opts:
         element = element.opts(**compat_opts, backend=hvplot_extension.compatibility)

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -542,6 +542,7 @@ def catch_and_notify(message=None):
             try:
                 return func(*args, **kwargs)
             except Exception as e:
+                # Deferred: .state imports extract_refs from this module.
                 from .state import state as session_state  # noqa: PLC0415
                 if session_state.config and session_state.config.on_error:
                     state.execute(partial(state.config.on_error, e))

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from subprocess import check_output
 
 import bokeh
+import chardet
 import narwhals as narwhals_any
 import narwhals.stable.v2 as nw
 import numpy as np
@@ -23,6 +24,7 @@ import panel as pn
 import param
 import yaml
 
+from hvplot.utilities import hvplot_extension  # type: ignore
 from jinja2 import DebugUndefined, Environment, Undefined
 from packaging.version import Version
 from pandas.core.dtypes.dtypes import CategoricalDtype
@@ -641,22 +643,15 @@ def detect_file_encoding(file_obj: Path | str | io.BytesIO | io.StringIO | bytes
     except UnicodeDecodeError:
         pass
 
-    # Use chardet if available, otherwise fallback
-    try:
-        import chardet  # noqa: PLC0415
-        result = chardet.detect(data)
-        encoding = result.get('encoding', 'latin-1')
-        # Clean up common names
-        if encoding and encoding.lower() in ['iso-8859-1', 'ascii']:
-            return 'utf-8' if encoding.lower() == 'ascii' else 'latin-1'
-        return encoding.lower() if encoding else 'latin-1'
-    except ImportError:
-        # Simple fallback without chardet
-        return 'latin-1'  # Can decode any byte sequence
+    result = chardet.detect(data)
+    encoding = result.get('encoding', 'latin-1')
+    # Clean up common names
+    if encoding and encoding.lower() in ['iso-8859-1', 'ascii']:
+        return 'utf-8' if encoding.lower() == 'ascii' else 'latin-1'
+    return encoding.lower() if encoding else 'latin-1'
 
 def _set_backend_opts(element, cur_opts, compat_opts):
     """Utility to make it possible to serialize hvPlot generated plots"""
-    from hvplot.utilities import hvplot_extension  # noqa: PLC0415
     element = element.opts(**cur_opts, backend='bokeh')
     if hvplot_extension.compatibility and compat_opts:
         element = element.opts(**compat_opts, backend=hvplot_extension.compatibility)

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from subprocess import check_output
 
 import bokeh
-import chardet
 import narwhals as narwhals_any
 import narwhals.stable.v2 as nw
 import numpy as np
@@ -643,12 +642,19 @@ def detect_file_encoding(file_obj: Path | str | io.BytesIO | io.StringIO | bytes
     except UnicodeDecodeError:
         pass
 
-    result = chardet.detect(data)
-    encoding = result.get('encoding', 'latin-1')
-    # Clean up common names
-    if encoding and encoding.lower() in ['iso-8859-1', 'ascii']:
-        return 'utf-8' if encoding.lower() == 'ascii' else 'latin-1'
-    return encoding.lower() if encoding else 'latin-1'
+    # Use chardet if available, otherwise fallback; the core install does not
+    # pull it in, only the ai extra does.
+    try:
+        import chardet  # noqa: PLC0415
+        result = chardet.detect(data)
+        encoding = result.get('encoding', 'latin-1')
+        # Clean up common names
+        if encoding and encoding.lower() in ['iso-8859-1', 'ascii']:
+            return 'utf-8' if encoding.lower() == 'ascii' else 'latin-1'
+        return encoding.lower() if encoding else 'latin-1'
+    except ImportError:
+        # Simple fallback without chardet
+        return 'latin-1'  # Can decode any byte sequence
 
 def _set_backend_opts(element, cur_opts, compat_opts):
     """Utility to make it possible to serialize hvPlot generated plots"""

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -243,7 +243,7 @@ class View(MultiTypeComponent, Viewer):
             View._selections[doc] = {}
         self._ls = View._selections.get(doc, {}).get(self.selection_group)
         if self._ls is None:
-            from holoviews.selection import link_selections
+            from holoviews.selection import link_selections  # noqa: PLC0415
             self._ls = link_selections.instance()
             if self.selection_group:
                 View._selections[doc][self.selection_group] = self._ls
@@ -312,7 +312,7 @@ class View(MultiTypeComponent, Viewer):
         return components
 
     def _serialize_operation(self, obj, objects, refs, depth=0):
-        from holoviews.operation import method
+        from holoviews.operation import method  # noqa: PLC0415
         op_spec = self._serialize_parameterized(obj, objects, refs, depth=depth, include_name=False)
         # TODO: Find way to clean this up in hvPlot. No references to hvPlot Converter should be held
         #       by a HoloViews object.
@@ -351,7 +351,7 @@ class View(MultiTypeComponent, Viewer):
 
     @bothmethod
     def _serialize_holoviews(self, obj, objects=None, refs=None, depth=0, include_name=True):
-        from holoviews.core import (
+        from holoviews.core import (  # noqa: PLC0415
             Dataset, Dimension, DynamicMap, Element, NdMapping, ViewableTree,
         )
         if obj is None:
@@ -398,18 +398,18 @@ class View(MultiTypeComponent, Viewer):
 
     @classmethod
     def _materialize_dimension(cls, spec):
-        from holoviews.core import Dimension
+        from holoviews.core import Dimension  # noqa: PLC0415
         spec = dict(spec)
         name = (spec.pop('name'), spec.pop('label')) if 'label' in spec else spec.pop('name')
         return Dimension(name, **spec)
 
     @classmethod
     def _materialize_holoviews(cls, spec, objects=None, unresolved=None, depth=0, obj_type=None):
-        from holoviews.core import (
+        from holoviews.core import (  # noqa: PLC0415
             Dataset, DynamicMap, NdMapping, ViewableTree,
         )
-        from holoviews.core.operation import Operation
-        from holoviews.element import Annotation
+        from holoviews.core.operation import Operation  # noqa: PLC0415
+        from holoviews.element import Annotation  # noqa: PLC0415
 
         spec = dict(spec)
         spec_type = spec.pop('type')
@@ -844,7 +844,7 @@ class HoloViews(View):
     _panel_type = pn.pane.HoloViews
 
     def __init__(self, **params):
-        from holoviews.streams import Pipe
+        from holoviews.streams import Pipe  # noqa: PLC0415
         super().__init__(**params)
         self._data_stream = Pipe()
 
@@ -988,7 +988,7 @@ class hvPlotBaseView(View):
     def __init__(self, **params):
         if 'dask' in sys.modules:
             try:
-                import hvplot.dask  # type: ignore  # noqa: F401
+                import hvplot.dask  # type: ignore  # noqa: F401, PLC0415
             except Exception:
                 pass
         if 'by' in params and isinstance(params['by'], str):
@@ -1040,7 +1040,9 @@ class hvPlotUIView(hvPlotBaseView):
     view_type = 'hvplot_ui'
 
     def _get_args(self, explorer_cls=None, data=None):
-        from hvplot.ui import Geographic, hvPlotExplorer  # type: ignore
+        from hvplot.ui import (  # type: ignore  # noqa: PLC0415
+            Geographic, hvPlotExplorer,
+        )
         if explorer_cls is None:
             explorer_cls = hvPlotExplorer
         if data is None:
@@ -1062,7 +1064,7 @@ class hvPlotUIView(hvPlotBaseView):
         return pn.bind(ui, self.param.rerender)
 
     def get_panel(self):
-        from hvplot.ui import (  # type: ignore
+        from hvplot.ui import (  # type: ignore  # noqa: PLC0415
             hvDataFrameExplorer, hvGridExplorer,
         )
 
@@ -1071,7 +1073,7 @@ class hvPlotUIView(hvPlotBaseView):
         # and quadmesh work; tabular data uses the dataframe explorer.
         gridded = self._source_dataset()
         if gridded is not None:
-            import hvplot.xarray  # type: ignore  # noqa: F401
+            import hvplot.xarray  # type: ignore  # noqa: F401, PLC0415
             args, kwargs = self._get_args(hvGridExplorer, gridded)
             return hvGridExplorer(*args, **kwargs)
         args, kwargs = self._get_args()
@@ -1154,7 +1156,7 @@ class hvPlotView(hvPlotBaseView):
         # Reached only when xarray is available (an xarray object passed
         # through, or a pivotable DataFrame). Register hvPlot's xarray accessor
         # so .hvplot works on the returned xarray object.
-        import hvplot.xarray  # type: ignore  # noqa: F401
+        import hvplot.xarray  # type: ignore  # noqa: F401, PLC0415
         if not isinstance(df, pd.DataFrame):
             return df
         return df.set_index(self._gridded_index())[self.z].to_xarray()
@@ -1165,7 +1167,7 @@ class hvPlotView(hvPlotBaseView):
         else the long-form frame pivoted to xarray."""
         gridded = self._source_dataset()
         if gridded is not None:
-            import hvplot.xarray  # type: ignore  # noqa: F401
+            import hvplot.xarray  # type: ignore  # noqa: F401, PLC0415
             return gridded
         if isinstance(df, pd.DataFrame):
             blocker = self._gridded_pivot_blocker(df)
@@ -1248,7 +1250,7 @@ class hvPlotView(hvPlotBaseView):
     def _get_params(self):
         df = self.get_data()
         if self.streaming:
-            from holoviews.streams import Pipe  # type: ignore
+            from holoviews.streams import Pipe  # type: ignore  # noqa: PLC0415
             self._data_stream = Pipe(data=df)
         return dict(object=self.get_plot(df))
 
@@ -1300,7 +1302,7 @@ class hvOverlayView(View):
     _supports_selections = True
 
     def _get_params(self):
-        from holoviews import Overlay
+        from holoviews import Overlay  # noqa: PLC0415
         overlay = Overlay([layer.get_plot(layer.get_data()) for layer in self.layers])
         return dict(object=overlay)
 
@@ -1663,7 +1665,7 @@ class AltairView(View):
     _panel_type = pn.pane.Vega
 
     def _transform_encoding(self, encoding: str, value: Any) -> Any:
-        import altair as alt  # type: ignore
+        import altair as alt  # type: ignore  # noqa: PLC0415
         if isinstance(value, dict):
             value = dict(value)
             for kw, val in value.items():
@@ -1679,7 +1681,7 @@ class AltairView(View):
         return value
 
     def _get_params(self) -> dict[str, Any]:
-        import altair as alt
+        import altair as alt  # noqa: PLC0415
         df = self.get_data()
         chart = alt.Chart(df, **self.chart)
         mark = getattr(chart, f'mark_{self.marker}')(**self.mark)
@@ -1714,7 +1716,7 @@ class YdataProfilingView(View):
         return dict(df=df, **self.kwargs)
 
     def get_panel(self) -> pn.pane.HTML:
-        from ydata_profiling import ProfileReport
+        from ydata_profiling import ProfileReport  # noqa: PLC0415
         report_html = ProfileReport(**self._get_params()).html
 
         escaped_html = html.escape(report_html)
@@ -1760,13 +1762,13 @@ class GraphicWalker(View):
     @classproperty
     def _panel_type(cls):
         try:
-            from panel_gwalker import GraphicWalker
+            from panel_gwalker import GraphicWalker  # noqa: PLC0415
         except Exception:
             GraphicWalker = None
         return GraphicWalker
 
     def _get_params(self) -> dict[str, Any]:
-        from ..transforms.sql import SQLLimit
+        from ..transforms.sql import SQLLimit  # noqa: PLC0415
         pipeline = self.pipeline
         if (
             pipeline.source.source_type == 'duckdb' and

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -986,6 +986,7 @@ class hvPlotBaseView(View):
     def __init__(self, **params):
         if 'dask' in sys.modules:
             try:
+                # Deferred: registers hvPlot's dask accessor, and dask is optional.
                 import hvplot.dask  # type: ignore  # noqa: F401, PLC0415
             except Exception:
                 pass
@@ -1064,6 +1065,7 @@ class hvPlotUIView(hvPlotBaseView):
         # and quadmesh work; tabular data uses the dataframe explorer.
         gridded = self._source_dataset()
         if gridded is not None:
+            # Deferred: registers hvPlot's xarray accessor, and xarray is optional.
             import hvplot.xarray  # type: ignore  # noqa: F401, PLC0415
             args, kwargs = self._get_args(hvGridExplorer, gridded)
             return hvGridExplorer(*args, **kwargs)
@@ -1158,6 +1160,7 @@ class hvPlotView(hvPlotBaseView):
         else the long-form frame pivoted to xarray."""
         gridded = self._source_dataset()
         if gridded is not None:
+            # Deferred: registers hvPlot's xarray accessor, and xarray is optional.
             import hvplot.xarray  # type: ignore  # noqa: F401, PLC0415
             return gridded
         if isinstance(df, pd.DataFrame):
@@ -1751,6 +1754,8 @@ class GraphicWalker(View):
     @classproperty
     def _panel_type(cls):
         try:
+            # Deferred so the view class still resolves without panel_gwalker,
+            # which the core install does not pull in.
             from panel_gwalker import GraphicWalker  # noqa: PLC0415
         except Exception:
             GraphicWalker = None

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -21,7 +21,19 @@ import panel as pn
 import param  # type: ignore
 
 from bokeh.models import NumeralTickFormatter  # type: ignore
+from holoviews import Overlay  # type: ignore
+from holoviews.core import (  # type: ignore
+    Dataset, Dimension, DynamicMap, Element, NdMapping, ViewableTree,
+)
+from holoviews.core.operation import Operation  # type: ignore
+from holoviews.element import Annotation  # type: ignore
+from holoviews.operation import method as hv_method  # type: ignore
+from holoviews.selection import link_selections  # type: ignore
+from holoviews.streams import Pipe  # type: ignore
 from hvplot import hvPlotTabular  # type: ignore
+from hvplot.ui import (  # type: ignore
+    Geographic, hvDataFrameExplorer, hvGridExplorer, hvPlotExplorer,
+)
 from panel.io.document import immediate_dispatch
 from panel.pane.base import PaneBase
 from panel.pane.holoviews import HoloViews as HoloViewsPane
@@ -42,7 +54,7 @@ from ..panel import HtmlPdfDownloadButton
 from ..pipeline import Pipeline
 from ..state import state
 from ..transforms.base import Transform
-from ..transforms.sql import SQLTransform
+from ..transforms.sql import SQLLimit, SQLTransform
 from ..util import (
     VARIABLE_RE, as_pandas, catch_and_notify, geometry_to_geojson,
     geometry_to_wkt, is_geodataframe, is_ref, resolve_module_reference,
@@ -52,7 +64,6 @@ from ..validation import ValidationError
 
 if TYPE_CHECKING:
     from bokeh.document import Document  # type: ignore
-    from holoviews.selection import link_selections  # type: ignore
 
 DOWNLOAD_FORMATS = ['csv', 'xlsx', 'json', 'parquet']
 
@@ -243,7 +254,6 @@ class View(MultiTypeComponent, Viewer):
             View._selections[doc] = {}
         self._ls = View._selections.get(doc, {}).get(self.selection_group)
         if self._ls is None:
-            from holoviews.selection import link_selections  # noqa: PLC0415
             self._ls = link_selections.instance()
             if self.selection_group:
                 View._selections[doc][self.selection_group] = self._ls
@@ -312,11 +322,10 @@ class View(MultiTypeComponent, Viewer):
         return components
 
     def _serialize_operation(self, obj, objects, refs, depth=0):
-        from holoviews.operation import method  # noqa: PLC0415
         op_spec = self._serialize_parameterized(obj, objects, refs, depth=depth, include_name=False)
         # TODO: Find way to clean this up in hvPlot. No references to hvPlot Converter should be held
         #       by a HoloViews object.
-        if isinstance(obj, method) and obj.args and "_set_backends_opts" in str(obj.args[0]):
+        if isinstance(obj, hv_method) and obj.args and "_set_backends_opts" in str(obj.args[0]):
             op_spec["args"] = [{"type": "lumen.util._set_backend_opts", "instance": False}]
         return op_spec
 
@@ -351,9 +360,6 @@ class View(MultiTypeComponent, Viewer):
 
     @bothmethod
     def _serialize_holoviews(self, obj, objects=None, refs=None, depth=0, include_name=True):
-        from holoviews.core import (  # noqa: PLC0415
-            Dataset, Dimension, DynamicMap, Element, NdMapping, ViewableTree,
-        )
         if obj is None:
             return None
         pipeline = self.pipeline
@@ -398,19 +404,12 @@ class View(MultiTypeComponent, Viewer):
 
     @classmethod
     def _materialize_dimension(cls, spec):
-        from holoviews.core import Dimension  # noqa: PLC0415
         spec = dict(spec)
         name = (spec.pop('name'), spec.pop('label')) if 'label' in spec else spec.pop('name')
         return Dimension(name, **spec)
 
     @classmethod
     def _materialize_holoviews(cls, spec, objects=None, unresolved=None, depth=0, obj_type=None):
-        from holoviews.core import (  # noqa: PLC0415
-            Dataset, DynamicMap, NdMapping, ViewableTree,
-        )
-        from holoviews.core.operation import Operation  # noqa: PLC0415
-        from holoviews.element import Annotation  # noqa: PLC0415
-
         spec = dict(spec)
         spec_type = spec.pop('type')
         obj_type = resolve_module_reference(spec_type)
@@ -844,7 +843,6 @@ class HoloViews(View):
     _panel_type = pn.pane.HoloViews
 
     def __init__(self, **params):
-        from holoviews.streams import Pipe  # noqa: PLC0415
         super().__init__(**params)
         self._data_stream = Pipe()
 
@@ -1040,9 +1038,6 @@ class hvPlotUIView(hvPlotBaseView):
     view_type = 'hvplot_ui'
 
     def _get_args(self, explorer_cls=None, data=None):
-        from hvplot.ui import (  # type: ignore  # noqa: PLC0415
-            Geographic, hvPlotExplorer,
-        )
         if explorer_cls is None:
             explorer_cls = hvPlotExplorer
         if data is None:
@@ -1064,10 +1059,6 @@ class hvPlotUIView(hvPlotBaseView):
         return pn.bind(ui, self.param.rerender)
 
     def get_panel(self):
-        from hvplot.ui import (  # type: ignore  # noqa: PLC0415
-            hvDataFrameExplorer, hvGridExplorer,
-        )
-
         # An xarray-backed pipeline explores the compact gridded Dataset (via
         # to_dataset) with hvPlot's grid explorer, so gridded kinds like image
         # and quadmesh work; tabular data uses the dataframe explorer.
@@ -1250,7 +1241,6 @@ class hvPlotView(hvPlotBaseView):
     def _get_params(self):
         df = self.get_data()
         if self.streaming:
-            from holoviews.streams import Pipe  # type: ignore  # noqa: PLC0415
             self._data_stream = Pipe(data=df)
         return dict(object=self.get_plot(df))
 
@@ -1302,7 +1292,6 @@ class hvOverlayView(View):
     _supports_selections = True
 
     def _get_params(self):
-        from holoviews import Overlay  # noqa: PLC0415
         overlay = Overlay([layer.get_plot(layer.get_data()) for layer in self.layers])
         return dict(object=overlay)
 
@@ -1768,7 +1757,6 @@ class GraphicWalker(View):
         return GraphicWalker
 
     def _get_params(self) -> dict[str, Any]:
-        from ..transforms.sql import SQLLimit  # noqa: PLC0415
         pipeline = self.pipeline
         if (
             pipeline.source.source_type == 'duckdb' and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ exclude = ["tests"]
 
 [tool.ruff.lint]
 select = [
+    "PLC0415", # import should be at the top-level of a file
     "B",   # flake8-bugbear (includes T20 for print detection)
     "E",
     "F",
@@ -177,7 +178,6 @@ ignore = [
     "PLW2901", # `for` loop variable is overwritten
     "RUF005", # Consider {expr} instead of concatenation
     "RUF012", # Mutable class attributes should use `typing.ClassVar`
-    "UP038", # isinstance and issubclass uses a |-separated union
 ]
 extend-unsafe-fixes = [
     "F401", # Unused imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ ignore = [
     "PLW2901", # `for` loop variable is overwritten
     "RUF005", # Consider {expr} instead of concatenation
     "RUF012", # Mutable class attributes should use `typing.ClassVar`
+    "UP038", # isinstance and issubclass uses a |-separated union
 ]
 extend-unsafe-fixes = [
     "F401", # Unused imports


### PR DESCRIPTION
Turns on ruff's PLC0415 so imports buried inside functions get caught by lint instead of in review. Imports that were deferred for no reason are moved to the top; the noqa is left only where the deferral is real, meaning an optional dependency, a circular import, or a module heavy enough to keep off the import path.