### PR TITLE
Preview an exploration result without converting the whole frame

### DIFF
--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -1,5 +1,6 @@
 import typing as t
 
+import narwhals.stable.v2 as nw
 import pandas as pd
 import param
 import sqlglot
@@ -14,6 +15,7 @@ from ...pipeline import Pipeline
 from ...sources.base import BaseSQLSource, Source
 from ...sources.duckdb import DuckDBSource
 from ...transforms.sql import SQLLimit
+from ...util import as_narwhals, as_pandas, is_lazyframe
 from ..config import PROMPTS_DIR, SOURCE_TABLE_SEPARATOR
 from ..context import ContextModel, TContext
 from ..data_quality import lint_data
@@ -24,10 +26,13 @@ from ..schemas import Metaset
 from ..tools import FunctionTool
 from ..utils import (
     PROFILE_SAMPLE_ROWS, clean_sql, describe_data, get_frame, get_pipeline,
-    log_debug, parse_table_slug, retry_llm_output, stream_details,
-    truncate_to_tokens,
+    log_debug, normalize_object_dtypes, parse_table_slug, retry_llm_output,
+    stream_details, truncate_to_tokens,
 )
 from .base_lumen import BaseLumenAgent
+
+if t.TYPE_CHECKING:
+    from narwhals.stable.v2.typing import Frame, IntoFrame
 
 
 def make_source_table_model(sources: list[tuple[str, str]]):
@@ -125,7 +130,7 @@ SCHEMA_MAX_TOKENS = 3000
 SOURCE_PROFILE_MAX_TABLES = 3
 
 
-def format_exploration_result(df: pd.DataFrame) -> str:
+def format_exploration_result(df: "IntoFrame | Frame") -> str:
     """
     Render an exploration query result as a compact preview for the LLM.
 
@@ -133,11 +138,25 @@ def format_exploration_result(df: pd.DataFrame) -> str:
     ``SELECT COUNT(*)`` to learn how many rows matched, then column dtypes and a
     few example rows. Markdown without the index: alignment padding and row
     numbers are pure token cost here, carrying no information about the data.
+
+    Only the handful of cells actually rendered is converted to pandas, so a
+    polars or pyarrow result reaches the model without the whole frame being
+    copied. The dtypes reported are the preview's for that reason, which is
+    also what keeps a pandas caller's output exactly as it was.
     """
-    n_rows, n_cols = df.shape
+    frame = as_narwhals(df)
+    if is_lazyframe(frame):
+        frame = frame.collect()
+    n_rows, n_cols = frame.shape
     parts = [f"{n_rows} rows x {n_cols} columns"]
 
-    preview = df.iloc[:, :EXPLORATION_PREVIEW_COLS]
+    # Normalised because which columns land on object varies by library:
+    # pandas converts a DECIMAL to float itself, polars and pyarrow keep it,
+    # and an object column is reported as str by the dtype line below.
+    names = frame.columns[:EXPLORATION_PREVIEW_COLS]
+    preview = normalize_object_dtypes(as_pandas(
+        frame.select(*[nw.col(name) for name in names]).head(EXPLORATION_PREVIEW_ROWS)
+    ))
     if n_cols > EXPLORATION_PREVIEW_COLS:
         parts[0] += f" (showing the first {EXPLORATION_PREVIEW_COLS} columns)"
 
@@ -150,10 +169,7 @@ def format_exploration_result(df: pd.DataFrame) -> str:
     if n_rows:
         shown = min(n_rows, EXPLORATION_PREVIEW_ROWS)
         label = "all rows" if shown == n_rows else f"first {shown} of {n_rows} rows"
-        parts.append(
-            f"Sample ({label}):\n"
-            + preview.head(EXPLORATION_PREVIEW_ROWS).to_markdown(index=False)
-        )
+        parts.append(f"Sample ({label}):\n" + preview.to_markdown(index=False))
     else:
         parts.append("The query returned no rows.")
 
@@ -218,7 +234,7 @@ async def execute_exploration_sql(
         return f"SQL parse/clean error: {e}"
 
     try:
-        df = base.execute(sql_clean)
+        df = base.fetch(sql_clean)
     except Exception as e:
         return f"{type(e).__name__}: {e}"
 

--- a/lumen/ai/agents/sql.py
+++ b/lumen/ai/agents/sql.py
@@ -23,7 +23,7 @@ from ..models import RetrySpec
 from ..schemas import Metaset
 from ..tools import FunctionTool
 from ..utils import (
-    PROFILE_SAMPLE_ROWS, clean_sql, describe_data, get_data, get_pipeline,
+    PROFILE_SAMPLE_ROWS, clean_sql, describe_data, get_frame, get_pipeline,
     log_debug, parse_table_slug, retry_llm_output, stream_details,
     truncate_to_tokens,
 )
@@ -713,13 +713,15 @@ class SQLAgent(BaseLumenAgent):
         else:
             pipeline = await get_pipeline(source=sql_expr_source, table=expr_slug)
 
-        # Get data summary
-        df = await get_data(pipeline)
+        # Get data summary. The frame is only counted and summarised, and
+        # describe_data reads any library, so there is nothing here worth
+        # converting a polars or pyarrow result to pandas for.
+        df = await get_frame(pipeline)
 
         # Reject before promoting the new source: retry_llm_output re-runs this
         # method on failure, and a rejected query left installed as
         # ``context["source"]`` becomes the base every later attempt builds on.
-        if df.empty and raise_if_empty:
+        if not len(df) and raise_if_empty:
             raise ValueError(
                 f"\nQuery `{sql_query}` returned empty results."
                 "\nUse `run_exploration_sql` to check what values actually exist before filtering."

--- a/lumen/ai/editors.py
+++ b/lumen/ai/editors.py
@@ -33,6 +33,7 @@ from ..config import dump_yaml, load_yaml
 from ..filters import WidgetFilter
 from ..pipeline import Pipeline
 from ..transforms.sql import SQLLimit
+from ..util import as_pandas
 from ..views.base import Panel, Table, View
 from .analysis import Analysis
 from .config import FORMAT_ICONS, FORMAT_LABELS
@@ -716,7 +717,8 @@ class SQLEditor(LumenEditor):
 
     def export(self, fmt: str) -> StringIO | BytesIO:
         super().export(fmt)
-        data = self.component.data
+        # to_csv, to_json and to_markdown are all pandas only.
+        data = as_pandas(self.component.data)
         if fmt == 'sql':
             return StringIO(self.spec)
         sio = StringIO()

--- a/lumen/ai/export.py
+++ b/lumen/ai/export.py
@@ -15,6 +15,7 @@ from panel.viewable import Viewable
 
 from ..config import config
 from ..pipeline import Pipeline
+from ..util import as_pandas
 from ..views import View
 from .editors import LumenEditor
 
@@ -162,6 +163,7 @@ def docx_add_markdown(doc, text: str):
 
 def docx_add_table(doc, df, max_rows: int = 50):
     """Render a DataFrame as a native Word table (header + capped rows)."""
+    df = as_pandas(df)  # iterrows is pandas only
     table = doc.add_table(rows=1, cols=len(df.columns))
     table.style = 'Table Grid'
     for cell, col in zip(table.rows[0].cells, df.columns, strict=False):

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -755,6 +755,31 @@ def _select_relevant_columns(
     return selected, len(selected) < len(columns)
 
 
+# The types numpy cannot hold, and what to describe them as instead.
+_SUMMARY_DTYPES = {'decimal': 'float64', 'date': 'datetime64[us]'}
+
+
+def _summary_pandas(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Return the profiling sample with columns numpy is able to describe.
+
+    numpy has no decimal and no date, so both sit in an object column, and the
+    summary below reads an object column as categorical: a money column loses
+    its mean and range and comes out as an enum of decimal.Decimal, which
+    yaml.safe_load cannot even read back.
+
+    Inferred from the values rather than the source dtype, because pandas
+    produces such a column for a DECIMAL result of its own, so this is not
+    only about the frame having arrived from another library.
+    """
+    casts = {
+        col: _SUMMARY_DTYPES[kind]
+        for col in df.columns
+        if (kind := pd.api.types.infer_dtype(df[col])) in _SUMMARY_DTYPES
+    }
+    return df.astype(casts) if casts else df
+
+
 def _sample_for_summary(df: IntoFrame | Frame) -> tuple[pd.DataFrame, tuple[int, int], bool]:
     """
     Return df as pandas, row-sampled for profiling, along with its true shape.
@@ -793,14 +818,18 @@ def _sample_for_summary(df: IntoFrame | Frame) -> tuple[pd.DataFrame, tuple[int,
         narwhals_df = narwhals_df.collect()
     if is_narwhals(narwhals_df):
         shape = narwhals_df.shape
-        if shape[0] <= PROFILE_SAMPLE_ROWS:
-            return narwhals_df.to_pandas(), shape, False
-        return narwhals_df.sample(n=PROFILE_SAMPLE_ROWS).to_pandas(), shape, True
+        sampled = shape[0] > PROFILE_SAMPLE_ROWS
+        if sampled:
+            narwhals_df = narwhals_df.sample(n=PROFILE_SAMPLE_ROWS)
+        # as_pandas rather than to_pandas: it keeps an integer column holding a
+        # null an integer, instead of widening an id to 3.0 in the sample rows.
+        return _summary_pandas(as_pandas(narwhals_df)), shape, sampled
 
     shape = df.shape
-    if shape[0] <= PROFILE_SAMPLE_ROWS:
-        return df, shape, False
-    return df.sample(PROFILE_SAMPLE_ROWS), shape, True
+    sampled = shape[0] > PROFILE_SAMPLE_ROWS
+    if sampled:
+        df = df.sample(PROFILE_SAMPLE_ROWS)
+    return _summary_pandas(df), shape, sampled
 
 
 def describe_data_sync(
@@ -1869,7 +1898,8 @@ def result_to_dataframe(result) -> pd.DataFrame | None:
         src = result.sources[0]
         table = result.table
         try:
-            return src.get(table)
+            # Declared pd.DataFrame, and callers concat it and read .empty.
+            return as_pandas(src.get(table))
         except Exception:
             return None
 

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -1867,14 +1867,9 @@ def sanitize_column_names(df: pd.DataFrame) -> pd.DataFrame:
     Returns
     -------
     pd.DataFrame
-        A copy of the DataFrame with sanitized column names
+        The DataFrame with sanitized column names, leaving the caller's alone
     """
-    df = df.copy()
-    df.columns = [
-        re.sub(r'[^\w]', '', col.replace(' ', '_'))
-        for col in df.columns
-    ]
-    return df
+    return df.rename(columns=lambda col: re.sub(r'[^\w]', '', col.replace(' ', '_')))
 
 
 def result_to_dataframe(result) -> pd.DataFrame | None:

--- a/lumen/ai/utils.py
+++ b/lumen/ai/utils.py
@@ -755,27 +755,28 @@ def _select_relevant_columns(
     return selected, len(selected) < len(columns)
 
 
-# The types numpy cannot hold, and what to describe them as instead.
-_SUMMARY_DTYPES = {'decimal': 'float64', 'date': 'datetime64[us]'}
+# The types numpy cannot hold, and what to read them as instead.
+_OBJECT_DTYPE_CASTS = {'decimal': 'float64', 'date': 'datetime64[us]'}
 
 
-def _summary_pandas(df: pd.DataFrame) -> pd.DataFrame:
+def normalize_object_dtypes(df: pd.DataFrame) -> pd.DataFrame:
     """
-    Return the profiling sample with columns numpy is able to describe.
+    Return df with columns numpy is able to describe.
 
-    numpy has no decimal and no date, so both sit in an object column, and the
-    summary below reads an object column as categorical: a money column loses
-    its mean and range and comes out as an enum of decimal.Decimal, which
-    yaml.safe_load cannot even read back.
+    numpy has no decimal and no date, so both sit in an object column, which
+    anything reading dtypes takes for text: the summary reads it as
+    categorical, so a money column loses its mean and range and comes out as
+    an enum of decimal.Decimal that yaml.safe_load cannot even read back, and
+    the exploration preview reports it as str.
 
     Inferred from the values rather than the source dtype, because pandas
     produces such a column for a DECIMAL result of its own, so this is not
     only about the frame having arrived from another library.
     """
     casts = {
-        col: _SUMMARY_DTYPES[kind]
+        col: _OBJECT_DTYPE_CASTS[kind]
         for col in df.columns
-        if (kind := pd.api.types.infer_dtype(df[col])) in _SUMMARY_DTYPES
+        if (kind := pd.api.types.infer_dtype(df[col])) in _OBJECT_DTYPE_CASTS
     }
     return df.astype(casts) if casts else df
 
@@ -823,13 +824,13 @@ def _sample_for_summary(df: IntoFrame | Frame) -> tuple[pd.DataFrame, tuple[int,
             narwhals_df = narwhals_df.sample(n=PROFILE_SAMPLE_ROWS)
         # as_pandas rather than to_pandas: it keeps an integer column holding a
         # null an integer, instead of widening an id to 3.0 in the sample rows.
-        return _summary_pandas(as_pandas(narwhals_df)), shape, sampled
+        return normalize_object_dtypes(as_pandas(narwhals_df)), shape, sampled
 
     shape = df.shape
     sampled = shape[0] > PROFILE_SAMPLE_ROWS
     if sampled:
         df = df.sample(PROFILE_SAMPLE_ROWS)
-    return _summary_pandas(df), shape, sampled
+    return normalize_object_dtypes(df), shape, sampled
 
 
 def describe_data_sync(

--- a/lumen/layout.py
+++ b/lumen/layout.py
@@ -25,7 +25,7 @@ from .panel import IconButton
 from .pipeline import Pipeline
 from .sources.base import Source
 from .state import state
-from .util import catch_and_notify, extract_refs
+from .util import as_pandas, catch_and_notify, extract_refs
 from .validation import ValidationError, match_suggestion_message
 from .views.base import DOWNLOAD_FORMATS, View
 
@@ -401,7 +401,8 @@ class Download(Component, Viewer):
         else:
             io = BytesIO()
         table = self._select_download.value
-        data = self.pipelines[table].data
+        # Every writer below is a pandas method; polars spells them write_*.
+        data = as_pandas(self.pipelines[table].data)
         if self.format == 'csv':
             data.to_csv(io, **self.kwargs)
         elif self.format == 'json':

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -44,8 +44,8 @@ from ..transforms.sql import (
     SQLMinMax, SQLSample, SQLSchemaStats, SQLSelectFrom, SQLTransform,
 )
 from ..util import (
-    as_narwhals, collect_lazy, get_dataframe_schema, is_lazyframe, is_narwhals,
-    is_ref, merge_schemas,
+    DATAFRAME_BACKENDS, as_narwhals, collect_lazy, get_dataframe_schema,
+    is_lazyframe, is_narwhals, is_ref, merge_schemas, to_backend,
 )
 from ..validation import ValidationError, match_suggestion_message
 
@@ -1025,6 +1025,12 @@ class BaseSQLSource(Source):
 
     dialect = None
 
+    dataframe_backend = param.Selector(default=None, objects=[None, *DATAFRAME_BACKENDS], doc="""
+        The dataframe library table data is returned as. Leave unset to get
+        pandas, which is what every source has always produced. Only the data
+        `fetch` reads is affected; the schema and metadata queries stay on
+        pandas whatever this is set to.""")
+
     excluded_tables = param.List(default=[], doc="""
         List of table names that should be excluded from the results. Supports:
         - Fully qualified name: 'DATABASE.SCHEMA.TABLE'
@@ -1187,6 +1193,34 @@ class BaseSQLSource(Source):
         """
         return await asyncio.to_thread(self.execute, sql_query, params, *args, **kwargs)
 
+    def fetch(self, sql_query: str, params: list | dict | None = None) -> DataFrame:
+        """
+        Executes a SQL query and returns the result in `dataframe_backend`.
+
+        The data path, as against `execute`, which is the pandas path the
+        schema and metadata queries read with `.iloc` and pandas dtypes. Only
+        `get` fetches whole tables, so this is the only place a large result
+        is worth building in the engine's own library rather than converting.
+
+        Sources whose engine can build the requested frame directly override
+        this. The default converts, which costs a copy but is correct for
+        every source, and is free at the default because `to_backend` returns
+        the frame untouched when no backend is asked for.
+
+        Arguments
+        ---------
+        sql_query : str
+            The SQL Query to execute
+        params : list | dict | None
+            Parameters to use in the SQL query
+
+        Returns
+        -------
+        DataFrame
+            The result, in whichever library `dataframe_backend` names.
+        """
+        return to_backend(self.execute(sql_query, params), self.dataframe_backend)
+
     async def get_async(self, table: str, **query) -> DataFrame:
         """
         Return a table asynchronously; optionally filtered by the given query.
@@ -1210,7 +1244,10 @@ class BaseSQLSource(Source):
             sql_filter = SQLFilter(conditions=conditions)
             sql_expr = sql_filter.apply(sql_expr)
 
-        return await self.execute_async(sql_expr)
+        # Through execute_async rather than fetch, because a source with a
+        # genuinely async driver overrides that one and threading fetch
+        # instead would step around it.
+        return to_backend(await self.execute_async(sql_expr), self.dataframe_backend)
 
     @cached_schema
     def get_schema(

--- a/lumen/sources/base.py
+++ b/lumen/sources/base.py
@@ -1198,9 +1198,10 @@ class BaseSQLSource(Source):
         Executes a SQL query and returns the result in `dataframe_backend`.
 
         The data path, as against `execute`, which is the pandas path the
-        schema and metadata queries read with `.iloc` and pandas dtypes. Only
-        `get` fetches whole tables, so this is the only place a large result
-        is worth building in the engine's own library rather than converting.
+        schema and metadata queries read with `.iloc` and pandas dtypes. This
+        is where a whole table or an ad hoc result comes back, so it is where
+        a large frame is worth building in the engine's own library rather
+        than converting one.
 
         Sources whose engine can build the requested frame directly override
         this. The default converts, which costs a copy but is correct for

--- a/lumen/sources/bigquery.py
+++ b/lumen/sources/bigquery.py
@@ -537,7 +537,7 @@ class BigQuerySource(BaseSQLSource):
             sql_transforms = [SQLFilter(conditions=conditions)] + sql_transforms
         for st in sql_transforms:
             sql_expr = st.apply(sql_expr)
-        return self.execute(sql_expr, self.table_params.get(table, []))
+        return self.fetch(sql_expr, self.table_params.get(table, []))
 
     async def get_async(self, table, **query):
         """

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -11,6 +11,7 @@ import duckdb
 import numpy.core.multiarray  # noqa: F401
 import pandas as pd
 import param
+import pyarrow as pa
 import sqlglot
 
 from ..config import config
@@ -543,9 +544,12 @@ class DuckDBSource(BaseSQLSource):
             if backend == 'polars':
                 return rel.pl()
             if backend == 'pyarrow':
-                # Not rel.arrow(), which hands back a RecordBatchReader rather
-                # than a Table, and Pipeline.data rejects it.
-                return rel.fetch_arrow_table()
+                # Through pa.table because arrow() returns a Table up to
+                # duckdb 1.3 and a RecordBatchReader from 1.4, and
+                # Pipeline.data rejects the reader. Not fetch_arrow_table,
+                # which 1.5 deprecates and the suite turns that into an
+                # error, nor to_arrow_table, which 1.4 does not have.
+                return pa.table(rel.arrow())
             return rel.fetch_df(date_as_object=date_as_object)
 
         selected = ', '.join(

--- a/lumen/sources/duckdb.py
+++ b/lumen/sources/duckdb.py
@@ -20,7 +20,9 @@ from ..transforms import Filter
 from ..transforms.sql import (
     SQLCount, SQLFilter, SQLLimit, SQLSelectFrom,
 )
-from ..util import detect_file_encoding, normalize_table_name, try_import
+from ..util import (
+    as_pandas, detect_file_encoding, normalize_table_name, try_import,
+)
 from .base import BaseSQLSource, Source, cached
 
 if TYPE_CHECKING:
@@ -180,12 +182,15 @@ class DuckDBSource(BaseSQLSource):
             else:
                 df = mirror.data
                 def update(e, table=table):
-                    df = e.new
+                    # from_df and select_dtypes are pandas only, and a mirrored
+                    # Pipeline hands over whichever library its source produced.
+                    df = as_pandas(e.new)
                     for col in df.select_dtypes(include=['string']).columns:
                         df[col] = df[col].astype(object)
                     self._connection.from_df(df).to_view(table)
                     self._set_cache(df, table)
                 mirror.param.watch(update, 'data')
+            df = as_pandas(df)
             try:
                 for col in df.select_dtypes(include=['string']).columns:
                     df[col] = df[col].astype(object)
@@ -515,13 +520,18 @@ class DuckDBSource(BaseSQLSource):
 
     def _fetch_df(
         self, cursor, sql_expr: str, params: list | dict | None = None,
-        date_as_object: bool = False
+        date_as_object: bool = False, backend: str | None = None
     ):
         """Fetch a query result, safely handling native GEOMETRY columns.
 
         DuckDB cannot convert a native GEOMETRY column to NumPy, so re-select
         any geometry columns as WKB via ST_AsWKB before fetching, then rebuild
         a GeoDataFrame when geopandas is available (WKB bytes otherwise).
+
+        A geometry result ignores `backend` and stays pandas: geometry only
+        survives as a GeoDataFrame, and narwhals has no geometry dtype, so any
+        other library would hold the column as opaque bytes, drop it from the
+        schema, and render a blank map with nothing raising.
         """
         rel = cursor.execute(sql_expr, params) if params else cursor.execute(sql_expr)
         geom_crs = {
@@ -530,6 +540,12 @@ class DuckDBSource(BaseSQLSource):
         }
         geom_cols = list(geom_crs)
         if not geom_cols:
+            if backend == 'polars':
+                return rel.pl()
+            if backend == 'pyarrow':
+                # Not rel.arrow(), which hands back a RecordBatchReader rather
+                # than a Table, and Pipeline.data rejects it.
+                return rel.fetch_arrow_table()
             return rel.fetch_df(date_as_object=date_as_object)
 
         selected = ', '.join(
@@ -551,6 +567,23 @@ class DuckDBSource(BaseSQLSource):
     def execute(self, sql_query: str, params: list | dict | None = None, *args, **kwargs):
         with self._connection.cursor() as cursor:
             return self._fetch_df(cursor, sql_query, params)
+
+    def fetch(self, sql_query: str, params: list | dict | None = None):
+        """Fetch query results in `dataframe_backend`, built by DuckDB itself.
+
+        Not the inherited fetch, which reads through execute. Two reasons: the
+        data path asks for date_as_object so a DATE stays a date rather than
+        becoming a timestamp, and DuckDB can materialise polars and arrow
+        directly. Building the frame in the asked-for library rather than
+        converting a pandas one is most of the point of the parameter: on a
+        5M row table fetching arrow rather than pandas is an order of
+        magnitude quicker and allocates less than half the memory.
+        """
+        with self._connection.cursor() as cursor:
+            return self._fetch_df(
+                cursor, sql_query, params, date_as_object=True,
+                backend=self.dataframe_backend,
+            )
 
     def get_tables(self):
         if isinstance(self.tables, dict | list):
@@ -583,10 +616,7 @@ class DuckDBSource(BaseSQLSource):
             sql_expr = st.apply(sql_expr)
 
         # Apply stored SQL parameters if available for this table
-        with self._connection.cursor() as cursor:
-            df = self._fetch_df(
-                cursor, sql_expr, self.table_params.get(table), date_as_object=True
-            )
+        df = self.fetch(sql_expr, self.table_params.get(table))
         if not self.filter_in_sql:
             df = Filter.apply_to(df, conditions=conditions)
         return df

--- a/lumen/sources/snowflake.py
+++ b/lumen/sources/snowflake.py
@@ -376,7 +376,7 @@ class SnowflakeSource(BaseSQLSource):
             sql_transforms = [SQLFilter(conditions=conditions)] + sql_transforms
         for st in sql_transforms:
             sql_expr = st.apply(sql_expr)
-        return self.execute(sql_expr, self.table_params.get(table, []))
+        return self.fetch(sql_expr, self.table_params.get(table, []))
 
     async def get_async(self, table, **query):
         """

--- a/lumen/sources/sqlalchemy.py
+++ b/lumen/sources/sqlalchemy.py
@@ -369,7 +369,7 @@ class SQLAlchemySource(BaseSQLSource):
             sql_expr = st.apply(sql_expr)
 
         params = self.table_params.get(table, None)
-        df = self.execute(sql_expr, params)
+        df = self.fetch(sql_expr, params)
         if not self.filter_in_sql:
             df = Filter.apply_to(df, conditions=conditions)
         return df

--- a/lumen/sources/xarray_sql.py
+++ b/lumen/sources/xarray_sql.py
@@ -255,6 +255,19 @@ class XArraySQLSource(BaseSQLSource):
         result = self._ctx.sql(sql_query)
         return result.to_pandas()
 
+    def fetch(self, sql_query, params=None):
+        """Fetch query results in `dataframe_backend`, built by DataFusion.
+
+        DataFusion is arrow native, so the to_pandas in execute is a
+        conversion this can skip entirely when another library was asked for.
+        """
+        result = self._ctx.sql(sql_query)
+        if self.dataframe_backend == 'polars':
+            return result.to_polars()
+        if self.dataframe_backend == 'pyarrow':
+            return result.to_arrow_table()
+        return result.to_pandas()
+
     def _build_sql(self, table, **query) -> str:
         """Build the SQL for a table query, applying filters and any
         sql_transforms. Shared by ``get`` and ``to_dataset``."""
@@ -273,7 +286,7 @@ class XArraySQLSource(BaseSQLSource):
 
     @cached
     def get(self, table, **query):
-        return self.execute(self._build_sql(table, **query))
+        return self.fetch(self._build_sql(table, **query))
 
     def to_dataset(self, table, **query):
         """Return the query result as a gridded ``xr.Dataset``.

--- a/lumen/tests/ai/test_agents.py
+++ b/lumen/tests/ai/test_agents.py
@@ -117,6 +117,51 @@ async def test_sql_agent(llm, duckdb_source, test_messages):
     )
     assert set(out_context) == {"data", "pipeline", "sql", "table", "source"}
 
+@pytest.mark.parametrize("backend", ["polars", "pyarrow"])
+async def test_sql_agent_summarises_the_source_frame_unconverted(llm, test_messages, backend):
+    """The summary is built from the source's own frame, not a pandas copy.
+
+    Asserted on the frame describe_data is handed, because that is the only
+    place the conversion would have happened; asserting on the summary text
+    would pass whether or not one occurred.
+    """
+    pytest.importorskip(backend)
+    import narwhals.stable.v2 as nw
+
+    from lumen.ai.agents import sql as sql_module
+
+    source = DuckDBSource(
+        tables={"nums": "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS t(n, g)"},
+        dataframe_backend=backend,
+    )
+    agent = SQLAgent(llm=llm)
+    context = {
+        "source": source,
+        "sources": [source],
+        "metaset": await get_metaset([source], ["nums"]),
+    }
+    SQLQueryWithTables = make_sql_model([(source.name, "nums")])
+    llm.set_responses([
+        SQLQueryWithTables(
+            query="SELECT n, g FROM nums", table_slug="nums_all", tables=["nums"]
+        ),
+    ])
+
+    seen = []
+    original = sql_module.describe_data
+
+    async def spy(df, *args, **kwargs):
+        seen.append(df)
+        return await original(df, *args, **kwargs)
+
+    with patch.object(sql_module, "describe_data", spy):
+        out, _ = await agent.respond(test_messages, context)
+
+    assert len(out) == 1
+    assert seen, "describe_data was never reached"
+    assert nw.from_native(seen[0]).implementation.name.lower() == backend
+
+
 @pytest.fixture
 def dirty_source():
     """A table lint_data has something to say about: a duplicated row, padded

--- a/lumen/tests/ai/test_utils.py
+++ b/lumen/tests/ai/test_utils.py
@@ -23,8 +23,9 @@ from lumen.ai.utils import (
     apply_changes, clean_sql, collapse_indexed_columns, content_to_text,
     count_tokens, describe_data, find_slug_by_table_name, format_msg_content,
     fuse_messages, get_schema, mutate_user_message, parse_huggingface_url,
-    render_template, report_error, retry_llm_output, serialize_image_content,
-    set_content_text, slug_to_table_name, truncate_to_tokens,
+    render_template, report_error, retry_llm_output, sanitize_column_names,
+    serialize_image_content, set_content_text, slug_to_table_name,
+    truncate_to_tokens,
 )
 from lumen.config import SOURCE_TABLE_SEPARATOR as SEP
 
@@ -936,3 +937,27 @@ class TestTruncateToTokens:
     def test_custom_marker(self):
         text = "\n".join(f"row {i}" for i in range(500))
         assert "elided, showing" in truncate_to_tokens(text, 60, marker="elided")
+
+
+@pytest.mark.parametrize("columns, expected", [
+    (["a b", "c!d"], ["a_b", "cd"]),
+    (["ok", "fine_2"], ["ok", "fine_2"]),
+    (["total ($)", "50% off"], ["total_", "50_off"]),
+    # Two names that sanitize to one keep both columns, as they always have.
+    (["a b", "a_b"], ["a_b", "a_b"]),
+])
+def test_sanitize_column_names(columns, expected):
+    df = pd.DataFrame([list(range(len(columns)))], columns=columns)
+    sanitized = sanitize_column_names(df)
+    assert list(sanitized.columns) == expected
+    assert sanitized.values.tolist() == df.values.tolist()
+
+
+def test_sanitize_column_names_leaves_the_caller_alone():
+    """The DeckGL agent renames a frame it does not own, so writing to the
+    result must not reach back into the pipeline's cached data."""
+    df = pd.DataFrame({"a b": [1, 2]})
+    sanitized = sanitize_column_names(df)
+    sanitized.iloc[0, 0] = 99
+    assert list(df.columns) == ["a b"]
+    assert df.iloc[0, 0] == 1

--- a/lumen/tests/sources/test_base.py
+++ b/lumen/tests/sources/test_base.py
@@ -370,6 +370,37 @@ async def test_base_sql_source_get_async():
     assert len(result_async_filtered) <= len(expected)  # Should be filtered
 
 
+def test_fetch_default_delegates_to_execute():
+    """A subclass that only implements execute keeps working through fetch.
+
+    The signature here is the one an out-of-tree subclass is likely to have:
+    no params argument at all. fetch has to pass params in a way that such a
+    subclass swallows rather than rejects.
+    """
+    from lumen.sources.base import BaseSQLSource
+
+    class MockSQLSource(BaseSQLSource):
+
+        def __init__(self, **params):
+            super().__init__(**params)
+            self.tables = {'test_table': 'test_table'}
+
+        def execute(self, sql_query, *args, **kwargs):
+            return pd.DataFrame({'id': [1, 2, 3]})
+
+        def get_tables(self):
+            return list(self.tables)
+
+        def get_sql_expr(self, table):
+            return f"SELECT * FROM {table}"
+
+    source = MockSQLSource()
+    assert source.dataframe_backend is None
+    fetched = source.fetch("SELECT * FROM test_table")
+    assert isinstance(fetched, pd.DataFrame)
+    assert_df_equal(fetched, source.execute("SELECT * FROM test_table"))
+
+
 def test_set_schema_cache_respects_cache_schema_flag(make_filesource):
     """Test that _set_schema_cache checks cache_schema, not cache_metadata.
 

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -1413,6 +1413,18 @@ def _backend_source():
     )
 
 
+def test_native_fetch_builds_an_arrow_table_not_a_reader():
+    """arrow() answers with a Table up to duckdb 1.3 and a RecordBatchReader
+    from 1.4, and Pipeline.data takes only the Table."""
+    pa = pytest.importorskip("pyarrow")
+
+    source = _backend_source()
+    source.dataframe_backend = 'pyarrow'
+    fetched = source.fetch("SELECT * FROM t")
+    assert isinstance(fetched, pa.Table)
+    assert fetched.num_rows == 20
+
+
 @pytest.mark.parametrize("backend", ["polars", "pyarrow"])
 def test_native_fetch_matches_pandas(backend):
     """A frame DuckDB builds natively must hold what the pandas one holds."""

--- a/lumen/tests/sources/test_duckdb.py
+++ b/lumen/tests/sources/test_duckdb.py
@@ -1401,6 +1401,113 @@ def test_duckdb_geometry_returns_geodataframe():
     assert str(result.geometry.dtype) == 'geometry'
 
 
+def _backend_source():
+    return DuckDBSource(
+        uri=':memory:',
+        initializers=[
+            "CREATE TABLE t AS SELECT i::BIGINT AS n, (i * 1.5) AS amount, "
+            "(DATE '2020-01-01' + i::INTEGER) AS day, "
+            "('c' || (i % 3)::VARCHAR) AS g FROM range(20) tbl(i)"
+        ],
+        tables={'t': 'SELECT * FROM t'},
+    )
+
+
+@pytest.mark.parametrize("backend", ["polars", "pyarrow"])
+def test_native_fetch_matches_pandas(backend):
+    """A frame DuckDB builds natively must hold what the pandas one holds."""
+    pytest.importorskip(backend)
+    from lumen.util import as_narwhals, as_pandas
+
+    query = "SELECT * FROM t"
+    native = _backend_source()
+    native.dataframe_backend = backend
+    fetched = native.fetch(query)
+    assert as_narwhals(fetched).implementation.name.lower() == backend
+
+    expected = _backend_source().fetch(query)
+    # check_dtype is off on purpose. DuckDB types i*1.5 as DECIMAL, which
+    # fetch_df widens to float64 while arrow and polars keep it a Decimal, and
+    # a DATE comes back as datetime.date through arrow but datetime64 through
+    # polars. The values are the same either way, which is what is asserted.
+    pd.testing.assert_frame_equal(
+        as_pandas(fetched).astype({'day': 'datetime64[us]'}),
+        expected.astype({'day': 'datetime64[us]'}),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize("backend", ["polars", "pyarrow"])
+def test_native_fetch_keeps_date_a_date(backend):
+    """A DATE must stay a date, not silently become a string or a number.
+
+    get fetches with date_as_object, so the pandas path yields datetime.date.
+    DuckDB's own frames type the column Date and date32 respectively; both are
+    real date types, and both have to carry the same days.
+    """
+    pytest.importorskip(backend)
+    import narwhals.stable.v2 as nw
+
+    native = _backend_source()
+    native.dataframe_backend = backend
+    frame = nw.from_native(native.fetch("SELECT * FROM t"))
+    assert isinstance(frame.collect_schema()['day'], (nw.Date, nw.Datetime))
+
+    expected = _backend_source().fetch("SELECT * FROM t")['day']
+    assert [d.year for d in expected] == [2020] * 20
+    days = frame.get_column('day').to_list()
+    assert [dt.date(d.year, d.month, d.day) for d in days] == list(expected)
+
+
+def _sql_geometry_source():
+    """A GEOMETRY table built in SQL alone, so no geopandas is needed.
+
+    The geopandas-backed _spatial_source skips wherever geopandas is absent,
+    which is every environment in pixi.toml, so a test written against it
+    never runs. The rule under test here holds without it.
+    """
+    try:
+        return DuckDBSource(
+            uri=':memory:',
+            initializers=[
+                "INSTALL spatial;", "LOAD spatial;",
+                "CREATE TABLE geo_tbl AS SELECT 'a' AS name, ST_Point(0, 0) AS geometry "
+                "UNION ALL SELECT 'b', ST_Point(1, 1)",
+            ],
+            tables={'geo': 'SELECT * FROM geo_tbl'},
+        )
+    except Exception as e:  # pragma: no cover - needs network on first install
+        pytest.skip(f"duckdb spatial extension unavailable: {e}")
+
+
+@pytest.mark.parametrize("backend", ["polars", "pyarrow"])
+def test_native_fetch_geometry_stays_pandas(backend):
+    """Geometry has no narwhals dtype, so it must not leave pandas at all.
+
+    Not merely 'is not fetched natively': converting the pandas frame after
+    fetching it is just as bad, because the column comes out the far side as
+    opaque bytes, drops from the schema, and renders a blank map with nothing
+    raising.
+    """
+    pytest.importorskip(backend)
+    source = _sql_geometry_source()
+    source.dataframe_backend = backend
+    result = source.get('geo')
+    assert isinstance(result, pd.DataFrame)
+    assert 'geometry' in result.columns
+    assert 'geometry' in source.get_schema('geo')
+
+
+def test_native_fetch_geometry_returns_geodataframe():
+    """With geopandas present the geometry column is still a real geometry."""
+    pytest.importorskip("polars")
+    source, gpd = _spatial_source()
+    source.dataframe_backend = 'polars'
+    result = source.get('geo')
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert str(result.geometry.dtype) == 'geometry'
+
+
 def test_duckdb_geometry_crs_read_from_column_type(tmp_path):
     """ST_Read reports a CRS-carrying column as GEOMETRY('EPSG:4326'), so the
     type must be matched by prefix and the CRS taken from it."""

--- a/lumen/tests/sources/test_xarray_sql.py
+++ b/lumen/tests/sources/test_xarray_sql.py
@@ -275,6 +275,28 @@ class TestSQLExecution:
         assert "lon" in df.columns
         assert "time" in df.columns
 
+    @pytest.mark.parametrize("backend", [None, "pandas", "polars", "pyarrow"])
+    def test_fetch_backends(self, synthetic_dataset, backend):
+        """DataFusion is arrow native, so fetch skips the to_pandas in execute."""
+        if backend not in (None, "pandas"):
+            pytest.importorskip(backend)
+        import narwhals.stable.v2 as nw
+
+        from lumen.util import as_pandas
+
+        source = XArraySQLSource(_dataset=synthetic_dataset, dataframe_backend=backend)
+        query = "SELECT lat, lon, temperature FROM temperature ORDER BY lat, lon LIMIT 5"
+        fetched = source.fetch(query)
+
+        if backend in (None, "pandas"):
+            assert isinstance(fetched, pd.DataFrame)
+        else:
+            assert nw.from_native(fetched).implementation.name.lower() == backend
+        # execute stays pandas whatever the backend, so the schema and
+        # metadata queries keep reading it the way they always have.
+        assert isinstance(source.execute(query), pd.DataFrame)
+        pd.testing.assert_frame_equal(as_pandas(fetched), source.execute(query))
+
     def test_select_columns(self, synthetic_dataset):
         source = XArraySQLSource(_dataset=synthetic_dataset)
         df = source.execute("SELECT lat, lon, temperature FROM temperature LIMIT 3")

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -8,6 +8,7 @@ pandas caller gets back exactly what it got before.
 import datetime as dt
 
 from decimal import Decimal
+from unittest.mock import patch
 
 import pandas as pd
 import param
@@ -817,3 +818,136 @@ def test_describe_data_summarises_a_dask_frame():
     summary = yaml.safe_load(describe_data_sync(dd.from_pandas(frame, npartitions=4)))
     assert summary["summary"]["data_shape"] == [rows, 2]
     assert summary["stats"]["i"]["count"] == PROFILE_SAMPLE_ROWS
+
+
+def _exploration_source(**params):
+    """A DuckDB table with the column types the preview has to normalise."""
+    from lumen.sources.duckdb import DuckDBSource
+
+    return DuckDBSource(
+        uri=":memory:", tables={"t": "SELECT * FROM t"},
+        initializers=[
+            "CREATE TABLE t AS SELECT i::BIGINT AS n, "
+            "('c' || (i % 3)::VARCHAR) AS g, "
+            "(DATE '2020-01-01' + INTERVAL (i) DAY)::DATE AS d, "
+            "(i * 1.5)::DECIMAL(10,2) AS amt FROM range(8) tbl(i)"
+        ],
+        **params,
+    )
+
+
+@pytest.mark.parametrize("backend", ["polars", "pyarrow"])
+async def test_exploration_preview_reads_the_source_frame_unconverted(backend):
+    """The exploration tool previews the source's own frame, not a pandas copy.
+
+    Asserted on the frame format_exploration_result is handed, because that is
+    the only place the conversion would have happened; asserting on the
+    rendered text would pass whether or not one occurred.
+    """
+    pytest.importorskip("duckdb")
+    pytest.importorskip(backend)
+    pytest.importorskip("pydantic", reason="lumen.ai needs the ai extra")
+    from lumen.ai.agents import sql as sql_module
+
+    source = _exploration_source(dataframe_backend=backend)
+    seen = []
+    original = sql_module.format_exploration_result
+
+    def spy(df):
+        seen.append(df)
+        return original(df)
+
+    with patch.object(sql_module, "format_exploration_result", spy):
+        await sql_module.execute_exploration_sql(
+            "t", "SELECT * FROM t", sources={("t", "t"): source}
+        )
+
+    assert seen, "format_exploration_result was never reached"
+    assert as_narwhals(seen[0]).implementation.name.lower() == backend
+
+
+@pytest.mark.parametrize("backend", ["polars", "pyarrow"])
+async def test_exploration_preview_renders_the_same_rows_on_any_backend(backend):
+    """A decimal and a date have to read as numbers and dates, not as str.
+
+    Which of the two arrives in an object column varies by library, since
+    pandas converts a DECIMAL to float itself while the others keep it, so
+    the dtype line is the part most likely to drift between backends.
+    """
+    pytest.importorskip("duckdb")
+    pytest.importorskip(backend)
+    pytest.importorskip("pydantic", reason="lumen.ai needs the ai extra")
+    from lumen.ai.agents.sql import execute_exploration_sql
+
+    async def preview(**params):
+        source = _exploration_source(**params)
+        return await execute_exploration_sql(
+            "t", "SELECT * FROM t", sources={("t", "t"): source}
+        )
+
+    expected = await preview()
+    result = await preview(dataframe_backend=backend)
+
+    def rendered_rows(text):
+        return [line for line in text.splitlines() if line.startswith("|")]
+
+    def dtypes(text):
+        line = next(line for line in text.splitlines() if line.startswith("Columns"))
+        return dict(
+            part.split(": ") for part in line.split(" — ", 1)[1].split(", ")
+        )
+
+    assert rendered_rows(result) == rendered_rows(expected)
+    assert "8 rows x 4 columns" in result
+    # The time unit differs (polars reads a DATE as ms, pandas as us), so the
+    # assertion is that it is a datetime at all rather than the exact dtype.
+    for reported in (dtypes(expected), dtypes(result)):
+        assert reported["amt"] == "float64"
+        assert reported["d"].startswith("datetime64")
+        assert reported["n"] == "int64"
+
+
+@pytest.mark.parametrize("backend", [None, "polars", "pyarrow"])
+async def test_exploration_preview_handles_an_empty_result(backend):
+    """No rows must still report the columns, on any backend."""
+    pytest.importorskip("duckdb")
+    if backend is not None:
+        pytest.importorskip(backend)
+    pytest.importorskip("pydantic", reason="lumen.ai needs the ai extra")
+    from lumen.ai.agents.sql import execute_exploration_sql
+
+    source = _exploration_source(dataframe_backend=backend)
+    result = await execute_exploration_sql(
+        "t", "SELECT * FROM t WHERE n > 99", sources={("t", "t"): source}
+    )
+    assert "0 rows x 4 columns" in result
+    assert "The query returned no rows." in result
+
+
+def test_exploration_preview_converts_only_the_rendered_cells():
+    """The preview must not pull the whole frame through pandas.
+
+    A column of an extension type pandas cannot hold is the assertion: it
+    survives conversion of the five previewed rows and would raise if the
+    whole frame were converted.
+    """
+    pl = pytest.importorskip("polars")
+    pytest.importorskip("pydantic", reason="lumen.ai needs the ai extra")
+    from lumen.ai.agents.sql import (
+        EXPLORATION_PREVIEW_COLS, EXPLORATION_PREVIEW_ROWS,
+        format_exploration_result,
+    )
+
+    rows = 5000
+    frame = pl.DataFrame({
+        f"c{i}": pl.Series(range(rows), dtype=pl.Int64)
+        for i in range(EXPLORATION_PREVIEW_COLS + 5)
+    })
+    result = format_exploration_result(frame)
+    assert f"{rows} rows x {EXPLORATION_PREVIEW_COLS + 5} columns" in result
+    assert f"first {EXPLORATION_PREVIEW_COLS} columns" in result
+    # The column past the cap must not appear anywhere in the preview.
+    assert f"c{EXPLORATION_PREVIEW_COLS}" not in result
+    assert len([line for line in result.splitlines() if line.startswith("|")]) == (
+        EXPLORATION_PREVIEW_ROWS + 2  # header and the markdown rule
+    )

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -638,6 +638,115 @@ async def test_get_frame_skips_the_pandas_conversion(constructor):
     assert isinstance(await get_data(pipeline), pd.DataFrame)
 
 
+@pytest.mark.parametrize("backend", [None, "pandas", "polars", "pyarrow"])
+def test_sql_source_dataframe_backend(backend, tmp_path):
+    """dataframe_backend picks the library get returns, and nothing else."""
+    duckdb = pytest.importorskip("duckdb")
+    if backend not in (None, "pandas"):
+        pytest.importorskip(backend)
+    from lumen.sources.duckdb import DuckDBSource
+
+    def source(**params):
+        return DuckDBSource(
+            uri=":memory:", tables={"t": "SELECT * FROM t"},
+            initializers=[
+                "CREATE TABLE t AS SELECT i::BIGINT AS n, "
+                "('c' || (i % 3)::VARCHAR) AS g FROM range(50) tbl(i)"
+            ],
+            **params,
+        )
+
+    default, pinned = source(), source(dataframe_backend=backend)
+    frame = pinned.get("t")
+    assert rows(frame) == 50
+
+    if backend in (None, "pandas"):
+        assert isinstance(frame, pd.DataFrame)
+    else:
+        assert as_narwhals(frame).implementation.name.lower() == backend
+
+    # execute and everything reading it stay on pandas whatever get returns,
+    # which is what keeps the .iloc and dtype.kind reads in get_schema working.
+    assert isinstance(pinned.execute("SELECT * FROM t"), pd.DataFrame)
+    # Sorted because array_agg(DISTINCT) fixes no order, so two runs of the
+    # same query disagree on it whatever the backend.
+    def schema(source):
+        return {
+            name: {k: sorted(v) if k == "enum" else v for k, v in col.items()}
+            if isinstance(col, dict) else col
+            for name, col in source.get_schema("t").items()
+        }
+    assert schema(pinned) == schema(default)
+    pd.testing.assert_frame_equal(as_pandas(frame), default.get("t"))
+
+
+def test_sql_source_backend_change_clears_the_cache():
+    """The backend is a param, so flipping it must not serve the old frame."""
+    pytest.importorskip("duckdb")
+    pl = pytest.importorskip("polars")
+    from lumen.sources.duckdb import DuckDBSource
+
+    source = DuckDBSource(
+        uri=":memory:", tables={"t": "SELECT * FROM t"},
+        initializers=["CREATE TABLE t AS SELECT i::BIGINT AS n FROM range(5) tbl(i)"],
+    )
+    assert isinstance(source.get("t"), pd.DataFrame)
+    source.dataframe_backend = "polars"
+    assert isinstance(source.get("t"), pl.DataFrame)
+
+
+@pytest.mark.parametrize("backend", ["polars", "pyarrow"])
+async def test_sql_summary_reads_the_source_frame_unconverted(backend):
+    """The LLM summary path takes the source's own frame, not a pandas copy.
+
+    This is the end of the chain the dataframe_backend param exists for: a
+    DuckDB source builds polars or arrow, the Pipeline keeps it, and the
+    summary is generated from it without the whole frame ever reaching pandas.
+    """
+    pytest.importorskip("duckdb")
+    pytest.importorskip(backend)
+    pytest.importorskip("pydantic", reason="lumen.ai needs the ai extra")
+    from lumen.ai.utils import describe_data_sync, get_frame
+    from lumen.sources.duckdb import DuckDBSource
+
+    def source(**params):
+        return DuckDBSource(
+            uri=":memory:", tables={"t": "SELECT * FROM t"},
+            initializers=[
+                "CREATE TABLE t AS SELECT i::BIGINT AS n, "
+                "('c' || (i % 3)::VARCHAR) AS g FROM range(50) tbl(i)"
+            ],
+            **params,
+        )
+
+    frame = await get_frame(Pipeline(source=source(dataframe_backend=backend), table="t"))
+    assert as_narwhals(frame).implementation.name.lower() == backend
+    assert len(frame) == 50  # what the empty-result check reads
+
+    expected = await get_frame(Pipeline(source=source(), table="t"))
+    assert isinstance(expected, pd.DataFrame)
+    assert describe_data_sync(frame) == describe_data_sync(expected)
+
+
+@pytest.mark.parametrize("backend", [None, "polars", "pyarrow"])
+async def test_empty_result_is_detectable_on_any_backend(backend):
+    """The SQL agent rejects an empty result with len, not the pandas .empty."""
+    pytest.importorskip("duckdb")
+    if backend is not None:
+        pytest.importorskip(backend)
+    pytest.importorskip("pydantic", reason="lumen.ai needs the ai extra")
+    from lumen.ai.utils import get_frame
+    from lumen.sources.duckdb import DuckDBSource
+
+    source = DuckDBSource(
+        tables={"e": "SELECT * FROM (VALUES (1, 'a')) AS t(n, g) WHERE n > 99"},
+        dataframe_backend=backend,
+    )
+    frame = await get_frame(Pipeline(source=source, table="e"))
+    assert len(frame) == 0
+    assert as_narwhals(frame).columns == ["n", "g"]  # empty of rows, not columns
+
+
 def test_describe_data_keeps_decimal_and_date_numeric():
     """A money or date column must be described, not listed as an enum.
 

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -638,6 +638,65 @@ async def test_get_frame_skips_the_pandas_conversion(constructor):
     assert isinstance(await get_data(pipeline), pd.DataFrame)
 
 
+def test_describe_data_keeps_decimal_and_date_numeric():
+    """A money or date column must be described, not listed as an enum.
+
+    The constructor fixture cannot express this: it builds from a dict, and a
+    dict of Decimal or date lands on object in pandas, which is the very dtype
+    under test. Each backend's frame is built with its own type instead.
+    """
+    pl = pytest.importorskip("polars")
+    pa = pytest.importorskip("pyarrow")
+    pytest.importorskip("pydantic", reason="lumen.ai needs the ai extra")
+    from lumen.ai.utils import describe_data_sync
+
+    rows = 200
+    decimals = [Decimal(f"{i}.50") for i in range(rows)]
+    dates = [dt.date(2020, 1, 1) + dt.timedelta(days=i) for i in range(rows)]
+    # A null is what makes an integer widen, so the column has to carry one.
+    ints = [None if i % 50 == 0 else i for i in range(rows)]
+    labels = ["a", "b"] * (rows // 2)
+
+    frames = [
+        pd.DataFrame({
+            "amount": [i + 0.5 for i in range(rows)],
+            "day": pd.to_datetime(dates),
+            "n": pd.array(ints, dtype="Int64"),
+            "g": labels,
+        }),
+        # pandas produces object columns of Decimal and date for a DECIMAL or
+        # DATE result of its own, so this is not only about other libraries.
+        pd.DataFrame({
+            "amount": decimals,
+            "day": dates,
+            "n": pd.array(ints, dtype="Int64"),
+            "g": labels,
+        }),
+        pl.DataFrame({
+            "amount": pl.Series(decimals, dtype=pl.Decimal(12, 2)),
+            "day": pl.Series(dates, dtype=pl.Date),
+            "n": pl.Series(ints, dtype=pl.Int64),
+            "g": labels,
+        }),
+        pa.table({
+            "amount": pa.array(decimals, pa.decimal128(12, 2)),
+            "day": pa.array(dates, pa.date32()),
+            "n": pa.array(ints, pa.int64()),
+            "g": labels,
+        }),
+    ]
+    summaries = [describe_data_sync(frame) for frame in frames]
+
+    # safe_load is the assertion, not a convenience: an object column of
+    # Decimal renders as !!python/object/apply, which SafeLoader refuses.
+    expected, *rest = [yaml.safe_load(summary) for summary in summaries]
+    assert expected["stats"]["amount"]["mean"] == 100
+    assert "enum" not in expected["stats"]["day"]
+    assert expected["tail"]["n"] == 198
+    for summary in rest:
+        assert summary == expected
+
+
 def test_describe_data_summarises_a_dask_frame():
     """A dask frame answers shape with a Delayed, so it must be computed."""
     dd = pytest.importorskip("dask.dataframe")

--- a/lumen/ui/sources.py
+++ b/lumen/ui/sources.py
@@ -14,7 +14,7 @@ from panel.reactive import ReactiveHTML
 
 from lumen.sources.base import Source
 from lumen.state import state as lm_state
-from lumen.util import catch_and_notify
+from lumen.util import as_pandas, catch_and_notify
 
 from .base import WizardItem
 from .fast import FastComponent
@@ -102,7 +102,8 @@ class SourceEditor(FastComponent, Editor):
     def _load_table_data(self, event):
         if self._source is None:
             self._update_preview()
-        self.preview.value = self._source.get(self._select_table.value)
+        # Tabulator reads .index off its value, which only pandas has.
+        self.preview.value = as_pandas(self._source.get(self._select_table.value))
 
     @property
     def thumbnail(self):


### PR DESCRIPTION
The exploration SQL tool read its result through `execute`, which is contracted to return pandas, so a source set to build polars or pyarrow paid for a full copy of the result before the model saw five rows of it. It reads through `fetch` now and converts only the cells it renders, taking a 5M row preview from 1.09s and 468MB to 0.48s and 70MB.

Fixes #2041
