### PR TITLE
fix: update broken external links in docs

### DIFF
--- a/docs/configuration/spec/authentication.md
+++ b/docs/configuration/spec/authentication.md
@@ -46,8 +46,8 @@ config:
 
 For complete authentication documentation, see:
 
-- [Panel Authentication Guide](https://panel.holoviz.org/user_guide/Authentication.html)
-- [OAuth Setup Guide](https://panel.holoviz.org/user_guide/Authentication.html#oauth)
+- [Panel Authentication Guide](https://panel.holoviz.org/how_to/authentication/index.html)
+- [OAuth Setup Guide](https://panel.holoviz.org/how_to/authentication/index.html)
 
 ## Common patterns
 
@@ -90,6 +90,6 @@ layouts:
 
 ## Next steps
 
-- **[Panel Authentication Guide](https://panel.holoviz.org/user_guide/Authentication.html)** - Complete authentication documentation
+- **[Panel Authentication Guide](https://panel.holoviz.org/how_to/authentication/index.html)** - Complete authentication documentation
 - **[Deployment guide](deployment.md)** - Deploy secured dashboards
 - **[Variables guide](variables.md)** - Use environment variables for secrets

--- a/docs/configuration/spec/deployment.md
+++ b/docs/configuration/spec/deployment.md
@@ -510,5 +510,5 @@ Test dashboards in CI/CD:
 ## Next steps
 
 - **[Authentication guide](authentication.md)** - Secure your deployments
-- **[Panel deployment docs](https://panel.holoviz.org/user_guide/Deploy_and_Export.html)** - Advanced deployment options
+- **[Panel deployment docs](https://panel.holoviz.org/how_to/deployment/index.html)** - Advanced deployment options
 - **[Variables guide](variables.md)** - Manage environment-specific configuration

--- a/docs/configuration/spec/views.md
+++ b/docs/configuration/spec/views.md
@@ -694,4 +694,4 @@ Now that you can visualize data:
 - **[Customization guide](customization.md)** - Build custom view types
 - **[Deployment guide](deployment.md)** - Deploy your dashboard
 
-For complete plot options, see the [hvPlot reference](https://hvplot.holoviz.org/reference/index.html).
+For complete plot options, see the [hvPlot reference](https://hvplot.holoviz.org/en/docs/latest/ref/index.html).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -168,7 +168,7 @@ When contributing to `lumen.ai.controls` source loaders, keep these output invar
 ## Code of Conduct
 
 We're committed to providing a welcoming and inclusive environment.
-By participating, you agree to uphold the [HoloViz Code of Conduct](https://holoviz.org/code_of_conduct.html).
+By participating, you agree to uphold the [HoloViz Code of Conduct](https://holoviz.org/about/governance/org-docs/CODE-OF-CONDUCT.html).
 
 ---
 


### PR DESCRIPTION
Fix 4 broken external URLs identified in #1948:
- Panel Authentication: user_guide/Authentication.html -> how_to/authentication/index.html
- Panel Deployment: user_guide/Deploy_and_Export.html -> how_to/deployment/index.html
- HoloViz Code of Conduct: code_of_conduct.html -> about/governance/org-docs/CODE-OF-CONDUCT.html
- hvPlot Reference: reference/index.html -> en/docs/latest/ref/index.html

<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

Fixes #1948

Four external URLs in the documentation were returning 404 because the target sites restructured their pages. Updated each to the correct current URL:

| Old URL | New URL |
|---------|---------|
| `panel.holoviz.org/user_guide/Authentication.html` | `panel.holoviz.org/how_to/authentication/index.html` |
| `panel.holoviz.org/user_guide/Deploy_and_Export.html` | `panel.holoviz.org/how_to/deployment/index.html` |
| `holoviz.org/code_of_conduct.html` | `holoviz.org/about/governance/org-docs/CODE-OF-CONDUCT.html` |
| `hvplot.holoviz.org/en/docs/latest/reference/index.html` | `hvplot.holoviz.org/en/docs/latest/ref/index.html` |

All replacement URLs were verified to return the expected page content.

## AI Disclosure

Tool & Model: opencode/big-pickle
Usage: Identified broken URLs across the codebase, verified replacement URLs return correct content, and generated the fix

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [ ] Tests added and are passing
- [x] Added documentation