### PR TITLE
Add Codex CLI and Claude Code providers

### DIFF
--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -113,6 +113,8 @@ If not specified, Lumen auto-detects from environment variables.
 - `ollama` - Local models
 - `llama-cpp` - Local models
 - `litellm` - Multi-provider
+- `codex-cli` - Locally authenticated Codex CLI
+- `claude-code` - Locally authenticated Claude Code CLI
 
 ### Set API key
 

--- a/docs/configuration/llm_providers.md
+++ b/docs/configuration/llm_providers.md
@@ -116,6 +116,39 @@ For installation and API key setup instructions, see the [Installation guide](..
 - **Coding:** `qwen3-coder:32b`, `qwen2.5-coder:32b`
 - **Reasoning:** `nemotron-3-nano:30b`
 
+### Experimental subscription CLI providers
+
+Lumen can also use a **locally authenticated** Codex CLI or Claude Code CLI.
+This is useful for local development when you already sign in to one of those
+tools with a subscription. Lumen does not read, save, or pass an API key for
+these providers—the respective CLI performs its own authentication.
+
+``` bash title="Codex CLI"
+# First sign in outside Lumen, then launch Lumen.
+codex login
+lumen-ai serve penguins.csv --provider codex-cli
+```
+
+``` bash title="Claude Code CLI"
+# First sign in outside Lumen, then launch Lumen.
+claude login
+lumen-ai serve penguins.csv --provider claude-code
+```
+
+Use `--model` if you want to select a model supported by your logged-in CLI:
+
+``` bash
+lumen-ai serve penguins.csv --provider codex-cli --model gpt-5.3-codex
+lumen-ai serve penguins.csv --provider claude-code --model sonnet
+```
+
+!!! warning "Local development only"
+    The server process launches a command-line agent for every LLM request. Do
+    not expose this configuration as a public or multi-user Lumen deployment.
+    Codex runs with its `read-only` sandbox and Claude Code uses `plan` mode by
+    default. The providers collect a completed response rather than streaming
+    tokens, and do not yet expose Lumen function tools to the coding CLIs.
+
 !!! tip "Small models (<= 8B)"
     Models with 8B parameters or fewer likely need [`--code-execution prompt`](cli.md#common-flags) to successfully create reliable Vega-Lite specifications.
 

--- a/docs/configuration/llm_providers.md
+++ b/docs/configuration/llm_providers.md
@@ -164,8 +164,10 @@ lumen-ai serve penguins.csv --provider claude-code
     The server process launches a command-line agent for every LLM request. Do
     not expose this configuration as a public or multi-user Lumen deployment.
     Codex runs with its `read-only` sandbox and Claude Code uses `plan` mode by
-    default. The providers collect a completed response rather than streaming
-    tokens, and do not yet expose Lumen function tools to the coding CLIs.
+    default. Claude Code can use up to three turns per Lumen request so it can
+    complete internal tool calls. The providers collect a completed response
+    rather than streaming tokens, and do not yet expose Lumen function tools to
+    the coding CLIs.
 
 !!! tip "Small models (<= 8B)"
     Models with 8B parameters or fewer likely need [`--code-execution prompt`](cli.md#common-flags) to successfully create reliable Vega-Lite specifications.

--- a/docs/configuration/llm_providers.md
+++ b/docs/configuration/llm_providers.md
@@ -116,30 +116,43 @@ For installation and API key setup instructions, see the [Installation guide](..
 - **Coding:** `qwen3-coder:32b`, `qwen2.5-coder:32b`
 - **Reasoning:** `nemotron-3-nano:30b`
 
-### Experimental subscription CLI providers
+### Locally authenticated coding CLI providers
 
-Lumen can also use a **locally authenticated** Codex CLI or Claude Code CLI.
-This is useful for local development when you already sign in to one of those
-tools with a subscription. Lumen does not read, save, or pass an API key for
-these providers—the respective CLI performs its own authentication.
+Use a locally authenticated Codex CLI or Claude Code CLI as Lumen's LLM
+provider. This lets an individual user run Lumen with an existing CLI
+subscription, without supplying an API key to Lumen.
+
+Before starting Lumen, install the relevant CLI, make sure its executable is
+on your `PATH`, and sign in to it once:
+
+``` bash
+codex login
+# or
+claude login
+```
+
+Start Lumen without loading any data:
 
 ``` bash title="Codex CLI"
-# First sign in outside Lumen, then launch Lumen.
-codex login
-lumen-ai serve penguins.csv --provider codex-cli
+lumen-ai serve --provider codex-cli
 ```
 
 ``` bash title="Claude Code CLI"
-# First sign in outside Lumen, then launch Lumen.
-claude login
-lumen-ai serve penguins.csv --provider claude-code
+lumen-ai serve --provider claude-code
 ```
 
-Use `--model` if you want to select a model supported by your logged-in CLI:
+The CLI's configured default model is used unless you select one explicitly:
 
 ``` bash
-lumen-ai serve penguins.csv --provider codex-cli --model gpt-5.3-codex
-lumen-ai serve penguins.csv --provider claude-code --model sonnet
+lumen-ai serve --provider codex-cli --model gpt-5.3-codex
+lumen-ai serve --provider claude-code --model sonnet
+```
+
+To start with a dataset, add its path before the provider arguments:
+
+``` bash
+lumen-ai serve penguins.csv --provider codex-cli
+lumen-ai serve penguins.csv --provider claude-code
 ```
 
 !!! warning "Local development only"

--- a/docs/configuration/llm_providers.md
+++ b/docs/configuration/llm_providers.md
@@ -116,7 +116,7 @@ For installation and API key setup instructions, see the [Installation guide](..
 - **Coding:** `qwen3-coder:32b`, `qwen2.5-coder:32b`
 - **Reasoning:** `nemotron-3-nano:30b`
 
-### Locally authenticated coding CLI providers
+### Codex CLI and Claude Code
 
 Use a locally authenticated Codex CLI or Claude Code CLI as Lumen's LLM
 provider. This lets an individual user run Lumen with an existing CLI
@@ -125,10 +125,12 @@ subscription, without supplying an API key to Lumen.
 Before starting Lumen, install the relevant CLI, make sure its executable is
 on your `PATH`, and sign in to it once:
 
-``` bash
+``` bash title="Codex CLI"
 codex login
-# or
-claude login
+```
+
+``` bash title="Claude Code"
+claude auth login
 ```
 
 Start Lumen without loading any data:
@@ -141,12 +143,15 @@ lumen-ai serve --provider codex-cli
 lumen-ai serve --provider claude-code
 ```
 
-The CLI's configured default model is used unless you select one explicitly:
+The CLI's configured default model is used unless you select one explicitly.
+For example, Claude Code provides a stable `sonnet` alias:
 
 ``` bash
-lumen-ai serve --provider codex-cli --model gpt-5.3-codex
 lumen-ai serve --provider claude-code --model sonnet
 ```
+
+The same `--model` option accepts model identifiers available to the
+authenticated Codex CLI account.
 
 To start with a dataset, add its path before the provider arguments:
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -23,7 +23,7 @@ from instructor import Mode, patch
 from instructor.dsl.partial import Partial
 from instructor.processing.multimodal import Image
 from openai import OpenAI as OpenAIClient
-from pydantic import BaseModel, ValidationError, create_model
+from pydantic import BaseModel, create_model
 
 from .interceptor import Interceptor
 from .services import (
@@ -1234,19 +1234,19 @@ class Llm(param.Parameterized):
 
 
 class _CLILlm(Llm):
-    """Base class for local, subscription-authenticated coding CLIs.
+    """Base class for locally authenticated coding CLIs.
 
-    These providers deliberately invoke an already authenticated local CLI instead
-    of handling credentials. They are intended for local development only: output
-    is collected after the command completes and native Lumen function tools are
-    not forwarded to the CLI.
+    These providers invoke an already authenticated local CLI instead of handling
+    credentials. They are intended for local development only: output is collected
+    after the command completes and native Lumen function tools are not forwarded
+    to the CLI.
     """
 
     executable = param.String(default="", constant=True, doc="Path or name of the CLI executable.")
 
     working_dir = param.String(default=None, allow_None=True, constant=True, doc="""
-        Directory passed to the CLI, if supported. By default, the CLI inherits
-        the directory from which Lumen was launched.""")
+        Working directory for CLI subprocesses. By default, the CLI inherits the
+        directory from which Lumen was launched.""")
 
     _supports_stream = False
     _supports_model_stream = False
@@ -1254,6 +1254,12 @@ class _CLILlm(Llm):
 
     def _create_base_client(self, **kwargs) -> Any:
         raise NotImplementedError("CLI-backed providers do not create an SDK client.")
+
+    def _check_for_image(self, messages: list[Message]) -> tuple[list[Message], bool]:
+        messages, contains_image = super()._check_for_image(messages)
+        if contains_image:
+            raise ValueError(f"{self.display_name} does not support image inputs.")
+        return messages, False
 
     @staticmethod
     def _content_to_text(content: str | Image | list[dict[str, Any]]) -> str:
@@ -1279,20 +1285,18 @@ class _CLILlm(Llm):
         for message in messages:
             role = message.get("role", "user").upper()
             content = self._content_to_text(message.get("content", ""))
-            if not content and message.get("tool_calls"):
-                content = json.dumps(message["tool_calls"], default=str, ensure_ascii=False)
+            tool_calls = message.get("tool_calls")
+            if not content and tool_calls:
+                content = json.dumps(tool_calls, default=str, ensure_ascii=False)
             rendered.append(f"[{role}]\n{content}")
         return "\n\n".join(rendered)
 
     @staticmethod
-    def _json_from_output(output: str) -> str:
-        """Extract one JSON object from plain output or a Markdown code fence."""
+    def _extract_json(output: str) -> Any:
+        """Extract the first JSON value from a CLI response."""
         output = output.strip()
-        if output.startswith("```") and output.endswith("```"):
-            output = output.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
         try:
-            json.loads(output)
-            return output
+            return json.loads(output)
         except json.JSONDecodeError:
             pass
 
@@ -1301,10 +1305,10 @@ class _CLILlm(Llm):
             if character not in "[{":
                 continue
             try:
-                _, end = decoder.raw_decode(output[index:])
+                value, _ = decoder.raw_decode(output[index:])
             except json.JSONDecodeError:
                 continue
-            return output[index:index + end]
+            return value
         raise ValueError("The CLI did not return valid JSON for Lumen's structured response.")
 
     def _structured_prompt(self, prompt: str, response_model: type[BaseModel]) -> str:
@@ -1316,12 +1320,16 @@ class _CLILlm(Llm):
             f"JSON Schema:\n{schema}"
         )
 
-    async def _run_command(self, command: list[str]) -> tuple[str, str]:
+    async def _run_command(self, command: list[str], prompt: str) -> str:
+        if self.working_dir and not Path(self.working_dir).is_dir():
+            raise ValueError(f"CLI working directory does not exist: {self.working_dir!r}")
         try:
             process = await asyncio.create_subprocess_exec(
                 *command,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                cwd=self.working_dir,
             )
         except FileNotFoundError as exc:
             raise RuntimeError(
@@ -1330,7 +1338,13 @@ class _CLILlm(Llm):
             ) from exc
 
         try:
-            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self.timeout)
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(prompt.encode("utf-8")), timeout=self.timeout
+            )
+        except asyncio.CancelledError:
+            process.kill()
+            await process.wait()
+            raise
         except TimeoutError as exc:
             process.kill()
             await process.wait()
@@ -1342,16 +1356,43 @@ class _CLILlm(Llm):
         stderr_text = stderr.decode("utf-8", errors="replace")
         if process.returncode:
             detail = stderr_text.strip() or stdout_text.strip() or "no error output"
+            detail = truncate_string(detail, max_length=4000)
             raise RuntimeError(
                 f"{self.display_name} exited with status {process.returncode}: {detail}"
             )
-        return stdout_text, stderr_text
+        return stdout_text
 
-    def _build_command(self, model: str | None, prompt: str) -> list[str]:
+    def _build_command(self, model: str | None) -> list[str]:
         raise NotImplementedError
 
     def _decode_output(self, output: str) -> str:
-        return output.strip()
+        raise NotImplementedError
+
+    async def _run_tool_loop(
+        self,
+        messages: list[Message],
+        structured_model: type[BaseModel] | None,
+        tool_instances: dict,
+        tool_contexts: dict,
+        model_spec: str | dict = "default",
+        max_tool_rounds: int = 16,
+        **kwargs,
+    ) -> BaseModel | str:
+        if tool_instances:
+            log_debug(
+                "CLI providers do not support native Lumen tools; continuing without them.",
+                prefix="[LLM tools]",
+            )
+        kwargs.pop("tools", None)
+        return await super()._run_tool_loop(
+            messages,
+            structured_model,
+            {},
+            {},
+            model_spec=model_spec,
+            max_tool_rounds=max_tool_rounds,
+            **kwargs,
+        )
 
     async def run_client(self, model_spec: str | dict, messages: list[Message], **kwargs):
         self._log_messages(messages)
@@ -1361,15 +1402,15 @@ class _CLILlm(Llm):
         if response_model is not None:
             prompt = self._structured_prompt(prompt, response_model)
 
-        command = self._build_command(model, prompt)
-        log_debug(f"CLI command: \033[96m{' '.join(command[:-1])} <prompt>\033[0m")
-        stdout, _ = await self._run_command(command)
+        command = self._build_command(model)
+        log_debug(f"CLI command: \033[96m{' '.join(command)} <stdin>\033[0m")
+        stdout = await self._run_command(command, prompt)
         output = self._decode_output(stdout)
 
         if response_model is not None:
             try:
-                result = response_model.model_validate_json(self._json_from_output(output))
-            except (ValueError, ValidationError) as exc:
+                result = response_model.model_validate(self._extract_json(output))
+            except ValueError as exc:
                 raise ValueError(
                     f"{self.display_name} returned an invalid structured response: {exc}"
                 ) from exc
@@ -1380,9 +1421,9 @@ class _CLILlm(Llm):
 
 
 class CodexCLI(_CLILlm):
-    """Use the locally authenticated Codex CLI as an experimental Lumen provider."""
+    """Use the locally authenticated Codex CLI as a Lumen provider."""
 
-    display_name = param.String(default="Codex CLI (experimental)", constant=True)
+    display_name = param.String(default="Codex CLI", constant=True)
 
     executable = param.String(default="codex", constant=True)
 
@@ -1395,19 +1436,17 @@ class CodexCLI(_CLILlm):
 
     model_kwargs = param.Dict(default={"default": {"model": None}})
 
-    def _build_command(self, model: str | None, prompt: str) -> list[str]:
+    def _build_command(self, model: str | None) -> list[str]:
         command = [
             self.executable, "exec", "--json", "--sandbox", self.sandbox,
             "--skip-git-repo-check", "--ephemeral",
         ]
-        if self.working_dir:
-            command.extend(["--cd", self.working_dir])
         if model:
             command.extend(["--model", model])
-        return [*command, prompt]
+        return [*command, "-"]
 
     def _decode_output(self, output: str) -> str:
-        messages = []
+        final_message = None
         for line in output.splitlines():
             try:
                 event = json.loads(line)
@@ -1417,20 +1456,22 @@ class CodexCLI(_CLILlm):
             if isinstance(item, dict) and item.get("type") == "agent_message":
                 text = item.get("text") or item.get("content")
                 if text:
-                    messages.append(str(text))
-        return "\n".join(messages).strip() or output.strip()
+                    final_message = str(text)
+        if final_message is None:
+            raise ValueError("Codex CLI did not return a final agent message.")
+        return final_message.strip()
 
 
 class ClaudeCodeCLI(_CLILlm):
-    """Use the locally authenticated Claude Code CLI as an experimental Lumen provider."""
+    """Use the locally authenticated Claude Code CLI as a Lumen provider."""
 
-    display_name = param.String(default="Claude Code CLI (experimental)", constant=True)
+    display_name = param.String(default="Claude Code CLI", constant=True)
 
     executable = param.String(default="claude", constant=True)
 
     permission_mode = param.Selector(
         default="plan",
-        objects=["plan", "default", "acceptEdits", "bypassPermissions"],
+        objects=["plan", "manual", "dontAsk", "acceptEdits", "auto", "bypassPermissions"],
         constant=True,
         doc="Claude Code permission mode. The non-writing plan mode is the default.",
     )
@@ -1439,26 +1480,28 @@ class ClaudeCodeCLI(_CLILlm):
 
     model_kwargs = param.Dict(default={"default": {"model": None}})
 
-    def _build_command(self, model: str | None, prompt: str) -> list[str]:
+    def _build_command(self, model: str | None) -> list[str]:
         command = [
             self.executable, "--print", "--output-format", "json",
-            "--max-turns", str(self.max_turns), "--permission-mode", self.permission_mode,
+            "--no-session-persistence", "--max-turns", str(self.max_turns),
+            "--permission-mode", self.permission_mode,
         ]
         if model:
             command.extend(["--model", model])
-        return [*command, prompt]
+        return command
 
     def _decode_output(self, output: str) -> str:
         try:
             response = json.loads(output)
-        except json.JSONDecodeError:
-            return output.strip()
-        if isinstance(response, dict):
-            if response.get("is_error"):
-                raise RuntimeError(str(response.get("result") or "Claude Code returned an error."))
-            if "result" in response:
-                return str(response["result"]).strip()
-        return output.strip()
+        except json.JSONDecodeError as exc:
+            raise ValueError("Claude Code CLI returned invalid JSON.") from exc
+        if not isinstance(response, dict):
+            raise ValueError("Claude Code CLI returned an unexpected JSON response.")
+        if response.get("is_error"):
+            raise RuntimeError(str(response.get("result") or "Claude Code returned an error."))
+        if "result" not in response:
+            raise ValueError("Claude Code CLI response did not include a result.")
+        return str(response["result"]).strip()
 
 
 class LlamaCpp(Llm, LlamaCppMixin):

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -23,7 +23,7 @@ from instructor import Mode, patch
 from instructor.dsl.partial import Partial
 from instructor.processing.multimodal import Image
 from openai import OpenAI as OpenAIClient
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel, ValidationError, create_model
 
 from .interceptor import Interceptor
 from .services import (
@@ -74,6 +74,8 @@ LLM_PROVIDERS = {
     'litellm': 'LiteLLM',
     'openrouter': 'OpenRouter',
     'kilo': 'Kilo',
+    'codex-cli': 'CodexCLI',
+    'claude-code': 'ClaudeCodeCLI',
 }
 
 # Request parameters an OpenAI-compatible model may reject, and the value to
@@ -1229,6 +1231,234 @@ class Llm(param.Parameterized):
                 result = result.output
         log_debug(f"LLM Response: \033[95m{truncate_string(str(result), max_length=10000)}\033[0m\n---")
         return result
+
+
+class _CLILlm(Llm):
+    """Base class for local, subscription-authenticated coding CLIs.
+
+    These providers deliberately invoke an already authenticated local CLI instead
+    of handling credentials. They are intended for local development only: output
+    is collected after the command completes and native Lumen function tools are
+    not forwarded to the CLI.
+    """
+
+    executable = param.String(default="", constant=True, doc="Path or name of the CLI executable.")
+
+    working_dir = param.String(default=None, allow_None=True, constant=True, doc="""
+        Directory passed to the CLI, if supported. By default, the CLI inherits
+        the directory from which Lumen was launched.""")
+
+    _supports_stream = False
+    _supports_model_stream = False
+    _supports_vision = False
+
+    def _create_base_client(self, **kwargs) -> Any:
+        raise NotImplementedError("CLI-backed providers do not create an SDK client.")
+
+    @staticmethod
+    def _content_to_text(content: str | Image | list[dict[str, Any]]) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict):
+                    if item.get("type") == "text":
+                        parts.append(str(item.get("text", "")))
+                    else:
+                        parts.append(json.dumps(item, default=str, ensure_ascii=False))
+                else:
+                    parts.append(str(item))
+            return "\n".join(parts)
+        return str(content)
+
+    def _messages_to_prompt(self, messages: list[Message]) -> str:
+        rendered = []
+        for message in messages:
+            role = message.get("role", "user").upper()
+            content = self._content_to_text(message.get("content", ""))
+            if not content and message.get("tool_calls"):
+                content = json.dumps(message["tool_calls"], default=str, ensure_ascii=False)
+            rendered.append(f"[{role}]\n{content}")
+        return "\n\n".join(rendered)
+
+    @staticmethod
+    def _json_from_output(output: str) -> str:
+        """Extract one JSON object from plain output or a Markdown code fence."""
+        output = output.strip()
+        if output.startswith("```") and output.endswith("```"):
+            output = output.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+        try:
+            json.loads(output)
+            return output
+        except json.JSONDecodeError:
+            pass
+
+        decoder = json.JSONDecoder()
+        for index, character in enumerate(output):
+            if character not in "[{":
+                continue
+            try:
+                _, end = decoder.raw_decode(output[index:])
+            except json.JSONDecodeError:
+                continue
+            return output[index:index + end]
+        raise ValueError("The CLI did not return valid JSON for Lumen's structured response.")
+
+    def _structured_prompt(self, prompt: str, response_model: type[BaseModel]) -> str:
+        schema = json.dumps(response_model.model_json_schema(), ensure_ascii=False)
+        return (
+            f"{prompt}\n\n"
+            "Return only one JSON value matching this JSON Schema. Do not use Markdown, "
+            "explain the answer, or call tools.\n"
+            f"JSON Schema:\n{schema}"
+        )
+
+    async def _run_command(self, command: list[str]) -> tuple[str, str]:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not find {self.executable!r}. Install it and sign in to its CLI before "
+                f"using the {self.display_name} provider."
+            ) from exc
+
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self.timeout)
+        except TimeoutError as exc:
+            process.kill()
+            await process.wait()
+            raise TimeoutError(
+                f"{self.display_name} did not finish within {self.timeout:g} seconds."
+            ) from exc
+
+        stdout_text = stdout.decode("utf-8", errors="replace")
+        stderr_text = stderr.decode("utf-8", errors="replace")
+        if process.returncode:
+            detail = stderr_text.strip() or stdout_text.strip() or "no error output"
+            raise RuntimeError(
+                f"{self.display_name} exited with status {process.returncode}: {detail}"
+            )
+        return stdout_text, stderr_text
+
+    def _build_command(self, model: str | None, prompt: str) -> list[str]:
+        raise NotImplementedError
+
+    def _decode_output(self, output: str) -> str:
+        return output.strip()
+
+    async def run_client(self, model_spec: str | dict, messages: list[Message], **kwargs):
+        self._log_messages(messages)
+        response_model = kwargs.get("response_model")
+        model = self._get_model_kwargs(model_spec).get("model")
+        prompt = self._messages_to_prompt(messages)
+        if response_model is not None:
+            prompt = self._structured_prompt(prompt, response_model)
+
+        command = self._build_command(model, prompt)
+        log_debug(f"CLI command: \033[96m{' '.join(command[:-1])} <prompt>\033[0m")
+        stdout, _ = await self._run_command(command)
+        output = self._decode_output(stdout)
+
+        if response_model is not None:
+            try:
+                result = response_model.model_validate_json(self._json_from_output(output))
+            except (ValueError, ValidationError) as exc:
+                raise ValueError(
+                    f"{self.display_name} returned an invalid structured response: {exc}"
+                ) from exc
+        else:
+            result = output
+        log_debug(f"LLM Response: \033[95m{truncate_string(str(result), max_length=10000)}\033[0m\n---")
+        return result
+
+
+class CodexCLI(_CLILlm):
+    """Use the locally authenticated Codex CLI as an experimental Lumen provider."""
+
+    display_name = param.String(default="Codex CLI (experimental)", constant=True)
+
+    executable = param.String(default="codex", constant=True)
+
+    sandbox = param.Selector(
+        default="read-only",
+        objects=["read-only", "workspace-write", "danger-full-access"],
+        constant=True,
+        doc="Codex sandbox policy. The safe read-only policy is the default.",
+    )
+
+    model_kwargs = param.Dict(default={"default": {"model": None}})
+
+    def _build_command(self, model: str | None, prompt: str) -> list[str]:
+        command = [
+            self.executable, "exec", "--json", "--sandbox", self.sandbox,
+            "--skip-git-repo-check", "--ephemeral",
+        ]
+        if self.working_dir:
+            command.extend(["--cd", self.working_dir])
+        if model:
+            command.extend(["--model", model])
+        return [*command, prompt]
+
+    def _decode_output(self, output: str) -> str:
+        messages = []
+        for line in output.splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            item = event.get("item") if isinstance(event, dict) else None
+            if isinstance(item, dict) and item.get("type") == "agent_message":
+                text = item.get("text") or item.get("content")
+                if text:
+                    messages.append(str(text))
+        return "\n".join(messages).strip() or output.strip()
+
+
+class ClaudeCodeCLI(_CLILlm):
+    """Use the locally authenticated Claude Code CLI as an experimental Lumen provider."""
+
+    display_name = param.String(default="Claude Code CLI (experimental)", constant=True)
+
+    executable = param.String(default="claude", constant=True)
+
+    permission_mode = param.Selector(
+        default="plan",
+        objects=["plan", "default", "acceptEdits", "bypassPermissions"],
+        constant=True,
+        doc="Claude Code permission mode. The non-writing plan mode is the default.",
+    )
+
+    max_turns = param.Integer(default=1, bounds=(1, None), constant=True, doc="Maximum Claude Code turns per Lumen request.")
+
+    model_kwargs = param.Dict(default={"default": {"model": None}})
+
+    def _build_command(self, model: str | None, prompt: str) -> list[str]:
+        command = [
+            self.executable, "--print", "--output-format", "json",
+            "--max-turns", str(self.max_turns), "--permission-mode", self.permission_mode,
+        ]
+        if model:
+            command.extend(["--model", model])
+        return [*command, prompt]
+
+    def _decode_output(self, output: str) -> str:
+        try:
+            response = json.loads(output)
+        except json.JSONDecodeError:
+            return output.strip()
+        if isinstance(response, dict):
+            if response.get("is_error"):
+                raise RuntimeError(str(response.get("result") or "Claude Code returned an error."))
+            if "result" in response:
+                return str(response["result"]).strip()
+        return output.strip()
 
 
 class LlamaCpp(Llm, LlamaCppMixin):

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1476,7 +1476,12 @@ class ClaudeCodeCLI(_CLILlm):
         doc="Claude Code permission mode. The non-writing plan mode is the default.",
     )
 
-    max_turns = param.Integer(default=1, bounds=(1, None), constant=True, doc="Maximum Claude Code turns per Lumen request.")
+    max_turns = param.Integer(
+        default=3,
+        bounds=(1, None),
+        constant=True,
+        doc="Maximum Claude Code turns per Lumen request, including internal tool calls.",
+    )
 
     model_kwargs = param.Dict(default={"default": {"model": None}})
 

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -1233,7 +1233,7 @@ class Llm(param.Parameterized):
         return result
 
 
-class _CLILlm(Llm):
+class LlmCli(Llm):
     """Base class for locally authenticated coding CLIs.
 
     These providers invoke an already authenticated local CLI instead of handling
@@ -1420,7 +1420,7 @@ class _CLILlm(Llm):
         return result
 
 
-class CodexCLI(_CLILlm):
+class CodexCLI(LlmCli):
     """Use the locally authenticated Codex CLI as a Lumen provider."""
 
     display_name = param.String(default="Codex CLI", constant=True)
@@ -1462,7 +1462,7 @@ class CodexCLI(_CLILlm):
         return final_message.strip()
 
 
-class ClaudeCodeCLI(_CLILlm):
+class ClaudeCodeCLI(LlmCli):
     """Use the locally authenticated Claude Code CLI as a Lumen provider."""
 
     display_name = param.String(default="Claude Code CLI", constant=True)

--- a/lumen/ai/llm.py
+++ b/lumen/ai/llm.py
@@ -74,8 +74,8 @@ LLM_PROVIDERS = {
     'litellm': 'LiteLLM',
     'openrouter': 'OpenRouter',
     'kilo': 'Kilo',
-    'codex-cli': 'CodexCLI',
-    'claude-code': 'ClaudeCodeCLI',
+    'codex-cli': 'CodexCli',
+    'claude-code': 'ClaudeCode',
 }
 
 # Request parameters an OpenAI-compatible model may reject, and the value to
@@ -1237,9 +1237,15 @@ class LlmCli(Llm):
     """Base class for locally authenticated coding CLIs.
 
     These providers invoke an already authenticated local CLI instead of handling
-    credentials. They are intended for local development only: output is collected
-    after the command completes and native Lumen function tools are not forwarded
-    to the CLI.
+    credentials. Lumen renders its messages as a text prompt and sends it over
+    standard input. Each subclass parses the CLI-specific response format to
+    obtain the final text response. For structured responses, Lumen appends the
+    Pydantic JSON Schema to the prompt, extracts the returned JSON value, and
+    validates it against the response model.
+
+    They are intended for local development only: output is collected after the
+    command completes and native Lumen function tools are not forwarded to the
+    CLI.
     """
 
     executable = param.String(default="", constant=True, doc="Path or name of the CLI executable.")
@@ -1420,7 +1426,7 @@ class LlmCli(Llm):
         return result
 
 
-class CodexCLI(LlmCli):
+class CodexCli(LlmCli):
     """Use the locally authenticated Codex CLI as a Lumen provider."""
 
     display_name = param.String(default="Codex CLI", constant=True)
@@ -1462,7 +1468,7 @@ class CodexCLI(LlmCli):
         return final_message.strip()
 
 
-class ClaudeCodeCLI(LlmCli):
+class ClaudeCode(LlmCli):
     """Use the locally authenticated Claude Code CLI as a Lumen provider."""
 
     display_name = param.String(default="Claude Code CLI", constant=True)

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -15,8 +15,9 @@ try:
 
     from lumen.ai.agents.vega_lite import VegaLiteAgent
     from lumen.ai.llm import (
-        MLX, Anthropic, AnthropicBedrock, AzureOpenAI, Bedrock, Google, Groq,
-        LiteLLM, LlamaCpp, Llm, Message, MistralAI, Ollama, OpenAI, WebLLM,
+        MLX, Anthropic, AnthropicBedrock, AzureOpenAI, Bedrock, ClaudeCodeCLI,
+        CodexCLI, Google, Groq, LiteLLM, LlamaCpp, Llm, Message, MistralAI,
+        Ollama, OpenAI, WebLLM,
     )
     from lumen.ai.tools import FunctionTool
 
@@ -162,6 +163,64 @@ def test_get_available_llm_respects_modified_provider_env_vars(monkeypatch):
     monkeypatch.setitem(lmai.llm.PROVIDER_ENV_VARS, "openai", "MY_CUSTOM_OPENAI_KEY")
     monkeypatch.setenv("MY_CUSTOM_OPENAI_KEY", "custom-value")
     assert lmai.llm.get_available_llm() is OpenAI
+
+
+def test_cli_providers_are_registered():
+    """CLI-backed subscription providers can be selected explicitly by the command line."""
+    assert lmai.llm.LLM_PROVIDERS["codex-cli"] == "CodexCLI"
+    assert lmai.llm.LLM_PROVIDERS["claude-code"] == "ClaudeCodeCLI"
+
+
+def test_codex_cli_command_defaults_to_read_only():
+    llm = CodexCLI(working_dir="/tmp/project")
+
+    command = llm._build_command("gpt-test", "Hello")
+
+    assert command == [
+        "codex", "exec", "--json", "--sandbox", "read-only",
+        "--skip-git-repo-check", "--ephemeral", "--cd", "/tmp/project",
+        "--model", "gpt-test", "Hello",
+    ]
+
+
+def test_claude_code_command_defaults_to_plan_mode():
+    llm = ClaudeCodeCLI()
+
+    command = llm._build_command("sonnet", "Hello")
+
+    assert command == [
+        "claude", "--print", "--output-format", "json", "--max-turns", "1",
+        "--permission-mode", "plan", "--model", "sonnet", "Hello",
+    ]
+
+
+def test_cli_output_decoders():
+    codex = CodexCLI()
+    codex_output = (
+        '{"type":"thread.started","thread_id":"abc"}\n'
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Ready"}}'
+    )
+    assert codex._decode_output(codex_output) == "Ready"
+
+    claude = ClaudeCodeCLI()
+    assert claude._decode_output('{"result":"Ready", "is_error":false}') == "Ready"
+
+
+async def test_cli_provider_validates_structured_output(monkeypatch):
+    class Reply(BaseModel):
+        ready: bool
+
+    async def fake_run_command(command):
+        return ('{"result": "{\\"ready\\": true}", "is_error": false}', "")
+
+    llm = ClaudeCodeCLI()
+    monkeypatch.setattr(llm, "_run_command", fake_run_command)
+
+    result = await llm.run_client(
+        "default", [{"role": "user", "content": "Ready?"}], response_model=Reply
+    )
+
+    assert result == Reply(ready=True)
 
 
 async def test_azure_open_ai_get_model_kwargs():

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -1,7 +1,7 @@
 """Test suite for LLM implementations."""
 
+import asyncio
 import base64
-import os
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -172,25 +172,24 @@ def test_cli_providers_are_registered():
 
 
 def test_codex_cli_command_defaults_to_read_only():
-    llm = CodexCLI(working_dir="/tmp/project")
+    llm = CodexCLI()
 
-    command = llm._build_command("gpt-test", "Hello")
+    command = llm._build_command("gpt-test")
 
     assert command == [
         "codex", "exec", "--json", "--sandbox", "read-only",
-        "--skip-git-repo-check", "--ephemeral", "--cd", "/tmp/project",
-        "--model", "gpt-test", "Hello",
+        "--skip-git-repo-check", "--ephemeral", "--model", "gpt-test", "-",
     ]
 
 
 def test_claude_code_command_defaults_to_plan_mode():
     llm = ClaudeCodeCLI()
 
-    command = llm._build_command("sonnet", "Hello")
+    command = llm._build_command("sonnet")
 
     assert command == [
-        "claude", "--print", "--output-format", "json", "--max-turns", "1",
-        "--permission-mode", "plan", "--model", "sonnet", "Hello",
+        "claude", "--print", "--output-format", "json", "--no-session-persistence",
+        "--max-turns", "1", "--permission-mode", "plan", "--model", "sonnet",
     ]
 
 
@@ -198,6 +197,7 @@ def test_cli_output_decoders():
     codex = CodexCLI()
     codex_output = (
         '{"type":"thread.started","thread_id":"abc"}\n'
+        '{"type":"item.completed","item":{"type":"agent_message","text":"First"}}\n'
         '{"type":"item.completed","item":{"type":"agent_message","text":"Ready"}}'
     )
     assert codex._decode_output(codex_output) == "Ready"
@@ -210,8 +210,8 @@ async def test_cli_provider_validates_structured_output(monkeypatch):
     class Reply(BaseModel):
         ready: bool
 
-    async def fake_run_command(command):
-        return ('{"result": "{\\"ready\\": true}", "is_error": false}', "")
+    async def fake_run_command(command, prompt):
+        return '{"result": "{\\"ready\\": true}", "is_error": false}'
 
     llm = ClaudeCodeCLI()
     monkeypatch.setattr(llm, "_run_command", fake_run_command)
@@ -221,6 +221,57 @@ async def test_cli_provider_validates_structured_output(monkeypatch):
     )
 
     assert result == Reply(ready=True)
+
+
+async def test_cli_provider_sends_prompt_over_stdin(monkeypatch):
+    captured = {}
+
+    class Process:
+        returncode = 0
+
+        async def communicate(self, data):
+            captured["stdin"] = data
+            return b'{"result":"Ready","is_error":false}', b""
+
+    async def create_subprocess(*command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return Process()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
+    llm = ClaudeCodeCLI(working_dir="/tmp")
+
+    output = await llm._run_command(["claude", "--print"], "Private prompt")
+
+    assert output == '{"result":"Ready","is_error":false}'
+    assert captured["stdin"] == b"Private prompt"
+    assert captured["command"] == ("claude", "--print")
+    assert captured["kwargs"]["stdin"] is asyncio.subprocess.PIPE
+    assert captured["kwargs"]["cwd"] == "/tmp"
+
+
+async def test_cli_provider_skips_unsupported_tool_loop(monkeypatch):
+    class Reply(BaseModel):
+        ready: bool
+
+    calls = []
+
+    async def run_client(model_spec, messages, **kwargs):
+        calls.append(kwargs)
+        return Reply(ready=True)
+
+    llm = ClaudeCodeCLI()
+    monkeypatch.setattr(llm, "run_client", run_client)
+
+    result = await llm._run_tool_loop(
+        [{"role": "user", "content": "Ready?"}],
+        Reply,
+        {"unsupported": object()},
+        {},
+    )
+
+    assert result == Reply(ready=True)
+    assert len(calls) == 1
 
 
 async def test_azure_open_ai_get_model_kwargs():

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -189,7 +189,7 @@ def test_claude_code_command_defaults_to_plan_mode():
 
     assert command == [
         "claude", "--print", "--output-format", "json", "--no-session-persistence",
-        "--max-turns", "1", "--permission-mode", "plan", "--model", "sonnet",
+        "--max-turns", "3", "--permission-mode", "plan", "--model", "sonnet",
     ]
 
 

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -223,7 +223,7 @@ async def test_cli_provider_validates_structured_output(monkeypatch):
     assert result == Reply(ready=True)
 
 
-async def test_cli_provider_sends_prompt_over_stdin(monkeypatch):
+async def test_cli_provider_sends_prompt_over_stdin(monkeypatch, tmp_path):
     captured = {}
 
     class Process:
@@ -239,7 +239,7 @@ async def test_cli_provider_sends_prompt_over_stdin(monkeypatch):
         return Process()
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
-    llm = ClaudeCodeCLI(working_dir="/tmp")
+    llm = ClaudeCodeCLI(working_dir=str(tmp_path))
 
     output = await llm._run_command(["claude", "--print"], "Private prompt")
 
@@ -247,7 +247,7 @@ async def test_cli_provider_sends_prompt_over_stdin(monkeypatch):
     assert captured["stdin"] == b"Private prompt"
     assert captured["command"] == ("claude", "--print")
     assert captured["kwargs"]["stdin"] is asyncio.subprocess.PIPE
-    assert captured["kwargs"]["cwd"] == "/tmp"
+    assert captured["kwargs"]["cwd"] == str(tmp_path)
 
 
 async def test_cli_provider_skips_unsupported_tool_loop(monkeypatch):

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -16,8 +16,8 @@ try:
     from lumen.ai.agents.vega_lite import VegaLiteAgent
     from lumen.ai.llm import (
         MLX, Anthropic, AnthropicBedrock, AzureOpenAI, Bedrock, ClaudeCodeCLI,
-        CodexCLI, Google, Groq, LiteLLM, LlamaCpp, Llm, Message, MistralAI,
-        Ollama, OpenAI, WebLLM,
+        CodexCLI, Google, Groq, LiteLLM, LlamaCpp, Llm, LlmCli, Message,
+        MistralAI, Ollama, OpenAI, WebLLM,
     )
     from lumen.ai.tools import FunctionTool
 
@@ -169,6 +169,8 @@ def test_cli_providers_are_registered():
     """CLI-backed subscription providers can be selected explicitly by the command line."""
     assert lmai.llm.LLM_PROVIDERS["codex-cli"] == "CodexCLI"
     assert lmai.llm.LLM_PROVIDERS["claude-code"] == "ClaudeCodeCLI"
+    assert issubclass(CodexCLI, LlmCli)
+    assert issubclass(ClaudeCodeCLI, LlmCli)
 
 
 def test_codex_cli_command_defaults_to_read_only():

--- a/lumen/tests/ai/test_llm.py
+++ b/lumen/tests/ai/test_llm.py
@@ -15,8 +15,8 @@ try:
 
     from lumen.ai.agents.vega_lite import VegaLiteAgent
     from lumen.ai.llm import (
-        MLX, Anthropic, AnthropicBedrock, AzureOpenAI, Bedrock, ClaudeCodeCLI,
-        CodexCLI, Google, Groq, LiteLLM, LlamaCpp, Llm, LlmCli, Message,
+        MLX, Anthropic, AnthropicBedrock, AzureOpenAI, Bedrock, ClaudeCode,
+        CodexCli, Google, Groq, LiteLLM, LlamaCpp, Llm, LlmCli, Message,
         MistralAI, Ollama, OpenAI, WebLLM,
     )
     from lumen.ai.tools import FunctionTool
@@ -167,14 +167,14 @@ def test_get_available_llm_respects_modified_provider_env_vars(monkeypatch):
 
 def test_cli_providers_are_registered():
     """CLI-backed subscription providers can be selected explicitly by the command line."""
-    assert lmai.llm.LLM_PROVIDERS["codex-cli"] == "CodexCLI"
-    assert lmai.llm.LLM_PROVIDERS["claude-code"] == "ClaudeCodeCLI"
-    assert issubclass(CodexCLI, LlmCli)
-    assert issubclass(ClaudeCodeCLI, LlmCli)
+    assert lmai.llm.LLM_PROVIDERS["codex-cli"] == "CodexCli"
+    assert lmai.llm.LLM_PROVIDERS["claude-code"] == "ClaudeCode"
+    assert issubclass(CodexCli, LlmCli)
+    assert issubclass(ClaudeCode, LlmCli)
 
 
 def test_codex_cli_command_defaults_to_read_only():
-    llm = CodexCLI()
+    llm = CodexCli()
 
     command = llm._build_command("gpt-test")
 
@@ -185,7 +185,7 @@ def test_codex_cli_command_defaults_to_read_only():
 
 
 def test_claude_code_command_defaults_to_plan_mode():
-    llm = ClaudeCodeCLI()
+    llm = ClaudeCode()
 
     command = llm._build_command("sonnet")
 
@@ -196,7 +196,7 @@ def test_claude_code_command_defaults_to_plan_mode():
 
 
 def test_cli_output_decoders():
-    codex = CodexCLI()
+    codex = CodexCli()
     codex_output = (
         '{"type":"thread.started","thread_id":"abc"}\n'
         '{"type":"item.completed","item":{"type":"agent_message","text":"First"}}\n'
@@ -204,7 +204,7 @@ def test_cli_output_decoders():
     )
     assert codex._decode_output(codex_output) == "Ready"
 
-    claude = ClaudeCodeCLI()
+    claude = ClaudeCode()
     assert claude._decode_output('{"result":"Ready", "is_error":false}') == "Ready"
 
 
@@ -215,7 +215,7 @@ async def test_cli_provider_validates_structured_output(monkeypatch):
     async def fake_run_command(command, prompt):
         return '{"result": "{\\"ready\\": true}", "is_error": false}'
 
-    llm = ClaudeCodeCLI()
+    llm = ClaudeCode()
     monkeypatch.setattr(llm, "_run_command", fake_run_command)
 
     result = await llm.run_client(
@@ -241,7 +241,7 @@ async def test_cli_provider_sends_prompt_over_stdin(monkeypatch, tmp_path):
         return Process()
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
-    llm = ClaudeCodeCLI(working_dir=str(tmp_path))
+    llm = ClaudeCode(working_dir=str(tmp_path))
 
     output = await llm._run_command(["claude", "--print"], "Private prompt")
 
@@ -262,7 +262,7 @@ async def test_cli_provider_skips_unsupported_tool_loop(monkeypatch):
         calls.append(kwargs)
         return Reply(ready=True)
 
-    llm = ClaudeCodeCLI()
+    llm = ClaudeCode()
     monkeypatch.setattr(llm, "run_client", run_client)
 
     result = await llm._run_tool_loop(


### PR DESCRIPTION
## Description

Add `codex-cli` and `claude-code` providers that use locally authenticated CLI subscriptions, without a separate API key.

```bash
lumen-ai serve --provider codex-cli
lumen-ai serve --provider claude-code
```


## AI Disclosure

Tool & Model: ChatGPT Codex

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
- [x] Added documentation