### PR TITLE
Add ComponentController tools

### DIFF
--- a/examples/ai/epidemic_copilot.py
+++ b/examples/ai/epidemic_copilot.py
@@ -1,0 +1,499 @@
+"""
+Outbreak simulator whose scenario is steered by a conversation.
+
+Unlike `penguin_copilot.py`, which walks a whole page for widgets, this demo
+hands the `ComponentController` two `param.Parameterized` objects directly: the
+model, whose parameters and docstrings are all the assistant needs to reason
+about the simulation, and a read-only `Outcome` whose values it can read back
+after every change. Because it can both act and observe, the assistant in the
+drawer on the right can iterate towards a goal instead of just flipping
+switches:
+
+- "What can you control here?"
+- "Model a measles-like outbreak in a city of three million"
+- "What if we start vaccinating on day 40 at one percent of the population a day?"
+- "Save this as the baseline, then find the weakest lockdown that keeps hospital load under 100%"
+- "Halve the peak without locking down harder than 50%"
+
+Run it with::
+
+    panel serve examples/ai/epidemic_copilot.py --show
+"""
+
+import holoviews as hv
+import hvplot.pandas  # noqa
+import pandas as pd
+import panel as pn
+import panel_material_ui as pmui
+import param
+
+from bokeh.models import NumeralTickFormatter
+
+from lumen.ai import Planner
+from lumen.ai.agents import ChatAgent, ComponentControlAgent
+from lumen.ai.llm import OpenAI
+from lumen.ai.tools import ComponentController
+
+pn.extension(notifications=True, respect_explicit_sizing=True)
+
+HOSPITALISATION_RATE = 0.02
+
+COMPARTMENTS = {
+    "Susceptible": "susceptible",
+    "Exposed": "exposed",
+    "Infected": "infected",
+    "Recovered": "recovered",
+    "Vaccinated": "vaccinated",
+    "Deaths": "deaths",
+}
+
+GOOD, BAD, DEMAND = "#2e7d32", "#c62828", "#1976d2"
+
+
+class Epidemic(param.Parameterized):
+    """Compartmental SEIR model of an outbreak in a single, closed population."""
+
+    population = param.Integer(default=1_000_000, bounds=(10_000, 20_000_000), doc="""
+        Number of people in the population.""")
+
+    initial_infections = param.Integer(default=50, bounds=(1, 10_000), doc="""
+        Number of people already infectious on day zero.""")
+
+    r0 = param.Number(default=2.5, bounds=(0.5, 20.0), doc="""
+        Basic reproduction number, i.e. how many people the average case infects
+        while everybody around them is still susceptible.""")
+
+    incubation_days = param.Number(default=5.0, bounds=(0.5, 21.0), doc="""
+        Average number of days between catching the disease and becoming
+        infectious.""")
+
+    infectious_days = param.Number(default=7.0, bounds=(1.0, 30.0), doc="""
+        Average number of days a case stays infectious.""")
+
+    fatality_rate = param.Number(default=0.6, bounds=(0.0, 60.0), doc="""
+        Percentage of cases that end in death.""")
+
+    intervention_day = param.Integer(default=0, bounds=(0, 365), doc="""
+        Day on which an intervention such as a lockdown starts. Zero means no
+        intervention at all.""")
+
+    intervention_strength = param.Number(default=0.4, bounds=(0.0, 0.95), doc="""
+        Fraction by which the intervention reduces transmission, e.g. 0.5 halves
+        the rate at which the disease spreads.""")
+
+    vaccination_day = param.Integer(default=0, bounds=(0, 365), doc="""
+        Day on which the vaccination campaign starts. Zero means no campaign.""")
+
+    vaccination_rate = param.Number(default=0.5, bounds=(0.0, 5.0), doc="""
+        Percentage of the population vaccinated per day once the campaign has
+        started.""")
+
+    vaccine_efficacy = param.Number(default=90.0, bounds=(0.0, 100.0), doc="""
+        Percentage of the vaccinated who actually become immune.""")
+
+    hospital_beds_per_100k = param.Number(default=30.0, bounds=(1.0, 500.0), doc="""
+        Hospital beds available per 100,000 people; two percent of the people
+        infected at any one time are assumed to need one.""")
+
+    days = param.Integer(default=240, bounds=(30, 730), doc="""
+        Number of days to simulate.""")
+
+    @property
+    def hospital_beds(self) -> float:
+        return self.hospital_beds_per_100k * self.population / 100_000
+
+    def simulate(self) -> pd.DataFrame:
+        beta = self.r0 / self.infectious_days
+        onset_rate = 1 / self.incubation_days
+        removal_rate = 1 / self.infectious_days
+        fatality = self.fatality_rate / 100
+        doses = self.population * self.vaccination_rate / 100 * self.vaccine_efficacy / 100
+        susceptible = float(self.population - self.initial_infections)
+        infected = float(self.initial_infections)
+        exposed = recovered = vaccinated = deaths = 0.0
+        rows = []
+        for day in range(self.days + 1):
+            rows.append((day, susceptible, exposed, infected, recovered, vaccinated, deaths))
+            locked_down = self.intervention_day and day >= self.intervention_day
+            transmission = beta * (1 - self.intervention_strength if locked_down else 1)
+            infections = transmission * susceptible * infected / self.population
+            onsets = onset_rate * exposed
+            removals = removal_rate * infected
+            immunised = doses if self.vaccination_day and day >= self.vaccination_day else 0.0
+            immunised = min(immunised, max(susceptible - infections, 0.0))
+            susceptible -= infections + immunised
+            exposed += infections - onsets
+            infected += onsets - removals
+            recovered += removals * (1 - fatality)
+            deaths += removals * fatality
+            vaccinated += immunised
+        data = pd.DataFrame(rows, columns=["day", *COMPARTMENTS.values()])
+        return data.assign(hospitalised=data.infected * HOSPITALISATION_RATE)
+
+
+class Outcome(param.Parameterized):
+    """Results of the most recent simulation."""
+
+    peak_infections = param.Integer(default=0, constant=True, doc="""
+        Largest number of people infected at the same time.""")
+
+    peak_day = param.Integer(default=0, constant=True, doc="""
+        Day on which the number of infections peaks.""")
+
+    peak_hospital_load = param.Number(default=0.0, constant=True, doc="""
+        Beds needed at the peak as a percentage of the beds available; anything
+        above 100 means the health system is overwhelmed.""")
+
+    overflow_days = param.Integer(default=0, constant=True, doc="""
+        Number of days on which the demand for hospital beds exceeds capacity.""")
+
+    deaths = param.Integer(default=0, constant=True, doc="""
+        Total number of deaths over the course of the outbreak.""")
+
+    infected_share = param.Number(default=0.0, constant=True, doc="""
+        Percentage of the population infected over the course of the outbreak.""")
+
+    peak_vs_baseline = param.Number(default=0.0, constant=True, doc="""
+        Change in peak infections relative to the saved baseline scenario, in
+        percent; negative means this scenario is milder than the baseline.""")
+
+
+class Reference(param.Parameterized):
+    """The saved scenario the current one is compared against."""
+
+    label = param.String(default="baseline")
+
+    data = param.DataFrame(default=None)
+
+
+PRESETS = {
+    "Custom": {},
+    "Seasonal flu": dict(r0=1.4, incubation_days=1.5, infectious_days=5.0, fatality_rate=0.1),
+    "COVID-like": dict(r0=2.5, incubation_days=5.0, infectious_days=7.0, fatality_rate=0.6),
+    "Measles-like": dict(r0=14.0, incubation_days=10.0, infectious_days=8.0, fatality_rate=0.15),
+    "Ebola-like": dict(r0=1.8, incubation_days=9.0, infectious_days=10.0, fatality_rate=45.0),
+}
+
+DISEASE_PARAMETERS = list(PRESETS["COVID-like"])
+
+
+def scenario_label(model: Epidemic) -> str:
+    label = f"R0 {model.r0:g}"
+    if model.intervention_day:
+        label += f", day {model.intervention_day} -{model.intervention_strength:.0%}"
+    if model.vaccination_day:
+        label += f", vaccines day {model.vaccination_day}"
+    return label
+
+
+model = Epidemic()
+outcome = Outcome()
+reference = Reference(data=model.simulate(), label=scenario_label(model))
+
+preset = pmui.Select(
+    label="Scenario preset", options=list(PRESETS), value="COVID-like",
+    description="Disease profile to load; picking one overwrites the disease parameters of the model",
+)
+
+curves = pmui.MultiChoice(
+    label="Curves", options=list(COMPARTMENTS), value=["Infected", "Deaths"],
+    description="Compartments to draw in the epidemic curves plot",
+)
+
+scale = pmui.RadioButtonGroup(
+    label="Y axis", options=["linear", "log"], value="linear",
+    description="Scale of the y axis",
+)
+
+capacity_line = pmui.Switch(
+    label="Show capacity", value=True,
+    description="Whether to mark the available hospital beds and shade the demand exceeding them",
+)
+
+compare = pmui.Switch(
+    label="Compare to baseline", value=True,
+    description="Whether to overlay the infections of the saved baseline scenario",
+)
+
+save = pmui.Button(label="Save as baseline", icon="bookmark_add", variant="outlined")
+
+reset = pmui.Button(label="Reset scenario", icon="restart_alt", variant="outlined")
+
+def apply_preset(event):
+    values = PRESETS[event.new]
+    if values:
+        model.param.update(**values)
+
+
+def sync_preset(*events):
+    """
+    Keep the preset honest about the disease the model describes.
+
+    Applying a preset lands back here, but the name it resolves to is the one
+    that was just selected, so param drops the update and nothing loops.
+    """
+    preset.value = next(
+        (name for name, values in PRESETS.items()
+         if values and all(getattr(model, key) == value for key, value in values.items())),
+        "Custom",
+    )
+
+
+def reset_scenario(event):
+    model.param.update(**{
+        name: parameter.default for name, parameter in model.param.objects().items()
+        if name != "name"
+    })
+
+
+def save_baseline(event):
+    reference.param.update(data=model.simulate(), label=scenario_label(model))
+    if pn.state.notifications:
+        pn.state.notifications.success(f"Saved '{reference.label}' as the baseline.")
+
+
+def format_value(value) -> str:
+    return f"{value:,}" if isinstance(value, int) else f"{value:,g}"
+
+
+def announce(*events):
+    if not pn.state.notifications:
+        return
+    changes = ", ".join(f"{event.name.replace('_', ' ')} {format_value(event.new)}" for event in events)
+    pn.state.notifications.info(f"Scenario updated: {changes}")
+
+
+preset.param.watch(apply_preset, "value")
+model.param.watch(sync_preset, DISEASE_PARAMETERS)
+model.param.watch(announce, [name for name in model.param if name != "name"])
+reset.on_click(reset_scenario)
+save.on_click(save_baseline)
+
+
+def simulate(baseline, **parameters):
+    """
+    Run the simulation and record its outcome.
+
+    The model parameters are passed in only so that the bound views re-render
+    whenever a slider (or the assistant) changes one of them; ``baseline`` does
+    the same for the comparison recorded on the outcome.
+    """
+    data = model.simulate()
+    beds = model.hospital_beds
+    peak = float(data.infected.max())
+    baseline_peak = None if baseline is None else float(baseline.infected.max())
+    with param.parameterized.edit_constant(outcome):
+        outcome.param.update(
+            peak_infections=int(peak),
+            peak_day=int(data.day[data.infected.idxmax()]),
+            peak_hospital_load=round(100 * float(data.hospitalised.max()) / beds, 1),
+            overflow_days=int((data.hospitalised > beds).sum()),
+            deaths=int(data.deaths.iloc[-1]),
+            infected_share=round(100 * float(data.recovered.iloc[-1] + data.deaths.iloc[-1]) / model.population, 1),
+            peak_vs_baseline=0.0 if not baseline_peak else round(100 * (peak / baseline_peak - 1), 1),
+        )
+    return data
+
+
+def metric(title, value, caption, colour=None):
+    return pmui.Paper(
+        pmui.Typography(title, variant="overline", sx={"opacity": 0.6, "lineHeight": 1.5}),
+        pmui.Typography(value, variant="h5", sx={"color": colour} if colour else {}),
+        pmui.Typography(caption, variant="caption", sx={"opacity": 0.6}),
+        elevation=2, styles={"padding": "6px 16px", "flex": "1 1 170px", "max-width": "320px"},
+    )
+
+
+def metrics(data, baseline, label):
+    load, change = outcome.peak_hospital_load, outcome.peak_vs_baseline
+    return pn.FlexBox(
+        metric("Peak infections", f"{outcome.peak_infections:,}", f"on day {outcome.peak_day}"),
+        metric("Total infected", f"{outcome.infected_share:g}%", "of the population"),
+        metric("Deaths", f"{outcome.deaths:,}", f"{100 * outcome.deaths / model.population:.2f}% of the population"),
+        metric(
+            "Peak hospital load", f"{load:g}%",
+            f"over capacity on {outcome.overflow_days} days" if outcome.overflow_days else "within capacity",
+            BAD if load > 100 else GOOD,
+        ),
+        metric(
+            "Peak vs baseline", f"{change:+g}%", f"baseline: {label}",
+            BAD if change > 0 else GOOD if change < 0 else None,
+        ),
+        sizing_mode="stretch_width", gap="10px", margin=(10, 10, 0, 10),
+    )
+
+
+def headline(data):
+    beds = model.hospital_beds
+    summary = (
+        f"Infections peak at {outcome.peak_infections:,} on day {outcome.peak_day}, "
+        f"{outcome.infected_share:g}% of the population is infected in total and "
+        f"{outcome.deaths:,} people die."
+    )
+    if outcome.overflow_days:
+        return pmui.Alert(
+            f"{summary} Demand peaks at {outcome.peak_hospital_load:g}% of the {beds:,.0f} available "
+            f"beds and stays above capacity for {outcome.overflow_days} days.",
+            severity="error", sizing_mode="stretch_width",
+        )
+    return pmui.Alert(
+        f"{summary} Hospital demand peaks at {outcome.peak_hospital_load:g}% of the "
+        f"{beds:,.0f} available beds, so the health system copes.",
+        severity="success", sizing_mode="stretch_width",
+    )
+
+
+def outbreak_plot(data, curves, scale, compare, baseline, label):
+    if not curves:
+        return pmui.Alert("Select at least one compartment to plot.", severity="info", sizing_mode="stretch_width")
+    columns = [COMPARTMENTS[curve] for curve in curves]
+    if scale == "log":
+        # a log axis cannot render the zeros the compartments start out at
+        data = data.assign(**{column: data[column].mask(data[column] < 1) for column in columns})
+    elements = [data.hvplot.line(
+        x="day", y=columns, responsive=True, height=340, logy=scale == "log",
+        ylabel="people", yformatter=NumeralTickFormatter(format="0,0"), grid=True, line_width=2,
+    )]
+    if model.intervention_day:
+        elements.append(hv.VLine(model.intervention_day).opts(color="#616161", line_dash="dotted"))
+    if model.vaccination_day:
+        elements.append(hv.VLine(model.vaccination_day).opts(color="#0288d1", line_dash="dotted"))
+    if compare and baseline is not None:
+        elements.append(hv.Curve(baseline, "day", "infected", label=f"infected ({label})").opts(
+            color="black", line_dash="dashed", line_width=1.5, alpha=0.7
+        ))
+    return hv.Overlay(elements).opts(toolbar="above", legend_position="top_right", active_tools=[])
+
+
+def hospital_plot(data, capacity_line):
+    # expressed as a share of capacity, so the 100% line is what matters
+    load = data.assign(load=100 * data.hospitalised / model.hospital_beds)
+    elements = [load.hvplot.area(
+        x="day", y="load", responsive=True, height=220, alpha=0.35,
+        color=DEMAND, ylabel="% of capacity", grid=True, label="demand",
+    )]
+    if capacity_line:
+        # a band between the capacity and the demand shades the unmet demand
+        band = load.assign(capacity=100.0, over=load.load.clip(lower=100))
+        elements.append(hv.Area(band, "day", ["capacity", "over"], label="over capacity").opts(
+            color=BAD, alpha=0.5, line_alpha=0
+        ))
+        elements.append(hv.HLine(100).opts(color="#212121", line_dash="dashed", line_width=1.5))
+    return hv.Overlay(elements).opts(toolbar=None, legend_position="top_right")
+
+
+data = pn.bind(
+    simulate, reference.param.data,
+    **{name: model.param[name] for name in model.param if name != "name"},
+)
+
+main = pn.Row(
+    pn.Column(
+        pn.panel(pn.bind(metrics, data, reference.param.data, reference.param.label), sizing_mode="stretch_width"),
+        pn.panel(pn.bind(headline, data), sizing_mode="stretch_width", margin=10),
+        pmui.Card(
+            pn.panel(
+                pn.bind(outbreak_plot, data, curves, scale, compare, reference.param.data, reference.param.label),
+                sizing_mode="stretch_width",
+            ),
+            title="Epidemic curves", sizing_mode="stretch_width", margin=10,
+        ),
+        pmui.Card(
+            pn.panel(pn.bind(hospital_plot, data, capacity_line), sizing_mode="stretch_width"),
+            title="Hospital demand", sizing_mode="stretch_width", margin=10,
+        ),
+    ),
+    sizing_mode="stretch_both"
+)
+
+page = pmui.Page(
+    title="Outbreak Simulator",
+    sidebar=[
+        pmui.Column(
+            preset,
+            pmui.Accordion(
+                ("Disease", pmui.Column(
+                    pmui.FloatSlider.from_param(model.param.r0, step=0.1),
+                    pmui.FloatSlider.from_param(model.param.incubation_days, step=0.5),
+                    pmui.FloatSlider.from_param(model.param.infectious_days, step=0.5),
+                    pmui.FloatSlider.from_param(model.param.fatality_rate, step=0.1),
+                )),
+                ("Response", pmui.Column(
+                    pmui.IntSlider.from_param(model.param.intervention_day, step=5),
+                    pmui.FloatSlider.from_param(model.param.intervention_strength, step=0.05),
+                    pmui.IntSlider.from_param(model.param.vaccination_day, step=5),
+                    pmui.FloatSlider.from_param(model.param.vaccination_rate, step=0.1),
+                    pmui.FloatSlider.from_param(model.param.vaccine_efficacy, step=5),
+                )),
+                ("Population", pmui.Column(
+                    pmui.IntSlider.from_param(model.param.population, step=50_000),
+                    pmui.IntSlider.from_param(model.param.initial_infections, step=10),
+                    pmui.FloatSlider.from_param(model.param.hospital_beds_per_100k, step=5),
+                    pmui.IntSlider.from_param(model.param.days, step=10),
+                )),
+                active=[0, 1], sizing_mode="stretch_width",
+            ),
+            pmui.Row(reset, save),
+            pmui.Divider(),
+            pmui.Typography("Plot", variant="overline"),
+            curves, scale, capacity_line, compare,
+        )
+    ],
+    main=[main],
+    sidebar_width=340,
+)
+
+controller = ComponentController(
+    components={
+        "model": model,
+        "outcome": outcome,
+        "scenario_preset": preset,
+        "curves": curves,
+        "y_axis": scale,
+        "capacity_line": capacity_line,
+        "compare_to_baseline": compare,
+        "save_baseline": save,
+        "reset_scenario": reset,
+    },
+    # Outcome parameters are constant, so they are reported to the LLM but no
+    # tool is generated for them; listing them makes the result of a change
+    # readable and lets the assistant iterate towards a target.
+    parameters={"outcome": [
+        "peak_infections", "peak_day", "peak_hospital_load", "overflow_days",
+        "deaths", "infected_share", "peak_vs_baseline",
+    ]},
+    descriptions={
+        "model": "The epidemiological scenario that is re-simulated whenever one of its parameters changes",
+        "outcome": "Read-only results of the latest simulation; read these back after changing the model",
+        "save_baseline": "Stores the current scenario as the baseline that later scenarios are compared against",
+        "reset_scenario": "Restores every model parameter to its default",
+    },
+    purpose="""
+        Model and display options of an outbreak simulator. The model is
+        re-simulated on every change and the outcome reflects the result, so a
+        scenario can be tuned towards a target such as keeping the peak
+        hospital load below 100%.""",
+)
+
+assistant = Planner(
+    agents=[ChatAgent, ComponentControlAgent(controller=controller)],
+    # Searching for a setting that meets a target takes many write-then-read
+    # rounds; the smaller models tend to stop after the first write.
+    llm=OpenAI(model_kwargs={"default": {"model": "gpt-5.4"}, "ui": {"model": "gpt-5.4-mini"}}),
+)
+
+assistant.interface.send(
+    "I can drive this simulation. Try *'model a measles-like outbreak in a city of three million'* or "
+    "*'find the weakest lockdown that keeps hospital load under 100%'*.",
+    user="Assistant", respond=False,
+)
+
+main.append(
+    pmui.Drawer(
+        assistant, anchor="right", variant="docked",
+        dock_icon="chat", dock_position="end",
+        inline=True, size=400, width_policy="min"
+    )
+)
+
+page.servable()

--- a/examples/ai/penguin_copilot.py
+++ b/examples/ai/penguin_copilot.py
@@ -1,0 +1,187 @@
+"""
+Palmer Penguins explorer with a natural language copilot.
+
+Every widget on the page is discovered by the `ComponentController`, which
+hands one tool per widget to the assistant docked on the right, so the
+conversation drives the dashboard:
+
+- "Which controls do you have and what are they set to?"
+- "Show only Gentoo penguins from Biscoe"
+- "Plot flipper length against body mass, colour by sex and make the points bigger"
+- "Narrow it down to the heaviest third of the penguins"
+- "Reset the filters"
+
+Run it with::
+
+    panel serve examples/ai/penguin_copilot.py --show
+"""
+
+import hvplot.pandas  # noqa
+import pandas as pd
+import panel as pn
+import panel_material_ui as pmui
+
+from lumen.ai import Planner
+from lumen.ai.agents import ChatAgent, ComponentControlAgent
+from lumen.ai.llm import OpenAI
+from lumen.ai.tools import ComponentController
+
+pn.extension(notifications=True)
+
+DATA_URL = "https://datasets.holoviz.org/penguins/v1/penguins.csv"
+MEASURES = ["bill_length_mm", "bill_depth_mm", "flipper_length_mm", "body_mass_g"]
+
+df = pd.read_csv(DATA_URL).dropna()
+
+species = pmui.MultiChoice(
+    label="Species", options=sorted(df.species.unique()), value=sorted(df.species.unique()),
+    description="Species to include; an empty selection includes all of them",
+)
+
+islands = pmui.MultiChoice(
+    label="Islands", options=sorted(df.island.unique()), value=sorted(df.island.unique()),
+    description="Islands the penguins were observed on",
+)
+
+sex = pmui.RadioButtonGroup(
+    label="Sex", options=["all", "male", "female"], value="all",
+    description="Restrict the selection to one sex",
+)
+
+bill_length = pmui.RangeSlider(
+    label="Bill length", start=30, end=60, step=0.5, value=(30, 60),
+    description="Range of bill lengths in millimetres",
+)
+
+body_mass = pmui.RangeSlider(
+    label="Body mass", start=2500, end=6500, step=50, value=(2500, 6500),
+    description="Range of body masses in grams",
+)
+
+x = pmui.Select(label="X axis", options=MEASURES, value="bill_length_mm")
+
+y = pmui.Select(label="Y axis", options=MEASURES, value="body_mass_g")
+
+color_by = pmui.Select(
+    label="Colour by", options=["species", "island", "sex"], value="species",
+    description="Column the points and histograms are grouped and coloured by",
+)
+
+point_size = pmui.IntSlider(
+    label="Point size", start=20, end=200, step=10, value=60,
+    description="Size of the scatter markers",
+)
+
+show_distribution = pmui.Switch(
+    label="Show distribution", value=True,
+    description="Whether to show the histogram below the scatter plot",
+)
+
+reset = pmui.Button(label="Reset filters", icon="restart_alt", variant="outlined")
+
+FILTERS = (species, islands, sex, bill_length, body_mass)
+
+
+def reset_filters(event):
+    for widget in FILTERS:
+        widget.value = widget.param.value.default
+
+
+reset.on_click(reset_filters)
+
+
+def filter_data(species, islands, sex, bill_length, body_mass):
+    data = df
+    if species:
+        data = data[data.species.isin(species)]
+    if islands:
+        data = data[data.island.isin(islands)]
+    if sex != "all":
+        data = data[data.sex == sex]
+    return data[data.bill_length_mm.between(*bill_length) & data.body_mass_g.between(*body_mass)]
+
+
+def scatter(data, x, y, color_by, point_size):
+    if data.empty:
+        return pmui.Alert("No penguins match the current filters.", severity="warning", sizing_mode="stretch_width")
+    return data.hvplot.scatter(
+        x=x, y=y, by=color_by, size=point_size, alpha=0.7, responsive=True,
+        height=380, legend="top_left", hover_cols=["species", "island", "sex"],
+    ).opts(toolbar="above")
+
+
+def distribution(data, x, color_by, show_distribution):
+    if not show_distribution or data.empty:
+        return None
+    return data.hvplot.hist(
+        y=x, by=color_by, bins=25, alpha=0.6, responsive=True, height=220, legend=False,
+    ).opts(toolbar=None)
+
+
+def stats(data, y):
+    if data.empty:
+        return pmui.Row()
+    cards = [("Penguins", f"{len(data):,}"), ("Species", f"{data.species.nunique()}")]
+    cards.append((f"Mean {y.replace('_', ' ')}", f"{data[y].mean():.1f}"))
+    return pmui.Row(*[
+        pmui.Paper(
+            pmui.Typography(title, variant="overline"),
+            pmui.Typography(value, variant="h5"),
+            elevation=1, sizing_mode="stretch_width", styles={"padding": "8px 16px"},
+        )
+        for title, value in cards
+    ], sizing_mode="stretch_width")
+
+
+data = pn.bind(filter_data, species, islands, sex, bill_length, body_mass)
+
+page = pmui.Page(
+    title="Penguin Explorer",
+    sidebar=[
+        pmui.Column(
+            pmui.Typography("Filters", variant="overline"),
+            species, islands, sex, bill_length, body_mass, reset,
+            pmui.Divider(),
+            pmui.Typography("Plot", variant="overline"),
+            x, y, color_by, point_size, show_distribution,
+        )
+    ],
+    main=[
+        pn.panel(pn.bind(stats, data, y), sizing_mode="stretch_width"),
+        pmui.Card(
+            pn.panel(pn.bind(scatter, data, x, y, color_by, point_size), sizing_mode="stretch_width"),
+            pn.panel(pn.bind(distribution, data, x, color_by, show_distribution), sizing_mode="stretch_width"),
+            title="Measurements", sizing_mode="stretch_width",
+        ),
+    ],
+    sidebar_width=320,
+)
+
+controller = ComponentController(
+    components=page,
+    purpose="""
+        Filters and plot options of a dashboard exploring the Palmer Penguins
+        dataset, which measures the bills, flippers and body mass of penguins
+        observed on three islands.""",
+    descriptions={"reset_filters": "Restores every filter to its default, i.e. selects all the penguins again"},
+)
+
+assistant = Planner(
+    agents=[ChatAgent, ComponentControlAgent(controller=controller)],
+    llm=OpenAI(),
+)
+
+assistant.interface.send(
+    "I can drive this dashboard. Try *'show only Gentoo penguins from Biscoe'* or "
+    "*'colour by sex and plot flipper length against body mass'*.",
+    user="Assistant", respond=False,
+)
+
+page.main.append(
+    pmui.Drawer(
+        assistant, anchor="right", variant="docked", size=460,
+        dock_icon="chat", dock_position="middle",
+    )
+)
+
+page.servable()

--- a/lumen/ai/agents/__init__.py
+++ b/lumen/ai/agents/__init__.py
@@ -2,6 +2,7 @@ from .analysis import AnalysisAgent
 from .base import Agent
 from .base_code import BaseCodeAgent
 from .chat import ChatAgent
+from .component_control import ComponentControlAgent
 from .dbtsl import DbtslAgent
 from .deck_gl import DeckGLAgent
 from .document_list import DocumentListAgent
@@ -18,6 +19,7 @@ __all__ = [
     "AnalysisAgent",
     "BaseCodeAgent",
     "ChatAgent",
+    "ComponentControlAgent",
     "DbtslAgent",
     "DeckGLAgent",
     "DocumentListAgent",

--- a/lumen/ai/agents/component_control.py
+++ b/lumen/ai/agents/component_control.py
@@ -1,0 +1,109 @@
+from textwrap import dedent
+from typing import Any, NotRequired
+
+import param
+
+from ..config import PROMPTS_DIR
+from ..context import ContextModel, TContext
+from ..llm import Message
+from ..tools.component_control import ComponentController
+from ..utils import truncate_string
+from .base import Agent
+
+
+class ComponentControlOutputs(ContextModel):
+
+    ui_state: NotRequired[str]
+
+
+class ComponentControlAgent(Agent):
+    """
+    The ComponentControlAgent inspects and drives the components of the
+    application the chat interface is embedded in, e.g. the widgets of a
+    dashboard.
+    """
+
+    components = param.Parameter(default=None, doc="""
+        Shorthand for ``ComponentController(components=...)``. Provide a
+        widget, a list or dictionary of components or an entire layout such as
+        a ``panel_material_ui.Page``. Ignored if a ``controller`` is given.""")
+
+    conditions = param.List(
+        default=[
+            "Use when the user asks to change, set, select, toggle, enable, disable or reset a control of the application",
+            "Use when the user asks which controls, widgets or settings the application has, or what they are currently set to",
+            "Use when the user describes a desired state of the application in words, e.g. 'show only the last five years'",
+            "Use when the user asks for a relative change to something the application controls, e.g. 'twice as fast', 'a bit stronger', 'half of that'",
+            "Use when the user asks to reach a goal that the application controls can be tuned towards, e.g. 'find a setting that keeps the queue under ten'",
+            "NOT when the user asks to query, aggregate or transform data; the application controls do not run queries",
+        ]
+    )
+
+    controller = param.ClassSelector(class_=ComponentController, default=ComponentController(), doc="""
+        The controller exposing the components of the application.""")
+
+    purpose = param.String(default="""
+        Inspects and controls the components of the running application, such as
+        the widgets of a dashboard. Discovers which controls exist, reports their
+        current values and writes new values to them.""")
+
+    prompts = param.Dict(
+        default={
+            "main": {
+                "template": PROMPTS_DIR / "ComponentControlAgent" / "main.jinja2",
+            },
+        }
+    )
+
+    user = param.String(default="UI")
+
+    output_schema = ComponentControlOutputs
+
+    def __init__(self, **params):
+        if params.get("controller") is None and params.get("components") is not None:
+            params["controller"] = ComponentController(components=params["components"])
+        super().__init__(**params)
+        if self.components is None:
+            self.components = self.controller.components
+        self._purpose = self.purpose
+        # The controller resolves its components lazily, so listing it as an
+        # llm_tool is enough for the tools to track a live, changing layout.
+        self.llm_tools = [*self.llm_tools, self.controller]
+        self.param.watch(self._sync_components, "components")
+
+    def _sync_components(self, event):
+        self.controller.components = event.new
+
+    async def applies(self, context: TContext) -> bool:
+        """
+        Name the controls that currently exist on the purpose.
+
+        A coordinator routes on the purpose alone, so spelling out what can
+        actually be controlled is what lets it tell a request about the
+        application apart from a request about data.
+        """
+        specs = self.controller.specs
+        if not specs:
+            return False
+        controls = []
+        for spec in specs:
+            names = [info.name for info in spec.settable]
+            controls.append(spec.key if names == ["value"] else f"{spec.key} ({', '.join(names)})")
+        purpose = f"{dedent(self._purpose).strip()}\n\nThe application currently exposes: "
+        self.purpose = purpose + truncate_string("; ".join(controls), max_length=1500)
+        return True
+
+    async def _gather_prompt_context(self, prompt_name: str, messages: list, context: TContext, **kwargs):
+        prompt_context = await super()._gather_prompt_context(prompt_name, messages, context, **kwargs)
+        prompt_context["ui_state"] = self.controller.summary()
+        prompt_context["list_tool"] = self.controller._tool_name("list")
+        return prompt_context
+
+    async def respond(
+        self,
+        messages: list[Message],
+        context: TContext,
+        step_title: str | None = None,
+    ) -> tuple[list[Any], dict[str, Any]]:
+        result = await self._stream(messages, context)
+        return [result], {"ui_state": self.controller.summary()}

--- a/lumen/ai/coordinator/base.py
+++ b/lumen/ai/coordinator/base.py
@@ -404,9 +404,16 @@ class Coordinator(Viewer, VectorLookupToolUser):
                 state.execute(partial(tool.prepare, context))
 
     @wrap_logfire(span_name="Chat Invoke")
-    async def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface) -> Plan:
+    async def _chat_invoke(self, contents: list | str, user: str, instance: ChatInterface) -> None:
         log_debug(f"New Message: \033[91m{contents!r}\033[0m", show_sep="above")
-        return await self.respond(contents, self.context)
+        plan = await self.respond(contents, self.context)
+        # A UI drives the plan itself (so it can lay the outputs out, replan and
+        # rerun); a coordinator used on its own has to run what it planned. The
+        # plan is not returned, since a Plan added to the feed as a message
+        # cannot be serialized back into the conversation on the next turn.
+        if plan is not None:
+            with plan.param.update(interface=self.interface):
+                await plan.execute()
 
     def _process_tools(self, tools: list[type[Tool] | Tool] | None) -> list[type[Tool] | Tool | FunctionType]:
         tools = list(tools) if tools else []

--- a/lumen/ai/prompts/ComponentControlAgent/main.jinja2
+++ b/lumen/ai/prompts/ComponentControlAgent/main.jinja2
@@ -1,0 +1,39 @@
+{% extends 'Agent/main.jinja2' %}
+
+{%- block instructions -%}
+You control the user interface of the running application by calling the tools that write to its components.
+
+## Your Role
+- Translate what the user asks for into concrete values and write them with the `set_*` / `click_*` tools
+- Set every control the request implies in one go; the tools may be called in parallel
+- Only touch the controls the request calls for, never reset unrelated ones
+- Report what you changed, using the labels the user sees rather than internal names
+- If a tool reports a rejected value, say why and either pick the nearest valid value or ask for clarification
+
+## Reaching a target
+- When the user describes an outcome to reach rather than a value to set, search for it yourself instead of asking them to iterate
+- Write a candidate value, call `{{ list_tool }}` to read the state it produced, and repeat until the target is met
+- Asking for the weakest, smallest, latest or cheapest setting that meets a target rules out simply jumping to the extreme: once a value meets it, step back towards what the user asked for for as long as the target still holds and settle on the last value that held
+- Never leave the application in a state that fails the target; if your last attempt broke it, write the last value that held back before answering
+- If the target turns out to be out of reach, report the closest state you found and which control limits it
+- Report the value you settled on and the outcome it produces, not the intermediate attempts
+
+## Guidelines
+- The state below is the state at the time this prompt was rendered; if you need more detail about a component call `{{ list_tool }}` again
+- Read-only values only show the effect of a change after `{{ list_tool }}` is called again
+- When a request is ambiguous, e.g. several controls could match, ask which one is meant instead of guessing
+- If nothing in the application matches the request, say so plainly rather than inventing controls
+- Do not describe the tools themselves, describe the effect on the application
+{%- endblock -%}
+
+{%- block context -%}
+{%- if ui_state is defined and ui_state %}
+
+## Current state of the application
+{{ ui_state }}
+{%- endif -%}
+{%- endblock -%}
+
+{%- block footer -%}
+Be concise: one or two sentences confirming the new state.
+{%- endblock -%}

--- a/lumen/ai/tools/__init__.py
+++ b/lumen/ai/tools/__init__.py
@@ -1,6 +1,7 @@
 from .base import (
     FunctionTool, Tool, ToolUser, define_tool,
 )
+from .component_control import ComponentController, ComponentSpec
 from .dbtsl_lookup import DbtslLookup
 from .mcp import MCPTool
 from .metadata_lookup import MetadataLookup
@@ -8,6 +9,8 @@ from .source_lookup import SourceLookup
 from .vector_lookup import VectorLookupTool, VectorLookupToolUser
 
 __all__ = [
+    "ComponentController",
+    "ComponentSpec",
     "DbtslLookup",
     "FunctionTool",
     "MCPTool",

--- a/lumen/ai/tools/component_control.py
+++ b/lumen/ai/tools/component_control.py
@@ -1,0 +1,1042 @@
+"""
+Hand Lumen AI the controls of an application.
+
+:class:`ComponentController` takes a set of Panel widgets, ``Parameterized``
+objects or an entire layout (e.g. a ``panel_material_ui.Page``) and turns them
+into LLM tools:
+
+* ``list_<namespace>_components`` -- an overview of every controllable
+  component including the current value of each widget.
+* ``describe_<namespace>_component`` -- every parameter of one component,
+  with types, allowed values, current values and their ``doc`` strings.
+* ``set_<component>`` / ``click_<component>`` -- one tool per component that
+  writes the exposed parameters (or triggers a button).
+
+The controller is re-resolved every time the tools are requested, so a layout
+whose contents change over the lifetime of a session stays in sync and the
+schemas the LLM sees always reflect the live state of the application.
+
+Usage::
+
+    controller = ComponentController(
+        components=page, purpose="Controls for the wind turbine dashboard."
+    )
+    ui = ExplorerUI(llm_tools=[controller])
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import inspect
+import re
+
+from typing import Annotated, Any, Literal
+
+import pandas as pd
+import param
+
+from panel.layout.base import ListLike, NamedListLike
+from panel.viewable import Layoutable, Viewable, Viewer
+from panel.widgets.base import WidgetBase
+from pydantic import Field
+
+from ..utils import truncate_string
+from .base import FunctionTool
+
+# Number of allowed values that are inlined into a schema before truncating
+MAX_OPTIONS = 50
+
+# Components from these modules are never picked up when walking a layout;
+# they belong to the chat UI itself rather than to the application being
+# driven, which matters because the assistant is usually mounted inside the
+# very layout it is being handed.
+EXCLUDED_MODULES = ("lumen.ai.", "panel.chat", "panel_material_ui.chat")
+
+# Parameters that are only ever exposed when explicitly requested
+ALWAYS_SKIPPED = frozenset({"name", "value_throttled"})
+
+_UNSET = object()
+
+
+def _chrome_parameters() -> frozenset[str]:
+    """
+    Parameters contributed by framework baseclasses (layout, styling, chrome).
+
+    These are excluded when the exposed parameters of a component are derived
+    automatically; they can still be exposed by requesting them explicitly.
+    """
+    names: set[str] = set(param.Parameterized.param) | set(Layoutable.param) | set(Viewable.param)
+    for module, cls_name in (
+        ("panel.widgets.base", "WidgetBase"),
+        ("panel_material_ui.base", "MaterialComponent"),
+        ("panel_material_ui.widgets.base", "MaterialWidget"),
+    ):
+        try:
+            cls = getattr(importlib.import_module(module), cls_name, None)
+        except ImportError:
+            continue
+        if cls is not None:
+            names |= set(cls.param)
+    return frozenset(names - {"value", "options"})
+
+
+CHROME_PARAMETERS = _chrome_parameters()
+
+
+def _slugify(name: str) -> str:
+    """Convert a label into a valid, lowercase Python identifier."""
+    slug = re.sub(r"\W+", "_", (name or "").strip()).strip("_").lower()
+    if not slug or slug[0].isdigit():
+        slug = f"c_{slug}" if slug else "component"
+    return slug[:48]
+
+
+def _label(component: param.Parameterized) -> str:
+    """The human readable label of a component, if it has a meaningful one."""
+    for attr in ("label", "name"):
+        if attr not in component.param:
+            continue
+        value = getattr(component, attr, None)
+        if not isinstance(value, str) or not value:
+            continue
+        # param auto-generates names of the form ``ClassName00001``
+        if re.fullmatch(rf"{re.escape(type(component).__name__)}\d*", value):
+            continue
+        return value
+    return ""
+
+
+def _serializer(parameter: param.Parameter):
+    """
+    The parameter's own JSON serializer, if it declares one.
+
+    ``param.Parameter`` defines identity ``serialize``/``deserialize``
+    classmethods that subclasses override to describe how their values cross a
+    JSON boundary (dates as ISO strings, tuples as lists). Honouring them means
+    the values shown to the LLM are exactly the values it has to send back.
+    """
+    return _custom_classmethod(parameter, "serialize")
+
+
+def _deserializer(parameter: param.Parameter):
+    """The parameter's own JSON deserializer, if it declares one."""
+    return _custom_classmethod(parameter, "deserialize")
+
+
+def _custom_classmethod(parameter: param.Parameter, name: str):
+    method = getattr(type(parameter), name, None)
+    base = getattr(param.Parameter, name)
+    if method is None or getattr(method, "__func__", method) is getattr(base, "__func__", base):
+        return None
+    return method
+
+
+def _format_value(value: Any, options: dict[str, Any] | None = None) -> str:
+    """Render a parameter value for display to the LLM."""
+    if options is not None:
+        if isinstance(value, list):
+            labels = [_option_label(v, options) for v in value]
+            return "[" + ", ".join(labels) + "]"
+        return _option_label(value, options)
+    if getattr(value, "shape", None) == () and hasattr(value, "item"):
+        # unwrap numpy scalars, whose repr is noise to an LLM
+        value = value.item()
+    if isinstance(value, str):
+        return repr(truncate_string(value, max_length=200))
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    if isinstance(value, (bool, int, float, type(None))):
+        return repr(value)
+    if isinstance(value, (list, tuple, dict, set)):
+        return truncate_string(repr(value), max_length=200)
+    if isinstance(value, param.Parameterized):
+        return _label(value) or type(value).__name__
+    return truncate_string(repr(value), max_length=100)
+
+
+def _option_label(value: Any, options: dict[str, Any]) -> str:
+    """The label an option value is listed under."""
+    for label, option in options.items():
+        try:
+            if option is value or option == value:
+                return repr(label)
+        except Exception:
+            continue
+    return _format_value(value)
+
+
+class ParameterInfo:
+    """
+    Everything needed to expose a single ``param.Parameter`` to the LLM.
+
+    Bundles the parameter itself with the constraints that Panel widgets
+    declare on sibling parameters (a ``Select``'s ``options``, a slider's
+    ``start``/``end``/``step``) so both the generated schema and the coercion
+    of incoming values can take them into account.
+    """
+
+    def __init__(self, component: param.Parameterized, name: str):
+        self.component = component
+        self.name = name
+        self.parameter = component.param[name]
+        self.options = _options(component, self.parameter)
+        # param.List declares bounds on the number of items rather than on the
+        # values themselves, so the two are tracked separately
+        self.length_bounds = _bounds(component, self.parameter) if isinstance(self.parameter, param.List) else None
+        self.bounds = None if self.options or self.length_bounds else _bounds(component, self.parameter)
+        self.step = getattr(component, "step", None) if self.name == "value" else None
+        self.annotation = _annotation(self.parameter, self.options, self.bounds)
+
+    @property
+    def value(self) -> Any:
+        return getattr(self.component, self.name)
+
+    @property
+    def settable(self) -> bool:
+        parameter = self.parameter
+        return (
+            self.annotation is not None
+            and not parameter.readonly
+            and not parameter.constant
+        )
+
+    @property
+    def doc(self) -> str:
+        return " ".join((self.parameter.doc or "").split())
+
+    def display(self, value: Any = _UNSET) -> str:
+        """Render a value in the form the LLM is expected to supply it in."""
+        if value is _UNSET:
+            value = self.value
+        if self.options is None:
+            serialize = _serializer(self.parameter)
+            if serialize is not None:
+                try:
+                    return _format_value(serialize(value))
+                except Exception:
+                    pass
+        return _format_value(value, self.options)
+
+    def constraints(self) -> str:
+        """A description of the values this parameter accepts."""
+        parts = []
+        if self.options is not None:
+            labels = list(self.options)
+            listed = ", ".join(labels[:MAX_OPTIONS])
+            if len(labels) > MAX_OPTIONS:
+                listed += f", ... ({len(labels)} options in total)"
+            multiple = isinstance(self.parameter, (param.List, param.ListSelector))
+            parts.append(f"{'any of' if multiple else 'one of'}: {listed}")
+        elif self.bounds:
+            low, high = self.bounds
+            if low is not None or high is not None:
+                low_str = "unbounded" if low is None else self.display(low)
+                high_str = "unbounded" if high is None else self.display(high)
+                parts.append(f"between {low_str} and {high_str}")
+            if self.step:
+                parts.append(f"step {_format_value(self.step)}")
+        if self.length_bounds:
+            low, high = self.length_bounds
+            if low:
+                parts.append(f"at least {low} items")
+            if high is not None:
+                parts.append(f"at most {high} items")
+        return "; ".join(parts)
+
+    def nullable(self) -> bool:
+        """Whether the LLM may pass null to clear the parameter."""
+        return bool(self.parameter.allow_None) and self.options is None
+
+    def summary(self) -> str:
+        """One line description of the parameter and its current value."""
+        summary = f"{self.name}: {self.display()}"
+        notes = [note for note in (self.constraints(), "may be null" if self.nullable() else "") if note]
+        if notes:
+            summary += " (" + "; ".join(notes) + ")"
+        return summary
+
+    def describe(self) -> str:
+        """Multi-line description including the parameter's doc string."""
+        type_name = type(self.parameter).__name__
+        lines = [f"- `{self.name}` ({type_name}) = {self.display()}"]
+        constraints = self.constraints()
+        if constraints:
+            lines.append(f"  Accepts: {constraints}" + (" (or null)" if self.nullable() else ""))
+        elif self.nullable():
+            lines.append("  Accepts: null to clear it")
+        if self.doc:
+            lines.append(f"  Doc: {truncate_string(self.doc, max_length=500)}")
+        if not self.settable:
+            reason = "read-only" if (self.parameter.readonly or self.parameter.constant) else "not settable via this API"
+            lines.append(f"  ({reason})")
+        return "\n".join(lines)
+
+    def argument_doc(self) -> str:
+        """The docstring entry generated for this parameter in a setter tool."""
+        doc = self.doc or f"The {self.name} of the component."
+        constraints = self.constraints()
+        if constraints:
+            doc += f" Accepts {constraints}."
+        if self.nullable():
+            doc += " May be null."
+        return f"{doc} Currently {self.display()}."
+
+
+def _options(component: param.Parameterized, parameter: param.Parameter) -> dict[str, Any] | None:
+    """
+    The allowed values of a parameter as a ``{label: value}`` mapping.
+
+    Covers both ``param.Selector`` parameters and Panel widgets, which declare
+    the allowed values of their ``value`` on a sibling ``options`` parameter.
+    """
+    objects: Any = None
+    if isinstance(parameter, param.Selector):
+        try:
+            objects = parameter.get_range()
+        except Exception:
+            objects = None
+    elif parameter.name == "value" and "options" in component.param:
+        objects = getattr(component, "options", None)
+    if not objects:
+        return None
+    if isinstance(objects, dict):
+        return {str(label): value for label, value in objects.items()}
+    return {str(value): value for value in objects}
+
+
+def _bounds(component: param.Parameterized, parameter: param.Parameter) -> tuple[Any, Any] | None:
+    """
+    The bounds of a parameter.
+
+    Panel sliders declare the range of their ``value`` on sibling ``start`` and
+    ``end`` parameters rather than on the value parameter itself.
+    """
+    bounds = getattr(parameter, "bounds", None) or getattr(parameter, "softbounds", None)
+    if bounds is None and parameter.name == "value":
+        start = getattr(component, "start", None)
+        end = getattr(component, "end", None)
+        if start is not None or end is not None:
+            bounds = (start, end)
+    if bounds and len(bounds) == 2:
+        return (bounds[0], bounds[1])
+    return None
+
+
+def _numeric_annotation(base: type, bounds: tuple[Any, Any] | None) -> Any:
+    """Annotate a numeric type with its bounds so they show up in the schema."""
+    if not bounds:
+        return base
+    low, high = bounds
+    constraints = {}
+    if isinstance(low, (int, float)) and not isinstance(low, bool):
+        constraints["ge"] = low
+    if isinstance(high, (int, float)) and not isinstance(high, bool):
+        constraints["le"] = high
+    if not constraints:
+        return base
+    return Annotated[base, Field(**constraints)]
+
+
+def _annotation(
+    parameter: param.Parameter,
+    options: dict[str, Any] | None,
+    bounds: tuple[Any, Any] | None,
+) -> Any:
+    """
+    The type annotation to expose a parameter under, or None if it cannot be
+    represented in a JSON schema.
+    """
+    if options is not None:
+        literal = Literal[tuple(list(options)[:MAX_OPTIONS])]
+        if isinstance(parameter, (param.List, param.ListSelector)):
+            return list[literal]
+        return literal
+    if isinstance(parameter, param.Boolean):  # includes param.Event
+        return bool
+    if isinstance(parameter, param.Integer):
+        return _numeric_annotation(int, bounds)
+    if isinstance(parameter, param.CalendarDate):
+        return dt.date
+    if isinstance(parameter, param.Date):
+        return dt.datetime
+    if isinstance(parameter, param.Number):
+        return _numeric_annotation(float, bounds)
+    if isinstance(parameter, param.CalendarDateRange):
+        return tuple[dt.date, dt.date]
+    if isinstance(parameter, param.DateRange):
+        return tuple[dt.datetime, dt.datetime]
+    if isinstance(parameter, param.Range):
+        return tuple[float, float]
+    if isinstance(parameter, param.NumericTuple):
+        return tuple[float, ...]
+    if isinstance(parameter, param.Tuple):
+        return tuple
+    if isinstance(parameter, param.Color):
+        return str
+    if isinstance(parameter, (param.String, param.Path)):
+        return str
+    if isinstance(parameter, param.List):
+        item_type = getattr(parameter, "item_type", None)
+        if item_type in (str, int, float, bool):
+            return list[item_type]
+        return list
+    if isinstance(parameter, param.Dict):
+        return dict[str, Any]
+    if isinstance(parameter, param.ClassSelector):
+        classes = parameter.class_ if isinstance(parameter.class_, tuple) else (parameter.class_,)
+        if all(cls in (str, int, float, bool, list, dict) for cls in classes):
+            return classes[0] if len(classes) == 1 else Any
+        return None
+    if type(parameter) is param.Parameter:
+        return Any
+    return None
+
+
+def _to_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "yes", "1", "on"):
+            return True
+        if lowered in ("false", "no", "0", "off", ""):
+            return False
+    return bool(value)
+
+
+def _to_datetime(value: Any) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        return value
+    if isinstance(value, dt.date):
+        return dt.datetime(value.year, value.month, value.day)
+    if isinstance(value, str):
+        try:
+            return dt.datetime.fromisoformat(value)
+        except ValueError:
+            pass
+    timestamp = pd.Timestamp(value)
+    if not isinstance(timestamp, pd.Timestamp):  # i.e. NaT
+        raise ValueError(f"{value!r} could not be interpreted as a date")
+    return dt.datetime.fromisoformat(timestamp.isoformat())
+
+
+def _to_date(value: Any) -> dt.date:
+    converted = _to_datetime(value)
+    return converted.date()
+
+
+def _to_number(value: Any) -> float:
+    if isinstance(value, bool):
+        return float(value)
+    if value is None or isinstance(value, (list, tuple, dict)):
+        raise ValueError(f"{value!r} is not a number")
+    return float(value)
+
+
+def _to_int(value: Any) -> int:
+    return round(_to_number(value))
+
+
+def _coerce_option(info: ParameterInfo, value: Any) -> Any:
+    """Map a label (or raw value) supplied by the LLM onto an allowed value."""
+    options = info.options or {}
+    if isinstance(value, str) and value in options:
+        return options[value]
+    lowered = {label.lower(): label for label in options}
+    if isinstance(value, str) and value.strip().lower() in lowered:
+        return options[lowered[value.strip().lower()]]
+    for option in options.values():
+        try:
+            if option is value or option == value:
+                return option
+        except Exception:
+            continue
+    labels = ", ".join(list(options)[:MAX_OPTIONS]) or "(none)"
+    raise ValueError(f"{value!r} is not one of the allowed values: {labels}")
+
+
+def _coerce(info: ParameterInfo, value: Any) -> Any:
+    """Coerce a raw JSON value from the LLM into a valid parameter value."""
+    parameter = info.parameter
+    if value is None and parameter.allow_None:
+        return None
+    if info.options is not None:
+        if isinstance(parameter, (param.List, param.ListSelector)):
+            values = value if isinstance(value, (list, tuple)) else [value]
+            return [_coerce_option(info, item) for item in values]
+        return _coerce_option(info, value)
+    # Prefer the parameter's own JSON contract, but only if it yields a value
+    # param actually accepts; the declared formats are strict (param.Date
+    # insists on microseconds) and an LLM will happily send "2020-01-01".
+    deserialize = _deserializer(parameter)
+    if deserialize is not None:
+        try:
+            deserialized = deserialize(value)
+        except Exception:
+            deserialized = _UNSET
+        if deserialized is not _UNSET and _validation_error(info, deserialized) is None:
+            return deserialized
+    if isinstance(parameter, param.Boolean):
+        return _to_bool(value)
+    if isinstance(parameter, param.Integer):
+        return _to_int(value)
+    if isinstance(parameter, param.CalendarDate):
+        return _to_date(value)
+    if isinstance(parameter, param.Date):
+        return _to_datetime(value)
+    if isinstance(parameter, param.Number):
+        return _to_number(value)
+    if isinstance(parameter, (param.CalendarDateRange, param.DateRange, param.Range, param.Tuple)):
+        if not isinstance(value, (list, tuple)):
+            raise ValueError(f"{value!r} is not a list of values")
+        if isinstance(parameter, param.CalendarDateRange):
+            return tuple(_to_date(item) for item in value)
+        elif isinstance(parameter, param.DateRange):
+            return tuple(_to_datetime(item) for item in value)
+        elif isinstance(parameter, param.NumericTuple):  # includes param.Range
+            return tuple(_to_number(item) for item in value)
+        return tuple(value)
+    if isinstance(parameter, (param.String, param.Path, param.Color)):
+        return value if isinstance(value, str) else str(value)
+    if isinstance(parameter, param.List):
+        items = list(value) if isinstance(value, (list, tuple, set)) else [value]
+        item_type = getattr(parameter, "item_type", None)
+        converter = {bool: _to_bool, int: _to_int, float: _to_number, str: str}.get(item_type)
+        return [converter(item) for item in items] if converter else items
+    return value
+
+
+def _validation_error(info: ParameterInfo, value: Any) -> str | None:
+    """
+    Validate a coerced value, returning an error message if it is rejected.
+
+    Bounds that a Panel widget declares on sibling parameters (a slider's
+    ``start`` and ``end``) are not enforced by the value parameter itself, so
+    they are checked here rather than silently accepting an invalid value.
+    """
+    try:
+        info.parameter._validate(value)
+    except Exception as e:
+        return str(e)
+    if info.bounds and not isinstance(value, bool):
+        low, high = info.bounds
+        # A range widget bounds every element of its value tuple
+        values = value if isinstance(value, tuple) else (value,)
+        for item in values:
+            try:
+                if low is not None and item < low:
+                    return f"{info.display(item)} is below the lower bound {info.display(low)}"
+                if high is not None and item > high:
+                    return f"{info.display(item)} is above the upper bound {info.display(high)}"
+            except TypeError:
+                continue
+    return None
+
+
+def _describe_function(function, name: str, doc: str, arguments: list[inspect.Parameter], docs: list[str]):
+    """
+    Attach the metadata :func:`~lumen.ai.translate.function_to_model`
+    introspects to a dynamically generated tool function.
+    """
+    if docs:
+        doc = f"{doc}\n\nParameters\n----------\n" + "\n".join(docs)
+    function.__name__ = name
+    function.__qualname__ = name
+    function.__doc__ = doc
+    function.__signature__ = inspect.Signature(arguments)
+    function.__annotations__ = {
+        argument.name: argument.annotation for argument in arguments
+    }
+    return function
+
+
+def _dress(function, name: str, doc: str, arguments: list[tuple[ParameterInfo, bool]]):
+    """
+    Give a ``**kwargs`` function the signature, annotations and docstring
+    of the parameters it writes.
+
+    Arguments are declared as ``(info, required)`` pairs; optional arguments
+    default to None which is interpreted as "leave unchanged".
+    """
+    signature, docs = [], []
+    for info, required in arguments:
+        annotation = info.annotation
+        default = inspect.Parameter.empty
+        if not required:
+            annotation = annotation | None
+            default = None
+        signature.append(
+            inspect.Parameter(info.name, inspect.Parameter.KEYWORD_ONLY, default=default, annotation=annotation)
+        )
+        docs.append(f"{info.name}\n    {info.argument_doc()}")
+    return _describe_function(function, name, doc, signature, docs)
+
+
+class ComponentSpec:
+    """
+    A single component the LLM may inspect and control.
+
+    Resolved by :class:`ComponentController`; holds the tool-safe key the
+    component is addressed by, the description the LLM is given and the names
+    of the parameters that are exposed for writing.
+    """
+
+    def __init__(
+        self,
+        key: str,
+        component: param.Parameterized,
+        description: str = "",
+        parameters: list[str] | None = None,
+    ):
+        self.key = key
+        self.component = component
+        self.description = " ".join((description or "").split())
+        self.parameters = list(parameters) if parameters else _exposed_parameters(component)
+
+    @property
+    def label(self) -> str:
+        return _label(self.component)
+
+    @property
+    def type_name(self) -> str:
+        return type(self.component).__name__
+
+    @property
+    def infos(self) -> list[ParameterInfo]:
+        """Information about every exposed parameter."""
+        infos = []
+        for name in self.parameters:
+            if name in self.component.param:
+                infos.append(ParameterInfo(self.component, name))
+        return infos
+
+    @property
+    def settable(self) -> list[ParameterInfo]:
+        return [info for info in self.infos if info.settable]
+
+    @property
+    def primary(self) -> ParameterInfo | None:
+        """The parameter that holds the component's value, if it has one."""
+        settable = self.settable
+        for info in settable:
+            if info.name == "value":
+                return info
+        return settable[0] if len(settable) == 1 else None
+
+    @property
+    def is_trigger(self) -> bool:
+        """Whether controlling this component means firing an event (a button)."""
+        primary = self.primary
+        return (
+            primary is not None
+            and len(self.settable) == 1
+            and isinstance(primary.parameter, param.Event)
+        )
+
+    def _headline(self) -> str:
+        headline = f"`{self.key}` — {self.type_name}"
+        label = self.label
+        if label and label != self.key:
+            headline += f' labelled "{label}"'
+        return headline
+
+    def _auto_description(self) -> str:
+        """Description derived from the component itself."""
+        if self.description:
+            return self.description
+        for attr in ("description", "tooltip"):
+            value = getattr(self.component, attr, None)
+            if isinstance(value, str) and value.strip():
+                return " ".join(value.split())
+        return ""
+
+    def summary(self) -> str:
+        """Overview of the component and its current state."""
+        lines = [f"- {self._headline()}"]
+        description = self._auto_description()
+        if description:
+            lines.append(f"  {truncate_string(description, max_length=300)}")
+        if not self.is_trigger:
+            for info in self.infos:
+                lines.append(f"  {info.summary()}")
+        tool_name = self.tool_name()
+        if tool_name:
+            lines.append(f"  Control with: {tool_name}")
+        return "\n".join(lines)
+
+    def describe(self) -> str:
+        """Full description of every parameter of the component."""
+        lines = [f"### {self._headline()}"]
+        description = self._auto_description()
+        if description:
+            lines.append(description)
+        class_doc = " ".join((type(self.component).__doc__ or "").split())
+        if class_doc:
+            lines.append(f"{self.type_name}: {truncate_string(class_doc, max_length=400)}")
+        exposed = self.parameters
+        lines.append(f"\nParameters exposed for control ({len(exposed)}):")
+        lines += [info.describe() for info in self.infos] or ["(none)"]
+        others = [
+            name for name in sorted(self.component.param)
+            if name not in exposed and name not in ALWAYS_SKIPPED
+        ]
+        if others:
+            lines.append(
+                "\nOther parameters (not exposed): " + ", ".join(
+                    f"`{name}`={_format_value(getattr(self.component, name, None))}"
+                    for name in others[:40]
+                )
+            )
+        tool_name = self.tool_name()
+        if tool_name:
+            lines.append(f"\nControl with: {tool_name}")
+        return "\n".join(lines)
+
+    def tool_name(self) -> str | None:
+        """Name of the tool that controls this component."""
+        if not self.settable:
+            return None
+        if self.is_trigger:
+            return f"click_{self.key}" if "clicks" in self.component.param else f"trigger_{self.key}"
+        return f"set_{self.key}"
+
+    def apply(self, values: dict[str, Any]) -> str:
+        """Write *values* onto the component, reporting what changed."""
+        infos = {info.name: info for info in self.settable}
+        updates, messages, errors = {}, [], []
+        for name, value in values.items():
+            info = infos.get(name)
+            if info is None:
+                errors.append(f"`{name}` cannot be set on `{self.key}`")
+                continue
+            try:
+                updates[name] = _coerce(info, value)
+            except (ValueError, TypeError) as e:
+                errors.append(f"`{name}`: {e}")
+        for name, value in list(updates.items()):
+            info = infos[name]
+            error = _validation_error(info, value)
+            if error:
+                del updates[name]
+                errors.append(f"`{name}`: {error}")
+                continue
+            messages.append(f"`{name}` {info.display()} → {info.display(value)}")
+        if updates:
+            try:
+                self.component.param.update(**updates)
+            except Exception as e:
+                return f"Failed to update `{self.key}`: {e}"
+        label = self.label or self.key
+        result = f"Updated {label}: " + ", ".join(messages) if messages else f"No changes applied to {label}."
+        if errors:
+            result += "\nRejected: " + "; ".join(errors)
+        return result
+
+    def trigger(self) -> str:
+        """Fire the component's event parameter, i.e. click a button."""
+        primary = self.primary
+        if primary is None:
+            return f"`{self.key}` cannot be triggered."
+        if "clicks" in self.component.param:
+            # Panel buttons dispatch on_click callbacks off the clicks parameter
+            self.component.param.update(clicks=getattr(self.component, "clicks", 0) + 1)
+        self.component.param.trigger(primary.name)
+        return f"Clicked {self.label or self.key}."
+
+    def tool(self) -> FunctionTool | None:
+        """Build the tool that controls this component."""
+        settable = self.settable
+        tool_name = self.tool_name()
+        if not settable or tool_name is None:
+            return None
+        label = self.label or self.key
+        description = self._auto_description()
+        if self.is_trigger:
+            async def control(**values) -> str:
+                return self.trigger()
+            _dress(control, tool_name, f'Click the "{label}" {self.type_name}.', [])
+            purpose = f'Click the "{label}" {self.type_name} in the application UI.'
+        else:
+            primary = self.primary
+            arguments = [(info, info is primary) for info in settable]
+
+            async def control(**values) -> str:
+                return self.apply({k: v for k, v in values.items() if v is not None})
+            _dress(
+                control,
+                tool_name,
+                f'Set parameters of the "{label}" {self.type_name}. '
+                'Arguments that are left out (or null) are not modified.',
+                arguments,
+            )
+            purpose = f'Change the "{label}" {self.type_name} in the application UI.'
+        if description:
+            purpose += f" {truncate_string(description, max_length=300)}"
+        return FunctionTool(control, purpose=purpose)
+
+
+def _exposed_parameters(component: param.Parameterized) -> list[str]:
+    """
+    Derive the parameters of a component to expose to the LLM.
+
+    Widgets are controlled through their ``value``; for any other
+    ``Parameterized`` object every parameter it declares itself is exposed,
+    i.e. everything but layout, styling and other framework chrome.
+    """
+    if "value" in component.param and isinstance(component, WidgetBase):
+        return ["value"]
+    exposed = []
+    for name, parameter in component.param.objects("existing").items():
+        if name in ALWAYS_SKIPPED or name in CHROME_PARAMETERS:
+            continue
+        if parameter.readonly or parameter.constant:
+            continue
+        if parameter.precedence is not None and parameter.precedence < 0:
+            continue
+        if _annotation(parameter, _options(component, parameter), _bounds(component, parameter)) is None:
+            continue
+        exposed.append(name)
+    return exposed
+
+
+def _is_excluded(component: Any, exclude: list[Any]) -> bool:
+    for excluded in exclude:
+        if component is excluded:
+            return True
+        if isinstance(excluded, type) and isinstance(component, excluded):
+            return True
+    module = type(component).__module__ or ""
+    return module.startswith(EXCLUDED_MODULES)
+
+
+def _children(component: Any):
+    """Yield the children of a container, layout, pane or ``Viewer``."""
+    if isinstance(component, (ListLike, NamedListLike)):
+        yield from list(component.objects)
+    if isinstance(component, Viewer):
+        view = getattr(component, "_view__", None)
+        if view is None:
+            try:
+                view = component.__panel__()
+            except Exception:
+                view = None
+        if isinstance(view, Viewable):
+            yield view
+    if not isinstance(component, param.Parameterized):
+        return
+    for name, parameter in component.param.objects("existing").items():
+        if name == "name" or isinstance(parameter, param.Callable):
+            continue
+        try:
+            value = getattr(component, name)
+        except Exception:
+            continue
+        if isinstance(value, (Viewable, Viewer)):
+            yield value
+        elif isinstance(value, (list, tuple)):
+            yield from (item for item in value if isinstance(item, (Viewable, Viewer)))
+
+
+def _walk(component: Any, exclude: list[Any], seen: set[int], depth: int = 0):
+    """Recursively collect the widgets nested inside a layout."""
+    if depth > 25 or id(component) in seen:
+        return
+    seen.add(id(component))
+    if not isinstance(component, (Viewable, Viewer)) or _is_excluded(component, exclude):
+        return
+    if isinstance(component, WidgetBase):
+        infos = (ParameterInfo(component, name) for name in _exposed_parameters(component))
+        if any(info.settable for info in infos):
+            yield component
+        return
+    for child in _children(component):
+        yield from _walk(child, exclude, seen, depth + 1)
+
+
+class ComponentController(param.Parameterized):
+    """
+    Exposes a set of components to an LLM so it can drive an application.
+
+    Accepts individual widgets, ``Parameterized`` objects, layouts or a whole
+    ``panel_material_ui.Page`` (which is walked for the widgets it contains)
+    and generates one control tool per component alongside two discovery
+    tools. Pass the controller anywhere ``llm_tools`` are accepted, e.g.
+    ``ExplorerUI(llm_tools=[controller])``, or hand it to a
+    ``ComponentControlAgent``.
+
+    The components are resolved lazily, every time :attr:`tools` is accessed,
+    so containers whose contents change stay in sync and the schemas handed to
+    the LLM always describe the current state of the application.
+    """
+
+    components = param.Parameter(default=None, doc="""
+        The components to expose. Either a single component, a list of
+        components or a dictionary mapping from the name the LLM addresses a
+        component by to the component. Layouts, templates and ``Page``
+        objects are walked to collect the widgets they contain, while
+        components declared with an explicit name are always treated as a
+        single component.""")
+
+    descriptions = param.Dict(default={}, doc="""
+        Optional mapping from component name to a description of what the
+        component does, for cases where the label and the ``description`` of
+        the component itself are not enough.""")
+
+    exclude = param.List(default=[], doc="""
+        Components or component types to ignore when walking layouts.""")
+
+    namespace = param.String(default="ui", doc="""
+        Namespace inserted into the names of the discovery tools, e.g.
+        ``list_ui_components``. Set it to distinguish multiple controllers.""")
+
+    parameters = param.Dict(default={}, doc="""
+        Optional mapping from component name to the list of parameters to
+        expose for that component. By default widgets expose their ``value``
+        and other ``Parameterized`` objects expose every parameter they
+        declare themselves.""")
+
+    purpose = param.String(default="", doc="""
+        Description of what the set of components does as a whole, e.g.
+        "Controls for the wind turbine dashboard". Shown to the LLM alongside
+        the list of components.""")
+
+    def __call__(self, context: Any = None) -> list[FunctionTool]:
+        """Allows passing the controller directly as an ``llm_tools`` entry."""
+        return self.tools
+
+    @property
+    def specs(self) -> list[ComponentSpec]:
+        """
+        Resolve the components into :class:`ComponentSpec` objects.
+
+        Re-resolved on every access so that components added to or removed
+        from a layout are picked up immediately.
+        """
+        components = self.components
+        if components is None:
+            entries: list[tuple[str | None, Any]] = []
+        elif isinstance(components, dict):
+            entries = list(components.items())
+        elif isinstance(components, (list, tuple)):
+            entries = [(None, component) for component in components]
+        else:
+            entries = [(None, components)]
+
+        specs: list[ComponentSpec] = []
+        keys: set[str] = set()
+        seen: set[int] = set()
+        for key, component in entries:
+            if isinstance(component, ComponentSpec):
+                resolved = [(key or component.key, component.component, component)]
+            elif key is None and not isinstance(component, WidgetBase) and isinstance(component, (Viewable, Viewer)):
+                resolved = [(None, found, None) for found in _walk(component, self.exclude, seen)]
+            else:
+                resolved = [(key, component, None)]
+            for resolved_key, resolved_component, spec in resolved:
+                if not isinstance(resolved_component, param.Parameterized):
+                    self.param.warning(
+                        f"Cannot control {resolved_component!r}; components must be "
+                        "Parameterized objects such as Panel widgets."
+                    )
+                    continue
+                spec_key = self._unique_key(resolved_key, resolved_component, keys)
+                keys.add(spec_key)
+                specs.append(ComponentSpec(
+                    spec_key,
+                    resolved_component,
+                    description=self._lookup(self.descriptions, spec_key, resolved_key) or (spec.description if spec else ""),
+                    parameters=self._lookup(self.parameters, spec_key, resolved_key) or (spec.parameters if spec else None),
+                ))
+        return specs
+
+    @staticmethod
+    def _lookup(mapping: dict, key: str, original: str | None) -> Any:
+        """Look up per-component overrides by either the resolved or original key."""
+        if key in mapping:
+            return mapping[key]
+        if original is not None and original in mapping:
+            return mapping[original]
+        return None
+
+    def _unique_key(self, key: str | None, component: param.Parameterized, taken: set[str]) -> str:
+        base = _slugify(key or _label(component) or type(component).__name__)
+        if base not in taken:
+            return base
+        index = 2
+        while f"{base}_{index}" in taken:
+            index += 1
+        return f"{base}_{index}"
+
+    @property
+    def tools(self) -> list[FunctionTool]:
+        """The discovery and control tools for the current set of components."""
+        specs = self.specs
+        tools = [self._list_tool(), self._describe_tool(specs)]
+        for spec in specs:
+            tool = spec.tool()
+            if tool is not None:
+                tools.append(tool)
+        return tools
+
+    def summary(self) -> str:
+        """An overview of every component and its current state."""
+        specs = self.specs
+        if not specs:
+            return "No controllable components are currently available."
+        header = f"Controllable UI components ({len(specs)}):"
+        if self.purpose:
+            header = f"{' '.join(self.purpose.split())}\n\n{header}"
+        listing = "\n".join(spec.summary() for spec in specs)
+        return (
+            f"{header}\n{listing}\n\n"
+            f"Call {self._tool_name('describe')} for the full parameter list of one component."
+        )
+
+    def _tool_name(self, kind: Literal["list", "describe"]) -> str:
+        namespace = _slugify(self.namespace)
+        if kind == "list":
+            return f"list_{namespace}_components" if namespace else "list_components"
+        return f"describe_{namespace}_component" if namespace else "describe_component"
+
+    def _list_tool(self) -> FunctionTool:
+        async def list_components() -> str:
+            return self.summary()
+
+        _describe_function(
+            list_components,
+            self._tool_name("list"),
+            "List the interactive components of the application that can be controlled, "
+            "including the current value of each one.",
+            [], [],
+        )
+        purpose = (
+            "Discover the interactive components of the application UI that can be "
+            "inspected and controlled, and their current values. Call this before "
+            "changing the UI when unsure which components exist."
+        )
+        if self.purpose:
+            purpose += f" {' '.join(self.purpose.split())}"
+        return FunctionTool(list_components, purpose=purpose)
+
+    def _describe_tool(self, specs: list[ComponentSpec]) -> FunctionTool:
+        lookup = {spec.key: spec for spec in specs}
+
+        async def describe_component(component: str) -> str:
+            spec = lookup.get(component)
+            if spec is None:
+                keys = ", ".join(lookup) or "(none)"
+                return f"Unknown component {component!r}. Available components: {keys}."
+            return spec.describe()
+
+        annotation = Literal[tuple(lookup)] if lookup else str
+        _describe_function(
+            describe_component,
+            self._tool_name("describe"),
+            "Describe every parameter of one component of the application UI.",
+            [inspect.Parameter("component", inspect.Parameter.KEYWORD_ONLY, annotation=annotation)],
+            [f"component\n    Name of the component, one of: {', '.join(lookup) or '(none)'}."],
+        )
+        return FunctionTool(describe_component, purpose=(
+            "Inspect one component of the application UI in detail: all of its "
+            "parameters, their types, allowed values, current values and documentation. "
+            f"Use {self._tool_name('list')} first to discover the component names."
+        ))

--- a/lumen/ai/tools/generic.py
+++ b/lumen/ai/tools/generic.py
@@ -1,0 +1,59 @@
+"""
+General-purpose LLM tools: literal Python values and HTTP GET via aiohttp.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from .base import define_tool
+
+try:
+    import aiohttp
+except ImportError:
+    aiohttp = None  # type: ignore[misc, assignment]
+
+
+@define_tool(purpose="Parse an expression, e.g. to perform calculations or conversions.")
+def parse_literal(literal: str) -> str:
+    """
+    Parse *literal* as a Python literal (str, int, float, bool, None, list, dict, tuple, set).
+    Only constant expressions are allowed — not arbitrary code or function calls.
+    """
+    s = (literal or "").strip()
+    if not s:
+        return "Empty input; provide a Python literal (e.g. '[1, 2]', '{\"a\": 1}')."
+    try:
+        value = ast.literal_eval(s)
+    except (ValueError, SyntaxError) as e:
+        return f"literal_eval failed: {e}"
+    return repr(value)
+
+
+@define_tool(purpose="Download public HTTP(S) content by URL for inspection (GET, text body, size-limited). Use when the user points at a web resource to summarize or extract from.")
+async def fetch_url(
+    url: str,
+    timeout_seconds: float = 30.0,
+    max_chars: int = 120_000,
+) -> str:
+    """
+    HTTP GET *url* (https or http). Returns status line and response text, truncated to *max_chars*.
+    """
+    if aiohttp is None:
+        return "aiohttp is not installed; cannot fetch URLs."
+    u = (url or "").strip()
+    if not u:
+        return "Empty URL."
+    timeout = aiohttp.ClientTimeout(total=max(1.0, min(timeout_seconds, 120.0)))
+    cap = max(256, min(int(max_chars), 2_000_000))
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(u) as resp:
+                text = await resp.text()
+                if len(text) > cap:
+                    text = text[:cap] + "\n... (truncated)"
+                return f"HTTP {resp.status} {resp.reason}\n{text}"
+    except aiohttp.ClientError as e:
+        return f"Request failed: {e}"
+    except TimeoutError:
+        return "Request timed out."

--- a/lumen/tests/ai/test_component_control.py
+++ b/lumen/tests/ai/test_component_control.py
@@ -1,0 +1,320 @@
+import datetime as dt
+
+import param
+import pytest
+
+try:
+    import lumen.ai  # noqa
+except ModuleNotFoundError:
+    pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
+
+import panel_material_ui as pmui
+
+from panel.viewable import Viewer
+
+from lumen.ai.agents import ComponentControlAgent
+from lumen.ai.tools import ComponentController
+
+
+class Config(param.Parameterized):
+    """Configuration of the model."""
+
+    n_estimators = param.Integer(default=100, bounds=(10, 500), doc="Number of trees.")
+
+    criterion = param.Selector(default="gini", objects=["gini", "entropy"], doc="Split criterion.")
+
+    normalize = param.Boolean(default=True, doc="Whether to normalize inputs.")
+
+    weights = param.List(default=[1.0], item_type=float, doc="Class weights.")
+
+    _private = param.String(default="hidden", precedence=-1)
+
+
+@pytest.fixture
+def widgets():
+    return {
+        "slider": pmui.FloatSlider(
+            label="Temperature", start=0, end=40, step=0.5, value=21.5,
+            description="Target temperature of the simulation",
+        ),
+        "select": pmui.Select(label="Colormap", options={"Viridis": "viridis", "Plasma": "plasma"}),
+        "multi": pmui.MultiChoice(label="Regions", options=["EU", "US", "APAC"], value=["EU"]),
+        "range": pmui.RangeSlider(label="Year range", start=2000, end=2024, value=(2010, 2020)),
+        "date": pmui.DatePicker(label="Day", value=dt.date(2020, 5, 1)),
+        "toggle": pmui.Switch(label="Show outliers", value=False),
+        "button": pmui.Button(label="Reset"),
+    }
+
+
+@pytest.fixture
+def page(widgets):
+    return pmui.Page(
+        main=[pmui.Column(*[w for k, w in widgets.items() if k != "button"])],
+        sidebar=[widgets["button"]],
+    )
+
+
+def tools_by_name(controller):
+    return {tool.name: tool for tool in controller.tools}
+
+
+def schema(tool):
+    return tool._model.model_json_schema()
+
+
+class TestDiscovery:
+
+    def test_walks_page(self, page):
+        controller = ComponentController(components=page)
+        assert [spec.key for spec in controller.specs] == [
+            "temperature", "colormap", "regions", "year_range", "day", "show_outliers", "reset"
+        ]
+
+    def test_summary_lists_labels_values_and_tools(self, page):
+        summary = ComponentController(components=page, purpose="Turbine dashboard.").summary()
+        assert "Turbine dashboard." in summary
+        assert '`temperature` — FloatSlider labelled "Temperature"' in summary
+        assert "Target temperature of the simulation" in summary
+        assert "value: 21.5 (between 0 and 40; step 0.5)" in summary
+        assert "value: 'Viridis' (one of: Viridis, Plasma)" in summary
+        assert "Control with: set_temperature" in summary
+        assert "Control with: click_reset" in summary
+
+    def test_summary_without_components(self):
+        assert "No controllable components" in ComponentController().summary()
+
+    def test_discovery_tool_names_use_namespace(self, page):
+        tools = tools_by_name(ComponentController(components=page, namespace="dashboard"))
+        assert "list_dashboard_components" in tools
+        assert "describe_dashboard_component" in tools
+
+    async def test_describe_tool_reports_parameters_and_docs(self):
+        controller = ComponentController(components={"config": Config()})
+        tools = tools_by_name(controller)
+        described = await tools["describe_ui_component"].function(component="config")
+        assert "Configuration of the model." in described
+        assert "`n_estimators` (Integer) = 100" in described
+        assert "Accepts: between 10 and 500" in described
+        assert "Doc: Number of trees." in described
+        assert "Control with: set_config" in described
+
+    async def test_describe_tool_rejects_unknown_component(self, page):
+        tools = tools_by_name(ComponentController(components=page))
+        described = await tools["describe_ui_component"].function(component="nope")
+        assert "Unknown component 'nope'" in described
+
+    async def test_list_tool_reflects_current_values(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        widgets["slider"].value = 33.0
+        assert "value: 33.0" in await tools["list_ui_components"].function()
+
+    def test_describe_tool_enumerates_components(self, page):
+        tools = tools_by_name(ComponentController(components=page))
+        assert schema(tools["describe_ui_component"])["properties"]["component"]["enum"][0] == "temperature"
+
+
+class TestSchemas:
+
+    def test_one_tool_per_component(self, page):
+        tools = tools_by_name(ComponentController(components=page))
+        assert set(tools) == {
+            "list_ui_components", "describe_ui_component", "set_temperature", "set_colormap",
+            "set_regions", "set_year_range", "set_day", "set_show_outliers", "click_reset",
+        }
+
+    def test_slider_bounds_are_declared(self, page):
+        tools = tools_by_name(ComponentController(components=page))
+        value = schema(tools["set_temperature"])["properties"]["value"]
+        assert {"type": "number", "minimum": 0, "maximum": 40} in value["anyOf"]
+        assert "Currently 21.5" in value["description"]
+
+    def test_options_become_literals(self, page):
+        tools = tools_by_name(ComponentController(components=page))
+        value = schema(tools["set_colormap"])["properties"]["value"]
+        assert {"type": "string", "enum": ["Viridis", "Plasma"]} in value["anyOf"]
+
+    def test_multi_select_options_become_list_of_literals(self, page):
+        tools = tools_by_name(ComponentController(components=page))
+        value = schema(tools["set_regions"])["properties"]["value"]
+        assert {"type": "array", "items": {"type": "string", "enum": ["EU", "US", "APAC"]}} in value["anyOf"]
+
+    def test_button_tool_takes_no_arguments(self, page):
+        tools = tools_by_name(ComponentController(components=page))
+        assert schema(tools["click_reset"])["properties"] == {}
+
+    def test_parameterized_exposes_own_parameters(self):
+        tools = tools_by_name(ComponentController(components={"config": Config()}))
+        properties = schema(tools["set_config"])["properties"]
+        assert set(properties) == {"n_estimators", "criterion", "normalize", "weights"}
+        assert properties["n_estimators"]["description"].startswith("Number of trees.")
+
+    def test_explicit_parameters_override(self):
+        controller = ComponentController(
+            components={"config": Config()}, parameters={"config": ["criterion"]}
+        )
+        assert set(schema(tools_by_name(controller)["set_config"])["properties"]) == {"criterion"}
+
+    def test_descriptions_are_added_to_the_purpose(self):
+        controller = ComponentController(
+            components={"config": Config()}, descriptions={"config": "Hyper-parameters."}
+        )
+        assert "Hyper-parameters." in tools_by_name(controller)["set_config"].purpose
+
+
+class TestApply:
+
+    async def test_sets_value(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        result = await tools["set_temperature"].function(value=30)
+        assert widgets["slider"].value == 30
+        assert result == "Updated Temperature: `value` 21.5 → 30.0"
+
+    async def test_coerces_string_number(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        await tools["set_temperature"].function(value="12.25")
+        assert widgets["slider"].value == 12.25
+
+    async def test_rejects_out_of_bounds_value(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        result = await tools["set_temperature"].function(value=99)
+        assert widgets["slider"].value == 21.5
+        assert "above the upper bound 40" in result
+
+    async def test_rejects_out_of_bounds_range(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        result = await tools["set_year_range"].function(value=[1990, 2015])
+        assert widgets["range"].value == (2010, 2020)
+        assert "below the lower bound 2000" in result
+
+    async def test_resolves_option_label_to_value(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        await tools["set_colormap"].function(value="Plasma")
+        assert widgets["select"].value == "plasma"
+
+    async def test_resolves_raw_option_value(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        await tools["set_colormap"].function(value="viridis")
+        assert widgets["select"].value == "viridis"
+
+    async def test_rejects_unknown_option(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        result = await tools["set_colormap"].function(value="magma")
+        assert widgets["select"].value == "viridis"
+        assert "not one of the allowed values: Viridis, Plasma" in result
+
+    async def test_coerces_single_value_to_list(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        await tools["set_regions"].function(value="US")
+        assert widgets["multi"].value == ["US"]
+
+    async def test_coerces_boolean_string(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        await tools["set_show_outliers"].function(value="yes")
+        assert widgets["toggle"].value is True
+
+    async def test_coerces_date_string(self, page, widgets):
+        tools = tools_by_name(ComponentController(components=page))
+        await tools["set_day"].function(value="2021-07-04")
+        assert widgets["date"].value == dt.date(2021, 7, 4)
+
+    async def test_coerces_datetime_range(self):
+        slider = pmui.DatetimeRangeSlider(
+            label="Window", start=dt.datetime(2020, 1, 1), end=dt.datetime(2020, 12, 31),
+            value=(dt.datetime(2020, 2, 1), dt.datetime(2020, 3, 1)),
+        )
+        tools = tools_by_name(ComponentController(components=[slider]))
+        await tools["set_window"].function(value=["2020-04-01", "2020-06-15T12:00:00"])
+        assert slider.value == (dt.datetime(2020, 4, 1), dt.datetime(2020, 6, 15, 12))
+
+    async def test_coerces_list_items_to_item_type(self):
+        config = Config()
+        tools = tools_by_name(ComponentController(components={"config": config}))
+        await tools["set_config"].function(weights=[1, 2.5])
+        assert config.weights == [1.0, 2.5]
+
+    async def test_omitted_arguments_are_left_alone(self):
+        config = Config()
+        tools = tools_by_name(ComponentController(components={"config": config}))
+        result = await tools["set_config"].function(n_estimators=250)
+        assert (config.n_estimators, config.criterion, config.normalize) == (250, "gini", True)
+        assert result == "Updated config: `n_estimators` 100 → 250"
+
+    async def test_reports_parameter_rejected_by_param(self):
+        config = Config()
+        tools = tools_by_name(ComponentController(components={"config": config}))
+        result = await tools["set_config"].function(n_estimators=1000)
+        assert config.n_estimators == 100
+        assert "must be at most 500" in result
+
+    async def test_click_triggers_button(self, page, widgets):
+        clicks = []
+        widgets["button"].on_click(clicks.append)
+        tools = tools_by_name(ComponentController(components=page))
+        result = await tools["click_reset"].function()
+        assert len(clicks) == 1
+        assert result == "Clicked Reset."
+
+
+class TestLiveSync:
+
+    def test_added_components_are_picked_up(self, page):
+        controller = ComponentController(components=page)
+        assert "set_bins" not in tools_by_name(controller)
+        page.main[0].append(pmui.IntSlider(label="Bins", start=1, end=100, value=10))
+        assert "set_bins" in tools_by_name(controller)
+
+    def test_removed_components_disappear(self, page, widgets):
+        controller = ComponentController(components=page)
+        page.main[0].remove(widgets["select"])
+        assert "set_colormap" not in tools_by_name(controller)
+
+    def test_walks_nested_viewer(self):
+        class Dashboard(Viewer):
+            def __init__(self, **params):
+                super().__init__(**params)
+                self.search = pmui.TextInput(label="Search")
+                self._layout = pmui.Column(
+                    self.search, pmui.Tabs(("A", pmui.Column(pmui.IntInput(label="Limit", value=10))))
+                )
+
+            def __panel__(self):
+                return self._layout
+
+        assert [spec.key for spec in ComponentController(components=Dashboard()).specs] == ["search", "limit"]
+
+    def test_excluded_components_are_skipped(self, page, widgets):
+        controller = ComponentController(components=page, exclude=[widgets["slider"], pmui.Switch])
+        keys = [spec.key for spec in controller.specs]
+        assert "temperature" not in keys
+        assert "show_outliers" not in keys
+
+    def test_duplicate_labels_are_disambiguated(self):
+        column = pmui.Column(pmui.IntSlider(label="Count"), pmui.IntSlider(label="Count"))
+        assert [spec.key for spec in ComponentController(components=column).specs] == ["count", "count_2"]
+
+    def test_explicitly_named_container_is_not_walked(self, widgets):
+        column = pmui.Column(widgets["slider"])
+        controller = ComponentController(components={"panel": column})
+        assert [spec.key for spec in controller.specs] == ["panel"]
+
+
+class TestAgent:
+
+    def test_components_build_a_controller(self, page):
+        agent = ComponentControlAgent(components=page)
+        assert agent.controller.components is page
+        assert agent.controller in agent.llm_tools
+
+    def test_controller_is_not_shared_between_instances(self):
+        assert ComponentControlAgent().controller is not ComponentControlAgent().controller
+
+    def test_setting_components_updates_the_controller(self, page, widgets):
+        agent = ComponentControlAgent()
+        agent.components = page
+        assert next(spec.key for spec in agent.controller.specs) == "temperature"
+
+    async def test_prompt_context_includes_live_state(self, page, widgets):
+        agent = ComponentControlAgent(components=page)
+        widgets["slider"].value = 12.0
+        prompt_context = await agent._gather_prompt_context("main", [], {})
+        assert "value: 12.0" in prompt_context["ui_state"]


### PR DESCRIPTION
## Problem

lumen.ai can answer questions about data, but it cannot touch the application it lives in. A
dashboard that already has the right filters, the right axes and the right model parameters
still forces the user to find and move every widget by hand, and the assistant sitting next
to those widgets can only describe what the user should click.

There was also no way to point an assistant at an application at all. Agents and tools take
data sources, not widgets, so exposing "the eight controls in the sidebar" meant hand-writing
one `FunctionTool` per widget, repeating each label, each set of options and each bound as
prose in the tool description, and rewriting all of it whenever the layout changed.

## Approach

Widgets already carry everything needed to describe themselves. A `param.Parameter` knows its
type, its bounds, its allowed values and its `doc` string, a widget knows its `label` and
`description`, and `param` knows how to serialize and deserialize a value. So the tools are
derived rather than declared: hand over the components and the schemas fall out of them.

## Changes

### `ComponentController` (`lumen/ai/tools/component_control.py`)

Takes a widget, a list, a dict keyed by the name the LLM should use, or an entire layout such
as a `panel_material_ui.Page`, and produces:

- `list_ui_components`, an overview of every component with its current value,
- `describe_ui_component`, the full parameter list of one component with `doc` strings,
  bounds and allowed values,
- `set_<key>` per component, and
- `click_<key>` instead, when a component's only settable parameter is a `param.Event`.

Pass it anywhere `llm_tools` are accepted (`ExplorerUI(llm_tools=[controller])`) or hand it to
a `ComponentControlAgent`.

**What gets exposed.** Widgets expose `value` alone and take their meaning from `label` and
`description`. Any other `Parameterized` object exposes every parameter it declares itself,
with the inherited `Parameterized`/`Layoutable`/`Viewable` chrome filtered out, so a domain
model can be handed over directly and its parameter docstrings become the tool documentation.
`constant` and `readonly` parameters produce no setter but are still reported, which is how a
model reads back the effect of a change. `descriptions`, `parameters` and `exclude` cover the
cases where the component does not describe itself well enough.

**Values go through param.** `_serializer`/`_deserializer` use a parameter's own
`serialize`/`deserialize` when the class overrides the identity implementations on
`param.Parameter`, so dates, ranges and dataframes round-trip in the form the parameter
expects instead of whatever JSON the model guessed at. Writes are validated by `param` and a
rejected value comes back to the model as a message it can act on, along with the constraint
it violated. Selector constraints are rendered as "any of" for multi-valued parameters and
"one of" for single-valued ones, since a model that is told "one of" will not send a list.

**Live layouts.** `specs` re-resolves on every access rather than at construction, so a
controller pointed at a `Page` picks up components added or removed at runtime, and listing
the controller in `llm_tools` is enough for the tool set handed to the LLM to describe the
application as it is now. Layout keys come from slugified labels, deduplicated with a numeric
suffix; explicit dict keys always win.

### `ComponentControlAgent` (`lumen/ai/agents/component_control.py`)

Wires a controller into a coordinator. Its `applies` hook writes the current list of controls
onto the `purpose`, because a coordinator routes on the purpose alone and "show only Gentoo
penguins" is only distinguishable from a data query if the router can see that a species
filter exists. Its prompt covers three things beyond plain writes: relative changes ("a bit
stronger"), the fact that read-only values only reflect a change after the listing tool is
called again, and goal seeking, where the agent writes a candidate, re-reads the resulting
state and iterates instead of asking the user to try values themselves. For a "weakest
setting that still meets the target" request it is told to step back towards what the user
asked for while the target holds and to never leave the application in a state that fails it.

### Two fixes found on the way

`Coordinator._chat_invoke` planned a response and returned the `Plan` without running it. A
`UI` supplies its own `_chat_invoke` and so was unaffected, but a coordinator used on its own,
which is exactly what a small embedded assistant is, produced a plan and then did nothing. It
now executes the plan and returns `None`, since a `Plan` placed in the message feed cannot be
serialized back into the conversation on the next turn.

`Planner._resolve_plan` looked up `agents["ChatAgent"]` unconditionally to check `not_with`,
so any agent set without a `ChatAgent` died with `KeyError` before running a single step. It
now uses `agents.get` and only appends the summarize step when that agent exists.

## Demos

`examples/ai/penguin_copilot.py` walks a whole `Page` and exposes 11 components as 13 tools,
with the assistant in a docked `Drawer` on the right. "Colour by sex and plot flipper length
against body mass" moves four widgets in one turn.

`examples/ai/epidemic_copilot.py` is an SEIR outbreak simulator with disease presets, a
saveable baseline, KPI cards and a hospital demand plot drawn relative to capacity. It hands
over the model, a read-only `Outcome` and the display controls, so the assistant can both act
and observe. That is what makes "find the weakest lockdown that keeps hospital load under
100%" work: it searches down from an intervention strength of 0.7 to 0.495 and settles on a
97.5% peak load with zero overflow days. The demo pins the larger model, since the smaller
ones tend to stop after the first write rather than iterate.

## Tests

41 tests in `lumen/tests/ai/test_component_control.py`, covering spec discovery for widgets
and plain `Parameterized` objects, walking a layout, re-resolution after the layout changes,
key collisions, serializer round-trips, rejected writes, trigger detection, per-component
overrides and the generated summaries and schemas.

Both demos were verified three ways: rendered into a bokeh document, screenshotted through
Playwright against `panel serve` with no console errors, and driven by real LLM runs that
changed presets, population, plotted curves, the axis scale and the baseline button, and that
carried out the bounded search described above.

Existing suite: 89 passed in the planner and coordinator tests. The 8 failures in
`lumen/tests/ai` are pre-existing and unrelated (an `asyncio.iscoroutinefunction`
deprecation raised as an error, two prompt-heading checks for unrelated in-progress agents,
`param_to_pydantic`, two xarray upload handlers, a csv `resolve_data` and an edit callback).

## AI Disclosure

Written with assistance of Claude Opus 5