### PR TITLE
chore: move YAML_SUFFIXES constant above YamlHandler class

### DIFF
--- a/lumen/command/__init__.py
+++ b/lumen/command/__init__.py
@@ -24,6 +24,8 @@ from .builder import Builder
 from .precache import Precache
 from .validate import Validate
 
+YAML_SUFFIXES = ('.yml', '.yaml')
+
 
 class YamlHandler(CodeHandler):
     ''' Modify Bokeh documents by creating Dashboard from Lumen yaml spec.
@@ -60,9 +62,6 @@ class YamlHandler(CodeHandler):
         # Temporary fix for issues with --warm flag
         with set_curdoc(doc):
             super().modify_document(doc)
-
-
-YAML_SUFFIXES = ('.yml', '.yaml')
 
 
 def build_single_handler_application(path, argv):


### PR DESCRIPTION
Small follow-up to #2075: YAML_SUFFIXES ended up defined between the YamlHandler class and the function that uses it. Moved it up with the other module-level constants.