### PR TITLE
fix: avoid passing how with DropNA thresh

### DIFF
--- a/lumen/tests/transforms/test_base.py
+++ b/lumen/tests/transforms/test_base.py
@@ -82,6 +82,17 @@ def test_dropna_transform(mixed_df):
     assert len(DropNA.apply_to(mixed_df, axis=1, how='all').columns) == 4
 
 
+def test_dropna_transform_with_thresh():
+    df = pd.DataFrame({
+        'a': [1.0, None, 3.0],
+        'b': [1.0, 2.0, None],
+    })
+
+    result = DropNA.apply_to(df, thresh=2)
+
+    pd.testing.assert_frame_equal(result, df.dropna(thresh=2))
+
+
 def test_project_lnglat_default_params():
     """Regression test: latitude default was 'longitude' (copy-paste bug)."""
     transform = project_lnglat()

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -877,9 +877,9 @@ class DropNA(Transform):
 
     def apply(self, table: DataFrame) -> DataFrame:
         kwargs = {'axis': self.axis, 'subset': self.subset}
-        if self.how:
+        if self.how and self.thresh is None:
             kwargs['how'] = self.how
-        if self.thresh:
+        if self.thresh is not None:
             kwargs['thresh'] = self.thresh
         return table.dropna(**kwargs)
 


### PR DESCRIPTION
Fixes #2012.

## Summary

- Add regression coverage for `DropNA.apply_to(..., thresh=2)`.
- Avoid passing the default `how` argument to `DataFrame.dropna` when `thresh` is set.
- Preserve existing `DropNA` behavior for default `how`, explicit `how`, and `axis`.

## Validation

- Red check before fix: `python -m pytest lumen/tests/transforms/test_base.py::test_dropna_transform_with_thresh -q` failed with `TypeError: You cannot set both the how and thresh arguments at the same time.`
- `python -m pytest lumen/tests/transforms/test_base.py::test_dropna_transform_with_thresh -q` -> `1 passed`
- `python -m pytest lumen/tests/transforms/test_base.py -k dropna -q` -> `2 passed, 8 deselected`
- `python -m pytest lumen/tests/transforms/test_base.py -q` -> `10 passed`
- `python -m pytest lumen/tests -q` -> `1874 passed, 73 skipped`
- `python -m build` -> built sdist and wheel successfully
- `ruff check lumen/tests/transforms/test_base.py` -> passed
- `ruff check lumen/transforms/base.py --ignore PLC0415` -> passed; without the ignore, ruff reports an existing local-import warning at `lumen/transforms/base.py:617`
- `pyright` currently reports existing type errors outside this change; `pyright lumen/transforms/base.py lumen/tests/transforms/test_base.py` also reports pre-existing errors in `base.py`
