### PR TITLE
Narrow the query to the columns the transforms need

### DIFF
--- a/lumen/pipeline.py
+++ b/lumen/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 
 from functools import partial
@@ -23,8 +24,8 @@ from .base import Component
 from .filters.base import Filter, ParamFilter, WidgetFilter
 from .sources.base import Source
 from .state import state
-from .transforms.base import Filter as FilterTransform, Transform
-from .transforms.sql import SQLTransform
+from .transforms.base import Columns, Filter as FilterTransform, Transform
+from .transforms.sql import SQLColumns, SQLTransform
 from .util import (
     DATAFRAME_BACKENDS, VARIABLE_RE, as_narwhals, as_pandas, catch_and_notify,
     collect_lazy, get_dataframe_schema, is_narwhals, is_ref, to_backend,
@@ -145,6 +146,13 @@ class Pipeline(Viewer, Component):
 
     sql_transforms = param.List(item_type=SQLTransform, doc="""
         A list of SQLTransforms to apply to the source data."""
+    )
+
+    sql_pushdown = param.Boolean(default=True, doc="""
+        Whether to narrow the query to the columns the transforms actually
+        need when the Source supports SQL, instead of fetching every column
+        and projecting in pandas. Only applied where the result is provably
+        identical; set to False to always fetch the full table."""
     )
 
     transforms = param.List(item_type=Transform, doc="""
@@ -306,6 +314,56 @@ class Pipeline(Viewer, Component):
             query['sql_transforms'] = self.sql_transforms
         return self.source.to_dataset(self.table, **query)
 
+    def _pushdown_transform(self) -> SQLColumns | None:
+        """
+        Return a projection to push into the query, or None when narrowing
+        the query cannot be proven to leave the result unchanged.
+
+        The transforms still run in pandas afterwards. This only spares the
+        source from sending columns that nothing downstream reads: on a
+        2M x 9 DuckDB table, projecting to one column takes the frame the
+        source hands back from 454MB to 16MB.
+        """
+        if not self.sql_pushdown or self.pipeline is not None or not self.source._supports_sql:
+            return None
+        if any(isinstance(filt, ParamFilter) for filt in self.filters):
+            # _compute_data runs these against the source output before the
+            # transforms, so they may read a column no transform names.
+            return None
+
+        # The last Columns decides how wide the result is. Without one the
+        # pipeline returns every column, so there is nothing to narrow to.
+        projections = [i for i, t in enumerate(self.transforms) if isinstance(t, Columns) and t.columns]
+        if not projections:
+            return None
+        last = projections[-1]
+
+        required = set(self.transforms[last].columns)
+        for transform in self.transforms[:last]:
+            columns = transform.requires_columns()
+            if columns is None:
+                # The transform may read a column it does not name, so the
+                # union below would be incomplete.
+                return None
+            required |= columns
+        # A source with filter_in_sql off filters in pandas after the query,
+        # so every filtered column has to survive the projection. Keeping them
+        # unconditionally costs a column or two and spares this from having to
+        # know which sources declare that parameter.
+        required |= {filt.field for filt in self.filters if filt.field}
+
+        if any(re.search(r'\W', col) for col in required):
+            # SQLColumns renders the names unquoted, and quoting them here
+            # would change identifier case-sensitivity for existing users.
+            return None
+        # The schema carries the row count alongside the columns.
+        schema_columns = [col for col in self.schema if col != '__len__']
+        columns = [col for col in schema_columns if col in required]
+        if len(columns) != len(required) or len(columns) == len(schema_columns):
+            # A column the schema does not know, or nothing to save.
+            return None
+        return SQLColumns(columns=columns)
+
     def _compute_data(self):
         query = self._filter_query()
 
@@ -318,6 +376,10 @@ class Pipeline(Viewer, Component):
                         f'Found source typed {self.source.source_type!r} instead.'
                     )
                 query['sql_transforms'] = self.sql_transforms
+            if pushdown := self._pushdown_transform():
+                # Last, so the filter and the declared transforms above still
+                # see every column.
+                query['sql_transforms'] = [*query.get('sql_transforms', []), pushdown]
             data = self.source.get(self.table, **query)
         else:
             pipelines = []

--- a/lumen/tests/test_pipeline.py
+++ b/lumen/tests/test_pipeline.py
@@ -17,13 +17,15 @@ except Exception:
 
 from panel.widgets import Select
 
-from lumen.filters.base import ConstantFilter
+from lumen.filters.base import ConstantFilter, ParamFilter
 from lumen.pipeline import Pipeline
 from lumen.sources.intake_sql import IntakeSQLSource
 from lumen.state import state
 from lumen.tests.utils import Polygon, gpd, requires_geopandas
-from lumen.transforms.base import Columns, Transform
-from lumen.transforms.sql import SQLColumns, SQLGroupBy
+from lumen.transforms.base import (
+    Aggregate, Columns, Query, Sort, Transform,
+)
+from lumen.transforms.sql import SQLColumns, SQLGroupBy, SQLSort
 from lumen.validation import ValidationError
 
 sql_available = pytest.mark.skipif(intake_sql is None or duckdb is None, reason="intake-sql is not installed")
@@ -432,3 +434,152 @@ def test_pipeline_preserves_geodataframe():
     assert 'geometry' in data.columns
     assert len(data) == 2
     assert data.geometry.notna().all()
+
+
+@pytest.fixture
+def duckdb_pushdown_source():
+    """A three-column DuckDB table plus a record of every query it runs."""
+    if duckdb is None:
+        pytest.skip("duckdb is not installed")
+    queries = []
+
+    def make():
+        source = DuckDBSource(tables={'t': 'SELECT * FROM t'}, uri=':memory:')
+        source._connection.execute(
+            "CREATE TABLE t AS SELECT * FROM "
+            "(VALUES (3, 'b', 1.5), (1, 'a', 2.5), (2, 'b', 3.5)) v(n, grp, f)"
+        )
+        return source
+
+    original = DuckDBSource._fetch_df
+
+    def record(self, cursor, sql_expr, *args, **kwargs):
+        queries.append(sql_expr)
+        return original(self, cursor, sql_expr, *args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(DuckDBSource, '_fetch_df', record)
+        yield make, queries
+
+
+def _query_and_data(make, queries, **params):
+    """Return the SQL that materialised the data, and the data itself.
+
+    The Pipeline queries the schema on construction, so the query that
+    matters is the one issued once ``data`` is read.
+    """
+    pipeline = Pipeline(source=make(), table='t', **params)
+    queries.clear()
+    data = pipeline.data
+    return queries[-1], data
+
+
+def test_pipeline_pushes_projection_into_sql(duckdb_pushdown_source):
+    """The columns a pipeline projects to are selected by the query, not by pandas."""
+    make, queries = duckdb_pushdown_source
+    transforms = [Sort(by=['n']), Columns(columns=['n'])]
+    sql, data = _query_and_data(make, queries, transforms=transforms)
+    assert 'SELECT n FROM' in sql
+    assert 'grp' not in sql
+
+    plain_sql, plain_data = _query_and_data(
+        make, queries, transforms=transforms, sql_pushdown=False
+    )
+    assert plain_sql == 'SELECT * FROM t'
+    assert_df_equal(data, plain_data)
+
+
+def test_pipeline_pushdown_keeps_filtered_columns(duckdb_pushdown_source):
+    """A column that is only filtered on still has to reach the filter."""
+    make, queries = duckdb_pushdown_source
+    sql, data = _query_and_data(
+        make, queries, transforms=[Columns(columns=['n'])],
+        filters=[ConstantFilter(field='grp', value='b')],
+    )
+    assert sql.startswith('SELECT n, grp FROM')
+    assert list(data.columns) == ['n']
+    assert sorted(data['n']) == [2, 3]
+
+
+def test_pipeline_pushdown_skipped_without_a_columns_transform(duckdb_pushdown_source):
+    """With no projection the pipeline still owes the caller every column."""
+    make, queries = duckdb_pushdown_source
+    sql, data = _query_and_data(make, queries, transforms=[Sort(by=['n'])])
+    assert sql == 'SELECT * FROM t'
+    assert list(data.columns) == ['n', 'grp', 'f']
+
+
+def test_pipeline_pushdown_covers_any_transform_that_names_its_columns(duckdb_pushdown_source):
+    """Aggregate declares what it reads, so a projection can still be proven."""
+    make, queries = duckdb_pushdown_source
+    transforms = [
+        Aggregate(by=['grp'], columns=['n'], with_index=False),
+        Columns(columns=['n']),
+    ]
+    sql, data = _query_and_data(make, queries, transforms=transforms)
+    assert sql.startswith('SELECT n, grp FROM')
+    assert 'f' not in sql
+
+    _, plain_data = _query_and_data(
+        make, queries, transforms=transforms, sql_pushdown=False
+    )
+    assert_df_equal(data, plain_data)
+
+
+def test_pipeline_pushdown_skipped_for_open_ended_aggregate(duckdb_pushdown_source):
+    """Without an explicit selection Aggregate reads every numeric column."""
+    make, queries = duckdb_pushdown_source
+    sql, _ = _query_and_data(
+        make, queries,
+        transforms=[Aggregate(by=['grp'], with_index=False), Columns(columns=['n'])],
+    )
+    assert sql == 'SELECT * FROM t'
+
+
+def test_pipeline_pushdown_skipped_for_unknown_transform(duckdb_pushdown_source):
+    """Query names its columns in a string, so its needs cannot be read off."""
+    make, queries = duckdb_pushdown_source
+    sql, data = _query_and_data(
+        make, queries, transforms=[Query(query='grp == "b"'), Columns(columns=['n'])]
+    )
+    assert sql == 'SELECT * FROM t'
+    assert sorted(data['n']) == [2, 3]
+
+
+def test_pipeline_pushdown_skipped_with_param_filter(duckdb_pushdown_source):
+    """A ParamFilter reads the source output before the transforms narrow it."""
+    make, queries = duckdb_pushdown_source
+    sql, _ = _query_and_data(
+        make, queries, transforms=[Columns(columns=['n'])], filters=[ParamFilter()]
+    )
+    assert sql == 'SELECT * FROM t'
+
+
+def test_pipeline_pushdown_skipped_when_nothing_is_dropped(duckdb_pushdown_source):
+    """Projecting to every column is not worth a subquery."""
+    make, queries = duckdb_pushdown_source
+    sql, _ = _query_and_data(
+        make, queries, transforms=[Columns(columns=['n', 'grp', 'f'])]
+    )
+    assert sql == 'SELECT * FROM t'
+
+
+def test_pipeline_pushdown_runs_after_declared_sql_transforms(duckdb_pushdown_source):
+    """A user's own SQL transform still sees the columns it was written against."""
+    make, queries = duckdb_pushdown_source
+    sql, data = _query_and_data(
+        make, queries, transforms=[Columns(columns=['n'])],
+        sql_transforms=[SQLSort(by=['grp'])],
+    )
+    assert 'ORDER BY grp' in sql
+    assert sql.startswith('SELECT n FROM')
+    assert list(data.columns) == ['n']
+
+
+def test_pipeline_pushdown_ignores_non_sql_source(make_filesource, mixed_df):
+    """A source with no SQL to push into is left alone."""
+    root = pathlib.Path(__file__).parent / 'sources'
+    source = make_filesource(str(root))
+    pipeline = Pipeline(source=source, table='test', transforms=[Columns(columns=['A', 'B'])])
+    assert pipeline._pushdown_transform() is None
+    assert_df_equal(pipeline.data, mixed_df[['A', 'B']])

--- a/lumen/tests/transforms/test_base.py
+++ b/lumen/tests/transforms/test_base.py
@@ -5,7 +5,8 @@ import pandas as pd
 import param  # type: ignore
 
 from lumen.transforms.base import (
-    Count, DropNA, Eval, Filter, Sum, Transform, project_lnglat,
+    Aggregate, Columns, Count, DropNA, Eval, Filter, SetIndex, Sort, Sum,
+    Transform, project_lnglat,
 )
 
 
@@ -110,3 +111,24 @@ def test_filter_invalid_condition_warns(caplog):
         "Condition {'unexpected': True} on 'A' column not understood. "
         "Filter query will not be applied."
     ) in caplog.text
+
+
+def test_requires_columns_defaults_to_unknown():
+    """The default has to be the safe answer, since a subclass may read anything."""
+    assert Transform().requires_columns() is None
+    assert DropNA().requires_columns() is None
+
+
+def test_requires_columns_reports_declared_columns():
+    assert Sort(by=['a', 'b']).requires_columns() == {'a', 'b'}
+    assert Columns(columns=['a']).requires_columns() == {'a'}
+    assert SetIndex(keys='a').requires_columns() == {'a'}
+    assert SetIndex(keys=['a', 'b']).requires_columns() == {'a', 'b'}
+    assert Aggregate(by=['a'], columns=['b']).requires_columns() == {'a', 'b'}
+
+
+def test_requires_columns_is_unknown_for_open_ended_parameters():
+    """A parameter that means "all the rest" has to report None, not a subset."""
+    assert Aggregate(by=['a']).requires_columns() is None
+    assert SetIndex().requires_columns() is None
+    assert Sort().requires_columns() == set()

--- a/lumen/tests/transforms/test_sql.py
+++ b/lumen/tests/transforms/test_sql.py
@@ -11,7 +11,7 @@ import lumen as lm
 from lumen.transforms.sql import (
     SQLColumns, SQLCount, SQLDistinct, SQLFilter, SQLFormat, SQLGroupBy,
     SQLLimit, SQLMinMax, SQLOverride, SQLPreFilter, SQLRemoveSourceSeparator,
-    SQLSample, SQLSchemaStats, SQLSelectFrom, SQLTransform,
+    SQLSample, SQLSchemaStats, SQLSelectFrom, SQLSort, SQLTransform,
 )
 
 try:
@@ -204,6 +204,55 @@ def test_sql_columns():
     result = SQLColumns.apply_to("SELECT * FROM TABLE", columns=["A", "B"])
     expected = "SELECT A, B FROM (SELECT * FROM TABLE) AS subquery"
     assert result == expected
+
+
+def test_sql_sort():
+    result = SQLSort.apply_to("SELECT * FROM TABLE", by=["A"])
+    expected = "SELECT * FROM (SELECT * FROM TABLE) AS subquery ORDER BY A ASC"
+    assert result == expected
+
+
+def test_sql_sort_descending():
+    result = SQLSort.apply_to("SELECT * FROM TABLE", by=["A"], ascending=False)
+    expected = "SELECT * FROM (SELECT * FROM TABLE) AS subquery ORDER BY A DESC"
+    assert result == expected
+
+
+def test_sql_sort_per_column_direction():
+    result = SQLSort.apply_to("SELECT * FROM TABLE", by=["A", "B"], ascending=[True, False])
+    expected = "SELECT * FROM (SELECT * FROM TABLE) AS subquery ORDER BY A ASC, B DESC"
+    assert result == expected
+
+
+def test_sql_sort_nonalphanum_characters():
+    result = SQLSort.apply_to("SELECT * FROM TABLE", by=["A_B-123"])
+    expected = 'SELECT * FROM (SELECT * FROM TABLE) AS subquery ORDER BY "A_B-123" ASC'
+    assert result == expected
+
+
+def test_sql_sort_without_columns_is_a_noop():
+    assert SQLSort.apply_to("SELECT * FROM TABLE", by=[]) == "SELECT * FROM TABLE"
+
+
+@pytest.mark.parametrize("dialect", ["duckdb", "postgres", "mysql", "snowflake", "bigquery", "sqlite"])
+def test_sql_sort_renders_for_dialect(dialect):
+    """Every dialect gets an ORDER BY, whatever it does with null placement."""
+    result = SQLSort.apply_to("SELECT * FROM TABLE", by=["A"], ascending=False, write=dialect)
+    assert "ORDER BY" in result and "DESC" in result
+
+
+def test_sql_sort_before_limit_is_a_top_n_query():
+    """The pairing SQLSort exists for: ordering inside, limit outside."""
+    if DuckDBSource is None:
+        pytest.skip("duckdb is not installed")
+    source = DuckDBSource(tables={"t": "SELECT * FROM t"}, uri=":memory:")
+    source._connection.execute(
+        "CREATE TABLE t AS SELECT * FROM (VALUES (3), (1), (2)) v(n)"
+    )
+    sql = SQLLimit.apply_to(
+        SQLSort.apply_to("SELECT * FROM t", by=["n"], ascending=False), limit=2
+    )
+    assert source._connection.execute(sql).fetchall() == [(3,), (2,)]
 
 
 def test_sql_distinct():

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -276,6 +276,19 @@ class Transform(MultiTypeComponent):
         """
         return table
 
+    def requires_columns(self) -> set[str] | None:
+        """
+        Return the columns this transform reads, or None if it may read any.
+
+        A Pipeline uses this to narrow the query it sends to a SQL source to
+        the columns something actually needs. None is the safe answer and the
+        default: it means the query cannot be narrowed, because a projection
+        might drop a column this transform reads. Only override it where
+        every column the transform touches is named by its parameters, and
+        return None for the parameter values that mean "all the rest".
+        """
+        return None
+
     @property
     def control_panel(self) -> Viewable:
         return pn.Param(
@@ -514,6 +527,12 @@ class Aggregate(Transform):
 
     _narwhals: ClassVar[bool] = True
 
+    def requires_columns(self) -> set[str] | None:
+        if not self.columns:
+            # Without an explicit selection every numeric column is aggregated.
+            return None
+        return set(self.by or []) | set(self.columns)
+
     def apply(self, table: DataFrame) -> DataFrame:
         def build(frame):
             if self.method not in _NARWHALS_AGGREGATIONS:
@@ -588,6 +607,9 @@ class Sort(Transform):
 
     _narwhals: ClassVar[bool] = True
 
+    def requires_columns(self) -> set[str] | None:
+        return set(self.by or [])
+
     def apply(self, table: DataFrame) -> DataFrame:
         def build(frame):
             if not self.by:
@@ -658,6 +680,9 @@ class Columns(Transform):
     _field_params: ClassVar[list[str]] = ['columns']
 
     _narwhals: ClassVar[bool] = True
+
+    def requires_columns(self) -> set[str] | None:
+        return set(self.columns or [])
 
     def apply(self, table: DataFrame) -> DataFrame:
         result, table = self._try_narwhals(table, lambda f: f.select(self.columns))
@@ -960,6 +985,11 @@ class SetIndex(Transform):
     transform_type: ClassVar[str] = 'set_index'
 
     _field_params: ClassVar[list[str]] = ['keys']
+
+    def requires_columns(self) -> set[str] | None:
+        if self.keys is None:
+            return None
+        return {self.keys} if isinstance(self.keys, str) else set(self.keys)
 
     def apply(self, table: DataFrame) -> DataFrame:
         return table.set_index(

--- a/lumen/transforms/sql.py
+++ b/lumen/transforms/sql.py
@@ -596,6 +596,44 @@ class SQLColumns(SQLTransform):
         return self.to_sql(expression)
 
 
+class SQLSort(SQLTransform):
+    """
+    Performs an ORDER BY on the query.
+
+    Null and NaN placement follows the database engine, which does not always
+    agree with `lumen.transforms.base.Sort`: pandas puts both last whichever
+    way the sort runs, while DuckDB orders NaN above every value on a
+    descending sort. Reach for this to have the engine do the ordering, e.g.
+    ahead of an `SQLLimit` to get a real top-N query, rather than as a
+    drop-in for the pandas transform.
+    """
+
+    by = param.List(default=[], doc="Columns to sort by.")
+
+    ascending = param.ClassSelector(default=True, class_=(bool, list), doc="""
+        Sort ascending vs. descending. Specify a list to give each column in
+        `by` its own direction.""")
+
+    transform_type: ClassVar[str] = 'sql_sort'
+
+    def apply(self, sql_in: str) -> str:
+        if not self.by:
+            return sql_in
+
+        ascending = (
+            self.ascending if isinstance(self.ascending, list)
+            else [self.ascending] * len(self.by)
+        )
+        subquery = self._to_subquery(self.parse_sql(sql_in))
+        order = []
+        for col, asc in zip(self.by, ascending, strict=True):
+            quoted = self.identify or bool(re.search(r'\W', col))
+            column = Column(this=Identifier(this=col, quoted=quoted)).sql(dialect=self.write)
+            order.append(f'{column} {"ASC" if asc else "DESC"}')
+        expression = select("*").from_(subquery).order_by(*order)
+        return self.to_sql(expression)
+
+
 class SQLFilterBase(SQLTransform):
     """
     Base class for SQL filtering transforms that provides common filtering logic.


### PR DESCRIPTION
A Pipeline on a SQL source ran `SELECT *` and projected in pandas, so `transforms=[Sort(by=['n']), Columns(columns=['n'])]` fetched every column of the table to hand back one. I push the projection into the query instead, working out the columns to keep from a new `Transform.requires_columns()`, which reports the columns a transform reads or None when it may read one its parameters do not name.

Measured on a 2M x 9 DuckDB table:

| | before | after |
| --- | --- | --- |
| frame the source returns | 9 columns, 454MB | 1 column, 16MB |
| `Pipeline.data` | 2.205s | 0.103s |

The transforms still run in pandas afterwards, so the result is the same frame by construction, and the projection is only applied where that is provable: no chained pipeline, no `ParamFilter`, a `Columns` transform to narrow to, every transform ahead of it able to name what it reads, and no column that would have to be quoted. Filtered columns are always kept. `sql_pushdown=False` turns it off.

Ordering is deliberately not pushed down, so this also adds `SQLSort` for anyone who wants the engine to sort, e.g. ahead of an `SQLLimit` for a real top-N query. It is not a drop-in for the pandas `Sort`: pandas puts NaN last whichever way the sort runs, DuckDB orders NaN above every value on a descending sort, and `NULLS LAST` is not renderable on mysql, sqlite or tsql.

Fixes #2038
