### PR TITLE
docs: add spec tutorial to nav

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -25,7 +25,8 @@ nav = [
       {"Weather Data AI Explorer" = "examples/tutorials/weather_data_ai_explorer.md"},
       {"SaaS Company Report Dashboard" = "examples/tutorials/saas_company_report_dashboard.md"},
       {"Census Data AI Explorer" = "examples/tutorials/census_data_ai_explorer.md"},
-      {"Mesonet Weather Explorer" = "examples/tutorials/mesonet_weather_explorer.md"}
+      {"Mesonet Weather Explorer" = "examples/tutorials/mesonet_weather_explorer.md"},
+      {"Build Dashboard with Spec" = "examples/tutorials/penguins_dashboard_spec.md"}
     ]},
     {"Gallery" = [
       {"Overview" = "examples/gallery/index.md"},

--- a/zensical.toml
+++ b/zensical.toml
@@ -27,7 +27,8 @@ nav = [
       {"Census Data AI Explorer" = "examples/tutorials/census_data_ai_explorer.md"},
       {"Mesonet Weather Explorer" = "examples/tutorials/mesonet_weather_explorer.md"},
       {"Weather API Explorer" = "examples/tutorials/weather_openapi_explorer.md"},
-      {"Massive Stock Explorer" = "examples/tutorials/massive_stock_explorer.md"}
+      {"Massive Stock Explorer" = "examples/tutorials/massive_stock_explorer.md"},
+      {"Build Dashboard with Spec" = "examples/tutorials/penguins_dashboard_spec.md"}
     ]},
     {"Gallery" = [
       {"Overview" = "examples/gallery/index.md"},


### PR DESCRIPTION
`penguins_dashboard_spec.md` is linked from the homepage and three spec pages but was missing from the nav, so it had no sidebar entry and no prev/next links.