### PR TITLE
fix: stop awaiting the async generator that streams view specs

### DIFF
--- a/lumen/ai/agents/base_view.py
+++ b/lumen/ai/agents/base_view.py
@@ -90,7 +90,7 @@ class BaseViewAgent(BaseLumenAgent):
         errors_context = self._build_errors_context(pipeline, context, errors)
         doc = self.view_type.__doc__.split("\n\n")[0] if self.view_type.__doc__ else self.view_type.__name__
         gridded = get_gridded_metadata(pipeline)
-        response = await self._stream_prompt(
+        response = self._stream_prompt(
             "main",
             messages,
             context,

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -887,9 +887,9 @@ async def test_view_retry_keeps_context_and_passes_spec_by_keyword(llm):
         chain_of_thought = ""
 
     async def fake_stream_prompt(*args, **kwargs):
-        async def gen():
-            yield _Out(yaml_spec="kind: line")
-        return gen()
+        # _stream_prompt is an async generator function, so the caller iterates
+        # what it returns rather than awaiting it.
+        yield _Out(yaml_spec="kind: line")
 
     async def fake_extract_spec(context, spec):
         raise ValueError("bad spec")
@@ -929,10 +929,8 @@ async def test_view_retry_recovers_using_revised_spec(llm):
         chain_of_thought = ""
 
     async def fake_stream_prompt(*args, **kwargs):
-        async def gen():
-            # realistic hvPlot output shape: view params, no yaml_spec
-            yield _Out(kind="line", x="a", y="b")
-        return gen()
+        # realistic hvPlot output shape: view params, no yaml_spec
+        yield _Out(kind="line", x="a", y="b")
 
     async def fake_extract_spec(context, spec):
         seen_specs.append(dict(spec))


### PR DESCRIPTION
`_stream_prompt` is an async generator function, so awaiting its return value raises TypeError and every view the agent generates fails after exhausting its retries. Every other call site iterates it directly; the two retry tests hid this by mocking it as a coroutine, so those mocks now mirror the real signature.