### PR TITLE
Fix hvPlotUIView controls clipping on short windows (#2066)

### DIFF
--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1162,13 +1162,20 @@ class hvPlotUIView(hvPlotBaseView):
         return (data,), dict(params, **self.kwargs)
 
     def __panel__(self):
-        panel = self.get_panel()
+        layout = self.get_panel()
+        explorer = layout[0] if isinstance(layout, pn.Column) else layout
         def ui(*events):
             gridded = self._source_dataset()
-            panel._data = gridded if gridded is not None else self.get_data()
-            panel._plot()
-            return panel
+            explorer._data = gridded if gridded is not None else self.get_data()
+            explorer._plot()
+            return layout
         return pn.bind(ui, self.param.rerender)
+
+    def _fit_explorer(self, explorer):
+        layout = getattr(explorer, '_layout', None)
+        if layout is not None:
+            layout.param.update(height=None, min_height=500, sizing_mode='stretch_both')
+        return pn.Column(explorer, sizing_mode='stretch_both', scroll='y-auto')
 
     def get_panel(self):
         # An xarray-backed pipeline explores the compact gridded Dataset (via
@@ -1179,10 +1186,10 @@ class hvPlotUIView(hvPlotBaseView):
             # Deferred: registers hvPlot's xarray accessor, and xarray is optional.
             import hvplot.xarray  # type: ignore  # noqa: F401, PLC0415
             args, kwargs = self._get_args(hvGridExplorer, gridded)
-            return hvGridExplorer(*args, **kwargs)
+            return self._fit_explorer(hvGridExplorer(*args, **kwargs))
         args, kwargs = self._get_args()
         self._check_render_size(args[0])
-        return hvDataFrameExplorer(*args, **kwargs)
+        return self._fit_explorer(hvDataFrameExplorer(*args, **kwargs))
 
 
 class hvPlotView(hvPlotBaseView):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1162,8 +1162,8 @@ class hvPlotUIView(hvPlotBaseView):
         return (data,), dict(params, **self.kwargs)
 
     def __panel__(self):
-        layout = self.get_panel()
-        explorer = layout[0] if isinstance(layout, pn.Column) else layout
+        explorer = self.get_panel()
+        layout = self._fit_explorer(explorer)
         def ui(*events):
             gridded = self._source_dataset()
             explorer._data = gridded if gridded is not None else self.get_data()
@@ -1186,10 +1186,10 @@ class hvPlotUIView(hvPlotBaseView):
             # Deferred: registers hvPlot's xarray accessor, and xarray is optional.
             import hvplot.xarray  # type: ignore  # noqa: F401, PLC0415
             args, kwargs = self._get_args(hvGridExplorer, gridded)
-            return self._fit_explorer(hvGridExplorer(*args, **kwargs))
+            return hvGridExplorer(*args, **kwargs)
         args, kwargs = self._get_args()
         self._check_render_size(args[0])
-        return self._fit_explorer(hvDataFrameExplorer(*args, **kwargs))
+        return hvDataFrameExplorer(*args, **kwargs)
 
 
 class hvPlotView(hvPlotBaseView):


### PR DESCRIPTION

## Description
Added a _fit_explorer() helper that wraps the explorer's layout in a pn.Column with sizing_mode='stretch_both' and scroll='y-auto', and applies min_height=500 to the explorer's internal layout so it always has enough room to render properly.get_panel() is left untouched and still returns the raw hvGridExplorer / hvDataFrameExplorer object as before. The scroll/sizing fix is instead applied in __panel__(), which is where the view is actually rendered for display — so the fix only affects the rendered output, not the public contract of get_panel().

Fixes #2066 


## AI Disclosure

Tool & Model:Gemini 3.6 Flash
Usage: Assisted in CI fix and testing.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.
