### PR TITLE
Fix: expose widget_type and widget_location in hvplot params. Fixes #…

### DIFF
--- a/lumen/tests/views/test_hvplot_datashade.py
+++ b/lumen/tests/views/test_hvplot_datashade.py
@@ -122,6 +122,40 @@ def test_hvplot_view_omits_unset_datashade(categorical_pipeline, categorical_df)
     assert "color_key" not in recorded
 
 
+def test_widget_params_declared():
+    """The AI agent's schema is derived from these params, so they must exist."""
+    for name in ("widget_type", "widget_location"):
+        assert name in hvPlotBaseView.param
+
+
+def test_hvplot_view_forwards_widget_params(categorical_pipeline, categorical_df):
+    view = hvPlotView(
+        pipeline=categorical_pipeline,
+        kind="scatter",
+        x="x",
+        y="y",
+        groupby="ancestry",
+        widget_type="scrubber",
+        widget_location="bottom",
+    )
+
+    recorded = record_hvplot_call(view, categorical_df)
+
+    assert recorded["groupby"] == ["ancestry"]
+    assert recorded["widget_type"] == "scrubber"
+    assert recorded["widget_location"] == "bottom"
+
+
+def test_hvplot_view_omits_unset_widget_params(categorical_pipeline, categorical_df):
+    """Unset widget params must not appear, keeping existing plots unchanged."""
+    view = hvPlotView(pipeline=categorical_pipeline, kind="scatter", x="x", y="y")
+
+    recorded = record_hvplot_call(view, categorical_df)
+
+    assert "widget_type" not in recorded
+    assert "widget_location" not in recorded
+
+
 def test_hvplot_view_keeps_dict_cmap_kwarg(categorical_pipeline, categorical_df):
     """Specs predating color_key passed the mapping as cmap; hvPlot still maps a
     dict cmap onto color_key, so those must keep working."""

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1003,6 +1003,15 @@ class hvPlotBaseView(View):
 
     groupby = param.ListSelector(doc="The column(s) to group by.")
 
+    widget_type = param.String(default=None, doc="""
+        Whether to display the ``groupby`` widgets as a scrubber/player or as
+        static widgets. If not set, defers to hvPlot's default.""")
+
+    widget_location = param.ClassSelector(default=None, class_=(str, list, tuple), doc="""
+        The location of the ``groupby`` widgets relative to the plot, e.g.
+        'bottom', 'left' or ('left', 'top'). If not set, defers to hvPlot's
+        default.""")
+
     z = param.Selector(doc="""
         Column of z-values for gridded plot kinds (image, quadmesh, heatmap, contourf).
         Internally mapped to hvPlot's C= for kind='heatmap' and z= for other kinds.""")
@@ -1309,6 +1318,10 @@ class hvPlotView(hvPlotBaseView):
         if self.aggregator is not None:
             self._check_aggregator(processed)
             processed['aggregator'] = self.aggregator
+        if self.widget_type is not None:
+            processed['widget_type'] = self.widget_type
+        if self.widget_location is not None:
+            processed['widget_location'] = self.widget_location
 
         kind = self.kind
         plot_source = df


### PR DESCRIPTION
## Description

Fixes #1915

This PR exposes `widget_type` and `widget_location` as declared parameter attributes on `hvPlotBaseView`, which is shared by both `hvPlotView` and `hvPlotUIView`. These parameters are forwarded through `hvPlotView.get_plot` to the underlying `.hvplot(...)` call, mirroring the existing `groupby` forwarding behavior.

Both parameters default to `None`, so existing behavior remains unchanged when they are not specified.

This enables spec-based (`type: hvplot`) plots to control the groupby widget. For example, a scrubber/player can be placed at the bottom:

```yaml
sources:
  widget_source:
    type: file
    tables:
      widget_table: widget_test_data.csv

layouts:
  - title: Widget Type Test
    views:
      - type: hvplot
        kind: line
        x: year
        y: value
        groupby: region
        widget_type: scrubber
        widget_location: bottom
```

### Tests

Tests were added in `lumen/tests/views/test_hvplot_datashade.py`:

* `test_widget_params_declared` — verifies that both parameters exist on `hvPlotBaseView`, which is used by the AI agent schema.
* `test_hvplot_view_forwards_widget_params` — verifies that `widget_type`, `widget_location`, and `groupby` are correctly forwarded to `.hvplot()`.
* `test_hvplot_view_omits_unset_widget_params` — verifies that unset widget parameters are not passed, preserving existing behavior.

### Verification

* `lumen/tests/views/`: **83 passed, 11 skipped**
* Full test suite: **2539 passed, 304 skipped, 17 failed**
* The 17 full-suite failures are pre-existing and unrelated to this change. They reproduce identically on `main` and are related to LLM routing, xarray zarr dtype, and the xarray upload handler.
* `ruff check` passes on both modified files.

### Known Limitation

The chat/AI path (`lumen-ai`) routes through `hvPlotUIView`, which uses hvPlot's explorer (`hvDataFrameExplorer`/`hvGridExplorer`). These explorers currently hard-code their internal `pn.pane.HoloViews` pane with `widget_location='bottom'` and do not accept `widget_type`.

As a result, although `widget_type` and `widget_location` are valid parameters on `hvPlotUIView`, they are not currently applied in the chat window.

Supporting the scrubber in the chat path will require a follow-up change to hvPlot's explorer and additional forwarding from `hvPlotUIView`.

## AI Disclosure

Tool & Model: Cursor + Claude (opencode assistant)

Usage:

Drafted the parameter additions, wired the forwarding in `hvPlotView.get_plot`, and wrote the new tests. The changes were validated by reproducing the full test suite and running `ruff` locally.

* [x] I have tested all AI-generated content in my PR.
* [x] I take responsibility for all AI-generated content in my PR.

## Checklist

* [x] Tests added and are passing
* [ ] Added documentation
