### PR TITLE
Convert a pyarrow dictionary column with unsigned indices

### DIFF
--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -380,6 +380,39 @@ def test_a_dtype_pandas_cannot_hold_raises_rather_than_corrupting():
         as_pandas(frame)
 
 
+@pytest.mark.parametrize("index_type", ["uint8", "uint16", "uint32", "uint64"])
+def test_as_pandas_converts_an_unsigned_dictionary_column(index_type):
+    """polars writes uint32 indices for a Categorical, and pyarrow before 23
+    cannot convert an unsigned dictionary index to pandas at all."""
+    pa = pytest.importorskip("pyarrow")
+    table = pa.table({
+        "c": pa.DictionaryArray.from_arrays(
+            pa.array([0, 1, None], getattr(pa, index_type)()), pa.array(["x", "y"])
+        ),
+        "n": [1.0, 2.0, 3.0],
+    })
+    result = as_pandas(table)
+    assert isinstance(result["c"].dtype, pd.CategoricalDtype)
+    assert result["c"].tolist()[:2] == ["x", "y"]
+    assert result["c"].isna().tolist() == [False, False, True]
+
+
+def test_as_pandas_keeps_a_dictionary_column_ordered():
+    pa = pytest.importorskip("pyarrow")
+    table = pa.table({"c": pa.DictionaryArray.from_arrays(
+        pa.array([1, 0], pa.uint8()), pa.array(["lo", "hi"]), ordered=True
+    )})
+    assert as_pandas(table)["c"].dtype.ordered
+
+
+def test_as_pandas_keeps_a_polars_categorical_through_pyarrow():
+    """The end of the road for the issue: a polars Categorical read as arrow."""
+    pl = pytest.importorskip("polars")
+    pytest.importorskip("pyarrow")
+    table = pl.DataFrame({"c": pl.Series(["x", "y", "x"], dtype=pl.Categorical)}).to_arrow()
+    assert as_pandas(table)["c"].tolist() == ["x", "y", "x"]
+
+
 def test_as_pandas_keeps_nullable_integer_and_boolean(constructor):
     """Converting must not widen a nullable column, or an id renders as 3.0."""
     data = {

--- a/lumen/util.py
+++ b/lumen/util.py
@@ -122,6 +122,33 @@ _NULLABLE_DTYPES = {
 }
 
 
+def _cast_unsigned_dictionaries(narwhals_df):
+    """Return the frame with any unsigned dictionary index cast to int32.
+
+    pyarrow before 23 refuses to convert an unsigned dictionary index to
+    pandas, and polars writes uint32 indices for a Categorical, so a
+    pyarrow-backed frame carrying one cannot reach pandas at all. int32 is
+    the index pyarrow 23 produces for the same column, so the cast leaves the
+    resulting categorical identical and is dead weight once the floor moves.
+    """
+    table = narwhals_df.to_native()
+    if not isinstance(table, pa.Table):
+        return narwhals_df
+
+    def signed(field):
+        if not (pa.types.is_dictionary(field.type) and
+                pa.types.is_unsigned_integer(field.type.index_type)):
+            return field
+        return field.with_type(
+            pa.dictionary(pa.int32(), field.type.value_type, field.type.ordered)
+        )
+
+    fields = [signed(field) for field in table.schema]
+    if fields == list(table.schema):
+        return narwhals_df
+    return nw.from_native(table.cast(pa.schema(fields)))
+
+
 def _to_pandas(narwhals_df):
     """Convert to pandas without widening an integer or boolean column.
 
@@ -136,6 +163,7 @@ def _to_pandas(narwhals_df):
     dictionary indices behind a polars categorical, which polars itself
     converts fine.
     """
+    narwhals_df = _cast_unsigned_dictionaries(narwhals_df)
     df = narwhals_df.to_pandas()
     for name, dtype in narwhals_df.collect_schema().items():
         widened = df[name].dtype.kind in 'fO'


### PR DESCRIPTION
pyarrow before 23 refuses to convert an unsigned dictionary index to pandas, and polars writes uint32 indices for a Categorical, so a pyarrow-backed frame carrying one could not reach pandas at all. Built on #2046, which adds the conversion helper this changes.

Fixes #2047
