### PR TITLE
Give the Altair prompt the multi-series split rule

### DIFF
--- a/lumen/ai/prompts/VegaLiteAgent/main_altair.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main_altair.jinja2
@@ -16,6 +16,7 @@ Return several entries in `charts` ONLY when request spans distinct metrics or r
 - **Geo**: `longitude='lon:Q', latitude='lat:Q'` with `.project(type='mercator')`
 
 ## Rules
+- If a categorical column separates the rows into more than one series, split on it with `color` (or `detail` when no legend is wanted). A `mark_line`/`mark_area` with no split strings every series onto one path, so the line zigzags back across the axis.
 - When a discrete axis would carry more than 25 distinct values (check `nunique` in data summary), reduce before plotting: `.transform_window(rank='rank()', sort=[...])` then `.transform_filter('datum.rank <= 25')`, and name the cut in the title. Alternatives: group tail into `"Other"`, or bin the measure instead. Only add text labels to a chart already reduced to 25 marks or fewer.
 - When n_rows > 5000:
   - **MUST** include `alt.data_transformers.disable_max_rows()` and `alt.renderers.set_embed_options(renderer="canvas")`
@@ -42,7 +43,7 @@ chart = alt.Chart(df).mark_bar().encode(y=alt.Y('state:N', sort='-x'), x='count:
 
 Time series:
 ```python
-chart = alt.Chart(df).mark_line(point=True).encode(x='date:T', y='value:Q', tooltip=['date', 'value']).properties(width='container', height=300).interactive()
+chart = alt.Chart(df).mark_line(point=True).encode(x='date:T', y='value:Q', color='series:N', tooltip=['date', 'series', 'value']).properties(width='container', height=300).interactive()
 ```
 
 Scatter:

--- a/lumen/tests/ai/test_vega_lite.py
+++ b/lumen/tests/ai/test_vega_lite.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError:
 import vl_convert
 
 from lumen.ai.agents.vega_lite import VegaLiteAgent
+from lumen.ai.config import PROMPTS_DIR
 from lumen.ai.editors import VegaLiteEditor
 from lumen.ai.utils import category_palette, normalize_vegalite_spec
 from lumen.config import dump_yaml
@@ -253,3 +254,79 @@ class TestGeoshapeGeometryValidation:
             },
         }
         VegaLiteEditor.validate_spec(spec)
+
+
+class TestMultiSeriesLineSplit:
+    """A line over several series needs a split channel or every series lands on
+    one polyline, which zigzags back across a perfectly correct time axis.
+
+    Vega-Lite splits the path by wrapping the mark in a group whose
+    ``from.facet.groupby`` names the split field, so the compiled output says
+    plainly whether the chart draws one line or several.
+    """
+
+    ROWS = [
+        {"time": time, "band": band, "temp": temp}
+        for time in ("2020-01-01", "2020-04-01", "2020-07-01")
+        for band, temp in (("tropics", 28), ("midlat", 12), ("arctic", -15))
+    ]
+
+    @classmethod
+    def _line_spec(cls, **encoding):
+        return {
+            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+            "data": {"values": cls.ROWS},
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "time", "type": "temporal"},
+                "y": {"field": "temp", "type": "quantitative"},
+                **encoding,
+            },
+        }
+
+    @classmethod
+    def _split_field(cls, **encoding):
+        """The field the compiled chart splits its path on, None if it draws one."""
+        mark = vl_convert.vegalite_to_vega(cls._line_spec(**encoding))["marks"][0]
+        return ((mark.get("from") or {}).get("facet") or {}).get("groupby")
+
+    def test_a_line_with_no_split_channel_draws_a_single_path(self):
+        assert self._split_field() is None
+
+    def test_color_and_detail_each_split_the_path(self):
+        band = {"field": "band", "type": "nominal"}
+        assert self._split_field(color=band) == ["band"]
+        assert self._split_field(detail=band) == ["band"]
+
+    def test_shape_and_a_constant_color_leave_the_path_joined(self):
+        """Neither reaches the path, so a chart that names a series through them
+        still draws one polyline. A check that trusted the presence of a channel
+        rather than the compiled output would call both of these split.
+        """
+        assert self._split_field(shape={"field": "band", "type": "nominal"}) is None
+        assert self._split_field(color={"value": "#d62728"}) is None
+
+    def test_sorting_the_x_encoding_leaves_the_path_untouched(self):
+        """A path mark already sorts by x, so an explicit sort on a continuous
+        axis cannot be what joins or separates the series.
+        """
+        plain = vl_convert.vegalite_to_vega(self._line_spec())
+        sorted_x = vl_convert.vegalite_to_vega(
+            self._line_spec(x={"field": "time", "type": "temporal", "sort": "ascending"})
+        )
+
+        assert [mark.get("sort") for mark in plain["marks"]] == [{"field": "x"}]
+        assert sorted_x == plain
+
+    def test_the_altair_template_states_the_split_rule_and_shows_it(self):
+        """main.jinja2 carries this rule; main_altair.jinja2 is a separate
+        template that inherits none of it, so it needs its own copy and its own
+        worked example.
+        """
+        # ponytail: reads the template as text, which holds while the rule and
+        # the example both sit outside every conditional block.
+        altair = (PROMPTS_DIR / "VegaLiteAgent" / "main_altair.jinja2").read_text()
+        time_series = altair.split("Time series:")[1].split("```")[1]
+
+        assert "split on it with `color`" in altair
+        assert "mark_line" in time_series and "color=" in time_series


### PR DESCRIPTION
`main_altair.jinja2` extends `BaseViewAgent`, not `main.jinja2`, so it never got the multi-series split rule `main.jinja2` states at line 12, and its time series example shows a bare `mark_line()`.

Adds the rule and the split, with tests pinning which encodings actually split a compiled path.