### PR TITLE
docs: correct ExplorerUI upload parameter docs

### DIFF
--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -456,7 +456,7 @@ class UI(Viewer):
     source_controls = param.List(default=[UploadSourceControls, DownloadSourceControls], doc="""
         List of SourceControls types to manage datasets.""")
 
-    filedropper_kwargs = param.Dict(default={}, doc="""Keyword arguments to pass to FileDropper in UploadControls.
+    filedropper_kwargs = param.Dict(default={}, doc="""Keyword arguments to pass to FileDropper in UploadSourceControls.
         Common options include 'accepted_filetypes' and 'max_file_size'.
         See https://panel.holoviz.org/reference/widgets/FileDropper.html for all available options.""")
 


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

I corrected the `ExplorerUI.filedropper_kwargs` parameter docstring to refer to `UploadSourceControls`, the public class used by `source_controls`, so generated API documentation matches the implementation. This changes documentation only; there are no API behavior changes, new dependencies, or migration steps.

```python
from lumen.ai.ui import ExplorerUI

doc = ExplorerUI.param["filedropper_kwargs"].doc
assert "UploadSourceControls" in doc
assert "UploadControls" not in doc
```

I ran `pixi run -e test-312 pytest lumen/tests/ai/test_ui.py -q` (85 passed, 4 skipped) and `pixi run -e lint lint` (passed).

Fixes #2026


## AI Disclosure

Tool & Model: OpenAI Codex + GPT-5
Usage: I used Codex to inspect issue #2026, make the one-line documentation correction, run the targeted test and lint checks, and draft this description. I reviewed the resulting diff, verification, and disclosure before submission.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist

- [x] Added documentation