### PR TITLE
Fix validation fault 2062

### DIFF
--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -96,7 +96,7 @@ class ValidationAgent(Agent):
         previous_keys = set()
         if plan is not None:
             produced = {k for task in plan for k in task.out_context}
-            for key in ("chat", "sql", "data", "view", "listing"):
+            for key in ("chat", "sql", "view", "listing"):
                 if key in context and key not in produced:
                     previous_keys.add(key)
         ctx["previous_keys"] = previous_keys

--- a/lumen/ai/prompts/ValidationAgent/main.jinja2
+++ b/lumen/ai/prompts/ValidationAgent/main.jinja2
@@ -69,7 +69,7 @@ Current context contains keys: {{ ", ".join(memory) }}
 {% if 'sql' in previous_keys %}(From previous plan) {% endif %}SQL: `{{ memory['sql'] }}`
 {%- endif -%}
 {%- if memory.get('data') is not none %}
-{% if 'data' in previous_keys %}(From previous plan) {% endif %}Data Overview:
+Data Overview:
 {{ memory["data"] }}
 {%- endif -%}
 {% if memory.get('view') %}


### PR DESCRIPTION
Fixes #2062

Description & Root Cause: When a user asks a clarifying question (e.g. asking for columns on an active dataset), smaller models like Gemini 2.5 Flash were throwing a ValidationFault. Initially, it appeared to be a prompt issue. However, the true root cause was in validation.py:99, where active data pipelines were being incorrectly tagged as (From previous plan) simply because the current plan didn't re-run SQL. This caused the prompt to instruct literal LLMs to treat active data as stale, leading to validation failure.

Solution:

Removed "data" from the leftover keys list in validation.py, as the data is currently loaded pipeline context, not a leftover.
Cleaned up the dead branching logic {% if 'data' in previous_keys %} inside main.jinja2.