### PR TITLE
Feat validation heuristic

### DIFF
--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -1,5 +1,3 @@
-import re
-
 from typing import Any, NotRequired
 
 import param
@@ -50,6 +48,33 @@ class ValidationOutputs(ContextModel):
     validation_result: str
 
 
+def get_plan_required_keys(plan):
+    """
+    Check which context keys are required by the tasks in the plan.
+
+    Iterates over each task's ``input_schema`` annotations and checks
+    whether any task declares ``sql``, ``view``, ``chat``, or ``listing``
+    as an input dependency.
+
+    Parameters
+    ----------
+    plan : list[ActorTask]
+        The list of tasks produced by the planner.
+
+    Returns
+    -------
+    dict[str, bool]
+        A dictionary mapping each context key to ``True`` if any task
+        in the plan requires it, ``False`` otherwise.
+    """
+    context_keys = {"sql", "view", "chat", "listing"}
+    all_input_keys = set()
+    for task in plan:
+        annotations = set(task.input_schema.__annotations__.keys())
+        all_input_keys |= annotations
+    return {key: key in all_input_keys for key in context_keys}
+
+
 class ValidationAgent(Agent):
     """
     ValidationAgent focuses solely on validating whether the executed plan
@@ -94,39 +119,15 @@ class ValidationAgent(Agent):
         """
         ctx = await super()._gather_prompt_context(prompt_name, messages, context, **kwargs)
 
-        # Extract the latest user query
-        user_messages = [msg for msg in reversed(messages) if msg.get("role") == "user"]
-        query_text = content_to_text(user_messages[0].get("content", "")).lower() if user_messages else ""
-        query_words = set(re.findall(r'\b\w+\b', query_text))
-
-        # Define category-specific continuation keywords
-        general_keywords = {"it", "this", "that", "these", "those", "also", "and", "now", "previous"}
-        sql_keywords = {"filter", "sort", "limit", "top", "include", "group"}
-        view_keywords = {"color", "label", "chart", "plot", "axis", "instead", "make"}
-        chat_keywords = {"elaborate", "translate", "explain", "why", "point"}
-
-        # Determine which categories are requested to be kept
-        keep_sql = bool(query_words.intersection(sql_keywords | general_keywords))
-        keep_view = bool(query_words.intersection(view_keywords | general_keywords))
-        keep_chat = bool(query_words.intersection(chat_keywords | general_keywords))
-        keep_listing = bool(query_words.intersection(general_keywords))
-
         plan = context.get("plan")
         previous_keys = set()
         if plan is not None:
+            required_keys = get_plan_required_keys(plan)
             produced = {k for task in plan for k in task.out_context}
             for key in ("chat", "sql", "view", "listing"):
                 if key in context and key not in produced:
-                    # Check if we should KEEP this key (i.e., NOT mark as stale)
-                    if key == "sql" and keep_sql:
+                    if required_keys.get(key, False):
                         continue
-                    if key == "view" and keep_view:
-                        continue
-                    if key == "chat" and keep_chat:
-                        continue
-                    if key == "listing" and keep_listing:
-                        continue
-
                     previous_keys.add(key)
         ctx["previous_keys"] = previous_keys
         return ctx

--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -6,7 +6,7 @@ from panel_material_ui import Button
 from pydantic import Field
 
 from ..config import PROMPTS_DIR
-from ..context import ContextModel, TContext
+from ..context import ContextModel, TContext, input_dependency_keys
 from ..llm import Message
 from ..models import BaseModel
 from ..utils import content_to_text, log_debug
@@ -70,8 +70,7 @@ def get_plan_required_keys(plan):
     context_keys = {"sql", "view", "chat", "listing"}
     all_input_keys = set()
     for task in plan:
-        annotations = set(task.input_schema.__annotations__.keys())
-        all_input_keys |= annotations
+        all_input_keys |= input_dependency_keys(task.input_schema)
     return {key: key in all_input_keys for key in context_keys}
 
 
@@ -122,7 +121,9 @@ class ValidationAgent(Agent):
         plan = context.get("plan")
         previous_keys = set()
         if plan is not None:
-            required_keys = get_plan_required_keys(plan)
+            required_keys = get_plan_required_keys(
+                task for task in plan if task.actor is not self
+            )
             produced = {k for task in plan for k in task.out_context}
             for key in ("chat", "sql", "view", "listing"):
                 if key in context and key not in produced:

--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -48,32 +48,6 @@ class ValidationOutputs(ContextModel):
     validation_result: str
 
 
-def get_plan_required_keys(plan):
-    """
-    Check which context keys are required by the tasks in the plan.
-
-    Iterates over each task's ``input_schema`` annotations and checks
-    whether any task declares ``sql``, ``view``, ``chat``, or ``listing``
-    as an input dependency.
-
-    Parameters
-    ----------
-    plan : list[ActorTask]
-        The list of tasks produced by the planner.
-
-    Returns
-    -------
-    dict[str, bool]
-        A dictionary mapping each context key to ``True`` if any task
-        in the plan requires it, ``False`` otherwise.
-    """
-    context_keys = {"sql", "view", "chat", "listing"}
-    all_input_keys = set()
-    for task in plan:
-        all_input_keys |= input_dependency_keys(task.input_schema)
-    return {key: key in all_input_keys for key in context_keys}
-
-
 class ValidationAgent(Agent):
     """
     ValidationAgent focuses solely on validating whether the executed plan
@@ -121,13 +95,14 @@ class ValidationAgent(Agent):
         plan = context.get("plan")
         previous_keys = set()
         if plan is not None:
-            required_keys = get_plan_required_keys(
-                task for task in plan if task.actor is not self
-            )
+            required_keys = set()
+            for task in plan:
+                if task.actor is not self:
+                    required_keys |= input_dependency_keys(task.input_schema)
             produced = {k for task in plan for k in task.out_context}
             for key in ("chat", "sql", "view", "listing"):
                 if key in context and key not in produced:
-                    if required_keys.get(key, False):
+                    if key in required_keys:
                         continue
                     previous_keys.add(key)
         ctx["previous_keys"] = previous_keys

--- a/lumen/ai/agents/validation.py
+++ b/lumen/ai/agents/validation.py
@@ -1,3 +1,5 @@
+import re
+
 from typing import Any, NotRequired
 
 import param
@@ -92,12 +94,39 @@ class ValidationAgent(Agent):
         """
         ctx = await super()._gather_prompt_context(prompt_name, messages, context, **kwargs)
 
+        # Extract the latest user query
+        user_messages = [msg for msg in reversed(messages) if msg.get("role") == "user"]
+        query_text = content_to_text(user_messages[0].get("content", "")).lower() if user_messages else ""
+        query_words = set(re.findall(r'\b\w+\b', query_text))
+
+        # Define category-specific continuation keywords
+        general_keywords = {"it", "this", "that", "these", "those", "also", "and", "now", "previous"}
+        sql_keywords = {"filter", "sort", "limit", "top", "include", "group"}
+        view_keywords = {"color", "label", "chart", "plot", "axis", "instead", "make"}
+        chat_keywords = {"elaborate", "translate", "explain", "why", "point"}
+
+        # Determine which categories are requested to be kept
+        keep_sql = bool(query_words.intersection(sql_keywords | general_keywords))
+        keep_view = bool(query_words.intersection(view_keywords | general_keywords))
+        keep_chat = bool(query_words.intersection(chat_keywords | general_keywords))
+        keep_listing = bool(query_words.intersection(general_keywords))
+
         plan = context.get("plan")
         previous_keys = set()
         if plan is not None:
             produced = {k for task in plan for k in task.out_context}
             for key in ("chat", "sql", "view", "listing"):
                 if key in context and key not in produced:
+                    # Check if we should KEEP this key (i.e., NOT mark as stale)
+                    if key == "sql" and keep_sql:
+                        continue
+                    if key == "view" and keep_view:
+                        continue
+                    if key == "chat" and keep_chat:
+                        continue
+                    if key == "listing" and keep_listing:
+                        continue
+
                     previous_keys.add(key)
         ctx["previous_keys"] = previous_keys
         return ctx

--- a/lumen/tests/ai/test_validation_agent.py
+++ b/lumen/tests/ai/test_validation_agent.py
@@ -1,7 +1,4 @@
-import asyncio
 import datetime
-
-from typing import Any, NotRequired, TypedDict
 
 import jinja2
 import pytest
@@ -9,9 +6,7 @@ import pytest
 try:
     from lumen.ai.agents.chat import ChatAgent
     from lumen.ai.agents.sql import SQLAgent
-    from lumen.ai.agents.validation import (
-        ValidationAgent, get_plan_required_keys,
-    )
+    from lumen.ai.agents.validation import ValidationAgent
     from lumen.ai.config import PROMPTS_DIR
     from lumen.ai.coordinator.base import Plan
     from lumen.ai.report import ActorTask
@@ -72,139 +67,6 @@ def test_validation_agent_previous_keys_gating(jinja_env):
     assert "User: \"bar chart of sales by region\"" not in rendered
 
 
-class _SQLInputs(TypedDict):
-    """Mock input schema that declares 'sql' as a dependency."""
-    sql: NotRequired[str]
-    data: NotRequired[Any]
-    source: str
-
-
-class _ViewInputs(TypedDict):
-    """Mock input schema that declares 'view'-related inputs (no sql/chat/listing)."""
-    data: Any
-    pipeline: Any
-    table: str
-
-
-class _ChatOutputSchema(TypedDict):
-    """Mock input schema with 'chat' dependency."""
-    chat: NotRequired[str]
-
-
-class _EmptyInputs(TypedDict):
-    """Mock input schema with no context key dependencies."""
-    pass
-
-
-class _MockTask:
-    """Lightweight stand-in for ActorTask used in tests."""
-
-    def __init__(self, input_schema, out_context=None):
-        self.input_schema = input_schema
-        self.out_context = out_context or {}
-
-
-# -- Tests for get_plan_required_keys ----------------------------------------
-
-@pytest.mark.parametrize(
-    "plan_tasks, expected",
-    [
-        pytest.param(
-            [_MockTask(_SQLInputs, {"sql": "SELECT 1", "data": "..."})],
-            {"sql": True, "view": False, "chat": False, "listing": False},
-            id="sql_agent_only-sql_required",
-        ),
-        pytest.param(
-            [_MockTask(_ViewInputs, {"view": "..."})],
-            {"sql": False, "view": False, "chat": False, "listing": False},
-            id="view_agent_only-no_context_keys_required",
-        ),
-        pytest.param(
-            [
-                _MockTask(_SQLInputs, {"sql": "SELECT 1"}),
-                _MockTask(_ViewInputs, {"view": "..."}),
-            ],
-            {"sql": True, "view": False, "chat": False, "listing": False},
-            id="sql_then_view-sql_required",
-        ),
-        pytest.param(
-            [_MockTask(_ChatOutputSchema, {"chat": "hello"})],
-            {"sql": False, "view": False, "chat": True, "listing": False},
-            id="chat_agent_only-chat_required",
-        ),
-        pytest.param(
-            [_MockTask(_EmptyInputs)],
-            {"sql": False, "view": False, "chat": False, "listing": False},
-            id="empty_inputs-nothing_required",
-        ),
-    ],
-)
-def test_get_plan_required_keys(plan_tasks, expected):
-    """get_plan_required_keys correctly identifies which context keys are
-    declared as inputs by the tasks in a plan."""
-    result = get_plan_required_keys(plan_tasks)
-    assert result == expected
-
-
-# -- Regression: stale context should be tagged as previous_keys -------------
-
-@pytest.mark.parametrize(
-    "plan_tasks, context_keys_present, expected_previous_keys",
-    [
-        pytest.param(
-            # Plan has only ViewAgent (no sql input) but context has leftover sql
-            [_MockTask(_ViewInputs, {"view": "..."})],
-            {"sql": "SELECT old", "view": "old_chart"},
-            {"sql"},
-            id="stale_sql-view_only_plan",
-        ),
-        pytest.param(
-            # Plan has SQLAgent (needs sql input), so sql should NOT be stale
-            [_MockTask(_SQLInputs, {"data": "..."})],
-            {"sql": "SELECT old"},
-            set(),
-            id="reused_sql-sql_plan_keeps_it",
-        ),
-        pytest.param(
-            # Plan has empty inputs, all leftover keys should be stale
-            [_MockTask(_EmptyInputs)],
-            {"sql": "SELECT old", "chat": "hello", "view": "chart"},
-            {"sql", "chat", "view"},
-            id="all_stale-empty_plan",
-        ),
-        pytest.param(
-            # Plan has ChatAgent, chat should stay, sql/view should be stale
-            [_MockTask(_ChatOutputSchema, {"chat": "hi"})],
-            {"sql": "SELECT old", "chat": "old_chat", "view": "old_view"},
-            {"sql", "view"},
-            id="mixed-chat_kept_others_stale",
-        ),
-    ],
-)
-def test_previous_keys_provenance(plan_tasks, context_keys_present, expected_previous_keys):
-    """Regression test: context keys not required by any task in the plan
-    should be tagged as previous_keys (stale). Keys that ARE required
-    should be kept active.
-
-    On main (before the fix), all non-produced keys were blanket-tagged
-    as previous_keys regardless of plan provenance, causing this test to fail.
-    """
-    plan = plan_tasks
-    context = dict(context_keys_present, plan=plan)
-
-    # Replicate the logic from _gather_prompt_context
-    required_keys = get_plan_required_keys(plan)
-    produced = {k for task in plan for k in task.out_context}
-    previous_keys = set()
-    for key in ("chat", "sql", "view", "listing"):
-        if key in context and key not in produced:
-            if required_keys.get(key, False):
-                continue
-            previous_keys.add(key)
-
-    assert previous_keys == expected_previous_keys
-
-
 @pytest.mark.parametrize(
     ("agent_type", "expected_previous_keys"),
     [
@@ -212,14 +74,15 @@ def test_previous_keys_provenance(plan_tasks, context_keys_present, expected_pre
         pytest.param(SQLAgent, set(), id="reused_sql"),
     ],
 )
-def test_validation_agent_uses_prior_plan_dependencies(
+@pytest.mark.asyncio
+async def test_validation_agent_uses_prior_plan_dependencies(
     agent_type, expected_previous_keys,
 ):
     validation_agent = ValidationAgent()
     plan = Plan(ActorTask(agent_type()), ActorTask(validation_agent))
 
-    prompt_context = asyncio.run(validation_agent._gather_prompt_context(
+    prompt_context = await validation_agent._gather_prompt_context(
         "main", [], {"plan": plan, "sql": "SELECT old"},
-    ))
+    )
 
     assert prompt_context["previous_keys"] == expected_previous_keys

--- a/lumen/tests/ai/test_validation_agent.py
+++ b/lumen/tests/ai/test_validation_agent.py
@@ -60,3 +60,145 @@ def test_validation_agent_previous_keys_gating(jinja_env):
     assert "SQL: SELECT region, SUM(sales)" not in rendered
     assert "User: \"Summarize survey results\"" not in rendered
     assert "User: \"bar chart of sales by region\"" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for plan-provenance based stale context tagging
+# ---------------------------------------------------------------------------
+
+from typing import Any, NotRequired, TypedDict
+
+from lumen.ai.agents.validation import get_plan_required_keys
+
+
+class _SQLInputs(TypedDict):
+    """Mock input schema that declares 'sql' as a dependency."""
+    sql: NotRequired[str]
+    data: NotRequired[Any]
+    source: str
+
+
+class _ViewInputs(TypedDict):
+    """Mock input schema that declares 'view'-related inputs (no sql/chat/listing)."""
+    data: Any
+    pipeline: Any
+    table: str
+
+
+class _ChatOutputSchema(TypedDict):
+    """Mock input schema with 'chat' dependency."""
+    chat: NotRequired[str]
+
+
+class _EmptyInputs(TypedDict):
+    """Mock input schema with no context key dependencies."""
+    pass
+
+
+class _MockTask:
+    """Lightweight stand-in for ActorTask used in tests."""
+
+    def __init__(self, input_schema, out_context=None):
+        self.input_schema = input_schema
+        self.out_context = out_context or {}
+
+
+# -- Tests for get_plan_required_keys ----------------------------------------
+
+@pytest.mark.parametrize(
+    "plan_tasks, expected",
+    [
+        pytest.param(
+            [_MockTask(_SQLInputs, {"sql": "SELECT 1", "data": "..."})],
+            {"sql": True, "view": False, "chat": False, "listing": False},
+            id="sql_agent_only-sql_required",
+        ),
+        pytest.param(
+            [_MockTask(_ViewInputs, {"view": "..."})],
+            {"sql": False, "view": False, "chat": False, "listing": False},
+            id="view_agent_only-no_context_keys_required",
+        ),
+        pytest.param(
+            [
+                _MockTask(_SQLInputs, {"sql": "SELECT 1"}),
+                _MockTask(_ViewInputs, {"view": "..."}),
+            ],
+            {"sql": True, "view": False, "chat": False, "listing": False},
+            id="sql_then_view-sql_required",
+        ),
+        pytest.param(
+            [_MockTask(_ChatOutputSchema, {"chat": "hello"})],
+            {"sql": False, "view": False, "chat": True, "listing": False},
+            id="chat_agent_only-chat_required",
+        ),
+        pytest.param(
+            [_MockTask(_EmptyInputs)],
+            {"sql": False, "view": False, "chat": False, "listing": False},
+            id="empty_inputs-nothing_required",
+        ),
+    ],
+)
+def test_get_plan_required_keys(plan_tasks, expected):
+    """get_plan_required_keys correctly identifies which context keys are
+    declared as inputs by the tasks in a plan."""
+    result = get_plan_required_keys(plan_tasks)
+    assert result == expected
+
+
+# -- Regression: stale context should be tagged as previous_keys -------------
+
+@pytest.mark.parametrize(
+    "plan_tasks, context_keys_present, expected_previous_keys",
+    [
+        pytest.param(
+            # Plan has only ViewAgent (no sql input) but context has leftover sql
+            [_MockTask(_ViewInputs, {"view": "..."})],
+            {"sql": "SELECT old", "view": "old_chart"},
+            {"sql"},
+            id="stale_sql-view_only_plan",
+        ),
+        pytest.param(
+            # Plan has SQLAgent (needs sql input), so sql should NOT be stale
+            [_MockTask(_SQLInputs, {"data": "..."})],
+            {"sql": "SELECT old"},
+            set(),
+            id="reused_sql-sql_plan_keeps_it",
+        ),
+        pytest.param(
+            # Plan has empty inputs, all leftover keys should be stale
+            [_MockTask(_EmptyInputs)],
+            {"sql": "SELECT old", "chat": "hello", "view": "chart"},
+            {"sql", "chat", "view"},
+            id="all_stale-empty_plan",
+        ),
+        pytest.param(
+            # Plan has ChatAgent, chat should stay, sql/view should be stale
+            [_MockTask(_ChatOutputSchema, {"chat": "hi"})],
+            {"sql": "SELECT old", "chat": "old_chat", "view": "old_view"},
+            {"sql", "view"},
+            id="mixed-chat_kept_others_stale",
+        ),
+    ],
+)
+def test_previous_keys_provenance(plan_tasks, context_keys_present, expected_previous_keys):
+    """Regression test: context keys not required by any task in the plan
+    should be tagged as previous_keys (stale). Keys that ARE required
+    should be kept active.
+
+    On main (before the fix), all non-produced keys were blanket-tagged
+    as previous_keys regardless of plan provenance, causing this test to fail.
+    """
+    plan = plan_tasks
+    context = dict(context_keys_present, plan=plan)
+
+    # Replicate the logic from _gather_prompt_context
+    required_keys = get_plan_required_keys(plan)
+    produced = {k for task in plan for k in task.out_context}
+    previous_keys = set()
+    for key in ("chat", "sql", "view", "listing"):
+        if key in context and key not in produced:
+            if required_keys.get(key, False):
+                continue
+            previous_keys.add(key)
+
+    assert previous_keys == expected_previous_keys

--- a/lumen/tests/ai/test_validation_agent.py
+++ b/lumen/tests/ai/test_validation_agent.py
@@ -9,7 +9,9 @@ import pytest
 try:
     from lumen.ai.agents.chat import ChatAgent
     from lumen.ai.agents.sql import SQLAgent
-    from lumen.ai.agents.validation import ValidationAgent, get_plan_required_keys
+    from lumen.ai.agents.validation import (
+        ValidationAgent, get_plan_required_keys,
+    )
     from lumen.ai.config import PROMPTS_DIR
     from lumen.ai.coordinator.base import Plan
     from lumen.ai.report import ActorTask

--- a/lumen/tests/ai/test_validation_agent.py
+++ b/lumen/tests/ai/test_validation_agent.py
@@ -68,21 +68,25 @@ def test_validation_agent_previous_keys_gating(jinja_env):
 
 
 @pytest.mark.parametrize(
-    ("agent_type", "expected_previous_keys"),
+    ("agent_type", "out_context", "expected_previous_keys"),
     [
-        pytest.param(ChatAgent, {"sql"}, id="stale_sql"),
-        pytest.param(SQLAgent, set(), id="reused_sql"),
+        pytest.param(ChatAgent, {}, {"sql"}, id="stale_sql"),
+        pytest.param(SQLAgent, {}, set(), id="reused_sql"),
+        pytest.param(ChatAgent, {"sql": "SELECT current"}, set(), id="current_sql"),
     ],
 )
 @pytest.mark.asyncio
 async def test_validation_agent_uses_prior_plan_dependencies(
-    agent_type, expected_previous_keys,
+    agent_type, out_context, expected_previous_keys,
 ):
     validation_agent = ValidationAgent()
-    plan = Plan(ActorTask(agent_type()), ActorTask(validation_agent))
+    plan = Plan(
+        ActorTask(agent_type(), out_context=out_context),
+        ActorTask(validation_agent),
+    )
 
     prompt_context = await validation_agent._gather_prompt_context(
-        "main", [], {"plan": plan, "sql": "SELECT old"},
+        "main", [], {"plan": plan, "sql": "SELECT current"},
     )
 
     assert prompt_context["previous_keys"] == expected_previous_keys

--- a/lumen/tests/ai/test_validation_agent.py
+++ b/lumen/tests/ai/test_validation_agent.py
@@ -1,10 +1,18 @@
+import asyncio
 import datetime
+
+from typing import Any, NotRequired, TypedDict
 
 import jinja2
 import pytest
 
 try:
+    from lumen.ai.agents.chat import ChatAgent
+    from lumen.ai.agents.sql import SQLAgent
+    from lumen.ai.agents.validation import ValidationAgent, get_plan_required_keys
     from lumen.ai.config import PROMPTS_DIR
+    from lumen.ai.coordinator.base import Plan
+    from lumen.ai.report import ActorTask
 except ModuleNotFoundError:
     pytest.skip("lumen.ai could not be imported, skipping tests.", allow_module_level=True)
 
@@ -60,15 +68,6 @@ def test_validation_agent_previous_keys_gating(jinja_env):
     assert "SQL: SELECT region, SUM(sales)" not in rendered
     assert "User: \"Summarize survey results\"" not in rendered
     assert "User: \"bar chart of sales by region\"" not in rendered
-
-
-# ---------------------------------------------------------------------------
-# Regression tests for plan-provenance based stale context tagging
-# ---------------------------------------------------------------------------
-
-from typing import Any, NotRequired, TypedDict
-
-from lumen.ai.agents.validation import get_plan_required_keys
 
 
 class _SQLInputs(TypedDict):
@@ -202,3 +201,23 @@ def test_previous_keys_provenance(plan_tasks, context_keys_present, expected_pre
             previous_keys.add(key)
 
     assert previous_keys == expected_previous_keys
+
+
+@pytest.mark.parametrize(
+    ("agent_type", "expected_previous_keys"),
+    [
+        pytest.param(ChatAgent, {"sql"}, id="stale_sql"),
+        pytest.param(SQLAgent, set(), id="reused_sql"),
+    ],
+)
+def test_validation_agent_uses_prior_plan_dependencies(
+    agent_type, expected_previous_keys,
+):
+    validation_agent = ValidationAgent()
+    plan = Plan(ActorTask(agent_type()), ActorTask(validation_agent))
+
+    prompt_context = asyncio.run(validation_agent._gather_prompt_context(
+        "main", [], {"plan": plan, "sql": "SELECT old"},
+    ))
+
+    assert prompt_context["previous_keys"] == expected_previous_keys


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
This PR implements a granular, rule-based heuristic to intelligently tag `previous_keys` (stale context) in the `ValidationAgent`. 

**Motivation:**
Previously, any data (`sql`, `view`, `chat`) not produced in the current plan was blanket-tagged as `previous_keys`. This created a dilemma: if we completely gated out validation for `previous_keys`, the agent would fail to validate old context that was being reused as an input for a new prompt. On the other hand, if we didn't gate it, leftover context triggered false-positive `ValidationFault`s when strictly evaluated against completely new, unrelated queries.

**Changes:**
- Added category-specific heuristic keywords (SQL, View, Chat, General) in `validation.py`.
- The `_gather_prompt_context` now extracts the user's latest query text and tokenizes it.
- If the user uses a continuation keyword (like *"color"*, *"filter"*, *"it"*, *"elaborate"*), the agent dynamically identifies which contexts the user is trying to reuse/modify and keeps them **active** (i.e., does not tag them as `previous_keys`), while safely marking unrelated context as stale.

**Tests Run:**
- Successfully ran `pytest lumen/tests/ai/test_validation_agent.py` and `pytest lumen/tests/ai/test_prompts.py`. All tests passed.

Fixes #2080 


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Antigravity IDE (Gemini)
Usage: Used to brainstorm the architectural approach for the heuristic tagging, write the Python regex parsing logic for the context gatherer, and draft this PR description.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
