### PR TITLE
Fix VegaLiteView to coerce date fields to temporal encoding

### DIFF
--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1565,13 +1565,8 @@ class VegaLiteView(View):
     def _get_params(self) -> dict[str, Any]:
         df = self.get_data()
         spec_data = self.spec.get('data', {})
-
-        # Deepcopy the spec to avoid mutating the original instance state (like encoding types),
-        # but avoid deepcopying 'data' or 'datasets' which can be large DataFrames.
-        spec = copy.deepcopy({k: v for k, v in self.spec.items() if k not in ('data', 'datasets')})
-        if 'datasets' in self.spec:
-            spec['datasets'] = dict(self.spec['datasets'])
-
+        spec = dict(self.spec)
+        
         if "$schema" not in spec:
             spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
 
@@ -1581,9 +1576,11 @@ class VegaLiteView(View):
             # The spec brings its own data (e.g. map boundaries), so the pipeline
             # travels as a named dataset for lookups to join against rather than
             # replacing it.
-            datasets = spec.get('datasets', {})
+            # Copied rather than mutated in place: self.spec is reused across
+            # renders, and growing its datasets dict would leak frames.
+            datasets = dict(self.spec.get('datasets', {}))
             datasets[self.pipeline.table] = df
-            spec = {k: v for k, v in spec.items() if k != 'datasets'}
+            spec = copy.deepcopy({k: v for k, v in spec.items() if k != 'datasets'})
             self._retarget_lookup_datasets(spec, set(datasets), self.pipeline.table)
             encoded = dict(spec, datasets=datasets)
         elif is_geodataframe(df):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1513,22 +1513,64 @@ class VegaLiteView(View):
         for value in node.values():
             cls._retarget_lookup_datasets(value, known, table)
 
+    def _coerce_temporal(self, spec: dict[str, Any], df: pd.DataFrame) -> None:
+        """
+        Recursively walk the spec. If an encoding channel references a field that
+        contains datetimes (or strings that cleanly parse as datetimes), force
+        its type to 'temporal' to preserve chronological ordering.
+        """
+        if not isinstance(spec, dict):
+            return
+
+        if "encoding" in spec and isinstance(spec["encoding"], dict):
+            for channel, config in spec["encoding"].items():
+                if isinstance(config, dict) and "field" in config:
+                    field = config["field"]
+                    if field in df.columns:
+                        is_dt = False
+                        if pd.api.types.is_datetime64_any_dtype(df[field]):
+                            is_dt = True
+                        elif pd.api.types.is_string_dtype(df[field]) or df[field].dtype.name == 'category':
+                            first_valid = df[field].dropna()
+                            if not first_valid.empty:
+                                try:
+                                    pd.to_datetime(first_valid.iloc[0], errors='raise')
+                                    is_dt = True
+                                except (ValueError, TypeError):
+                                    pass
+                        if is_dt:
+                            config["type"] = "temporal"
+
+        for value in spec.values():
+            if isinstance(value, dict):
+                self._coerce_temporal(value, df)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        self._coerce_temporal(item, df)
+
     def _get_params(self) -> dict[str, Any]:
         df = self.get_data()
         spec_data = self.spec.get('data', {})
-        spec = dict(self.spec)
+        
+        # Deepcopy the spec to avoid mutating the original instance state (like encoding types),
+        # but avoid deepcopying 'data' or 'datasets' which can be large DataFrames.
+        spec = copy.deepcopy({k: v for k, v in self.spec.items() if k not in ('data', 'datasets')})
+        if 'datasets' in self.spec:
+            spec['datasets'] = dict(self.spec['datasets'])
+            
         if "$schema" not in spec:
             spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
+            
+        self._coerce_temporal(spec, df)
 
         if self._declares_own_data(spec):
             # The spec brings its own data (e.g. map boundaries), so the pipeline
             # travels as a named dataset for lookups to join against rather than
             # replacing it.
-            # Copied rather than mutated in place: self.spec is reused across
-            # renders, and growing its datasets dict would leak frames.
-            datasets = dict(self.spec.get('datasets', {}))
+            datasets = spec.get('datasets', {})
             datasets[self.pipeline.table] = df
-            spec = copy.deepcopy({k: v for k, v in spec.items() if k != 'datasets'})
+            spec = {k: v for k, v in spec.items() if k != 'datasets'}
             self._retarget_lookup_datasets(spec, set(datasets), self.pipeline.table)
             encoded = dict(spec, datasets=datasets)
         elif is_geodataframe(df):
@@ -1542,6 +1584,7 @@ class VegaLiteView(View):
         else:
             encoded = dict(spec, data={'values': df, **spec_data})
         return dict(object=encoded, **self.kwargs)
+
 
     def get_panel(self) -> pn.pane.Vega:
         spec = self._normalize_params(self._get_params())

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1585,7 +1585,7 @@ class VegaLiteView(View):
         df = self.get_data()
         spec_data = self.spec.get('data', {})
         spec = dict(self.spec)
-        
+
         if "$schema" not in spec:
             spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
 

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1530,24 +1530,29 @@ class VegaLiteView(View):
         if not isinstance(spec, dict):
             return
 
-        if "encoding" in spec and isinstance(spec["encoding"], dict):
+        if isinstance(spec.get("encoding"), dict):
             for _channel, config in spec["encoding"].items():
-                if isinstance(config, dict) and "field" in config:
-                    field = config["field"]
-                    if field in df.columns:
-                        is_dt = False
-                        if pd.api.types.is_datetime64_any_dtype(df[field]):
+                if not isinstance(config, dict) or "field" not in config:
+                    continue
+
+                field = config["field"]
+                if field not in df.columns:
+                    continue
+
+                series = df[field]
+                is_dt = pd.api.types.is_datetime64_any_dtype(series)
+
+                if not is_dt and (pd.api.types.is_string_dtype(series) or series.dtype.name == 'category'):
+                    first_valid = series.dropna()
+                    if not first_valid.empty:
+                        try:
+                            pd.to_datetime(first_valid.iloc[0], errors='raise')
                             is_dt = True
-                        elif pd.api.types.is_string_dtype(df[field]) or df[field].dtype.name == 'category':
-                            first_valid = df[field].dropna()
-                            if not first_valid.empty:
-                                try:
-                                    pd.to_datetime(first_valid.iloc[0], errors='raise')
-                                    is_dt = True
-                                except (ValueError, TypeError):
-                                    pass
-                        if is_dt:
-                            config["type"] = "temporal"
+                        except (ValueError, TypeError):
+                            pass
+
+                if is_dt:
+                    config["type"] = "temporal"
 
         for value in spec.values():
             if isinstance(value, dict):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1546,7 +1546,7 @@ class VegaLiteView(View):
                     first_valid = series.dropna()
                     if not first_valid.empty:
                         try:
-                            pd.to_datetime(first_valid.iloc[0], errors='raise')
+                            pd.to_datetime(first_valid, errors='raise')
                             is_dt = True
                         except (ValueError, TypeError):
                             pass

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import copy
 import html
 import sys
+import warnings
 
 from io import BytesIO, StringIO
 from typing import (
@@ -1545,11 +1546,13 @@ class VegaLiteView(View):
                     if not is_dt and (pd.api.types.is_string_dtype(series) or series.dtype.name == 'category'):
                         first_valid = series.dropna()
                         if not first_valid.empty:
-                            try:
-                                pd.to_datetime(first_valid, errors='raise')
-                                is_dt = True
-                            except (ValueError, TypeError):
-                                pass
+                            with warnings.catch_warnings():
+                                warnings.simplefilter("ignore", UserWarning)
+                                try:
+                                    pd.to_datetime(first_valid, errors='raise')
+                                    is_dt = True
+                                except (ValueError, TypeError):
+                                    pass
 
                     if is_dt and config.get("type") != "temporal":
                         if new_spec is None:

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1521,46 +1521,65 @@ class VegaLiteView(View):
         for value in node.values():
             cls._retarget_lookup_datasets(value, known, table)
 
-    def _coerce_temporal(self, spec: dict[str, Any], df: pd.DataFrame) -> None:
+    def _coerce_temporal(self, spec: Any, df: pd.DataFrame) -> Any:
         """
         Recursively walk the spec. If an encoding channel references a field that
         contains datetimes (or strings that cleanly parse as datetimes), force
         its type to 'temporal' to preserve chronological ordering.
+        Returns a new spec if changes were made, otherwise returns the original.
         """
-        if not isinstance(spec, dict):
-            return
+        if isinstance(spec, dict):
+            new_spec = None
+            if isinstance(spec.get("encoding"), dict):
+                for _channel, config in spec["encoding"].items():
+                    if not isinstance(config, dict) or "field" not in config:
+                        continue
 
-        if isinstance(spec.get("encoding"), dict):
-            for _channel, config in spec["encoding"].items():
-                if not isinstance(config, dict) or "field" not in config:
+                    field = config["field"]
+                    if field not in df.columns:
+                        continue
+
+                    series = df[field]
+                    is_dt = pd.api.types.is_datetime64_any_dtype(series)
+
+                    if not is_dt and (pd.api.types.is_string_dtype(series) or series.dtype.name == 'category'):
+                        first_valid = series.dropna()
+                        if not first_valid.empty:
+                            try:
+                                pd.to_datetime(first_valid, errors='raise')
+                                is_dt = True
+                            except (ValueError, TypeError):
+                                pass
+
+                    if is_dt and config.get("type") != "temporal":
+                        if new_spec is None:
+                            new_spec = dict(spec)
+                            new_spec["encoding"] = dict(spec["encoding"])
+                        new_config = dict(config)
+                        new_config["type"] = "temporal"
+                        new_spec["encoding"][_channel] = new_config
+
+            for key, value in spec.items():
+                if key == "encoding" and new_spec is not None and "encoding" in new_spec:
                     continue
+                coerced_value = self._coerce_temporal(value, df)
+                if coerced_value is not value:
+                    if new_spec is None:
+                        new_spec = dict(spec)
+                    new_spec[key] = coerced_value
+            return new_spec if new_spec is not None else spec
 
-                field = config["field"]
-                if field not in df.columns:
-                    continue
+        elif isinstance(spec, list):
+            new_list = None
+            for i, item in enumerate(spec):
+                coerced_item = self._coerce_temporal(item, df)
+                if coerced_item is not item:
+                    if new_list is None:
+                        new_list = list(spec)
+                    new_list[i] = coerced_item
+            return new_list if new_list is not None else spec
 
-                series = df[field]
-                is_dt = pd.api.types.is_datetime64_any_dtype(series)
-
-                if not is_dt and (pd.api.types.is_string_dtype(series) or series.dtype.name == 'category'):
-                    first_valid = series.dropna()
-                    if not first_valid.empty:
-                        try:
-                            pd.to_datetime(first_valid, errors='raise')
-                            is_dt = True
-                        except (ValueError, TypeError):
-                            pass
-
-                if is_dt:
-                    config["type"] = "temporal"
-
-        for value in spec.values():
-            if isinstance(value, dict):
-                self._coerce_temporal(value, df)
-            elif isinstance(value, list):
-                for item in value:
-                    if isinstance(item, dict):
-                        self._coerce_temporal(item, df)
+        return spec
 
     def _get_params(self) -> dict[str, Any]:
         df = self.get_data()
@@ -1570,7 +1589,7 @@ class VegaLiteView(View):
         if "$schema" not in spec:
             spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
 
-        self._coerce_temporal(spec, df)
+        spec = self._coerce_temporal(spec, df)
 
         if self._declares_own_data(spec):
             # The spec brings its own data (e.g. map boundaries), so the pipeline

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1523,7 +1523,7 @@ class VegaLiteView(View):
             return
 
         if "encoding" in spec and isinstance(spec["encoding"], dict):
-            for channel, config in spec["encoding"].items():
+            for _channel, config in spec["encoding"].items():
                 if isinstance(config, dict) and "field" in config:
                     field = config["field"]
                     if field in df.columns:
@@ -1552,16 +1552,16 @@ class VegaLiteView(View):
     def _get_params(self) -> dict[str, Any]:
         df = self.get_data()
         spec_data = self.spec.get('data', {})
-        
+
         # Deepcopy the spec to avoid mutating the original instance state (like encoding types),
         # but avoid deepcopying 'data' or 'datasets' which can be large DataFrames.
         spec = copy.deepcopy({k: v for k, v in self.spec.items() if k not in ('data', 'datasets')})
         if 'datasets' in self.spec:
             spec['datasets'] = dict(self.spec['datasets'])
-            
+
         if "$schema" not in spec:
             spec["$schema"] = "https://vega.github.io/schema/vega-lite/v5.json"
-            
+
         self._coerce_temporal(spec, df)
 
         if self._declares_own_data(spec):


### PR DESCRIPTION
## What this PR does

Adds a `_coerce_temporal()` helper method to `VegaLiteView` that
defensively corrects the Vega-Lite encoding type for date-like fields.

## Problem

When the LLM incorrectly sets a date column's encoding `type` to
`"nominal"` instead of `"temporal"`, the Vega-Lite library renders
the x-axis out of chronological order (following raw row order instead
of time).

## Solution

`_coerce_temporal()` recursively walks the generated Vega-Lite spec.
For each encoding channel that references a DataFrame field, it checks:
1. If the column dtype is already `datetime64` → force `"temporal"`
2. If the column is a string/category type → attempt `pd.to_datetime()`
   on the first non-null value. If it parses successfully → force `"temporal"`

This approach is non-destructive — the underlying DataFrame row order
is never modified, so `ORDER BY` rankings from SQL queries remain intact.

Closes #1906

## Testing

Manually tested by prompting the LLM to **forcefully** set 
`"type": "nominal"` on the date x-axis encoding.

**Before fix** (LLM forced nominal → dates out of chronological order):
<img width="978" height="707" alt="image" src="https://github.com/user-attachments/assets/504d9e43-5a13-4600-8a72-c00d3cdc34c1" />


**After fix** (code coerces to temporal → correct chronological order):
<img width="1105" height="742" alt="image" src="https://github.com/user-attachments/assets/decf7254-076f-4192-b4ee-be8d96bf3b7e" />


You may notice that the **code preview tab** in the UI still shows 
`type: nominal` even after the fix. This is **expected and intentional**.

The fix works on a `deepcopy` of `self.spec` (the original LLM-generated
spec), so `self.spec` itself is never mutated. The coercion is applied 
only to the copy that gets sent to the browser for rendering. This design:
- Prevents state leakage across multiple renders
- Avoids accidentally deep-copying large DataFrames stored in `datasets`
- Keeps the original LLM spec intact for debugging/display purposes

The rendered chart (right side) correctly shows chronological order,
confirming the coercion is working as intended.

