### PR TITLE
Give Astype and HistoryTransform narwhals paths

### DIFF
--- a/docs/configuration/spec/pipelines.md
+++ b/docs/configuration/spec/pipelines.md
@@ -262,7 +262,7 @@ transforms:
 | `aggregate` | Group and compute stats | Average sales by region |
 | `sort` | Order rows | Sort by date |
 | `query` | SQL-like filtering | `price > 100` |
-| `astype` | Change column data types | Convert to datetime |
+| `as_type` | Change column data types | Convert to datetime |
 | `project` | Create derived columns | `total = price * quantity` |
 
 ## Building pipelines declaratively

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -8,6 +8,7 @@ pandas caller gets back exactly what it got before.
 import datetime as dt
 
 from decimal import Decimal
+from types import SimpleNamespace
 
 import pandas as pd
 import param
@@ -203,7 +204,23 @@ def test_history_matches_pandas(constructor):
         assert got["i"].tolist() == expected["i"].tolist()
 
 
-def test_history_adds_date_column(constructor):
+def test_history_adds_date_column(constructor, monkeypatch):
+    """The stamp is taken once per call and shared by that call's rows.
+
+    The clock is fixed because Windows only advances it every 15 ms or so,
+    which is long enough for two calls to land on the same instant and read
+    as one stamp per frame rather than one per call.
+    """
+    from lumen.transforms import base
+
+    ticks = iter([dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 2)])
+
+    class FixedClock(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return next(ticks)
+
+    monkeypatch.setattr(base, "dt", SimpleNamespace(datetime=FixedClock, date=dt.date))
     frame = constructor({"i": [0, 1]})
     transform = HistoryTransform(length=2, date_column="ts")
     accumulate(transform, frame)
@@ -211,8 +228,7 @@ def test_history_adds_date_column(constructor):
     assert type(result) is type(frame)
     stamps = as_pandas(result)["ts"]
     assert stamps.dtype.kind == "M"
-    # One timestamp per call rather than per row, so two calls give two values.
-    assert stamps.nunique() == 2
+    assert stamps.tolist() == [dt.datetime(2020, 1, 1)] * 2 + [dt.datetime(2020, 1, 2)] * 2
 
 
 def test_history_buffer_survives_a_failed_concat():

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -232,6 +232,19 @@ def test_history_buffer_survives_a_failed_concat():
     assert rows(accumulate(transform, pl.DataFrame({"v": [3.0]}))) == 3
 
 
+def test_history_announces_the_conversion_once(caplog):
+    """A converted history must not re-announce itself on every render."""
+    pl = pytest.importorskip("polars")
+    transform = HistoryTransform(length=10)
+    with caplog.at_level("WARNING"):
+        accumulate(transform, pl.DataFrame({"v": [1.0]}))
+        accumulate(transform, pl.DataFrame({"v": [2]}))
+        assert caplog.text.count("converted to pandas") == 1
+        accumulate(transform, pl.DataFrame({"v": [3.0]}))
+        accumulate(transform, pl.DataFrame({"v": [4.0]}))
+        assert caplog.text.count("converted to pandas") == 1
+
+
 def test_iloc_matches_across_backends(constructor):
     frame = constructor({"i": [0, 1, 2, 3]})
     assert as_pandas(Iloc.apply_to(frame, start=1, end=3))["i"].tolist() == [1, 2]

--- a/lumen/tests/test_narwhals_boundary.py
+++ b/lumen/tests/test_narwhals_boundary.py
@@ -18,8 +18,8 @@ from lumen.filters.base import ConstantFilter
 from lumen.pipeline import DataFrame as PipelineDataFrame, Pipeline
 from lumen.sources.base import DerivedSource, InMemorySource, Source
 from lumen.transforms.base import (
-    Aggregate, Columns, DropNA, Filter as FilterTransform, Iloc, Melt, Query,
-    Rename, Sample, Sort,
+    Aggregate, Columns, DropNA, Filter as FilterTransform, HistoryTransform,
+    Iloc, Melt, Query, Rename, Sample, Sort,
 )
 from lumen.util import (
     _NULLABLE_DTYPES, as_narwhals, as_pandas, get_dataframe_schema,
@@ -170,6 +170,66 @@ def test_columns_matches_across_backends(constructor):
     frame = constructor({"i": [0, 1], "s": ["a", "b"]})
     selected = Columns.apply_to(frame, columns=["s"])
     assert as_narwhals(selected).collect_schema().names() == ["s"]
+
+
+# HistoryTransform is the one transform that keeps state, so it cannot go in
+# the parity matrix: apply_to builds a fresh instance per call and would only
+# ever exercise the first entry, which is the one path with no concat in it.
+
+
+def accumulate(transform, frame):
+    """Run one step the way a Pipeline runs it, coercing before applying."""
+    return transform.apply(transform._coerce(frame))
+
+
+def test_history_accumulates_and_preserves_backend(constructor):
+    frame = constructor({"i": [0, 1]})
+    transform = HistoryTransform(length=2)
+    results = [accumulate(transform, frame) for _ in range(4)]
+    assert [rows(result) for result in results] == [2, 4, 4, 4]
+    # The row counts above come out the same whether or not the narwhals path
+    # ran, because _coerce would have converted first. The type is what says
+    # the frame reached the end as the library it started as.
+    assert [type(result) for result in results] == [type(frame)] * 4
+
+
+def test_history_matches_pandas(constructor):
+    """The accumulated frame is the one pandas would have built, every step."""
+    frames = [{"i": [0, 1]}, {"i": [2]}, {"i": [3, 4]}]
+    reference, result = HistoryTransform(length=2), HistoryTransform(length=2)
+    for data in frames:
+        expected = accumulate(reference, pd.DataFrame(data))
+        got = as_pandas(accumulate(result, constructor(data)))
+        assert got["i"].tolist() == expected["i"].tolist()
+
+
+def test_history_adds_date_column(constructor):
+    frame = constructor({"i": [0, 1]})
+    transform = HistoryTransform(length=2, date_column="ts")
+    accumulate(transform, frame)
+    result = accumulate(transform, frame)
+    assert type(result) is type(frame)
+    stamps = as_pandas(result)["ts"]
+    assert stamps.dtype.kind == "M"
+    # One timestamp per call rather than per row, so two calls give two values.
+    assert stamps.nunique() == 2
+
+
+def test_history_buffer_survives_a_failed_concat():
+    """A concat that raises must not leave its frame in the buffer.
+
+    _try_narwhals runs the pandas branch on any failure, so a buffer committed
+    before the concat succeeded would accumulate the same frame twice.
+    """
+    pl = pytest.importorskip("polars")
+    transform = HistoryTransform(length=5)
+    accumulate(transform, pl.DataFrame({"v": [1.0]}))
+    # Int64 against Float64 is a polars SchemaError, so narwhals gives up.
+    result = as_pandas(accumulate(transform, pl.DataFrame({"v": [2]})))
+    assert result["v"].tolist() == [1.0, 2.0]
+    assert len(transform._buffer) == 2
+    # and the history keeps accumulating rather than restarting
+    assert rows(accumulate(transform, pl.DataFrame({"v": [3.0]}))) == 3
 
 
 def test_iloc_matches_across_backends(constructor):

--- a/lumen/tests/test_narwhals_parity.py
+++ b/lumen/tests/test_narwhals_parity.py
@@ -248,6 +248,28 @@ def test_dtypes_match_pandas(constructor, transform, kwargs, frame_name):
     assert result.dtypes.astype(str).to_dict() == reference.dtypes.astype(str).to_dict()
 
 
+@pytest.mark.parametrize("dtype", ['uint64', 'int32', 'float64', 'float32'])
+def test_astype_refuses_a_datetime_like_pandas(constructor, dtype):
+    """int64 is the only numeric target pandas lets a datetime out to.
+
+    polars hands back the epoch as a number for the rest instead of raising,
+    so a spec pandas rejects would come back holding microseconds.
+    """
+    data = {'d': [dt.datetime(2021, 12, 31), dt.datetime(2020, 1, 1)]}
+    with pytest.raises(Exception) as expected:
+        Astype.apply_to(pd.DataFrame(data), dtypes={'d': dtype})
+    with pytest.raises(type(expected.value)):
+        Astype.apply_to(constructor(data), dtypes={'d': dtype})
+
+
+def test_astype_still_casts_a_datetime_to_int64(constructor):
+    """The one temporal cast pandas allows must not be refused with the rest."""
+    data = {'d': [dt.datetime(2021, 12, 31), dt.datetime(2020, 1, 1)]}
+    reference = as_pandas(Astype.apply_to(pd.DataFrame(data), dtypes={'d': 'int64'}))
+    result = as_pandas(Astype.apply_to(constructor(data), dtypes={'d': 'int64'}))
+    assert result['d'].tolist() == reference['d'].tolist()
+
+
 @pytest.mark.parametrize("frame_name, column", [
     ('nulls', 'v'), ('nan', 'v'), ('nullable', 'i'),
 ])

--- a/lumen/tests/test_narwhals_parity.py
+++ b/lumen/tests/test_narwhals_parity.py
@@ -349,3 +349,52 @@ def test_filter_never_crashes_on_odd_values(constructor, value):
         assert len(as_pandas(
             Filter.apply_to(constructor(data), conditions=[(column, value)])
         )) == expected
+
+
+# Every source dtype an Astype spec is likely to meet, against every target it
+# is likely to ask for. Enumerating the pairs rather than picking the ones that
+# looked risky is what found three divergences the hand-written cases missed:
+# a null cast to an integer, a datetime cast to anything but int64, and a
+# category taking its order of appearance.
+ASTYPE_SOURCES = {
+    'int': [3, 1, 2, 1],
+    'float': [3.5, 1.0, 2.5, 1.0],
+    'float_null': [3.0, None, 2.0, 1.0],
+    'str_num': ['3', '1', '2', '1'],
+    'str_txt': ['b', 'a', 'c', 'a'],
+    'str_null': ['b', None, 'c', 'a'],
+    'bool': [True, False, True, True],
+    'datetime': [dt.datetime(2021, 12, 31), dt.datetime(2020, 1, 1),
+                 dt.datetime(2020, 6, 5), dt.datetime(2020, 1, 1)],
+}
+
+ASTYPE_TARGETS = [
+    'int64', 'int32', 'uint8', 'float64', 'float32', 'str', 'bool',
+    'datetime64[ns]', 'category', 'Int64', 'object', 'complex128',
+]
+
+
+def _cast_outcome(frame, dtype):
+    """What Astype does to the column, or the error it raises trying."""
+    try:
+        column = as_pandas(Astype.apply_to(frame, dtypes={'c': dtype}))['c']
+    except Exception as e:
+        return ('raised', type(e).__name__)
+    categories = (
+        list(column.cat.categories) if str(column.dtype) == 'category' else None
+    )
+    return ([str(v) for v in column.tolist()], str(column.dtype), categories)
+
+
+@pytest.mark.parametrize("source", list(ASTYPE_SOURCES))
+@pytest.mark.parametrize("dtype", ASTYPE_TARGETS)
+def test_astype_never_disagrees_with_the_pandas_path(constructor, source, dtype):
+    """Whatever the narwhals path answers, the pandas path must answer too.
+
+    The reference is the same frame handed to the pandas path rather than a
+    pandas-native frame, because a null column reaches pandas as a nullable
+    dtype and would otherwise look like a difference this transform caused.
+    """
+    frame = constructor({'c': ASTYPE_SOURCES[source]})
+    reference = as_pandas(frame).copy()
+    assert _cast_outcome(frame, dtype) == _cast_outcome(reference, dtype)

--- a/lumen/tests/test_narwhals_parity.py
+++ b/lumen/tests/test_narwhals_parity.py
@@ -248,6 +248,24 @@ def test_dtypes_match_pandas(constructor, transform, kwargs, frame_name):
     assert result.dtypes.astype(str).to_dict() == reference.dtypes.astype(str).to_dict()
 
 
+@pytest.mark.parametrize("frame_name, column", [
+    ('nulls', 'v'), ('nan', 'v'), ('nullable', 'i'),
+])
+def test_astype_refuses_a_missing_value_like_pandas(constructor, frame_name, column):
+    """Where pandas refuses a cast, no backend may quietly answer instead.
+
+    numpy has no missing integer, so pandas rejects the whole column. polars
+    and pyarrow write a null, which reads as a successful cast and leaves the
+    frame holding values pandas would never have produced.
+    """
+    data = FRAMES[frame_name]
+    spec = {'dtypes': {column: 'int64'}}
+    with pytest.raises(Exception) as expected:
+        Astype.apply_to(pd.DataFrame(data), **spec)
+    with pytest.raises(type(expected.value)):
+        Astype.apply_to(constructor(data), **spec)
+
+
 @pytest.mark.parametrize("transform, kwargs, frame_name", [
     pytest.param(t, k, f, id=f"{t.__name__}-{f}-{sorted(k.items())}")
     for t, k, f in CASES if t is Astype

--- a/lumen/tests/test_narwhals_parity.py
+++ b/lumen/tests/test_narwhals_parity.py
@@ -14,7 +14,8 @@ import pandas as pd
 import pytest
 
 from lumen.transforms.base import (
-    Aggregate, Columns, DropNA, Filter, Iloc, Melt, Rename, Sample, Sort,
+    Aggregate, Astype, Columns, DropNA, Filter, Iloc, Melt, Rename, Sample,
+    Sort,
 )
 from lumen.util import as_pandas
 
@@ -96,6 +97,22 @@ CASES = [
     (DropNA, {'how': 'all'}, 'nullable'),
     (Sort, {'by': []}, 'nullable'),
     (Aggregate, {'by': ['g'], 'with_index': False, 'method': 'median'}, 'nullable'),
+    (Astype, {'dtypes': {'i': 'float64'}}, 'plain'),
+    (Astype, {'dtypes': {'v': 'int64'}}, 'plain'),
+    (Astype, {'dtypes': {'i': 'uint8'}}, 'plain'),
+    (Astype, {'dtypes': {'v': 'float32'}}, 'plain'),
+    (Astype, {'dtypes': {'absent': 'int64'}}, 'plain'),
+    (Astype, {'dtypes': {'i': 'float64'}}, 'nulls'),
+    # Targets narwhals spells differently, so each converts rather than
+    # answering differently: a boolean is 'true' to polars and 'True' to
+    # pandas, an integer is a date to polars and a count of nanoseconds to
+    # pandas, and a category takes its order of appearance where pandas sorts
+    # it. Int64 and int64 are one narwhals dtype, so a nullable spec cannot
+    # come back as the dtype that was asked for.
+    (Astype, {'dtypes': {'i': 'Int64'}}, 'plain'),
+    (Astype, {'dtypes': {'g': 'category'}}, 'plain'),
+    (Astype, {'dtypes': {'v': 'str'}}, 'plain'),
+    (Astype, {'dtypes': {'i': 'datetime64[ns]'}}, 'plain'),
 ]
 
 # The subset of CASES above that converts to pandas on a frame holding a
@@ -150,14 +167,32 @@ def test_transform_matches_pandas(constructor, transform, kwargs, frame_name):
     pd.testing.assert_frame_equal(result, reference, check_dtype=False)
 
 
-# Specs that deliberately fall back: pandas-only options, or aggregations whose
-# narwhals meaning differs from the pandas one. Each is still checked for the
-# same answer above; this list only records that the fallback is intentional.
+# Specs that deliberately fall back: pandas-only options, aggregations whose
+# narwhals meaning differs from the pandas one, or a cast target narwhals
+# spells differently. Each is still checked for the same answer above; this
+# list only records that the fallback is intentional.
 FALLS_BACK = {
     ('Aggregate', 'nunique'), ('Aggregate', 'prod'), ('Aggregate', 'median'),
     ('Aggregate', 'first'), ('Aggregate', 'count'),
     ('DropNA', 'all'), ('Melt', '[]'), ('Sort', 'noby'),
+    ('Astype', 'Int64'), ('Astype', 'str'), ('Astype', 'datetime64[ns]'),
+    ('Astype', 'category'),
 }
+
+
+def _marker(transform, kwargs):
+    """The part of a spec that decides whether the narwhals path is taken.
+
+    Astype decides on the dtype it is asked for rather than on an option, so
+    the value has to be reachable here and not just the parameter name.
+    """
+    if transform is Astype:
+        return ','.join(sorted(str(d) for d in kwargs['dtypes'].values()))
+    return (
+        kwargs.get('method') or ('[]' if kwargs.get('value_vars') == [] else None)
+        or ('all' if kwargs.get('how') == 'all' else None)
+        or ('noby' if kwargs.get('by') == [] else None)
+    )
 
 
 @pytest.mark.parametrize("transform, kwargs, frame_name", [
@@ -165,13 +200,7 @@ FALLS_BACK = {
     for t, k, f in CASES
 ])
 def test_native_path_is_actually_taken(constructor, caplog, transform, kwargs, frame_name):
-    marker = (
-        transform.__name__,
-        kwargs.get('method') or ('[]' if kwargs.get('value_vars') == [] else None)
-        or ('all' if kwargs.get('how') == 'all' else None)
-        or ('noby' if kwargs.get('by') == [] else None)
-    )
-    if marker in FALLS_BACK:
+    if (transform.__name__, _marker(transform, kwargs)) in FALLS_BACK:
         pytest.skip('documented fallback')
     with caplog.at_level('WARNING'):
         transform.apply_to(constructor(FRAMES[frame_name]), **kwargs)
@@ -194,21 +223,48 @@ def test_row_order_matches_pandas(constructor, transform, kwargs, frame_name):
         [_missing_to_none(r) for r in reference.values.tolist()]
 
 
+# The fallbacks above, plus every Astype case: the requested dtype is the whole
+# contract of that transform, so a case of it that only compared values would
+# be checking the one thing it cannot get wrong.
+DTYPE_EXACT = NULLABLE_FALLBACKS + [c for c in CASES if c[0] is Astype]
+
+
 @pytest.mark.parametrize("transform, kwargs, frame_name", [
     pytest.param(t, k, f, id=f"{t.__name__}-{f}-{sorted(k.items())}")
-    for t, k, f in NULLABLE_FALLBACKS
+    for t, k, f in DTYPE_EXACT
 ])
-def test_fallback_dtypes_match_pandas(constructor, transform, kwargs, frame_name):
+def test_dtypes_match_pandas(constructor, transform, kwargs, frame_name):
     """The comparison above passes check_dtype=False; this is the dtype half.
 
     A configuration that converts must come back with the dtypes the pandas
     path produces, or two adjacent configurations of one transform disagree on
-    the schema and an id renders as 3.0.
+    the schema and an id renders as 3.0. Compared as pandas dtypes rather than
+    as a narwhals schema because narwhals calls both Int64 and int64 Int64,
+    which is exactly the difference this has to see.
     """
     data = FRAMES[frame_name]
     reference = as_pandas(transform.apply_to(pd.DataFrame(data), **kwargs))
     result = as_pandas(transform.apply_to(constructor(data), **kwargs))
     assert result.dtypes.astype(str).to_dict() == reference.dtypes.astype(str).to_dict()
+
+
+@pytest.mark.parametrize("transform, kwargs, frame_name", [
+    pytest.param(t, k, f, id=f"{t.__name__}-{f}-{sorted(k.items())}")
+    for t, k, f in CASES if t is Astype
+])
+def test_astype_keeps_its_backend(constructor, transform, kwargs, frame_name):
+    """Comparing dtypes alone would pass without the port at all.
+
+    The pandas fallback produces the same dtypes as the pandas path by
+    definition, so the only assertion that can tell a native cast from a
+    converted one is the type of the frame that comes back.
+    """
+    frame = constructor(FRAMES[frame_name])
+    result = transform.apply_to(frame, **kwargs)
+    if (transform.__name__, _marker(transform, kwargs)) in FALLS_BACK:
+        assert isinstance(result, pd.DataFrame)
+    else:
+        assert type(result) is type(frame)
 
 
 def test_schema_matches_pandas_over_dtypes(constructor):

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -55,6 +55,35 @@ def _is_missing(value):
     return value is None or (isinstance(value, float) and math.isnan(value))
 
 
+def _narwhals_dtype(dtype):
+    """Return the narwhals dtype to cast to, or refuse the cast.
+
+    narwhals has no public parser for a dtype name and every
+    native_to_narwhals_dtype is private to a backend, so the spec is resolved
+    through an empty pandas column. That reuses pandas' own parser and
+    narwhals' own mapping instead of restating either as a table here, and it
+    takes whatever a spec can carry: a string, a builtin, a numpy dtype or an
+    extension dtype instance.
+
+    Only a numeric target is allowed through, because a shared dtype name is
+    not a shared conversion and the disagreements are silent. pyarrow renders
+    1.0 as '1' where pandas renders '1.0', both spell a boolean 'true' where
+    pandas spells it 'True', polars reads an integer as a date rather than a
+    count of nanoseconds, and a category takes its order of appearance where
+    pandas sorts it, which decides how it later sorts and groups. None of
+    those raise, so nothing downstream could catch them.
+    """
+    asked = pd.api.types.pandas_dtype(dtype)
+    resolved = nw.from_native(pd.Series([], dtype=dtype), series_only=True).dtype
+    if not resolved.is_numeric():
+        raise NotImplementedError(f'{dtype!r} does not cast alike on every backend')
+    if pd.api.types.pandas_dtype(nw.Schema({'c': resolved}).to_pandas()['c']) != asked:
+        # Int64 and int64 are one narwhals dtype, so a nullable spec would come
+        # back as the numpy dtype rather than the one that was asked for.
+        raise NotImplementedError(f'{dtype!r} has no distinct narwhals dtype')
+    return resolved
+
+
 class Transform(MultiTypeComponent):
     """
     `Transform` components implement transforms of `DataFrame` objects.
@@ -465,9 +494,16 @@ class HistoryTransform(Transform):
     length = param.Integer(default=10, bounds=(1, None), doc="""
         Accumulates a history of data.""")
 
-    transform_type = 'history'
+    transform_type: ClassVar[str] = 'history'
 
-    _field_params = ['date_column']
+    _field_params: ClassVar[list[str]] = ['date_column']
+
+    # A buffered lazy frame is a query rather than a snapshot: collecting it
+    # later returns whatever the source holds then, so a history of ten
+    # entries would record the present ten times over.
+    _lazy: ClassVar[bool] = False
+
+    _narwhals: ClassVar[bool] = True
 
     def __init__(self, **params):
         super().__init__(**params)
@@ -489,12 +525,33 @@ class HistoryTransform(Transform):
         DataFrame
             A DataFrame containing the buffered history of the data.
         """
+        def build(frame):
+            if self.date_column:
+                frame = frame.with_columns(
+                    nw.lit(dt.datetime.now()).alias(self.date_column)
+                )
+            buffer = [*self._buffer, frame][-self.length:]
+            # Column names drift as a source changes shape, and only diagonal
+            # unions them the way pd.concat does.
+            result = nw.concat(buffer, how='diagonal') if len(buffer) > 1 else buffer[0]
+            # Recorded only once the concat has succeeded: _try_narwhals runs
+            # the pandas branch below on any failure, and a buffer already
+            # holding this frame would accumulate it a second time.
+            self._buffer[:] = buffer
+            return result
+
+        result, table = self._try_narwhals(table, build)
+        if result is not None:
+            return result
         if self.date_column:
             table = table.copy()
             table[self.date_column] = dt.datetime.now()
-        self._buffer.append(table)
-        self._buffer[:] = self._buffer[-self.length:]
-        return pd.concat(self._buffer)
+        # A buffer filled by an earlier narwhals call cannot go through
+        # pd.concat, so it converts alongside the frame that displaced it.
+        buffer = [*(as_pandas(entry) for entry in self._buffer), table][-self.length:]
+        result = pd.concat(buffer)
+        self._buffer[:] = buffer
+        return result
 
 
 class Aggregate(Transform):
@@ -689,36 +746,6 @@ class Columns(Transform):
         if result is not None:
             return result
         return table[self.columns]
-
-
-def _narwhals_dtype(dtype):
-    """Return the narwhals dtype to cast to, or refuse the cast.
-
-    narwhals has no public parser for a dtype name and every
-    native_to_narwhals_dtype is private to a backend, so the spec is resolved
-    through an empty pandas column. That reuses pandas' own parser and
-    narwhals' own mapping rather than restating either as a table here, and it
-    takes whatever a spec can carry: a string, a builtin, a numpy dtype or an
-    extension dtype instance.
-
-    Only a numeric target is allowed through, because a shared dtype name is
-    not a shared conversion and the disagreements are silent. pyarrow renders
-    1.0 as '1' where pandas renders '1.0', both spell a boolean 'true' where
-    pandas spells it 'True', polars reads an integer as a date rather than as
-    a count of nanoseconds, and a category takes its order of appearance where
-    pandas sorts it, which decides how it later sorts and groups. None of
-    those raise, so nothing downstream could catch them.
-    """
-    resolved = nw.from_native(pd.Series([], dtype=dtype), series_only=True).dtype
-    if not resolved.is_numeric():
-        raise NotImplementedError(f'{dtype!r} does not cast alike on every backend')
-    if pd.api.types.pandas_dtype(
-        nw.Schema({'c': resolved}).to_pandas()['c']
-    ) != pd.api.types.pandas_dtype(dtype):
-        # Int64 and int64 are one narwhals dtype, so a nullable spec would come
-        # back as the numpy dtype rather than the one that was asked for.
-        raise NotImplementedError(f'{dtype!r} has no distinct narwhals dtype')
-    return resolved
 
 
 class Astype(Transform):

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -766,13 +766,21 @@ class Astype(Transform):
 
     def apply(self, table: DataFrame) -> DataFrame:
         def build(frame):
-            # Columns not in the frame are skipped, because the pandas path
-            # skips them rather than raising.
-            known = set(frame.collect_schema().names())
-            return frame.with_columns(*[
-                nw.col(col).cast(_narwhals_dtype(dtype))
-                for col, dtype in self.dtypes.items() if col in known
-            ])
+            names = frame.collect_schema().names()
+            casts = []
+            for col, dtype in self.dtypes.items():
+                # Columns not in the frame are skipped, because the pandas
+                # path skips them rather than raising.
+                if col not in names:
+                    continue
+                target = _narwhals_dtype(dtype)
+                if target.is_integer() and frame[col].is_null().any():
+                    # numpy has no missing integer, so pandas refuses the
+                    # whole cast. Every other backend writes a null instead,
+                    # which would answer where pandas raises.
+                    raise NotImplementedError(f'{col!r} holds a missing value')
+                casts.append(nw.col(col).cast(target))
+            return frame.with_columns(*casts)
 
         result, table = self._try_narwhals(table, build)
         if result is not None:

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -771,14 +771,20 @@ class Astype(Transform):
 
     def apply(self, table: DataFrame) -> DataFrame:
         def build(frame):
-            names = frame.collect_schema().names()
+            schema = frame.collect_schema()
             casts = []
             for col, dtype in self.dtypes.items():
                 # Columns not in the frame are skipped, because the pandas
                 # path skips them rather than raising.
-                if col not in names:
+                if col not in schema.names():
                     continue
                 target = _narwhals_dtype(dtype)
+                if schema[col].is_temporal() and target != nw.Int64:
+                    # int64 is the only target pandas lets a datetime out to,
+                    # as a count of its own unit. It refuses every other
+                    # width and every float, where polars hands back the
+                    # epoch rather than raising.
+                    raise NotImplementedError(f'{col!r} holds a datetime')
                 if target.is_integer() and frame[col].is_null().any():
                     # numpy has no missing integer, so pandas refuses the
                     # whole cast. Every other backend writes a null instead,

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -540,9 +540,14 @@ class HistoryTransform(Transform):
             self._buffer[:] = buffer
             return result
 
-        result, table = self._try_narwhals(table, build)
-        if result is not None:
-            return result
+        # One converted entry means the whole history is pandas, and narwhals
+        # cannot concatenate across libraries. Retrying would fail and warn on
+        # every call after the first, which for a dashboard is once a render.
+        if not any(isinstance(entry, pd.DataFrame) for entry in self._buffer):
+            result, table = self._try_narwhals(table, build)
+            if result is not None:
+                return result
+        table = as_pandas(table)
         if self.date_column:
             table = table.copy()
             table[self.date_column] = dt.datetime.now()

--- a/lumen/transforms/base.py
+++ b/lumen/transforms/base.py
@@ -691,6 +691,36 @@ class Columns(Transform):
         return table[self.columns]
 
 
+def _narwhals_dtype(dtype):
+    """Return the narwhals dtype to cast to, or refuse the cast.
+
+    narwhals has no public parser for a dtype name and every
+    native_to_narwhals_dtype is private to a backend, so the spec is resolved
+    through an empty pandas column. That reuses pandas' own parser and
+    narwhals' own mapping rather than restating either as a table here, and it
+    takes whatever a spec can carry: a string, a builtin, a numpy dtype or an
+    extension dtype instance.
+
+    Only a numeric target is allowed through, because a shared dtype name is
+    not a shared conversion and the disagreements are silent. pyarrow renders
+    1.0 as '1' where pandas renders '1.0', both spell a boolean 'true' where
+    pandas spells it 'True', polars reads an integer as a date rather than as
+    a count of nanoseconds, and a category takes its order of appearance where
+    pandas sorts it, which decides how it later sorts and groups. None of
+    those raise, so nothing downstream could catch them.
+    """
+    resolved = nw.from_native(pd.Series([], dtype=dtype), series_only=True).dtype
+    if not resolved.is_numeric():
+        raise NotImplementedError(f'{dtype!r} does not cast alike on every backend')
+    if pd.api.types.pandas_dtype(
+        nw.Schema({'c': resolved}).to_pandas()['c']
+    ) != pd.api.types.pandas_dtype(dtype):
+        # Int64 and int64 are one narwhals dtype, so a nullable spec would come
+        # back as the numpy dtype rather than the one that was asked for.
+        raise NotImplementedError(f'{dtype!r} has no distinct narwhals dtype')
+    return resolved
+
+
 class Astype(Transform):
     """
     `Astype` transforms the type of one or more columns.
@@ -700,7 +730,26 @@ class Astype(Transform):
 
     transform_type: ClassVar[str] = 'as_type'
 
+    # A cast a backend refuses raises when the frame is collected, which
+    # happens in Pipeline.data, outside the try that would have sent the data
+    # to pandas. Collecting here puts the failure back inside that try.
+    _lazy: ClassVar[bool] = False
+
+    _narwhals: ClassVar[bool] = True
+
     def apply(self, table: DataFrame) -> DataFrame:
+        def build(frame):
+            # Columns not in the frame are skipped, because the pandas path
+            # skips them rather than raising.
+            known = set(frame.collect_schema().names())
+            return frame.with_columns(*[
+                nw.col(col).cast(_narwhals_dtype(dtype))
+                for col, dtype in self.dtypes.items() if col in known
+            ])
+
+        result, table = self._try_narwhals(table, build)
+        if result is not None:
+            return result
         table = table.copy()
         for col, dtype in self.dtypes.items():
             if col in table.columns:


### PR DESCRIPTION
`Astype` and `HistoryTransform` had no narwhals path, so a polars or pyarrow frame was copied into pandas before either one ran. `Astype` now casts natively wherever every backend agrees with pandas on the result, which measured out to numeric targets only, and anything else still converts.

Fixes #2042