### PR TITLE
fix: call _embed instead of undefined _embed_actions

### DIFF
--- a/lumen/ai/controls/ingest/open_api.py
+++ b/lumen/ai/controls/ingest/open_api.py
@@ -124,7 +124,7 @@ class OpenAPISourceControls(RESTAPISourceControls):
             self._layout.loading = False
 
         if self.vector_store is not None:
-            asyncio.create_task(self._embed_actions())  # noqa: RUF006
+            asyncio.create_task(self._embed())  # noqa: RUF006
 
     # ──────────────────────────────────────────────────────────────────────────
     # Type resolution (overrides RESTAPISourceControls default)

--- a/lumen/ai/controls/ingest/rest_api.py
+++ b/lumen/ai/controls/ingest/rest_api.py
@@ -198,7 +198,7 @@ class RESTAPISourceControls(ParametricSourceControls):
                 skip_params=self.skip_params if hasattr(self, "skip_params") else None,
             )
         if self.vector_store is not None:
-            pn.state.execute(self._embed_actions)
+            pn.state.execute(self._embed)
 
     def _make_endpoint_callable(self, spec: dict) -> Callable:
         """

--- a/lumen/tests/ai/test_controls/test_source_controls.py
+++ b/lumen/tests/ai/test_controls/test_source_controls.py
@@ -20,6 +20,7 @@ from lumen.ai.controls import (
 )
 from lumen.ai.controls.ingest.download import DownloadSourceControls
 from lumen.ai.controls.ingest.parametric import ParametricSourceControls
+from lumen.ai.controls.ingest.rest_api import RESTAPISourceControls
 from lumen.ai.controls.ingest.utils import (
     read_html_tables, read_json_to_dataframe,
 )
@@ -622,3 +623,29 @@ class TestApplyOverrides:
 
         assert "y" not in params_dict
         assert params_dict["x"].default == "value"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RESTAPISourceControls Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRESTAPISourceControlsEmbedding:
+    """Tests for vector store embedding in RESTAPISourceControls."""
+
+    def test_construction_with_vector_store(self, vector_store):
+        """A vector_store does not break action setup."""
+        controls = RESTAPISourceControls(
+            base_url="https://api.example.com",
+            endpoints={
+                "Alerts": {
+                    "method": "get",
+                    "path": "/alerts",
+                    "description": "Fetch alerts",
+                    "parameters": [{"name": "area", "in": "query"}],
+                },
+            },
+            vector_store=vector_store,
+        )
+
+        assert [name for name, _ in controls.as_tools()] == ["Alerts"]


### PR DESCRIPTION
Both REST API controls called `self._embed_actions`, which does not exist, so passing a `vector_store` raised `AttributeError` on init. The method is named `_embed` on `ParametricSourceControls`.

Fixes #2023