### PR TITLE
fix: allow all tabular hvPlot kinds

### DIFF
--- a/lumen/tests/views/test_hvplot_gridded.py
+++ b/lumen/tests/views/test_hvplot_gridded.py
@@ -5,10 +5,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from hvplot import hvPlotTabular
+
 from lumen.pipeline import Pipeline
 from lumen.sources.base import InMemorySource
 from lumen.views import base as views_base
-from lumen.views.base import hvPlotUIView, hvPlotView
+from lumen.views.base import GRIDDED_KINDS, hvPlotUIView, hvPlotView
 
 # ---- Fixtures ----
 
@@ -58,6 +60,16 @@ def test_hvplot_z_param_accepted():
 def test_hvplot_quadmesh_in_kind_objects():
     """quadmesh is a recognised kind value."""
     assert "quadmesh" in hvPlotView.param.kind.objects
+
+
+def test_hvplot_tabular_kinds_stay_in_sync_with_hvplot():
+    """All tabular hvPlot kinds are accepted except the UI explorer."""
+    expected = {
+        kind for kind in hvPlotTabular.__all__ if kind not in {"explorer", "dataset"}
+    }
+    assert set(hvPlotView.param.kind.objects) == expected | set(GRIDDED_KINDS)
+    assert "explorer" not in hvPlotView.param.kind.objects
+    assert "dataset" not in hvPlotView.param.kind.objects
 
 
 def test_hvplot_heatmap_from_longform_df(gridded_pipeline):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -81,10 +81,9 @@ REDUCING_KINDS = GRIDDED_KINDS + (
 # Keep the Selector in sync with tabular kinds that produce plots in hvPlot.
 # The explorer is handled by hvPlotUIView, while dataset returns a bare
 # hv.Dataset with no plotting class for hvPlotView to render.
-HVPLOT_TABULAR_KINDS = [
+HVPLOT_KINDS = [
     kind for kind in hvPlotTabular.__all__ if kind not in {"explorer", "dataset"}
-]
-HVPLOT_KINDS = HVPLOT_TABULAR_KINDS + list(GRIDDED_KINDS)
+] + list(GRIDDED_KINDS)
 
 
 class View(MultiTypeComponent, Viewer):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -21,6 +21,7 @@ import panel as pn
 import param  # type: ignore
 
 from bokeh.models import NumeralTickFormatter  # type: ignore
+from hvplot import hvPlotTabular  # type: ignore
 from panel.io.document import immediate_dispatch
 from panel.pane.base import PaneBase
 from panel.pane.holoviews import HoloViews as HoloViewsPane
@@ -76,6 +77,14 @@ MAX_RENDER_ROWS = 250_000
 REDUCING_KINDS = GRIDDED_KINDS + (
     "heatmap", "hexbin", "hist", "kde", "box", "violin", "bivariate",
 )
+
+# Keep the Selector in sync with tabular kinds that produce plots in hvPlot.
+# The explorer is handled by hvPlotUIView, while dataset returns a bare
+# hv.Dataset with no plotting class for hvPlotView to render.
+HVPLOT_TABULAR_KINDS = [
+    kind for kind in hvPlotTabular.__all__ if kind not in {"explorer", "dataset"}
+]
+HVPLOT_KINDS = HVPLOT_TABULAR_KINDS + list(GRIDDED_KINDS)
 
 
 class View(MultiTypeComponent, Viewer):
@@ -950,12 +959,7 @@ class hvPlotBaseView(View):
 
     kind = param.Selector(
         default=None, doc="The kind of plot, e.g. 'scatter' or 'line'.",
-        objects=[
-            'area', 'bar', 'barh', 'bivariate', 'box', 'contour', 'contourf',
-            'errorbars', 'hist', 'image', 'kde', 'labels',
-            'line', 'scatter', 'heatmap', 'hexbin', 'ohlc', 'paths', 'points',
-            'polygons', 'quadmesh', 'step', 'violin'
-        ]
+        objects=HVPLOT_KINDS
     )
 
     x = param.Selector(doc="The column to render on the x-axis.")


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

This PR derives `hvPlotView.kind` choices from hvPlot's public `hvPlotTabular.__all__`, while retaining the gridded kinds that Lumen handles through xarray conversion. The Selector now accepts `vectorfield`, `density`, and `table`, so valid DataFrame plots reach hvPlot instead of being rejected by Lumen; `explorer` remains reserved for `hvPlotUIView`, and `dataset` is excluded because it returns a bare `hv.Dataset` with no plotting class for `hvPlotView`.

```python
import pandas as pd
from lumen.pipeline import Pipeline
from lumen.sources.base import InMemorySource
from lumen.views.base import hvPlotView

df = pd.DataFrame({
    "x": [0.0, 1.0], "y": [1.0, 2.0],
    "angle": [0.0, 0.5], "mag": [1.0, 2.0],
})
pipeline = Pipeline(source=InMemorySource(tables={"data": df}), table="data")
hvPlotView(
    pipeline=pipeline, kind="vectorfield", x="x", y="y",
    angle="angle", mag="mag",
).get_plot(df)
```

Before this change, constructing the view raises `ValueError: Selector parameter 'hvPlotBaseView.kind' does not accept 'vectorfield'`; after it, the call reaches hvPlot and returns a `VectorField`. `dataset` remains rejected at construction because allowing it would defer the failure to rendering as `SkipRendering: No plotting class for Dataset found.` The change adds no dependencies, migration steps, or breaking behavior.

I ran `pixi run -e test-312 pytest lumen/tests/views/test_hvplot_gridded.py -q` (20 passed), `pixi run -e test-312 test-unit` (2042 passed, 42 skipped), and the targeted pre-commit hooks (all passed). Direct smoke checks confirmed `density`, `table`, and `vectorfield` render through `hvPlotView`, while the regression test verifies that `dataset` and `explorer` remain excluded.

Fixes #1940

## AI Disclosure

Tool & Model: OpenAI Codex + GPT-5
Usage: I used Codex to inspect issue #1940 and the existing hvPlot view, implement the narrow Selector synchronization and regression test, incorporate maintainer review feedback about unsupported `dataset` rendering, run the focused and full test suites, and draft this description. I reviewed the resulting diff, verification, and disclosure before submission.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
- [ ] Added documentation
