### PR TITLE
fix: let the hvPlot agent generate a plot at all

### DIFF
--- a/lumen/ai/agents/hvplot.py
+++ b/lumen/ai/agents/hvplot.py
@@ -37,7 +37,13 @@ class hvPlotAgent(BaseViewAgent):
 
     view_type = hvPlotUIView
 
-    def _get_model(self, prompt_name: str, schema: dict[str, Any]) -> type[BaseModel]:
+    def _get_model(self, prompt_name: str, schema: dict[str, Any] | None = None) -> type[BaseModel]:
+        # Only the main prompt describes the view. Every other prompt, revise
+        # among them, carries its own response model and is passed no schema,
+        # and revise is what runs when a spec fails to render.
+        if schema is None:
+            return super()._get_model(prompt_name)
+
         # Find parameters
         excluded = self.view_type._internal_params + [
             "controls",
@@ -95,6 +101,9 @@ class hvPlotAgent(BaseViewAgent):
     async def _extract_spec(self, context: TContext, spec: dict[str, Any]):
         pipeline = context["pipeline"]
         spec = {key: val for key, val in spec.items() if val is not None}
+        # Asked for to make the model reason about the plot, not to be plotted;
+        # hvPlotExplorer rejects any keyword none of its controls claims.
+        spec.pop("chain_of_thought", None)
         self._drop_conflicting_axes(spec)
         spec["type"] = "hvplot_ui"
         self.view_type.validate(spec)

--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -130,10 +130,13 @@ def _create_literal(obj: list[str | type]) -> type:
     for item in obj:
         if item is None:
             continue
-        elif isinstance(item, str):
+        elif isinstance(item, (str, bool, int)):
             enum.append(item)
-        else:
+        elif isinstance(item, type):
             enum.append(item.__name__)
+        # Anything else cannot be a Literal member. A Selector may hold one --
+        # hvPlot reads a dict cmap as a color key -- and the remaining choices
+        # still describe the option well enough to offer it.
     if enum:
         return Literal[tuple(enum)]
     else:
@@ -170,7 +173,10 @@ def parameter_to_field(parameter: param.Parameter, created_models: dict[str, typ
     if parameter.doc:
         field_kwargs["description"] = " ".join(parameter.doc.split())
     if not literals and hasattr(parameter, "get_range"):
-        literals = list(parameter.get_range())
+        # get_range maps a display name to the value behind it, and the name for
+        # None is the string "None". Taking the keys offers that string to the
+        # LLM as though it were a value, and the Selector then rejects it.
+        literals = list(parameter.get_range().values())
 
     if param_type in PARAM_TYPE_MAPPING:
         type_ = PARAM_TYPE_MAPPING[param_type]
@@ -262,6 +268,11 @@ def parameter_to_field(parameter: param.Parameter, created_models: dict[str, typ
     elif param_type in [param.Selector, param.ObjectSelector]:
         if parameter.default is not None:
             field_kwargs["default"] = parameter.default
+        elif None in getattr(parameter, "objects", ()):
+            # Defaulting to None is how a Selector says the option is off. With
+            # no default the field is required, and _create_literal drops None
+            # from the choices, leaving the LLM no way to answer that.
+            field_kwargs["default"] = None
 
         current_literals = literals
         if not current_literals and hasattr(parameter, "objects"):  # Use objects if literals not provided

--- a/lumen/tests/ai/test_hvplot_agent.py
+++ b/lumen/tests/ai/test_hvplot_agent.py
@@ -4,6 +4,7 @@ Each test here stands for one step of that failure: the schema offered the
 model a value its own view rejects, the recovery path raised instead of
 recovering, and the one field the agent adds to the schema reached the view.
 """
+import pandas as pd
 import param
 import pytest
 
@@ -14,8 +15,6 @@ from lumen.ai.translate import param_to_pydantic
 from lumen.pipeline import Pipeline
 from lumen.sources.base import InMemorySource
 from lumen.views.base import hvPlotUIView
-
-import pandas as pd
 
 
 @pytest.fixture

--- a/lumen/tests/ai/test_hvplot_agent.py
+++ b/lumen/tests/ai/test_hvplot_agent.py
@@ -1,0 +1,100 @@
+"""The hvPlot agent could not produce a renderable spec at all.
+
+Each test here stands for one step of that failure: the schema offered the
+model a value its own view rejects, the recovery path raised instead of
+recovering, and the one field the agent adds to the schema reached the view.
+"""
+import param
+import pytest
+
+from pydantic import BaseModel
+
+from lumen.ai.agents.hvplot import hvPlotAgent
+from lumen.ai.translate import param_to_pydantic
+from lumen.pipeline import Pipeline
+from lumen.sources.base import InMemorySource
+from lumen.views.base import hvPlotUIView
+
+import pandas as pd
+
+
+@pytest.fixture
+def pipeline():
+    df = pd.DataFrame({"x": [0.0, 1.0, 2.0], "y": [1.0, 2.0, 3.0]})
+    return Pipeline(source=InMemorySource(tables={"points": df}), table="points")
+
+
+# ---- A Selector holding None offered the model the string "None" ----
+
+class _Aggregating(param.Parameterized):
+
+    aggregator = param.Selector(default=None, objects=[None, "count", "mean"], doc="""
+        How to reduce the rows landing in one pixel.""")
+
+
+def test_a_none_option_is_not_offered_as_a_string():
+    """param names the None option 'None' for display, and that name was being
+    handed to the model as though it were a value."""
+    model = param_to_pydantic(_Aggregating, base_model=BaseModel)[_Aggregating.__name__]
+
+    enum = model.model_json_schema()["properties"]["aggregator"]["enum"]
+
+    assert "None" not in enum
+    assert set(enum) >= {"count", "mean"}
+
+
+def test_an_optional_selector_is_not_required():
+    """Requiring it leaves the model no way to say 'no aggregation', which is
+    what its default means."""
+    model = param_to_pydantic(_Aggregating, base_model=BaseModel)[_Aggregating.__name__]
+
+    schema = model.model_json_schema()
+
+    assert "aggregator" not in schema.get("required", [])
+    assert schema["properties"]["aggregator"]["default"] is None
+
+
+def test_the_view_accepts_every_aggregator_the_schema_offers(pipeline):
+    """The schema and the view have to agree, or a valid answer fails to render."""
+    model = hvPlotAgent()._get_model("main", {"x": {}, "y": {}})
+    enum = model.model_json_schema()["properties"]["aggregator"]["enum"]
+
+    for aggregator in enum:
+        hvPlotUIView(pipeline=pipeline, kind="scatter", x="x", y="y", aggregator=aggregator)
+
+
+# ---- The agent's own extra field reached the view ----
+
+async def test_chain_of_thought_does_not_reach_the_view(pipeline):
+    """It is added to the schema to make the model reason, not to be plotted;
+    hvPlotExplorer rejects any keyword none of its controls claims."""
+    spec = {"kind": "scatter", "x": "x", "y": "y", "chain_of_thought": "because"}
+
+    extracted = await hvPlotAgent()._extract_spec({"pipeline": pipeline}, spec)
+
+    assert "chain_of_thought" not in extracted
+    hvPlotUIView(pipeline=pipeline, **extracted).get_panel()
+
+
+# ---- The recovery path raised instead of recovering ----
+
+def test_a_prompt_other_than_main_still_resolves_its_model():
+    """_get_model is called for every prompt, so overriding it with a required
+    extra argument broke revise, which is what runs when a spec fails."""
+    assert hvPlotAgent()._get_model("revise_output") is not None
+
+
+class _Colormapped(param.Parameterized):
+
+    cmap = param.Selector(default="viridis", objects=["viridis", "fire"], check_on_set=False, doc="""
+        The colormap to use.""")
+
+
+def test_a_value_outside_the_choices_does_not_break_the_model():
+    """A Selector that accepts more than it lists (hvPlot reads a dict cmap as a
+    color key) puts that value in range, and it is not a Literal member."""
+    instance = _Colormapped(cmap={"Irish": "#e41a1c"})
+
+    model = param_to_pydantic(type(instance), base_model=BaseModel)[type(instance).__name__]
+
+    assert set(model.model_json_schema()["properties"]["cmap"]["enum"]) == {"viridis", "fire"}


### PR DESCRIPTION
## Description

The hvPlot agent could not produce a renderable spec at all: the schema offered the model a value the view itself rejects, the field added to make the model reason was passed through to the plot, and the retry path raised instead of recovering, so nothing could recover from the first two. Fixing the three lets an hvPlot request reach a plot.

