### PR TITLE
fix: draw the glyphs, not just the axes

### DIFF
--- a/lumen/ai/agents/hvplot.py
+++ b/lumen/ai/agents/hvplot.py
@@ -104,6 +104,25 @@ class hvPlotAgent(BaseViewAgent):
         if spec.get("aggregator") in VALUE_AGGREGATORS:
             spec.pop("aggregator", None)
 
+    @staticmethod
+    def _drop_unknown_columns(spec: dict[str, Any], columns) -> None:
+        """Drop axes naming a column the query did not produce.
+
+        The model is offered the columns of the table it was given, but it can
+        still answer with one it expected the query to create. hvPlot only
+        finds out while drawing, where it raises a bare KeyError and the whole
+        chart is lost; dropping the axis leaves hvPlot to infer one instead.
+        """
+        for field in ("x", "y", "z"):
+            if spec.get(field) is not None and spec[field] not in columns:
+                spec.pop(field)
+        for field in ("by", "groupby"):
+            known = [column for column in spec.get(field) or [] if column in columns]
+            if known:
+                spec[field] = known
+            else:
+                spec.pop(field, None)
+
     async def _extract_spec(self, context: TContext, spec: dict[str, Any]):
         pipeline = context["pipeline"]
         spec = {key: val for key, val in spec.items() if val is not None}
@@ -118,6 +137,7 @@ class hvPlotAgent(BaseViewAgent):
         # Add defaults
         spec["responsive"] = True
         data = await get_data(pipeline)
+        self._drop_unknown_columns(spec, set(data.columns))
         if len(data) > 20000 and spec["kind"] in ("line", "scatter", "points"):
             if spec.get("by"):
                 # rasterize reduces to a single number per pixel, which throws

--- a/lumen/ai/agents/hvplot.py
+++ b/lumen/ai/agents/hvplot.py
@@ -105,7 +105,7 @@ class hvPlotAgent(BaseViewAgent):
             spec.pop("aggregator", None)
 
     @staticmethod
-    def _drop_unknown_columns(spec: dict[str, Any], columns) -> None:
+    def _drop_unknown_columns(spec: dict[str, Any], columns: set[str]) -> None:
         """Drop axes naming a column the query did not produce.
 
         The model is offered the columns of the table it was given, but it can

--- a/lumen/ai/agents/hvplot.py
+++ b/lumen/ai/agents/hvplot.py
@@ -5,7 +5,7 @@ import param
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
-from ...views import hvPlotUIView
+from ...views import hvPlotView
 from ...views.base import GRIDDED_KINDS, VALUE_AGGREGATORS
 from ..config import PROMPTS_DIR
 from ..context import TContext
@@ -35,7 +35,7 @@ class hvPlotAgent(BaseViewAgent):
         }
     )
 
-    view_type = hvPlotUIView
+    view_type = hvPlotView
 
     def _get_model(self, prompt_name: str, schema: dict[str, Any] | None = None) -> type[BaseModel]:
         # Only the main prompt describes the view. Every other prompt, revise
@@ -54,6 +54,12 @@ class hvPlotAgent(BaseViewAgent):
             "download",
             "field",
             "selection_group",
+            # Runtime state and HoloViews-level escape hatches: nothing a plot
+            # request asks for, and nothing the model could fill sensibly.
+            "operations",
+            "opts",
+            "selection_expr",
+            "streaming",
         ]
         model = param_to_pydantic(
             self.view_type,
@@ -105,7 +111,7 @@ class hvPlotAgent(BaseViewAgent):
         # hvPlotExplorer rejects any keyword none of its controls claims.
         spec.pop("chain_of_thought", None)
         self._drop_conflicting_axes(spec)
-        spec["type"] = "hvplot_ui"
+        spec["type"] = "hvplot"
         self.view_type.validate(spec)
         spec.pop("type", None)
 

--- a/lumen/ai/prompts/SQLAgent/main.jinja2
+++ b/lumen/ai/prompts/SQLAgent/main.jinja2
@@ -15,7 +15,7 @@ Write SQL query for user's data transformation request, focusing on intent over 
 
 ## Query Patterns
 - Exclude NULLs unless specified, or unless the question is about missing data, completeness or data quality — then count and report them instead of filtering them out
-- Clean data: `TRIM("column") != ''`, filter -9999, empty strings, split text columns
+- Clean data: `TRIM("column") != ''` on text columns only, never on a numeric or date one; filter -9999, empty strings, split text columns
 - Headers: Use OFFSET 1 for header/metadata rows
 - Mixed units: Use CASE to normalize before aggregating
 - Temporal data: Check MIN/MAX dates before joining, ensure overlap validation

--- a/lumen/ai/prompts/hvPlotAgent/main.jinja2
+++ b/lumen/ai/prompts/hvPlotAgent/main.jinja2
@@ -4,7 +4,9 @@
 Generate plot user requested. `x`, `y`, `by` and `groupby` fields MUST ALL be unique columns;
 no repeated columns allowed. Do not arbitrarily set `groupby` and `by` fields unless explicitly requested. If
 histogram requested, use `y` instead of `x`. If x categorical or strings, prefer barh over bar, and use `y` for
-values. If column has `format: geometry`, set `kind` from its `geometry_type`: `polygons` for Polygon or
+values. A bar chart needs a discrete `x` with few values: never draw one against a continuous column such as a
+price or a measurement, and never against a column the query grouped by without bucketing it first. Pick the
+categorical column the user meant, or use a histogram to show how a continuous column is distributed. If column has `format: geometry`, set `kind` from its `geometry_type`: `polygons` for Polygon or
 MultiPolygon, `paths` for LineString or MultiLineString, otherwise `points`.
 
 To color a dense scatter or point cloud by a category, set `by` to that column and `datashade=True`; this

--- a/lumen/ai/translate.py
+++ b/lumen/ai/translate.py
@@ -268,10 +268,11 @@ def parameter_to_field(parameter: param.Parameter, created_models: dict[str, typ
     elif param_type in [param.Selector, param.ObjectSelector]:
         if parameter.default is not None:
             field_kwargs["default"] = parameter.default
-        elif None in getattr(parameter, "objects", ()):
+        else:
             # Defaulting to None is how a Selector says the option is off. With
-            # no default the field is required, and _create_literal drops None
-            # from the choices, leaving the LLM no way to answer that.
+            # no default the field comes out required, so the LLM has to answer
+            # it: z is asked for on a scatter that has no z, and the answer is
+            # then rejected for naming a column that means nothing there.
             field_kwargs["default"] = None
 
         current_literals = literals

--- a/lumen/tests/ai/test_hvplot_agent.py
+++ b/lumen/tests/ai/test_hvplot_agent.py
@@ -97,3 +97,16 @@ def test_a_value_outside_the_choices_does_not_break_the_model():
     model = param_to_pydantic(type(instance), base_model=BaseModel)[type(instance).__name__]
 
     assert set(model.model_json_schema()["properties"]["cmap"]["enum"]) == {"viridis", "fire"}
+
+
+async def test_an_axis_naming_a_missing_column_is_dropped(pipeline):
+    """The model can answer with a column it expected its query to create, and
+    hvPlot only finds out while drawing, where it raises a bare KeyError."""
+    spec = {"kind": "bar", "x": "elevation_band", "y": "y", "by": ["nope"], "groupby": ["x"]}
+
+    extracted = await hvPlotAgent()._extract_spec({"pipeline": pipeline}, spec)
+
+    assert "x" not in extracted
+    assert extracted["y"] == "y"
+    assert "by" not in extracted
+    assert extracted["groupby"] == ["x"]

--- a/lumen/tests/ai/test_hvplot_datashade.py
+++ b/lumen/tests/ai/test_hvplot_datashade.py
@@ -15,7 +15,10 @@ from lumen.views.base import hvPlotBaseView
 
 async def extract(spec, n_rows):
     """Run _extract_spec against a frame of the given size."""
-    data = pd.DataFrame({"x": range(n_rows), "y": range(n_rows), "c": ["a"] * n_rows})
+    data = pd.DataFrame({
+        "x": range(n_rows), "y": range(n_rows),
+        "c": ["a"] * n_rows, "other": ["b"] * n_rows,
+    })
     with patch("lumen.ai.agents.hvplot.get_data", return_value=data):
         return await hvPlotAgent()._extract_spec(
             {"pipeline": SimpleNamespace(table="t")}, dict(spec)

--- a/lumen/tests/views/test_hvplot_datashade.py
+++ b/lumen/tests/views/test_hvplot_datashade.py
@@ -427,3 +427,19 @@ def test_aggregator_reaches_the_explorer(categorical_pipeline):
     _args, kwargs = view._get_args()
 
     assert kwargs["aggregator"] == "count"
+
+
+def test_an_axis_the_frame_does_not_carry_is_dropped(categorical_pipeline, categorical_df):
+    """A spec can name a column the query never created, and hvPlot only finds
+    out while drawing, where it raises a bare KeyError."""
+    view = hvPlotView(
+        pipeline=categorical_pipeline, kind="scatter", x="nope", y="y",
+        by=["ancestry", "missing"], groupby=["gone"],
+    )
+
+    recorded = record_hvplot_call(view, categorical_df)
+
+    assert recorded["x"] is None
+    assert recorded["y"] == "y"
+    assert recorded["by"] == ["ancestry"]
+    assert recorded["groupby"] is None

--- a/lumen/tests/views/test_hvplot_datashade.py
+++ b/lumen/tests/views/test_hvplot_datashade.py
@@ -52,7 +52,18 @@ class RecordingFrame(pd.DataFrame):
 
     def hvplot(self, **kwargs):
         self.recorded.update(kwargs)
-        return object()
+        return RecordedPlot()
+
+
+class RecordedPlot:
+    """Stands in for the HoloViews element hvPlot returns.
+
+    The view goes on to set options on it, so a bare object is not enough of a
+    double.
+    """
+
+    def opts(self, *args, **kwargs):
+        return self
 
 
 def record_hvplot_call(view, df):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -109,6 +109,9 @@ AGGREGATORS = [None, "any", "count", "max", "mean", "min", "sum"]
 # told which column via `color`; without it datashader cannot pick a dimension.
 VALUE_AGGREGATORS = ("max", "mean", "min", "sum")
 
+# Kinds that draw one bar per x value, so the axis has to be categorical.
+BAR_KINDS = ("bar", "barh")
+
 
 class View(MultiTypeComponent, Viewer):
     """
@@ -1102,6 +1105,19 @@ class hvPlotBaseView(View):
         # tables and downloads keep the nullable columns.
         return widen_nullable(super().get_data())
 
+    @staticmethod
+    def _as_categorical(df, column):
+        """Label a bar chart's x values so hvPlot gives the axis factors.
+
+        hvPlot sizes a bar from the smallest gap between neighbouring x values.
+        A continuous column aggregated per distinct value leaves gaps far
+        smaller than the axis span, and every bar comes out a fraction of a
+        pixel wide, so the plot looks empty. Bars are categorical anyway.
+        """
+        if isinstance(df[column].dtype, pd.CategoricalDtype) or df[column].dtype == object:
+            return df
+        return df.assign(**{column: df[column].astype(str)})
+
     def _check_render_size(self, df) -> None:
         """Refuse to render more per-row glyphs than a browser tab can hold.
 
@@ -1320,6 +1336,8 @@ class hvPlotView(hvPlotBaseView):
             processed['geo'] = self.geo
         elif kind in GRIDDED_KINDS:
             plot_source = self._gridded_plot_source(df)
+        elif kind in BAR_KINDS and self.x in plot_source.columns:
+            plot_source = self._as_categorical(plot_source, self.x)
 
         plot = plot_source.hvplot(
             kind=kind, x=self.x, y=self.y, by=self.by, groupby=self.groupby, **processed

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1311,6 +1311,22 @@ class hvPlotView(hvPlotBaseView):
 
     def get_plot(self, df):
         self._check_render_size(df)
+        # A spec can name a column the frame does not carry, e.g. when the query
+        # meant to create it failed. hvPlot only finds out while drawing, where
+        # it raises a bare KeyError and nothing renders at all, so an axis with
+        # nothing behind it is dropped and hvPlot infers one instead. A gridded
+        # source arrives as an xarray Dataset whose axes are dims rather than
+        # columns, and _gridded_plot_source already checks those.
+        known = set(df.columns) if isinstance(df, pd.DataFrame) else None
+
+        def keep(name):
+            return known is None or name in known
+
+        x = self.x if keep(self.x) else None
+        y = self.y if keep(self.y) else None
+        z = self.z if keep(self.z) else None
+        by = [column for column in self.by or [] if keep(column)]
+        groupby = [column for column in self.groupby or [] if keep(column)]
         processed = {}
         for k, v in self.kwargs.items():
             if k in self._ignore_kwargs:
@@ -1320,8 +1336,8 @@ class hvPlotView(hvPlotBaseView):
             processed[k] = v
         if self.streaming:
             processed['stream'] = self._data_stream
-        if self.z is not None:
-            processed['C' if self.kind == 'heatmap' else 'z'] = self.z
+        if z is not None:
+            processed['C' if self.kind == 'heatmap' else 'z'] = z
         # Params are stripped out of kwargs by View.__init__, so anything hvPlot
         # needs has to be put back explicitly.
         if self.datashade:
@@ -1344,11 +1360,11 @@ class hvPlotView(hvPlotBaseView):
             processed['geo'] = self.geo
         elif kind in GRIDDED_KINDS:
             plot_source = self._gridded_plot_source(df)
-        elif kind in BAR_KINDS and self.x in plot_source.columns:
-            plot_source = self._as_categorical(plot_source, self.x)
+        elif kind in BAR_KINDS and x is not None:
+            plot_source = self._as_categorical(plot_source, x)
 
         plot = plot_source.hvplot(
-            kind=kind, x=self.x, y=self.y, by=self.by, groupby=self.groupby, **processed
+            kind=kind, x=x, y=y, by=by or None, groupby=groupby or None, **processed
         )
         plot = plot.opts(backend_opts=CANVAS_BACKEND)
         if self.operations:

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -112,6 +112,14 @@ VALUE_AGGREGATORS = ("max", "mean", "min", "sum")
 # Kinds that draw one bar per x value, so the axis has to be categorical.
 BAR_KINDS = ("bar", "barh")
 
+# HoloViews defaults a bokeh plot to the WebGL backend, which draws the glyphs
+# on an offscreen GL canvas and blits the result onto the 2D one carrying the
+# axes. Inside the chat UI that blit does not land, so a plot arrives with its
+# axes, its gridlines and none of its data. Drawing straight to 2D costs
+# nothing here: a frame past MAX_RENDER_ROWS is refused, and one past 20k is
+# datashaded into an image server-side long before WebGL would earn its keep.
+CANVAS_BACKEND = {"plot.output_backend": "canvas"}
+
 
 class View(MultiTypeComponent, Viewer):
     """
@@ -1342,6 +1350,7 @@ class hvPlotView(hvPlotBaseView):
         plot = plot_source.hvplot(
             kind=kind, x=self.x, y=self.y, by=self.by, groupby=self.groupby, **processed
         )
+        plot = plot.opts(backend_opts=CANVAS_BACKEND)
         if self.operations:
             for operation in self.operations:
                 plot = operation(plot)


### PR DESCRIPTION
## Description

HoloViews defaults a bokeh plot to the WebGL backend, which draws the glyphs on an offscreen GL canvas and blits the result onto the 2D one carrying the axes, and in the chat UI that blit does not land, so every hvPlot chart arrived with its axes and none of its data. This draws straight to 2D instead, and along the way stops the agent building the Explorer UI, stops it being asked for a `z` a scatter has none of, and gives bar charts an axis they can actually be a pixel wide on.

Fixes #2067

