### PR TITLE
Collect a lazy frame before it reaches Pipeline.data

### DIFF
--- a/docs/configuration/spec/customization.md
+++ b/docs/configuration/spec/customization.md
@@ -216,6 +216,12 @@ below run on it natively. Things to know before choosing one:
   Vega only read pandas. Returning polars saves work up to the view, not through
   it.
 
+A `Source` that skips the cache may return a lazy frame, such as a polars
+`LazyFrame` from `scan_parquet`. The Pipeline collects it once after the last
+transform, so `Pipeline.data` is eager as always. The built-in Sources collect
+before returning, because `Source.get` is contracted to hand back an eager
+frame and source mirrors and table previews rely on that.
+
 To pin what `Pipeline.data` comes back as regardless of the Source, set
 `dataframe_backend` to `pandas`, `polars` or `pyarrow`. Leaving it unset keeps
 whatever the Source produced, which avoids a conversion:

--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -27,7 +27,7 @@ from .transforms.base import Filter as FilterTransform, Transform
 from .transforms.sql import SQLTransform
 from .util import (
     DATAFRAME_BACKENDS, VARIABLE_RE, as_narwhals, as_pandas, catch_and_notify,
-    get_dataframe_schema, is_narwhals, is_ref, to_backend,
+    collect_lazy, get_dataframe_schema, is_narwhals, is_ref, to_backend,
 )
 from .validation import ValidationError, match_suggestion_message
 
@@ -346,7 +346,10 @@ class Pipeline(Viewer, Component):
         for transform in self.transforms:
             data = transform._coerce(data)
             data = transform.apply(data)
-        return to_backend(data, self.dataframe_backend)
+        # A lazy Source stays lazy through the transforms above and is
+        # collected exactly once here, because everything downstream of
+        # Pipeline.data calls len(), .iloc or .index on it.
+        return to_backend(collect_lazy(data), self.dataframe_backend)
 
     def get_schema(self):
         """

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -15,7 +15,7 @@ import pytest
 
 from lumen.filters.base import ConstantFilter
 from lumen.pipeline import DataFrame as PipelineDataFrame, Pipeline
-from lumen.sources.base import DerivedSource, InMemorySource
+from lumen.sources.base import DerivedSource, InMemorySource, Source
 from lumen.transforms.base import (
     Aggregate, Columns, DropNA, Filter as FilterTransform, Iloc, Melt, Query,
     Rename, Sample, Sort,
@@ -418,3 +418,38 @@ def test_describe_data_accepts_any_backend(constructor):
     from lumen.ai.utils import describe_data_sync
     summary = describe_data_sync(constructor({"i": [0, 1, 2], "s": ["a", "b", "c"]}))
     assert "data_shape" in summary
+
+
+def test_uncached_source_may_return_a_lazy_frame():
+    """A Source that skips the cache can hand back a frame it has not read."""
+    pl = pytest.importorskip("polars")
+
+    class ScanSource(Source):
+
+        def get_tables(self):
+            return ["t"]
+
+        def get(self, table, **query):
+            return pl.LazyFrame({"n": [0, 1, 2]})
+
+    pipeline = Pipeline(source=ScanSource(), table="t")
+    assert isinstance(pipeline.data, pl.DataFrame)
+    assert pipeline.data["n"].to_list() == [0, 1, 2]
+
+
+def test_pipeline_collects_a_lazy_frame_for_its_own_backend():
+    """dataframe_backend returns early when it already matches, so the collect
+    cannot be left to it.
+    """
+    pl = pytest.importorskip("polars")
+
+    class ScanSource(Source):
+
+        def get_tables(self):
+            return ["t"]
+
+        def get(self, table, **query):
+            return pl.LazyFrame({"n": [0, 1]})
+
+    pipeline = Pipeline(source=ScanSource(), table="t", dataframe_backend="polars")
+    assert isinstance(pipeline.data, pl.DataFrame)


### PR DESCRIPTION
A `Source` that skips the cache can return a lazy frame, and nothing collected it, so `Pipeline.data` ended up holding a `LazyFrame` and every consumer that calls `len`, `.iloc` or `.index` on it broke. It is now collected once after the last transform.