### PR TITLE
Decline to grid a to_dataset result that is not a grid

### DIFF
--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -276,34 +276,20 @@ class XArraySQLSource(BaseSQLSource):
         return self.execute(self._build_sql(table, **query))
 
     def to_dataset(self, table, **query):
-        """Return the query result as a gridded ``xr.Dataset``, or None.
+        """Return the query result as a gridded ``xr.Dataset``.
 
-        Uses xarray-sql's ``to_dataset`` (lazy, keeps the data gridded) when
-        the installed version supports it, so a gridded source is never
-        materialized as long-form. Falls back to pivoting the long-form result
-        on the dataset dims for xarray-sql < 0.3.
-
-        None means the result is not a grid, and callers fall back to the
-        long-form frame.
+        Uses xarray-sql's ``to_dataset``, which is lazy and keeps the data
+        gridded, so a gridded source is never materialized as long-form.
         """
         result = self._ctx.sql(self._build_sql(table, **query))
-        if hasattr(result, 'to_dataset'):
-            # Pass only the dims the result actually has a column for. Multiple
-            # data vars need dims passed explicitly (the FROM clause is
-            # ambiguous), but a bounds dim (e.g. nbnds) or a projecting/
-            # aggregating sql_transform can leave a dataset dim out of the
-            # result, and to_dataset(dims=...) errors on a dim it can't find.
-            names = set(result.schema().names)
-            dims = [d for d in self._dataset.dims if d in names]
-            return result.to_dataset(dims=dims)
-        df = result.to_pandas()
-        present = [d for d in self._dataset.dims if d in df.columns]
-        if not present or df.duplicated(subset=present).any():
-            # A projecting sql_transform that drops a dim leaves the rows that
-            # dim separated on top of each other, so the surviving dims no
-            # longer index one row each and there is no grid to build.
-            return None
-        return df.set_index(present).to_xarray()
+        # Pass only the dims the result actually has a column for. Multiple
+        # data vars need dims passed explicitly (the FROM clause is
+        # ambiguous), but a bounds dim (e.g. nbnds) or a projecting/
+        # aggregating sql_transform can leave a dataset dim out of the
+        # result, and to_dataset(dims=...) errors on a dim it can't find.
+        names = set(result.schema().names)
+        dims = [d for d in self._dataset.dims if d in names]
+        return result.to_dataset(dims=dims)
 
     def create_sql_expr_source(
         self,

--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -276,12 +276,15 @@ class XArraySQLSource(BaseSQLSource):
         return self.execute(self._build_sql(table, **query))
 
     def to_dataset(self, table, **query):
-        """Return the query result as a gridded ``xr.Dataset``.
+        """Return the query result as a gridded ``xr.Dataset``, or None.
 
         Uses xarray-sql's ``to_dataset`` (lazy, keeps the data gridded) when
         the installed version supports it, so a gridded source is never
         materialized as long-form. Falls back to pivoting the long-form result
         on the dataset dims for xarray-sql < 0.3.
+
+        None means the result is not a grid, and callers fall back to the
+        long-form frame.
         """
         result = self._ctx.sql(self._build_sql(table, **query))
         if hasattr(result, 'to_dataset'):
@@ -295,7 +298,12 @@ class XArraySQLSource(BaseSQLSource):
             return result.to_dataset(dims=dims)
         df = result.to_pandas()
         present = [d for d in self._dataset.dims if d in df.columns]
-        return df.set_index(present).to_xarray() if present else df
+        if not present or df.duplicated(subset=present).any():
+            # A projecting sql_transform that drops a dim leaves the rows that
+            # dim separated on top of each other, so the surviving dims no
+            # longer index one row each and there is no grid to build.
+            return None
+        return df.set_index(present).to_xarray()
 
     def create_sql_expr_source(
         self,

--- a/lumen/tests/sources/test_xarray_sql.py
+++ b/lumen/tests/sources/test_xarray_sql.py
@@ -662,6 +662,23 @@ class TestAsync:
 
 # ---- to_dataset (gridded output via xarray-sql) ----
 
+def _drop_native_to_dataset(source, monkeypatch):
+    """Make source take the long-form pivot fallback rather than the native
+    to_dataset, so the fallback is covered whatever xarray-sql is installed."""
+    real_sql = source._ctx.sql
+
+    class _NoNativeToDataset:
+        """A query result as xarray-sql < 0.3 returns it, without to_dataset."""
+
+        def __init__(self, result):
+            self._result = result
+
+        def to_pandas(self):
+            return self._result.to_pandas()
+
+    monkeypatch.setattr(source._ctx, "sql", lambda q: _NoNativeToDataset(real_sql(q)))
+
+
 class TestToDataset:
 
     def test_to_dataset_returns_gridded(self, synthetic_dataset):
@@ -692,12 +709,39 @@ class TestToDataset:
     def test_to_dataset_ignores_projected_away_dim(self, synthetic_dataset):
         """A projecting sql_transform (e.g. DeckGL keeping only lat/lon/value)
         drops a dim from the result; to_dataset must pass only the dims the
-        result still has a column for, not every dataset dim."""
-        source = XArraySQLSource(_dataset=synthetic_dataset)
+        result still has a column for, not every dataset dim.
+
+        One time step, so dropping the time column still leaves one row per
+        (lat, lon) and the result is a grid.
+        """
+        source = XArraySQLSource(_dataset=synthetic_dataset.isel(time=[0]))
         transform = SQLColumns(columns=["lat", "lon", "temperature"])  # drops time
         result = source.to_dataset("temperature", sql_transforms=[transform])
         assert "time" not in result.dims
         assert set(result.dims) == {"lat", "lon"}
+
+    def test_to_dataset_declines_a_result_that_is_not_a_grid(
+        self, synthetic_dataset, monkeypatch
+    ):
+        """Projecting a dim away leaves the rows it separated on top of each
+        other, so the remaining dims no longer index one row each. Callers
+        take the long-form frame when there is no grid, so None is the answer
+        rather than an error from inside xarray.
+        """
+        source = XArraySQLSource(_dataset=synthetic_dataset)
+        _drop_native_to_dataset(source, monkeypatch)
+        transform = SQLColumns(columns=["lat", "lon", "temperature"])
+        assert source.to_dataset("temperature", sql_transforms=[transform]) is None
+
+    def test_to_dataset_declines_a_result_with_no_dim_column(
+        self, synthetic_dataset, monkeypatch
+    ):
+        """An aggregating transform can leave no dim column at all, and a
+        Dataset cannot be built without one."""
+        source = XArraySQLSource(_dataset=synthetic_dataset)
+        _drop_native_to_dataset(source, monkeypatch)
+        transform = SQLColumns(columns=["temperature"])
+        assert source.to_dataset("temperature", sql_transforms=[transform]) is None
 
     def test_get_still_returns_long_form(self, synthetic_dataset):
         """get() is unchanged: it returns the long-form pandas frame."""
@@ -708,18 +752,7 @@ class TestToDataset:
         """When the query result lacks a native to_dataset (xarray-sql < 0.3),
         to_dataset falls back to pivoting the long-form result on the dims."""
         source = XArraySQLSource(_dataset=synthetic_dataset)
-        real_sql = source._ctx.sql
-
-        class _NoNativeToDataset:
-            def __init__(self, result):
-                self._result = result
-
-            def to_pandas(self):
-                return self._result.to_pandas()
-
-        monkeypatch.setattr(
-            source._ctx, "sql", lambda q: _NoNativeToDataset(real_sql(q))
-        )
+        _drop_native_to_dataset(source, monkeypatch)
         ds = source.to_dataset("temperature")
         assert isinstance(ds, xr.Dataset)
         assert set(ds.dims) >= {"time", "lat", "lon"}

--- a/lumen/tests/sources/test_xarray_sql.py
+++ b/lumen/tests/sources/test_xarray_sql.py
@@ -662,23 +662,6 @@ class TestAsync:
 
 # ---- to_dataset (gridded output via xarray-sql) ----
 
-def _drop_native_to_dataset(source, monkeypatch):
-    """Make source take the long-form pivot fallback rather than the native
-    to_dataset, so the fallback is covered whatever xarray-sql is installed."""
-    real_sql = source._ctx.sql
-
-    class _NoNativeToDataset:
-        """A query result as xarray-sql < 0.3 returns it, without to_dataset."""
-
-        def __init__(self, result):
-            self._result = result
-
-        def to_pandas(self):
-            return self._result.to_pandas()
-
-    monkeypatch.setattr(source._ctx, "sql", lambda q: _NoNativeToDataset(real_sql(q)))
-
-
 class TestToDataset:
 
     def test_to_dataset_returns_gridded(self, synthetic_dataset):
@@ -720,40 +703,7 @@ class TestToDataset:
         assert "time" not in result.dims
         assert set(result.dims) == {"lat", "lon"}
 
-    def test_to_dataset_declines_a_result_that_is_not_a_grid(
-        self, synthetic_dataset, monkeypatch
-    ):
-        """Projecting a dim away leaves the rows it separated on top of each
-        other, so the remaining dims no longer index one row each. Callers
-        take the long-form frame when there is no grid, so None is the answer
-        rather than an error from inside xarray.
-        """
-        source = XArraySQLSource(_dataset=synthetic_dataset)
-        _drop_native_to_dataset(source, monkeypatch)
-        transform = SQLColumns(columns=["lat", "lon", "temperature"])
-        assert source.to_dataset("temperature", sql_transforms=[transform]) is None
-
-    def test_to_dataset_declines_a_result_with_no_dim_column(
-        self, synthetic_dataset, monkeypatch
-    ):
-        """An aggregating transform can leave no dim column at all, and a
-        Dataset cannot be built without one."""
-        source = XArraySQLSource(_dataset=synthetic_dataset)
-        _drop_native_to_dataset(source, monkeypatch)
-        transform = SQLColumns(columns=["temperature"])
-        assert source.to_dataset("temperature", sql_transforms=[transform]) is None
-
     def test_get_still_returns_long_form(self, synthetic_dataset):
         """get() is unchanged: it returns the long-form pandas frame."""
         source = XArraySQLSource(_dataset=synthetic_dataset)
         assert isinstance(source.get("temperature"), pd.DataFrame)
-
-    def test_to_dataset_fallback_when_native_absent(self, synthetic_dataset, monkeypatch):
-        """When the query result lacks a native to_dataset (xarray-sql < 0.3),
-        to_dataset falls back to pivoting the long-form result on the dims."""
-        source = XArraySQLSource(_dataset=synthetic_dataset)
-        _drop_native_to_dataset(source, monkeypatch)
-        ds = source.to_dataset("temperature")
-        assert isinstance(ds, xr.Dataset)
-        assert set(ds.dims) >= {"time", "lat", "lon"}
-        assert "temperature" in ds.data_vars

--- a/pixi.toml
+++ b/pixi.toml
@@ -78,7 +78,7 @@ netcdf4 = "*"
 zarr = "*"
 
 [feature.xarray.pypi-dependencies]
-xarray-sql = "*"
+xarray-sql = ">=0.3.1"
 
 # =============================================
 # =================== TESTS ===================


### PR DESCRIPTION
A projecting sql_transform that drops a dim leaves the rows that dim separated on top of each other, and the pivot fallback handed those to xarray, which raised. Callers already fall back to the long-form frame when there is no grid, so this returns None instead.

Fixes #2048
