### PR TITLE
fix: preserve artifacts for a session (#1988)

### DIFF
--- a/lumen/ai/logs.py
+++ b/lumen/ai/logs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 
 import param
@@ -27,6 +28,22 @@ class ChatLogs(param.Parameterized):
                 disliked BOOLEAN DEFAULT FALSE,
                 removed BOOLEAN DEFAULT FALSE,
                 timestamp TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        self.conn.commit()
+
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS explorations (
+                exploration_id TEXT PRIMARY KEY,
+                session_id TEXT,
+                parent_id TEXT,
+                position INTEGER,
+                title TEXT,
+                subtitle TEXT,
+                spec TEXT,
+                updated TEXT DEFAULT CURRENT_TIMESTAMP
             )
             """
         )
@@ -78,6 +95,85 @@ class ChatLogs(param.Parameterized):
                 log_debug("Failed to insert message")
                 return
             self.conn.commit()
+
+    def upsert_exploration(
+        self,
+        session_id,
+        exploration_id,
+        parent_id,
+        position,
+        title,
+        subtitle,
+        spec,
+    ):
+        UPSERT_EXPLORATION_SCHEMA = """
+        INSERT INTO explorations (
+            session_id, exploration_id, parent_id, position, title, subtitle, spec, updated
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT (exploration_id)
+        DO UPDATE SET
+        session_id = excluded.session_id,
+        parent_id = excluded.parent_id,
+        position = excluded.position,
+        title = excluded.title,
+        subtitle = excluded.subtitle,
+        spec = excluded.spec,
+        updated = CURRENT_TIMESTAMP
+        """
+        try:
+            self.cursor.execute(
+                UPSERT_EXPLORATION_SCHEMA,
+                (
+                    session_id,
+                    exploration_id,
+                    parent_id,
+                    position,
+                    title,
+                    subtitle,
+                    json.dumps(spec),
+                ),
+            )
+            self.conn.commit()
+        except Exception:
+            log_debug("Failed to upsert exploration")
+
+    def load_session(self, session_id):
+        self.cursor.execute(
+            """
+            SELECT exploration_id, parent_id, position, title, subtitle, spec
+            FROM explorations
+            WHERE session_id = ?
+            ORDER BY position
+            """,
+            (session_id,),
+        )
+        rows = self.cursor.fetchall()
+        return [
+            {
+                "exploration_id": row[0],
+                "parent_id": row[1],
+                "position": row[2],
+                "title": row[3],
+                "subtitle": row[4],
+                "spec": json.loads(row[5]),
+            }
+            for row in rows
+        ]
+
+    def delete_exploration(self, exploration_id):
+        self.cursor.execute(
+            "DELETE FROM explorations WHERE exploration_id = ?",
+            (exploration_id,),
+        )
+        self.conn.commit()
+
+    def delete_stale(self, ttl_seconds):
+        self.cursor.execute(
+            "DELETE FROM explorations WHERE updated < datetime('now', ?)",
+            (f"-{ttl_seconds} seconds",),
+        )
+        self.conn.commit()
 
     def update_status(self, message_id, liked=None, disliked=None, removed=None):
         self.cursor.execute(

--- a/lumen/ai/ui.py
+++ b/lumen/ai/ui.py
@@ -5,6 +5,7 @@ import atexit
 import os
 import tempfile
 import traceback
+import uuid
 
 from contextlib import contextmanager
 from functools import partial
@@ -13,6 +14,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import panel as pn
 import param
 
 from panel.chat.feed import PLACEHOLDER_SVG
@@ -448,6 +450,16 @@ class UI(Viewer):
     logs_db_path = param.String(default=None, constant=True, doc="""
         The path to the log file that will store the messages exchanged with the LLM.""")
 
+    reconnect = param.Selector(default=True, objects=[True, False, "prompt"], doc="""
+    Whether to automatically re-connect to the server if the connection drops.""")
+
+    session_ttl = param.Integer(default=86400, doc="""
+    Seconds to keep persisted explorations before cleaning them up.""")
+
+    persist_session = param.Boolean(default=False, doc="""
+    Whether to persist explorations so they survive a page reload.
+    Requires logs_db_path to be set.""")
+
     notebook_preamble = param.String(default='', doc="""
         Preamble to add to exported notebook(s).""")
 
@@ -775,10 +787,26 @@ class UI(Viewer):
         Configure the Panel session state.
         """
         log_debug("New Session: \033[92mStarted\033[0m", show_sep="above")
-        self._session_id = id(self)
+        self._session_id = self._resolve_session_id()
+        if state.curdoc and state.curdoc.session_context:
+            pn.config.reconnect = self.reconnect
+            pn.config.notifications = True
         state.onload(self._initialize_new_llm)
         if state.curdoc and state.curdoc.session_context:
             state.on_session_destroyed(self._destroy)
+
+    def _resolve_session_id(self) -> str:
+        args = state.session_args or {}
+        sid = args.get("session_id")
+        if sid:
+            return sid[0].decode() if isinstance(sid[0], bytes) else str(sid[0])
+        sid = uuid.uuid4().hex
+        def _set_query():
+            if state.location:
+                state.location.update_query(session_id=sid)
+
+        state.onload(_set_query)
+        return sid
 
     def _configure_logs(self, interface):
         if not self.logs_db_path:
@@ -1533,12 +1561,18 @@ class UI(Viewer):
         self._idle.clear()
         with edit_readonly(self._page):
             self._page.busy = True
+        server = bool(state.curdoc and state.curdoc.session_context)
         try:
+            if server:
+                state.block_expiration()
             yield
         finally:
+            if server:
+                state.unblock_expiration()
             self._idle.set()
             with edit_readonly(self._page):
                 self._page.busy = old_busy
+
 
     def _update_help_getting_started(self):
         """Update the Getting Started help text based on whether data sources are connected."""
@@ -1864,7 +1898,6 @@ class UI(Viewer):
         server = bool(state.curdoc and state.curdoc.session_context)
         return self._create_view(server=server).servable(title, **kwargs)
 
-
 class ChatUI(UI):
     """
     ChatUI provides a high-level entrypoint to start chatting with your data
@@ -1890,7 +1923,6 @@ class ChatUI(UI):
     provider_choices = param.Dict(default={}, doc="""
         Available LLM providers to show in the configuration dialog.""")
 
-
 class Exploration(param.Parameterized):
 
     context = param.Dict(allow_refs=True)
@@ -1908,9 +1940,42 @@ class Exploration(param.Parameterized):
     view = Child()
 
     initialized = param.Boolean(default=False)
+    exploration_id = param.String(default="")
 
     def __panel__(self):
         return self.view
+
+    def to_spec(self) -> dict:
+        ctx = self.context or {}
+        return {
+            "title": self.title,
+            "subtitle": self.subtitle,
+            "sources": [src.to_spec() for src in ctx.get("sources", [])],
+            "visible_slugs": sorted(ctx.get("visible_slugs", [])),
+            "views": [v.to_spec() for v in (self.plan.views if self.plan else [])],
+            "conversation": [msg.serialize() for msg in self.conversation],
+            "exploration_id": self.exploration_id,
+        }
+
+    @classmethod
+    def from_spec(cls, spec: dict, view=None) -> Exploration:
+        sources = [Source.from_spec(s) for s in spec.get("sources", [])]
+        context = {"sources": sources, "visible_slugs": set(spec.get("visible_slugs", []))}
+        if sources:
+            context["source"] = sources[-1]
+        conversation = [
+            ChatMessage(object=msg) for msg in spec.get("conversation", [])
+        ]
+        return cls(
+            context=context,
+            conversation=conversation,
+            title=spec["title"],
+            subtitle=spec.get("subtitle", ""),
+            plan=None,
+            initialized=True,
+            exploration_id=spec.get("exploration_id", ""),
+            view=view,
+        )
 
 
 class ExplorerUI(UI):
@@ -2351,6 +2416,86 @@ class ExplorerUI(UI):
         super()._configure_session()
         self._idle = asyncio.Event()
         self._idle.set()
+        if self.persist_session and self._logs:
+            self._logs.delete_stale(self.session_ttl)
+            state.onload(self._restore_session)
+
+    def _restore_session(self):
+        if not (self.persist_session and self._logs):
+            return
+        try:
+            self._restore_explorations()
+        except Exception:
+            traceback.print_exc()
+
+    def _restore_explorations(self):
+        """
+        Called via state.onload once the page has loaded. Loads any
+        previously saved explorations for this session from the
+        persistence store and rebuilds them in the UI.
+        """
+        if not (self.persist_session and self._logs):
+            return
+
+        rows = self._logs.load_session(self._session_id)
+        if not rows:
+            return  # nothing saved for this session yet
+
+        id_to_item = {}  # maps saved exploration_id -> rebuilt view_item dict
+        last_item = None
+        last_conversation = None
+
+        with hold():
+            for row in rows:
+                spec = row["spec"]
+
+                # Rebuild the live Exploration object from its saved spec
+                exploration = Exploration.from_spec(spec)
+
+                # Rebuild its visual container the same way _add_exploration does
+                tabs = Tabs(dynamic=True, sizing_mode="stretch_both")
+                exploration.view = MultiSplit(tabs, sizing_mode="stretch_both")
+
+                # Resolve parent linkage: top-level explorations attach to Home,
+                # nested ones attach to their previously-restored parent item
+                parent_id = row["parent_id"]
+                if parent_id and parent_id in id_to_item:
+                    parent_item = id_to_item[parent_id]
+                else:
+                    parent_item = self._explorations.items[0]  # Home
+
+                # Build the same view_item shape used elsewhere (see _add_exploration)
+                view_item = {
+                    "label": row["title"],
+                    "view": exploration,
+                    "icon": None,
+                    "actions": [
+                        {"action": "export_notebook", "label": "Export Notebook", "icon": "download"},
+                        {"action": "remove", "label": "Remove", "icon": "delete"},
+                    ],
+                    "parent": parent_item,
+                    "items": [],
+                }
+
+                id_to_item[row["exploration_id"]] = view_item
+
+                if parent_item is self._explorations.items[0]:
+                    # top-level: add directly to the explorations list
+                    self._explorations.items = [*self._explorations.items, view_item]
+                else:
+                    # nested: add under its parent's own items
+                    self._explorations.update_item(
+                        parent_item, items=[*parent_item["items"], view_item]
+                    )
+
+                last_item = view_item
+                last_conversation = exploration.conversation
+
+            if last_item is not None:
+                # Show the most recently active exploration on restore
+                self._explorations.value = self._exploration = last_item
+                if last_conversation:
+                    self.interface.objects = last_conversation
 
     def _sync_active(self, event: param.parameterized.Event):
         if event.new is not self._exploration:
@@ -2359,6 +2504,26 @@ class ExplorerUI(UI):
     def _toggle_report_mode(self, active: bool):
         """Toggle between regular and report mode."""
         self._update_main_view(force_report_mode=active)
+
+    def _persist_state(self):
+        if not (self.persist_session and self._logs):
+            return
+
+        def walk(items, parent_id, position=0):
+            for i, item in enumerate(items, start=position):
+                exp = item["view"]
+                self._logs.upsert_exploration(
+                    session_id=self._session_id,
+                    exploration_id=exp.exploration_id,
+                    parent_id=parent_id,
+                    position=i,
+                    title=exp.title,
+                    subtitle=exp.subtitle,
+                    spec=exp.to_spec(),
+                )
+                walk(item.get("items", []), exp.exploration_id)
+
+        walk(self._explorations.items[1:], None)
 
     def _cleanup_exploration(self, item):
         """Clean up an exploration and its children, remove from tree,
@@ -2389,6 +2554,11 @@ class ExplorerUI(UI):
             )
             self._explorations.value = self._exploration = parent
             self._last_synced = parent['view']
+        if self.persist_session and self._logs:
+            for child in item.get('items', []):
+                self._logs.delete_exploration(child['view'].exploration_id)
+            self._logs.delete_exploration(exploration.exploration_id)
+        self._persist_state()
 
     async def _delete_exploration(self, item):
         await self._idle.wait()
@@ -2401,6 +2571,9 @@ class ExplorerUI(UI):
                 self._explorations.update_item(parent, items=[it for it in parent["items"] if it is not item])
                 self._explorations.value = parent
             self.interface.objects = []
+            if self.persist_session and self._logs:
+               self._logs.delete_exploration(item["view"].exploration_id)
+            self._persist_state()
 
     async def _export_exploration(self, item):
         """Export a single exploration as a Jupyter notebook."""
@@ -2422,6 +2595,9 @@ class ExplorerUI(UI):
         """
         Cleanup on session destroy
         """
+        self._persist_state()
+        if self.persist_session:
+            return
         for c in self._explorations.items[1:]:
             c['view'].context.clear()
 
@@ -2455,6 +2631,7 @@ class ExplorerUI(UI):
             self._update_main_view()
             self.interface._chat_log.scroll_to_latest()
         self._last_synced = exploration
+        self._persist_state()
 
     def _set_conversation(self, conversation: list[Any]):
         feed = self.interface._chat_log
@@ -2519,6 +2696,7 @@ class ExplorerUI(UI):
         exploration = Exploration(
             context=plan.param.out_context,
             conversation=conversation,
+            exploration_id=uuid.uuid4().hex,
             initialized=initialized,
             parent=parent if plan.is_followup else self._home,
             plan=plan,
@@ -2555,6 +2733,7 @@ class ExplorerUI(UI):
             self._output[1:] = [output]
             await self._update_conversation()
         self._last_synced = exploration
+        self._persist_state()
         return exploration
 
     def _render_pop_out(self, exploration: Exploration, view: Column, title: str):


### PR DESCRIPTION
## Description
Adds an opt-in `persist_session=True` param that saves explorations
to SQLite as you work, and restores them when you return to the
same session.

**Stable session IDs** — replaced `id(self)` (changes every time)
with a UUID read from/written to the URL (`?session_id=...`), so a
session can be found again later.

**Reconnect handling** — added a `reconnect` param, set
`pn.config.reconnect`/`notifications` in `_configure_session`, and
wrapped `_busy` with `state.block_expiration()` so brief connection
drops or long-running plans don't kill the session outright.

**Persistence store (`logs.py`)** — new `explorations` table plus
`upsert_exploration()`, `load_session()`, `delete_exploration()`,
`delete_stale(ttl_seconds)`, following the same upsert pattern as
the existing chat `logs` table.

**Serializable explorations (`ui.py`)** — added `exploration_id` and
`to_spec()`/`from_spec()` to `Exploration`, reusing each
source's/view's own `to_spec()`. Only `context`, `views`, and
serialized `conversation` are saved — the live `plan` and LLM
objects are excluded, since they can't be reconstructed.

**Save on change** — new `_persist_state()`, called from
`_add_exploration`, `_delete_exploration`, `_cleanup_exploration`,
and after each finished plan in `_update_conversation`. `_destroy`
now persists before clearing, and skips in-memory cleanup entirely
when `persist_session=True`.

**Restore on load** — `_configure_session` cleans up stale rows and
registers `state.onload(self._restore_session)`. `_restore_session`
rebuilds each saved `Exploration`, its `Tabs`/`MultiSplit` view, and
its parent/child links, then restores the chat feed and active
exploration from the most recent entry.

### New params on `UI`
- `reconnect` (default `True`)
- `persist_session` (default `False`, opt-in)
- `session_ttl` (default `86400`s)

Fixes #1988 


## AI Disclosure

Tool & Model: claude sonnet 5 medium 
Usage:Assisted in understanding existing code base, implementation 

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.
