### PR TITLE
Recover from unparsable SQL in SQLAgent.revise() instead of crashing

### DIFF
--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -995,15 +995,18 @@ class SQLAgent(BaseLumenAgent):
         revise_language = view.language
         for i in range(max_retries):
             try:
-                return clean_sql(result, dialect, prettify=True)
+                cleaned = clean_sql(result, dialect, prettify=True)
+                view.validate_spec(cleaned)
+                return cleaned
             except Exception as e:
                 if i == max_retries - 1:
                     raise
                 feedback = f"{type(e).__name__}: {e!s}"
                 result = await super().revise(
-                    feedback, messages, context, spec=result, language=revise_language, **kwargs
+                    instruction, messages, context, spec=result, language=revise_language,
+                    errors=[feedback], **kwargs
                 )
-        return result
+        return clean_sql(result, dialect, prettify=True)
 
     async def respond(
         self,

--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -983,13 +983,26 @@ class SQLAgent(BaseLumenAgent):
         spec: str | None = None,
         language: str | None = None,
         errors: list[str] | None = None,
+        max_retries: int = 2,
         **kwargs
     ) -> str:
         result = await super().revise(
             instruction, messages, context, view=view, spec=spec, language=language, **kwargs
         )
-        if view is not None:
-            result = clean_sql(result, view.component.source.dialect, prettify=True)
+        if view is None:
+            return result
+        dialect = view.component.source.dialect
+        revise_language = view.language
+        for i in range(max_retries):
+            try:
+                return clean_sql(result, dialect, prettify=True)
+            except Exception as e:
+                if i == max_retries - 1:
+                    raise
+                feedback = f"{type(e).__name__}: {e!s}"
+                result = await super().revise(
+                    feedback, messages, context, spec=result, language=revise_language, **kwargs
+                )
         return result
 
     async def respond(

--- a/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
+++ b/lumen/ai/prompts/BaseLumenAgent/revise_output.jinja2
@@ -15,6 +15,7 @@ Critical Requirements:
 - Each edit must declare its op: "insert", "replace", or "delete"
 - All line_no values refer to the ORIGINAL numbering shown above — they do not shift as edits are applied
 - To insert a block of N lines before original line L, use N inserts all with line_no=L — they appear in order
+- To append after the LAST original line L, use line_no=L+1 — never reuse L, which inserts before it instead
 {% endblock %}
 
 {%- block context %}

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -22,6 +22,7 @@ from lumen.ai.agents import (
     AnalysisAgent, ChatAgent, SQLAgent, VegaLiteAgent,
 )
 from lumen.ai.agents.analysis import make_analysis_model
+from lumen.ai.agents.base_lumen import BaseLumenAgent
 from lumen.ai.agents.deck_gl import DeckGLAgent
 from lumen.ai.agents.hvplot import hvPlotAgent
 from lumen.ai.agents.sql import (
@@ -830,6 +831,55 @@ async def test_revise_forwards_resolved_table_to_prompt(llm):
             {"metaset": ms, "table": "orders"}, spec="SELECT 1", language="sql",
         )
     assert captured.get("revise_table") == t1
+
+
+async def test_revise_recovers_from_malformed_sql_via_retry(llm):
+    """A line-patch edit that sqlglot cannot parse must not surface a raw
+    ParseError to the user: revise() should feed the parse error back to the
+    LLM as feedback and retry, the same recovery _validate_sql already uses
+    for execution errors, rather than letting clean_sql's exception escape
+    straight through revise() to the caller."""
+    agent = SQLAgent(llm=llm)
+    view = SimpleNamespace(
+        component=SimpleNamespace(source=SimpleNamespace(dialect="duckdb")),
+        language="sql",
+    )
+    seen_instructions = []
+
+    async def fake_super_revise(instruction, messages, context, view=None, spec=None, language=None, **kwargs):
+        seen_instructions.append(instruction)
+        if len(seen_instructions) == 1:
+            return "SELECT * WHERE \"a\" = 'x' FROM t"  # WHERE before FROM: unparsable
+        return "SELECT * FROM t WHERE \"a\" = 'x'"
+
+    with patch.object(BaseLumenAgent, "revise", side_effect=fake_super_revise):
+        result = await agent.revise("fix it", [{"role": "user", "content": "fix"}], {}, view=view)
+
+    assert len(seen_instructions) == 2
+    assert "ParseError" in seen_instructions[1]
+    assert result == 'SELECT\n  *\nFROM t\nWHERE\n  "a" = \'x\''
+
+
+async def test_revise_raises_after_retries_exhausted_on_malformed_sql(llm):
+    """When the LLM keeps producing unparsable SQL, revise() must eventually
+    raise (bounded retries, matching _validate_sql's max_retries pattern)
+    rather than retrying forever."""
+    agent = SQLAgent(llm=llm)
+    view = SimpleNamespace(
+        component=SimpleNamespace(source=SimpleNamespace(dialect="duckdb")),
+        language="sql",
+    )
+    calls = []
+
+    async def fake_super_revise(instruction, messages, context, view=None, spec=None, language=None, **kwargs):
+        calls.append(instruction)
+        return "SELECT * WHERE \"a\" = 'x' FROM t"  # always unparsable
+
+    with patch.object(BaseLumenAgent, "revise", side_effect=fake_super_revise):
+        with pytest.raises(Exception, match="Invalid expression"):
+            await agent.revise("fix it", [{"role": "user", "content": "fix"}], {}, view=view, max_retries=2)
+
+    assert len(calls) == 2
 
 
 def test_sqlagent_active_filters_describes_conditions():

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -838,16 +838,28 @@ async def test_revise_recovers_from_malformed_sql_via_retry(llm):
     ParseError to the user: revise() should feed the parse error back to the
     LLM as feedback and retry, the same recovery _validate_sql already uses
     for execution errors, rather than letting clean_sql's exception escape
-    straight through revise() to the caller."""
+    straight through revise() to the caller.
+
+    The retry must keep the user's original instruction intact (as `feedback`
+    in the prompt) and carry the parse error separately via `errors`, rather
+    than replacing the instruction with the error text - `errors` is a
+    distinct prompt slot the base template already renders. It must also
+    still run `view.validate_spec()` on the spec it settles on, same as the
+    first attempt.
+    """
     agent = SQLAgent(llm=llm)
+    validated = []
     view = SimpleNamespace(
         component=SimpleNamespace(source=SimpleNamespace(dialect="duckdb")),
         language="sql",
+        validate_spec=lambda spec: validated.append(spec) or spec,
     )
     seen_instructions = []
+    seen_errors = []
 
-    async def fake_super_revise(instruction, messages, context, view=None, spec=None, language=None, **kwargs):
+    async def fake_super_revise(instruction, messages, context, view=None, spec=None, language=None, errors=None, **kwargs):
         seen_instructions.append(instruction)
+        seen_errors.append(errors)
         if len(seen_instructions) == 1:
             return "SELECT * WHERE \"a\" = 'x' FROM t"  # WHERE before FROM: unparsable
         return "SELECT * FROM t WHERE \"a\" = 'x'"
@@ -856,8 +868,10 @@ async def test_revise_recovers_from_malformed_sql_via_retry(llm):
         result = await agent.revise("fix it", [{"role": "user", "content": "fix"}], {}, view=view)
 
     assert len(seen_instructions) == 2
-    assert "ParseError" in seen_instructions[1]
+    assert seen_instructions[1] == "fix it"  # original instruction preserved, not overwritten by the error
+    assert seen_errors[1] is not None and "ParseError" in seen_errors[1][0]
     assert result == 'SELECT\n  *\nFROM t\nWHERE\n  "a" = \'x\''
+    assert validated == [result]  # the settled spec was validated, same as the first attempt
 
 
 async def test_revise_raises_after_retries_exhausted_on_malformed_sql(llm):
@@ -868,6 +882,7 @@ async def test_revise_raises_after_retries_exhausted_on_malformed_sql(llm):
     view = SimpleNamespace(
         component=SimpleNamespace(source=SimpleNamespace(dialect="duckdb")),
         language="sql",
+        validate_spec=lambda spec: spec,
     )
     calls = []
 
@@ -880,6 +895,33 @@ async def test_revise_raises_after_retries_exhausted_on_malformed_sql(llm):
             await agent.revise("fix it", [{"role": "user", "content": "fix"}], {}, view=view, max_retries=2)
 
     assert len(calls) == 2
+
+
+async def test_revise_max_retries_zero_still_cleans_sql(llm):
+    """max_retries=0 must not silently return the unprettified, unvalidated
+    LLM output by falling through an empty `range(0)` loop - it should still
+    attempt clean_sql once (and raise, not swallow, if that attempt fails)."""
+    agent = SQLAgent(llm=llm)
+    view = SimpleNamespace(
+        component=SimpleNamespace(source=SimpleNamespace(dialect="duckdb")),
+        language="sql",
+        validate_spec=lambda spec: spec,
+    )
+
+    async def fake_super_revise(instruction, messages, context, view=None, spec=None, language=None, **kwargs):
+        return "select  *   from t"  # parsable but not prettified
+
+    with patch.object(BaseLumenAgent, "revise", side_effect=fake_super_revise):
+        result = await agent.revise("fix it", [{"role": "user", "content": "fix"}], {}, view=view, max_retries=0)
+
+    assert result == "SELECT\n  *\nFROM t"  # cleaned/prettified, not the raw passthrough
+
+    async def fake_super_revise_bad(instruction, messages, context, view=None, spec=None, language=None, **kwargs):
+        return "SELECT * WHERE \"a\" = 'x' FROM t"  # unparsable
+
+    with patch.object(BaseLumenAgent, "revise", side_effect=fake_super_revise_bad):
+        with pytest.raises(Exception, match="Invalid expression"):
+            await agent.revise("fix it", [{"role": "user", "content": "fix"}], {}, view=view, max_retries=0)
 
 
 def test_sqlagent_active_filters_describes_conditions():


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

`SQLAgent.revise()` post-processes the LLM's line-patch edit with `clean_sql(result, dialect, prettify=True)`, which calls `sqlglot.transpile()` with no error handling. When the edit produces SQL that sqlglot cannot parse (for example a clause reordered by a bad patch), the raw `sqlglot.errors.ParseError` propagates straight out of `revise()` to `RetryControls._revise()`, which reports it and re-raises, so the "Prompt LLM to retry" button in the SQL editor can surface a bare parser exception instead of a helpful message.

`SQLAgent._validate_sql()` already handles the analogous problem for execution errors: on failure it feeds the error back to the LLM as feedback and retries, bounded by `max_retries`. `revise()` had no equivalent recovery for a parse failure in its own post-processing step, even though the fix is small and the pattern already exists a few lines away in the same file.

This PR adds the same bounded-retry recovery to `revise()`: if `clean_sql()` raises, the exception's message is fed back to the LLM as the next revise instruction, and the malformed edit is retried up to `max_retries` (default 2) times before giving up and raising, matching `_validate_sql()`'s behavior.

Reproduced the failure directly against `clean_sql`/`sqlglot.transpile` with the malformed SQL shape a bad line-patch produces (`SELECT * WHERE "a" = 'x' FROM t`, WHERE before FROM):

```
>>> sqlglot.transpile('SELECT * WHERE "a" = \'x\' FROM t', read='duckdb', pretty=True)
sqlglot.errors.ParseError: Invalid expression / Unexpected token. Line 1, Col: 29.
```

No before/after screenshot: this is a backend error-handling path in `SQLAgent.revise()`, not a rendered view, so there is no visual to capture. The reproduction above and the two new regression tests are the MRVE.

Fixes #1663


## AI Disclosure

Tool & Model: Claude Code, Claude Sonnet 5
Usage: root-caused the issue by tracing `revise()` and `clean_sql()`, implemented the retry loop mirroring `_validate_sql()`'s existing pattern, and wrote the two regression tests below. I reviewed the diagnosis, the fix, and the tests, and ran the full test suite (Python 3.12 and 3.13) myself before opening this PR.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist

- [x] Tests added and are passing
