### PR TITLE
Fix ValidationAgent failing valid plans by skipping strict validation…

### DIFF
--- a/lumen/ai/prompts/ValidationAgent/main.jinja2
+++ b/lumen/ai/prompts/ValidationAgent/main.jinja2
@@ -2,7 +2,7 @@
 
 {%- block instructions %}
 ## Instructions
-{% if memory.get('sql') %}
+{% if memory.get('sql') and 'sql' not in previous_keys %}
 Analyze if SQL query matches user's request by checking:
 1. What user asked for
 2. What SQL actually does (read carefully)
@@ -14,10 +14,10 @@ VALID = SQL implements user's intent correctly
 - Accept reasonable interpretations; do not over-interpret `limit` (100,000 default)
 - When data fetched from external source, table already scoped to fetched parameters. `SELECT *` or unfiltered query against such table valid if data overview shows requested rows present.
 {% endif %}
-{% if memory.get('view') %}
+{% if memory.get('view') and 'view' not in previous_keys %}
 Analyze if generated view and responses match user's request.
 {% endif %}
-{% if memory.get('listing') %}
+{% if memory.get('listing') and 'listing' not in previous_keys %}
 Listing of items displayed to user. VALID if matches what they asked to see.
 {% endif %}
 Analyze if assistant's response addresses user's request given available context.

--- a/lumen/ai/prompts/ValidationAgent/main.jinja2
+++ b/lumen/ai/prompts/ValidationAgent/main.jinja2
@@ -25,6 +25,7 @@ Analyze if assistant's response addresses user's request given available context
 {% endif %}
 VALID = response uses available context to answer; do not penalize missing data never loaded or available.
 Clarifying question IS valid response when user's request ambiguous or when assistant lacks sufficient context to act directly.
+{% endif %}
 {%- if memory.get('clarifications') %}
 Clarifications collected from user during planning. User's answers refine or override original request. Validate against CLARIFIED intent, not original ambiguous request.
 {%- endif %}
@@ -33,7 +34,7 @@ Items labeled "(From previous plan)" leftover context from earlier plan. May pro
 
 {%- block examples %}
 ## Examples (illustrative — `data`, `sales`, `region` etc. placeholders, not real tables/columns)
-{% if memory.get('sql') -%}
+{% if memory.get('sql') and 'sql' not in previous_keys -%}
 User: "by region?"
 SQL: SELECT region, SUM(sales) FROM data GROUP BY region
 VALID - has GROUP BY region
@@ -54,10 +55,12 @@ User: "total by state"
 SQL: SELECT state, SUM(amount) FROM data GROUP BY state
 VALID - groups by state with SUM
 {% endif %}
+{% if 'chat' not in previous_keys -%}
 User: "Summarize survey results" → Response with field breakdowns and patterns → VALID
 User: "What are top selling products?" → Generic discussion, no rankings → INVALID
 User: "Show me data" → Response listing available columns and asking what to explore → VALID (clarifying question when request ambiguous)
-{% if memory.get('view') -%}
+{% endif %}
+{% if memory.get('view') and 'view' not in previous_keys -%}
 User: "bar chart of sales by region" → bar mark with region on x, sales on y → VALID
 User: "line chart over time" → bar chart with no time axis → INVALID
 {% endif %}

--- a/lumen/ai/prompts/ValidationAgent/main.jinja2
+++ b/lumen/ai/prompts/ValidationAgent/main.jinja2
@@ -20,7 +20,9 @@ Analyze if generated view and responses match user's request.
 {% if memory.get('listing') and 'listing' not in previous_keys %}
 Listing of items displayed to user. VALID if matches what they asked to see.
 {% endif %}
+{% if 'chat' not in previous_keys %}
 Analyze if assistant's response addresses user's request given available context.
+{% endif %}
 VALID = response uses available context to answer; do not penalize missing data never loaded or available.
 Clarifying question IS valid response when user's request ambiguous or when assistant lacks sufficient context to act directly.
 {%- if memory.get('clarifications') %}

--- a/lumen/ai/prompts/ValidationAgent/main.jinja2
+++ b/lumen/ai/prompts/ValidationAgent/main.jinja2
@@ -22,7 +22,6 @@ Listing of items displayed to user. VALID if matches what they asked to see.
 {% endif %}
 {% if 'chat' not in previous_keys %}
 Analyze if assistant's response addresses user's request given available context.
-{% endif %}
 VALID = response uses available context to answer; do not penalize missing data never loaded or available.
 Clarifying question IS valid response when user's request ambiguous or when assistant lacks sufficient context to act directly.
 {% endif %}

--- a/lumen/tests/ai/test_validation_agent.py
+++ b/lumen/tests/ai/test_validation_agent.py
@@ -1,6 +1,7 @@
 import datetime
-import pytest
+
 import jinja2
+import pytest
 
 try:
     from lumen.ai.config import PROMPTS_DIR

--- a/lumen/tests/ai/test_validation_agent.py
+++ b/lumen/tests/ai/test_validation_agent.py
@@ -1,0 +1,61 @@
+import datetime
+import pytest
+import jinja2
+
+try:
+    from lumen.ai.config import PROMPTS_DIR
+except ModuleNotFoundError:
+    pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
+
+
+@pytest.fixture
+def jinja_env():
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(PROMPTS_DIR)),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    env.filters['json_to_yaml'] = lambda x: str(x)
+    return env
+
+
+def test_validation_agent_previous_keys_gating(jinja_env):
+    template = jinja_env.get_template("ValidationAgent/main.jinja2")
+    
+    # Test 1: Keys present and NOT in previous_keys (should render gating instructions)
+    context = {
+        "current_datetime": datetime.datetime.now(),
+        "memory": {"sql": "SELECT 1", "view": "...", "chat": "hello", "listing": "list"},
+        "previous_keys": set()
+    }
+    rendered = template.render(**context)
+    
+    # Check instructions are present
+    assert "Analyze if SQL query matches user's request" in rendered
+    assert "Analyze if generated view and responses match" in rendered
+    assert "Listing of items displayed to user." in rendered
+    assert "Analyze if assistant's response addresses user's request" in rendered
+    
+    # Check examples are present
+    assert "SQL: SELECT region, SUM(sales)" in rendered
+    assert "User: \"Summarize survey results\"" in rendered
+    assert "User: \"bar chart of sales by region\"" in rendered
+    
+    # Test 2: Keys present but IN previous_keys (should NOT render gating instructions)
+    context = {
+        "current_datetime": datetime.datetime.now(),
+        "memory": {"sql": "SELECT 1", "view": "...", "chat": "hello", "listing": "list"},
+        "previous_keys": {"sql", "view", "chat", "listing"}
+    }
+    rendered = template.render(**context)
+    
+    # Check instructions are absent
+    assert "Analyze if SQL query matches user's request" not in rendered
+    assert "Analyze if generated view and responses match" not in rendered
+    assert "Listing of items displayed to user." not in rendered
+    assert "Analyze if assistant's response addresses user's request" not in rendered
+    
+    # Check examples are absent
+    assert "SQL: SELECT region, SUM(sales)" not in rendered
+    assert "User: \"Summarize survey results\"" not in rendered
+    assert "User: \"bar chart of sales by region\"" not in rendered


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
The `ValidationAgent` was strictly validating leftover context variables (`sql`, `view`, and `listing`) against new conversational requests because it did not check whether these keys belonged to `previous_keys`. This triggered false-positive `ValidationFault` errors on valid follow-up queries.

This PR updates `main.jinja2` to skip strict validation for `sql`, `view`, and `listing` when they are present in `previous_keys`, allowing the assistant to safely use previous background context without invalidating valid plans.

Fixes #2062


## AI Disclosure
Tool & Model: Antigravity IDE (Gemini 3.1 Pro / Claude Opus 4.6)
Usage: Used for analyzing the `ValidationAgent` architecture, debugging the Jinja2 template context handling, and preparing the fix.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist

- [ ] Tests added and are passing
- [ ] Added documentation
