### PR TITLE
Keep integer and boolean dtypes across the pandas fallback

### DIFF
--- a/docs/configuration/spec/customization.md
+++ b/docs/configuration/spec/customization.md
@@ -212,6 +212,10 @@ below run on it natively. Things to know before choosing one:
   empty `value_vars`.
 - Anything touching the pandas index (`query`, `eval`, `stack`, `unstack`,
   `set_index`, `reset_index`) always converts.
+- Converting does not change an integer or boolean column's type. numpy has no
+  missing value for either, so a column holding one comes across as the pandas
+  nullable dtype (`Int64`, `boolean`) rather than widening to `float64` or
+  `object`. An id stays an id, whichever configuration ran.
 - Views convert to pandas regardless, because hvPlot, Tabulator, Perspective and
   Vega only read pandas. Returning polars saves work up to the view, not through
   it.

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -352,6 +352,47 @@ def test_dropna_matches_pandas(constructor):
     assert result["a"].tolist() == reference["a"].tolist() == [1.0]
 
 
+def test_as_pandas_keeps_nullable_integer_and_boolean(constructor):
+    """Converting must not widen a nullable column, or an id renders as 3.0."""
+    data = {
+        "i": pd.Series([1, None, 3], dtype="Int64"),
+        "u": pd.Series([1, None, 3], dtype="UInt8"),
+        "b": pd.Series([True, None, False], dtype="boolean"),
+    }
+    result = as_pandas(constructor(data))
+    assert [str(dtype) for dtype in result.dtypes] == ["Int64", "UInt8", "boolean"]
+    assert result["i"].tolist() == [1, pd.NA, 3]
+
+
+def test_as_pandas_leaves_a_column_without_nulls_alone(constructor):
+    """Only the columns the conversion would widen may change."""
+    result = as_pandas(constructor({"i": [1, 2, 3], "b": [True, False, True]}))
+    assert [str(dtype) for dtype in result.dtypes] == ["int64", "bool"]
+
+
+def test_as_pandas_keeps_an_integer_beyond_float_precision(constructor):
+    """Above 2**53 the float detour returns a different number, silently."""
+    big = 2**62 + 1
+    result = as_pandas(constructor({"i": pd.Series([big, None], dtype="Int64")}))
+    # Compared as an int: a float64 comparison rounds both sides and passes on
+    # a value that has already been corrupted.
+    assert int(result["i"][0]) == big
+
+
+def test_fallback_keeps_the_dtype_the_narwhals_path_keeps(constructor):
+    """Two configurations of one transform must not disagree on the schema.
+
+    Both configurations here leave the null in ``id``: one drops on ``v``
+    natively, the other converts to pandas because ``how='all'`` has no
+    narwhals counterpart. The dtype must not depend on which one ran.
+    """
+    data = {"id": pd.Series([1, 2, None, 4], dtype="Int64"), "v": [1.0, None, 3.0, 4.0]}
+    native = as_pandas(DropNA.apply_to(constructor(data), subset=["v"]))
+    fallback = as_pandas(DropNA.apply_to(constructor(data), how="all"))
+    assert native["id"].isna().any() and fallback["id"].isna().any()
+    assert str(fallback["id"].dtype) == str(native["id"].dtype) == "Int64"
+
+
 def test_lazy_transforms_stay_lazy():
     pl = pytest.importorskip("polars")
     frame = pl.LazyFrame({"i": [0, 1, 2, 3]})

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -380,6 +380,39 @@ def test_a_dtype_pandas_cannot_hold_raises_rather_than_corrupting():
         as_pandas(frame)
 
 
+@pytest.mark.parametrize("index_type", ["uint8", "uint16", "uint32", "uint64"])
+def test_as_pandas_converts_an_unsigned_dictionary_column(index_type):
+    """polars writes uint32 indices for a Categorical, and pyarrow before 23
+    cannot convert an unsigned dictionary index to pandas at all."""
+    pa = pytest.importorskip("pyarrow")
+    table = pa.table({
+        "c": pa.DictionaryArray.from_arrays(
+            pa.array([0, 1, None], getattr(pa, index_type)()), pa.array(["x", "y"])
+        ),
+        "n": [1.0, 2.0, 3.0],
+    })
+    result = as_pandas(table)
+    assert isinstance(result["c"].dtype, pd.CategoricalDtype)
+    assert result["c"].tolist()[:2] == ["x", "y"]
+    assert result["c"].isna().tolist() == [False, False, True]
+
+
+def test_as_pandas_keeps_a_dictionary_column_ordered():
+    pa = pytest.importorskip("pyarrow")
+    table = pa.table({"c": pa.DictionaryArray.from_arrays(
+        pa.array([1, 0], pa.uint8()), pa.array(["lo", "hi"]), ordered=True
+    )})
+    assert as_pandas(table)["c"].dtype.ordered
+
+
+def test_as_pandas_keeps_a_polars_categorical_through_pyarrow():
+    """The end of the road for the issue: a polars Categorical read as arrow."""
+    pl = pytest.importorskip("polars")
+    pytest.importorskip("pyarrow")
+    table = pl.DataFrame({"c": pl.Series(["x", "y", "x"], dtype=pl.Categorical)}).to_arrow()
+    assert as_pandas(table)["c"].tolist() == ["x", "y", "x"]
+
+
 def test_as_pandas_keeps_nullable_integer_and_boolean(constructor):
     """Converting must not widen a nullable column, or an id renders as 3.0."""
     data = {

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -21,9 +21,10 @@ from lumen.transforms.base import (
     Rename, Sample, Sort,
 )
 from lumen.util import (
-    as_narwhals, as_pandas, get_dataframe_schema, is_lazyframe,
+    _NULLABLE_DTYPES, as_narwhals, as_pandas, get_dataframe_schema,
+    is_lazyframe,
 )
-from lumen.views.base import Table
+from lumen.views.base import Table, hvPlotView
 
 
 class ParamHolder(param.Parameterized):
@@ -352,6 +353,33 @@ def test_dropna_matches_pandas(constructor):
     assert result["a"].tolist() == reference["a"].tolist() == [1.0]
 
 
+def test_every_arrow_integer_type_has_a_nullable_pandas_dtype():
+    """An unmapped type would convert to whatever pandas defaults to.
+
+    The reroute in ``_to_pandas`` fires on any integer narwhals reports, so a
+    gap here is a column that silently keeps the widened dtype.
+    """
+    pa = pytest.importorskip("pyarrow")
+    arrow_integers = {
+        getattr(pa, f"{prefix}int{width}")()
+        for prefix in ("", "u") for width in (8, 16, 32, 64)
+    }
+    assert arrow_integers <= set(_NULLABLE_DTYPES)
+    assert pa.bool_() in _NULLABLE_DTYPES
+
+
+def test_a_dtype_pandas_cannot_hold_raises_rather_than_corrupting():
+    """polars Int128 has no pandas or arrow counterpart.
+
+    It already fails in ``to_pandas`` before the reroute, and failing is the
+    correct outcome: the alternative is a column of quietly wrong numbers.
+    """
+    pl = pytest.importorskip("polars")
+    frame = pl.DataFrame({"i": pl.Series([1, None], dtype=pl.Int128)})
+    with pytest.raises(Exception, match="i128"):
+        as_pandas(frame)
+
+
 def test_as_pandas_keeps_nullable_integer_and_boolean(constructor):
     """Converting must not widen a nullable column, or an id renders as 3.0."""
     data = {
@@ -379,7 +407,7 @@ def test_as_pandas_keeps_an_integer_beyond_float_precision(constructor):
     assert int(result["i"][0]) == big
 
 
-def test_fallback_keeps_the_dtype_the_narwhals_path_keeps(constructor):
+def test_fallback_and_native_paths_agree_on_dtype(constructor):
     """Two configurations of one transform must not disagree on the schema.
 
     Both configurations here leave the null in ``id``: one drops on ``v``
@@ -391,6 +419,23 @@ def test_fallback_keeps_the_dtype_the_narwhals_path_keeps(constructor):
     fallback = as_pandas(DropNA.apply_to(constructor(data), how="all"))
     assert native["id"].isna().any() and fallback["id"].isna().any()
     assert str(fallback["id"].dtype) == str(native["id"].dtype) == "Int64"
+
+
+def test_hvplot_view_gets_numpy_dtypes(constructor):
+    """datashader raises on a pandas extension dtype, so plots take numpy.
+
+    Rasterizing is the case that breaks, but every kind can reach datashader
+    through an operation, so the whole hvPlot path widens.
+    """
+    data = {"id": pd.Series([1, 2, None, 4], dtype="Int64"), "v": [1.0, None, 3.0, 4.0]}
+    pipeline = Pipeline(
+        source=InMemorySource(tables={"t": constructor(data)}), table="t",
+        transforms=[DropNA(how="all")],
+    )
+    plotted = hvPlotView(pipeline=pipeline, kind="scatter", x="v", y="id").get_data()
+    assert str(plotted["id"].dtype) == "float64"
+    # The table is not a datashader consumer and keeps the id an id.
+    assert str(Table(pipeline=pipeline).get_data()["id"].dtype) == "Int64"
 
 
 def test_lazy_transforms_stay_lazy():

--- a/lumen/tests/test_narwhals_parity.py
+++ b/lumen/tests/test_narwhals_parity.py
@@ -31,6 +31,11 @@ FRAMES = {
                'i': [4, 3, 2, 1]},
     'infkey': {'g': [1.0, float('inf'), 1.0, 2.0], 'v': [1.0, 2.0, 3.0, 4.0],
                'i': [4, 3, 2, 1]},
+    # A nullable integer and boolean is the one shape pandas cannot hold in a
+    # numpy dtype, so it is where a conversion silently changes the schema.
+    'nullable': {'g': ['b', 'a', 'b', 'a'], 'v': [1.0, 2.0, 3.0, 4.0],
+                 'i': pd.Series([4, None, 2, 1], dtype='Int64'),
+                 'b': pd.Series([True, None, False, True], dtype='boolean')},
 }
 
 # (transform, kwargs, frame name). Anything a spec can legally express.
@@ -88,7 +93,14 @@ CASES = [
     (Filter, {'conditions': [('v', (1.0, 3.0))]}, 'nulls'),
     (Filter, {'conditions': [('v', [(1.0, 1.0), (4.0, 4.0)])]}, 'nulls'),
     (Filter, {'conditions': [('i', 3), ('g', ['a'])]}, 'plain'),
+    (DropNA, {'how': 'all'}, 'nullable'),
+    (Sort, {'by': []}, 'nullable'),
+    (Aggregate, {'by': ['g'], 'with_index': False, 'method': 'median'}, 'nullable'),
 ]
+
+# The subset of CASES above that converts to pandas on a frame holding a
+# nullable column, which is where the conversion used to change the schema.
+NULLABLE_FALLBACKS = [c for c in CASES if c[2] == 'nullable']
 
 
 def assert_native_path(caplog, backend):
@@ -180,6 +192,23 @@ def test_row_order_matches_pandas(constructor, transform, kwargs, frame_name):
     result = as_pandas(transform.apply_to(constructor(data), **kwargs))
     assert [_missing_to_none(r) for r in result.values.tolist()] == \
         [_missing_to_none(r) for r in reference.values.tolist()]
+
+
+@pytest.mark.parametrize("transform, kwargs, frame_name", [
+    pytest.param(t, k, f, id=f"{t.__name__}-{f}-{sorted(k.items())}")
+    for t, k, f in NULLABLE_FALLBACKS
+])
+def test_fallback_dtypes_match_pandas(constructor, transform, kwargs, frame_name):
+    """The comparison above passes check_dtype=False; this is the dtype half.
+
+    A configuration that converts must come back with the dtypes the pandas
+    path produces, or two adjacent configurations of one transform disagree on
+    the schema and an id renders as 3.0.
+    """
+    data = FRAMES[frame_name]
+    reference = as_pandas(transform.apply_to(pd.DataFrame(data), **kwargs))
+    result = as_pandas(transform.apply_to(constructor(data), **kwargs))
+    assert result.dtypes.astype(str).to_dict() == reference.dtypes.astype(str).to_dict()
 
 
 def test_schema_matches_pandas_over_dtypes(constructor):

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -21,6 +21,7 @@ import numpy as np
 import pandas as pd
 import panel as pn
 import param
+import pyarrow as pa
 import yaml
 
 from jinja2 import DebugUndefined, Environment, Undefined
@@ -109,6 +110,41 @@ def collect_lazy(df):
 
 DATAFRAME_BACKENDS = ['pandas', 'polars', 'pyarrow']
 
+# The pandas dtype that holds each arrow integer and boolean type without
+# widening it. numpy has no missing value for either, which is the whole
+# problem _to_pandas below exists to solve.
+_NULLABLE_DTYPES = {
+    getattr(pa, f'{prefix}int{width}')(): pd.api.types.pandas_dtype(
+        f'{prefix.upper()}Int{width}'
+    )
+    for prefix in ('', 'u') for width in (8, 16, 32, 64)
+}
+_NULLABLE_DTYPES[pa.bool_()] = pd.BooleanDtype()
+
+
+def _to_pandas(narwhals_df):
+    """Convert to pandas without widening an integer or boolean column.
+
+    Every backend but pandas holds nulls in the column's own type, and
+    ``to_pandas`` lands those on numpy, which has no missing value for an
+    integer or a boolean. An id comes back as 3.0 and, past 2**53, as a
+    different number entirely. The columns that would widen come across
+    through arrow as the pandas nullable dtype instead.
+
+    Only those columns are rerouted. Sending the whole frame through arrow
+    would be shorter and would break more: pyarrow cannot convert the
+    dictionary indices behind a polars categorical, which polars itself
+    converts fine.
+    """
+    df = narwhals_df.to_pandas()
+    for name, dtype in narwhals_df.collect_schema().items():
+        widened = df[name].dtype.kind in 'fO'
+        if widened and (dtype.is_integer() or isinstance(dtype, nw.Boolean)):
+            df[name] = narwhals_df[name].to_arrow().to_pandas(
+                types_mapper=_NULLABLE_DTYPES.get
+            )
+    return df
+
 
 def to_backend(df, backend):
     """Return df as a frame of the named dataframe library.
@@ -127,7 +163,7 @@ def to_backend(df, backend):
     if narwhals_df.implementation.name.lower() == backend:
         return df
     if backend == 'pandas':
-        return narwhals_df.to_pandas()
+        return _to_pandas(narwhals_df)
     if backend == 'polars':
         return narwhals_df.to_polars()
     return narwhals_df.to_arrow()
@@ -148,7 +184,7 @@ def as_pandas(df):
         return df
     if is_lazyframe(narwhals_df):
         narwhals_df = narwhals_df.collect()
-    return narwhals_df.to_pandas()
+    return _to_pandas(narwhals_df)
 
 
 def _narwhals_dataframe_schema(df, columns=None):

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -122,6 +122,33 @@ _NULLABLE_DTYPES = {
 }
 
 
+def _cast_unsigned_dictionaries(narwhals_df):
+    """Return the frame with any unsigned dictionary index cast to int32.
+
+    pyarrow before 23 refuses to convert an unsigned dictionary index to
+    pandas, and polars writes uint32 indices for a Categorical, so a
+    pyarrow-backed frame carrying one cannot reach pandas at all. int32 is
+    the index pyarrow 23 produces for the same column, so the cast leaves the
+    resulting categorical identical and is dead weight once the floor moves.
+    """
+    table = narwhals_df.to_native()
+    if not isinstance(table, pa.Table):
+        return narwhals_df
+
+    def signed(field):
+        if not (pa.types.is_dictionary(field.type) and
+                pa.types.is_unsigned_integer(field.type.index_type)):
+            return field
+        return field.with_type(
+            pa.dictionary(pa.int32(), field.type.value_type, field.type.ordered)
+        )
+
+    fields = [signed(field) for field in table.schema]
+    if fields == list(table.schema):
+        return narwhals_df
+    return nw.from_native(table.cast(pa.schema(fields)))
+
+
 def _to_pandas(narwhals_df):
     """Convert to pandas without widening an integer or boolean column.
 
@@ -136,6 +163,7 @@ def _to_pandas(narwhals_df):
     dictionary indices behind a polars categorical, which polars itself
     converts fine.
     """
+    narwhals_df = _cast_unsigned_dictionaries(narwhals_df)
     df = narwhals_df.to_pandas()
     for name, dtype in narwhals_df.collect_schema().items():
         widened = df[name].dtype.kind in 'fO'

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -111,15 +111,15 @@ def collect_lazy(df):
 DATAFRAME_BACKENDS = ['pandas', 'polars', 'pyarrow']
 
 # The pandas dtype that holds each arrow integer and boolean type without
-# widening it. numpy has no missing value for either, which is the whole
-# problem _to_pandas below exists to solve.
+# widening it, because numpy has no missing value for either. Arrow has no
+# other integer type, so every column _to_pandas reroutes has an entry here.
 _NULLABLE_DTYPES = {
-    getattr(pa, f'{prefix}int{width}')(): pd.api.types.pandas_dtype(
-        f'{prefix.upper()}Int{width}'
-    )
-    for prefix in ('', 'u') for width in (8, 16, 32, 64)
+    pa.int8(): pd.Int8Dtype(), pa.int16(): pd.Int16Dtype(),
+    pa.int32(): pd.Int32Dtype(), pa.int64(): pd.Int64Dtype(),
+    pa.uint8(): pd.UInt8Dtype(), pa.uint16(): pd.UInt16Dtype(),
+    pa.uint32(): pd.UInt32Dtype(), pa.uint64(): pd.UInt64Dtype(),
+    pa.bool_(): pd.BooleanDtype(),
 }
-_NULLABLE_DTYPES[pa.bool_()] = pd.BooleanDtype()
 
 
 def _to_pandas(narwhals_df):
@@ -143,6 +143,27 @@ def _to_pandas(narwhals_df):
             df[name] = narwhals_df[name].to_arrow().to_pandas(
                 types_mapper=_NULLABLE_DTYPES.get
             )
+    return df
+
+
+def widen_nullable(df):
+    """Return df with the nullable dtypes _to_pandas keeps widened to numpy.
+
+    datashader reads the dtype of every plotted column and raises on a pandas
+    extension dtype, so a rasterized plot cannot take the nullable columns.
+    numpy widens them exactly the way ``to_pandas`` used to: an integer holding
+    a null becomes float64, a boolean becomes object, and a column with no
+    nulls keeps its type.
+    """
+    widened = [c for c in df.columns if df[c].dtype in _NULLABLE_DTYPES.values()]
+    if not widened:
+        return df
+    # Copied rather than assigned in place because the caller hands out a
+    # cached frame, and item assignment takes a column named anything, which
+    # DataFrame.assign does not.
+    df = df.copy()
+    for name in widened:
+        df[name] = np.asarray(df[name])
     return df
 
 

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -46,7 +46,7 @@ from ..transforms.sql import SQLTransform
 from ..util import (
     VARIABLE_RE, as_pandas, catch_and_notify, geometry_to_geojson,
     geometry_to_wkt, is_geodataframe, is_ref, resolve_module_reference,
-    try_import_xarray,
+    try_import_xarray, widen_nullable,
 )
 from ..validation import ValidationError
 
@@ -1002,6 +1002,13 @@ class hvPlotBaseView(View):
     @classproperty
     def _valid_keys_(cls):
         return None
+
+    def get_data(self):
+        # Every hvPlot kind can reach datashader, through rasterize/datashade
+        # or an operation, and datashader rejects the pandas nullable dtypes
+        # the pipeline now preserves. Plots take the numpy widening instead;
+        # tables and downloads keep the nullable columns.
+        return widen_nullable(super().get_data())
 
     def _check_render_size(self, df) -> None:
         """Refuse to render more per-row glyphs than a browser tab can hold.


### PR DESCRIPTION
Two configurations of one transform returned different schemas because the pandas fallback widened a nullable integer to float64, so an id rendered as 3.0 and, past 2**53, came back as a different number entirely. Plots still take the numpy widening, because datashader rejects a pandas extension dtype.

Fixes #2011
