### PR TITLE
fix: handle non-default catalog indexes

### DIFF
--- a/lumen/ai/controls/ingest/catalog.py
+++ b/lumen/ai/controls/ingest/catalog.py
@@ -238,19 +238,16 @@ class CatalogSourceControls(BaseSourceControls):
             return
 
         items = []
-        for idx, row in self.catalog_df.iterrows():
+        for pos, (_, row) in enumerate(self.catalog_df.iterrows()):
             text = self._entry_to_text(row)
             if not text:
                 continue
 
             # Structured metadata for post-semantic filtering
             # VectorStore metadata values must be str/int/float/bool
-            row_idx = idx.item() if hasattr(idx, "item") else idx
-            if not isinstance(row_idx, (str, int, float, bool)):
-                row_idx = str(row_idx)
             metadata = {
                 "type": "catalog_entry",
-                "_row_idx": row_idx,
+                "_row_idx": pos,
                 "_control_id": id(self),
             }
             for col in self.filter_columns:
@@ -286,24 +283,22 @@ class CatalogSourceControls(BaseSourceControls):
             return SourceResult.empty("Catalog not yet loaded.")
 
         match_idx = await self._search_catalog(query)
-        if match_idx is None:
-            return SourceResult.empty(
-                f"No dataset matching '{query}' found in catalog."
-            )
-
-        entry = self.catalog_df.loc[match_idx]
+        no_match = f"No dataset matching '{query}' found in catalog."
         try:
+            if (
+                not isinstance(match_idx, int)
+                or match_idx < 0
+                or match_idx >= len(self.catalog_df)
+            ):
+                return SourceResult.empty(no_match)
+            try:
+                entry = self.catalog_df.iloc[match_idx]
+            except (IndexError, TypeError):
+                return SourceResult.empty(no_match)
             result = await self._fetch_entry(entry)
-            # Register the source on the control so the UI's
-            # _sync_sources watcher fires and the SourceCatalog
-            # ("Available Sources") is updated.  When invoked
-            # via the Tabulator click path this happens inside
-            # _run_load → _handle_success; the SourceAgent path
-            # bypasses _run_load so we do it explicitly here.
-            if result and result.sources:
-                for src in result.sources:
-                    self._register_source_output(src)
-                self.param.trigger("outputs")
+            # The SourceAgent path bypasses _run_load, so apply the same output
+            # registration and event handling as the Tabulator click path.
+            self._handle_success(result)
             return result
         finally:
             # _fetch_entry may update the progress bar (e.g.
@@ -327,8 +322,8 @@ class CatalogSourceControls(BaseSourceControls):
         self._cached_catalog_tools = tools
         return tools
 
-    async def _search_catalog(self, query: str) -> object | None:
-        """Find the best matching catalog row index label for *query*.
+    async def _search_catalog(self, query: str) -> int | None:
+        """Find the best matching catalog row position for *query*.
 
         Uses vector search when a ``vector_store`` is available and
         falls back to keyword matching on ``search_columns``.
@@ -356,11 +351,11 @@ class CatalogSourceControls(BaseSourceControls):
         best_idx = None
         best_score = 0
 
-        for idx, row in self.catalog_df.iterrows():
+        for pos, (_, row) in enumerate(self.catalog_df.iterrows()):
             text = self._entry_to_text(row).lower()
             score = sum(1 for word in query_words if word in text)
             if score > best_score:
                 best_score = score
-                best_idx = idx
+                best_idx = pos
 
         return best_idx if best_score > 0 else None

--- a/lumen/ai/controls/ingest/catalog.py
+++ b/lumen/ai/controls/ingest/catalog.py
@@ -245,9 +245,12 @@ class CatalogSourceControls(BaseSourceControls):
 
             # Structured metadata for post-semantic filtering
             # VectorStore metadata values must be str/int/float/bool
+            row_idx = idx.item() if hasattr(idx, "item") else idx
+            if not isinstance(row_idx, (str, int, float, bool)):
+                row_idx = str(row_idx)
             metadata = {
                 "type": "catalog_entry",
-                "_row_idx": int(idx) if not isinstance(idx, int) else idx,
+                "_row_idx": row_idx,
                 "_control_id": id(self),
             }
             for col in self.filter_columns:
@@ -288,7 +291,7 @@ class CatalogSourceControls(BaseSourceControls):
                 f"No dataset matching '{query}' found in catalog."
             )
 
-        entry = self.catalog_df.iloc[match_idx]
+        entry = self.catalog_df.loc[match_idx]
         try:
             result = await self._fetch_entry(entry)
             # Register the source on the control so the UI's
@@ -298,10 +301,8 @@ class CatalogSourceControls(BaseSourceControls):
             # _run_load → _handle_success; the SourceAgent path
             # bypasses _run_load so we do it explicitly here.
             if result and result.sources:
-                existing = self.context.get("sources", [])
                 for src in result.sources:
-                    if src not in existing:
-                        self._register_source_output(src)
+                    self._register_source_output(src)
                 self.param.trigger("outputs")
             return result
         finally:
@@ -326,8 +327,8 @@ class CatalogSourceControls(BaseSourceControls):
         self._cached_catalog_tools = tools
         return tools
 
-    async def _search_catalog(self, query: str) -> int | None:
-        """Find the best matching catalog row index for *query*.
+    async def _search_catalog(self, query: str) -> object | None:
+        """Find the best matching catalog row index label for *query*.
 
         Uses vector search when a ``vector_store`` is available and
         falls back to keyword matching on ``search_columns``.

--- a/lumen/ai/controls/ingest/catalog.py
+++ b/lumen/ai/controls/ingest/catalog.py
@@ -291,10 +291,7 @@ class CatalogSourceControls(BaseSourceControls):
                 or match_idx >= len(self.catalog_df)
             ):
                 return SourceResult.empty(no_match)
-            try:
-                entry = self.catalog_df.iloc[match_idx]
-            except (IndexError, TypeError):
-                return SourceResult.empty(no_match)
+            entry = self.catalog_df.iloc[match_idx]
             result = await self._fetch_entry(entry)
             # The SourceAgent path bypasses _run_load, so apply the same output
             # registration and event handling as the Tabulator click path.

--- a/lumen/tests/ai/test_controls/test_catalog_source_controls.py
+++ b/lumen/tests/ai/test_controls/test_catalog_source_controls.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from unittest.mock import AsyncMock, patch
 
 import pandas as pd
@@ -10,18 +12,28 @@ from lumen.sources.duckdb import DuckDBSource
 class _CatalogControls(CatalogSourceControls):
     search_columns = ["name"]
 
+    def __init__(self, catalog_df, **params):
+        self._catalog = catalog_df
+        super().__init__(**params)
+
     async def _load_catalog(self):
-        return pd.DataFrame()
+        return self._catalog
 
     async def _fetch_entry(self, entry):
         return SourceResult(table=entry["name"], message=entry["name"])
 
 
+async def _make_controls(catalog_df, **params):
+    controls = _CatalogControls(catalog_df, **params)
+    await asyncio.sleep(0)
+    return controls
+
+
 @pytest.mark.asyncio
-async def test_load_from_query_uses_noncontiguous_integer_index_label():
-    controls = _CatalogControls(context={})
-    controls.catalog_df = pd.DataFrame(
-        {"name": ["first", "target"]}, index=[10, 20]
+async def test_load_from_query_uses_position_with_noncontiguous_index():
+    controls = await _make_controls(
+        pd.DataFrame({"name": ["first", "target"]}, index=[10, 20]),
+        context={},
     )
 
     result = await controls._load_from_query("target")
@@ -30,24 +42,36 @@ async def test_load_from_query_uses_noncontiguous_integer_index_label():
 
 
 @pytest.mark.asyncio
-async def test_load_from_query_preserves_string_index_through_vector_store():
-    controls = _CatalogControls(context={})
-    controls.catalog_df = pd.DataFrame(
-        {"name": ["first", "target"]}, index=["alpha", "beta"]
+async def test_load_from_query_uses_position_with_duplicate_index():
+    first = pd.DataFrame({"name": ["first", "second"]})
+    second = pd.DataFrame({"name": ["third", "target"]})
+    controls = await _make_controls(pd.concat([first, second]), context={})
+
+    result = await controls._load_from_query("target")
+
+    assert result.table == "target"
+
+
+@pytest.mark.asyncio
+async def test_load_from_query_stores_positions_for_multiindex():
+    index = pd.MultiIndex.from_tuples([("source", 1), ("source", 2)])
+    controls = await _make_controls(
+        pd.DataFrame({"name": ["first", "target"]}, index=index),
+        context={},
     )
     controls.vector_store = AsyncMock()
 
     await controls._embed()
 
     items = controls.vector_store.upsert.await_args.args[0]
-    assert [item["metadata"]["_row_idx"] for item in items] == ["alpha", "beta"]
+    assert [item["metadata"]["_row_idx"] for item in items] == [0, 1]
 
     controls.vector_store.query.return_value = [
         {
             "metadata": {
                 "type": "catalog_entry",
                 "_control_id": id(controls),
-                "_row_idx": "beta",
+                "_row_idx": 1,
             }
         }
     ]
@@ -57,39 +81,36 @@ async def test_load_from_query_preserves_string_index_through_vector_store():
 
 
 @pytest.mark.asyncio
-async def test_load_from_query_serializes_timestamp_index_for_vector_store():
-    controls = _CatalogControls(context={})
-    index = pd.to_datetime(["2025-01-01", "2025-01-02"])
-    controls.catalog_df = pd.DataFrame(
-        {"name": ["first", "target"]}, index=index
+async def test_load_from_query_handles_stale_vector_position():
+    controls = await _make_controls(
+        pd.DataFrame({"name": ["target"]}),
+        context={},
     )
     controls.vector_store = AsyncMock()
-
-    await controls._embed()
-
-    items = controls.vector_store.upsert.await_args.args[0]
-    row_idx = items[1]["metadata"]["_row_idx"]
-    assert row_idx == str(index[1])
-
     controls.vector_store.query.return_value = [
         {
             "metadata": {
                 "type": "catalog_entry",
                 "_control_id": id(controls),
-                "_row_idx": row_idx,
+                "_row_idx": 10,
             }
         }
     ]
+    controls.progress("Searching catalog")
+
     result = await controls._load_from_query("target")
 
-    assert result.table == "target"
+    assert result.message == "No dataset matching 'target' found in catalog."
+    assert controls.progress.visible is False
 
 
 @pytest.mark.asyncio
-async def test_load_from_query_registers_source_output_once_when_in_context():
+async def test_load_from_query_registers_complete_output_once():
     source = DuckDBSource.from_df(tables={"target": pd.DataFrame({"value": [1]})})
-    controls = _CatalogControls(context={"sources": [source]})
-    controls.catalog_df = pd.DataFrame({"name": ["target"]}, index=[10])
+    controls = await _make_controls(
+        pd.DataFrame({"name": ["target"]}, index=[10]),
+        context={"sources": [source]},
+    )
     source_result = SourceResult.from_source(source, table="target")
 
     with patch.object(controls, "_fetch_entry", AsyncMock(return_value=source_result)):
@@ -98,3 +119,5 @@ async def test_load_from_query_registers_source_output_once_when_in_context():
 
     assert controls.outputs["source"] is source
     assert controls.outputs["sources"] == [source]
+    assert controls.outputs["table"] == "target"
+    assert controls._last_table == "target"

--- a/lumen/tests/ai/test_controls/test_catalog_source_controls.py
+++ b/lumen/tests/ai/test_controls/test_catalog_source_controls.py
@@ -1,0 +1,71 @@
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pytest
+
+from lumen.ai.controls import CatalogSourceControls, SourceResult
+from lumen.sources.duckdb import DuckDBSource
+
+
+class _CatalogControls(CatalogSourceControls):
+    search_columns = ["name"]
+
+    async def _load_catalog(self):
+        return pd.DataFrame()
+
+    async def _fetch_entry(self, entry):
+        return SourceResult(table=entry["name"], message=entry["name"])
+
+
+@pytest.mark.asyncio
+async def test_load_from_query_uses_noncontiguous_integer_index_label():
+    controls = _CatalogControls(context={})
+    controls.catalog_df = pd.DataFrame(
+        {"name": ["first", "target"]}, index=[10, 20]
+    )
+
+    result = await controls._load_from_query("target")
+
+    assert result.table == "target"
+
+
+@pytest.mark.asyncio
+async def test_load_from_query_preserves_string_index_through_vector_store():
+    controls = _CatalogControls(context={})
+    controls.catalog_df = pd.DataFrame(
+        {"name": ["first", "target"]}, index=["alpha", "beta"]
+    )
+    controls.vector_store = AsyncMock()
+
+    await controls._embed()
+
+    items = controls.vector_store.upsert.await_args.args[0]
+    assert [item["metadata"]["_row_idx"] for item in items] == ["alpha", "beta"]
+
+    controls.vector_store.query.return_value = [
+        {
+            "metadata": {
+                "type": "catalog_entry",
+                "_control_id": id(controls),
+                "_row_idx": "beta",
+            }
+        }
+    ]
+    result = await controls._load_from_query("target")
+
+    assert result.table == "target"
+
+
+@pytest.mark.asyncio
+async def test_load_from_query_registers_source_output_once_when_in_context():
+    source = DuckDBSource.from_df(tables={"target": pd.DataFrame({"value": [1]})})
+    controls = _CatalogControls(context={"sources": [source]})
+    controls.catalog_df = pd.DataFrame({"name": ["target"]}, index=[10])
+    source_result = SourceResult.from_source(source, table="target")
+
+    with patch.object(controls, "_fetch_entry", AsyncMock(return_value=source_result)):
+        await controls._load_from_query("target")
+        await controls._load_from_query("target")
+
+    assert controls.outputs["source"] is source
+    assert controls.outputs["sources"] == [source]

--- a/lumen/tests/ai/test_controls/test_catalog_source_controls.py
+++ b/lumen/tests/ai/test_controls/test_catalog_source_controls.py
@@ -57,6 +57,35 @@ async def test_load_from_query_preserves_string_index_through_vector_store():
 
 
 @pytest.mark.asyncio
+async def test_load_from_query_serializes_timestamp_index_for_vector_store():
+    controls = _CatalogControls(context={})
+    index = pd.to_datetime(["2025-01-01", "2025-01-02"])
+    controls.catalog_df = pd.DataFrame(
+        {"name": ["first", "target"]}, index=index
+    )
+    controls.vector_store = AsyncMock()
+
+    await controls._embed()
+
+    items = controls.vector_store.upsert.await_args.args[0]
+    row_idx = items[1]["metadata"]["_row_idx"]
+    assert row_idx == str(index[1])
+
+    controls.vector_store.query.return_value = [
+        {
+            "metadata": {
+                "type": "catalog_entry",
+                "_control_id": id(controls),
+                "_row_idx": row_idx,
+            }
+        }
+    ]
+    result = await controls._load_from_query("target")
+
+    assert result.table == "target"
+
+
+@pytest.mark.asyncio
 async def test_load_from_query_registers_source_output_once_when_in_context():
     source = DuckDBSource.from_df(tables={"target": pd.DataFrame({"value": [1]})})
     controls = _CatalogControls(context={"sources": [source]})


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

I fixed `CatalogSourceControls` so catalog search results use row positions end to end: `_embed()` stores JSON-safe integer positions, `_search_catalog()` returns positions, and `_load_from_query()` validates them before using `.iloc`. This prevents filtered, concatenated, duplicate-label, and MultiIndex catalogs from loading the wrong entry or failing, and I route agent-driven loads through `_handle_success()` so `outputs["table"]`, `_last_table`, source deduplication, and events stay synchronized. There are no breaking API changes, new dependencies, or migration steps.

```python
import asyncio

import pandas as pd

from lumen.ai.controls import CatalogSourceControls, SourceResult


class Catalog(CatalogSourceControls):
    search_columns = ["name"]

    def __init__(self, frame):
        self._frame = frame
        super().__init__(context={})

    async def _load_catalog(self):
        return self._frame

    async def _fetch_entry(self, entry):
        return SourceResult(table=entry["name"])


async def main():
    first = pd.DataFrame({"name": ["first", "second"]})
    second = pd.DataFrame({"name": ["third", "target"]})
    controls = Catalog(pd.concat([first, second]))
    await asyncio.sleep(0)
    result = await controls._load_from_query("target")
    assert result.table == "target"


asyncio.run(main())
# Before: the duplicate label makes the old lookup load "second" instead of "target".
# After: the positional lookup loads "target".
```

I ran `pixi run -e test-312 pytest lumen/tests/ai/test_controls/test_catalog_source_controls.py -q` (5 passed), `pixi run -e test-312 pytest lumen/tests/ai/test_controls -q` (195 passed, 2 skipped), `pixi run -e test-312 test-unit` (2040 passed, 42 skipped), and `pixi run -e lint lint` (passed).

Fixes #2024


## AI Disclosure

Tool & Model: OpenAI Codex + GPT-5
Usage: I used Codex to inspect the issue and review feedback, implement the positional lookup and output synchronization changes, add regression tests, run the listed verification, and draft this description. I reviewed the resulting code, test coverage, and description before submission.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist

- [x] Tests added and are passing