### PR TITLE
feat(ai): Background LLM row explanations (#1983)

### DIFF
--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -1107,7 +1107,7 @@ class VegaLiteAgent(BaseCodeAgent):
 
         # Step 4: enhancements (LLM-driven creative decisions), per editable chart
         if not self.code_execution_enabled:
-            for editor, (spec, _) in zip(editors, charts):
+            for editor, (spec, _) in zip(editors, charts, strict=False):
                 state.execute(partial(self._polish_plot, editor, messages, context, doc))
                 # Step 5: Background LLM-driven row explanations, per chart.
                 # Skip aggregate specs (mean/sum bar charts etc.): adding a raw

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -948,13 +948,11 @@ class VegaLiteAgent(BaseCodeAgent):
         The pipeline's param watcher automatically triggers a UI re-render so
         the tooltip picks up the new field without any additional code.
         """
-        # 1. Get current pipeline data as pandas DataFrame
-        df = pipeline.data
-        if not isinstance(df, pd.DataFrame):
-            try:
-                df = df.to_pandas()
-            except AttributeError:
-                df = pd.DataFrame(df)
+        # 1. Get current pipeline data as pandas DataFrame.
+        # get_data handles lazy frames (narwhals/polars) correctly and runs
+        # off-thread — pd.DataFrame(lazyframe) would raise. Same pattern
+        # used elsewhere in this file (e.g. _generate_altair_spec).
+        df = await get_data(pipeline)
 
         # 2. Build prompt variables — cap rows to avoid blowing the context window.
         # We use PROFILE_SAMPLE_ROWS (same cap as the rest of the file) but take

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -970,8 +970,20 @@ class VegaLiteAgent(BaseCodeAgent):
             data_csv=data_csv,
         )
 
-        # 4. Inject explanations as a new column into the DataFrame
-        df["ai_explanation"] = result.explanations
+        # 4. Inject explanations as a new column into the DataFrame.
+        # Guard against LLM returning a different number of items than rows —
+        # pandas raises ValueError on length mismatch, which would silently
+        # swallow inside this fire-and-forget task with no visible error.
+        explanations = result.explanations
+        n_rows = len(df)
+        if len(explanations) != n_rows:
+            log_debug(
+                f"ai_explanation: LLM returned {len(explanations)} items for "
+                f"{n_rows} rows — truncating/padding to match."
+            )
+            # Truncate if too many, pad with empty string if too few
+            explanations = (explanations + [""] * n_rows)[:n_rows]
+        df["ai_explanation"] = explanations
 
         # 5. Update pipeline.data — the param watcher will auto-trigger UI re-render
         pipeline.data = df

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -946,6 +946,13 @@ class VegaLiteAgent(BaseCodeAgent):
         After this method runs, pipeline.data is updated with the new column.
         The pipeline's param watcher automatically triggers a UI re-render so
         the tooltip picks up the new field without any additional code.
+
+        Note: this mutates the pipeline's own data, so the ai_explanation
+        column is visible to anything else reading this pipeline afterward
+        (schema introspection, exports, another chart on the same table),
+        not just this chart's tooltip. respond() dedupes so only one call
+        runs per shared pipeline, but the column itself still leaks beyond
+        this one chart by design of the re-render mechanism.
         """
         # 1. Get current pipeline data as pandas DataFrame.
         # get_data handles lazy frames (narwhals/polars) correctly and runs
@@ -1007,17 +1014,24 @@ class VegaLiteAgent(BaseCodeAgent):
         # be treated as failure and trigger unnecessary retries.
         return True
 
-    @staticmethod
-    def _spec_has_aggregation(spec: dict) -> bool:
+    @classmethod
+    def _spec_has_aggregation(cls, spec: dict) -> bool:
         """
         Return True if any encoding channel in the Vega-Lite spec uses an
         aggregate function (e.g. mean, sum, count).
 
         Adding a raw per-row field (ai_explanation) to a tooltip alongside
         aggregated encodings causes Vega-Lite to group by that field too,
-        which silently splits a single bar into one bar per row.
+        which silently splits a single bar into one bar per row. Composition
+        containers are walked, mirroring _spec_has_tooltips, so a layered or
+        concatenated spec with an aggregated layer is still caught.
         """
-        encoding = spec.get("spec", spec).get("encoding", {})
+        spec = spec.get("spec", spec)
+        for key in ("layer", "concat", "hconcat", "vconcat"):
+            views = spec.get(key)
+            if isinstance(views, list):
+                return any(cls._spec_has_aggregation(v) for v in views)
+        encoding = spec.get("encoding", {})
         return any(
             isinstance(channel, dict) and "aggregate" in channel
             for channel in encoding.values()
@@ -1025,7 +1039,6 @@ class VegaLiteAgent(BaseCodeAgent):
 
     @staticmethod
     def _overview_item(editor: VegaLiteEditor) -> ParamFunction:
-
         """A plot for the "All" overview that tracks an editor's component.
 
         Binding to the editor's ``component`` means the overview re-renders when
@@ -1107,17 +1120,28 @@ class VegaLiteAgent(BaseCodeAgent):
 
         # Step 4: enhancements (LLM-driven creative decisions), per editable chart
         if not self.code_execution_enabled:
-            for editor, (spec, _) in zip(editors, charts, strict=False):
+            # editors is built one-to-one from charts (Step 2 above), so the
+            # lengths always match; strict=True surfaces it loudly if that
+            # invariant ever breaks instead of silently dropping entries.
+            explained_pipelines: set[int] = set()
+            for editor, (spec, _) in zip(editors, charts, strict=True):
                 state.execute(partial(self._polish_plot, editor, messages, context, doc))
                 # Step 5: Background LLM-driven row explanations, per chart.
                 # Skip aggregate specs (mean/sum bar charts etc.): adding a raw
                 # per-row field to a tooltip alongside aggregated encodings makes
                 # Vega-Lite group by that field too, silently splitting one bar
                 # into many.
-                if not self._spec_has_aggregation(spec):
+                pipeline = editor.component.pipeline
+                # subset_gridded_to_2d returns the same pipeline instance for
+                # every non-gridded chart, so two charts on one table would
+                # otherwise spawn concurrent tasks that read-modify-write the
+                # same pipeline.data, racing on the last write and paying for
+                # the same LLM call twice.
+                if not self._spec_has_aggregation(spec) and id(pipeline) not in explained_pipelines:
+                    explained_pipelines.add(id(pipeline))
                     state.execute(partial(
                         self._generate_ai_explanations,
-                        editor.component.pipeline, messages, context,
+                        pipeline, messages, context,
                     ))
 
         out_context = await editors[-1].render_context()

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -521,6 +521,7 @@ class VegaLiteAgent(BaseCodeAgent):
                 doc=doc,
                 doc_pages=doc_pages,
                 gridded=gridded,
+                code_execution_enabled=self.code_execution_enabled,
                 **errors_context,
             )
             async for output in response:

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -4,6 +4,7 @@ from collections import Counter
 from functools import partial
 from typing import Any
 
+import pandas as pd
 import param
 import requests
 
@@ -126,6 +127,18 @@ class AltairSpec(BaseModel):
     )
 
 
+class PointExplanations(BaseModel):
+    """LLM-generated natural language explanations for each data point in a chart."""
+
+    explanations: list[str] = Field(
+        description=(
+            "One short human-readable explanation per data row, in the same order as the input rows. "
+            "Each string should describe what makes that specific data point notable or interesting "
+            "in the context of the chart being shown."
+        )
+    )
+
+
 class VegaLiteAgent(BaseCodeAgent):
 
     conditions = param.List(
@@ -146,6 +159,7 @@ class VegaLiteAgent(BaseCodeAgent):
             "interaction_polish": {"response_model": VegaLiteSpecUpdate, "template": PROMPTS_DIR / "VegaLiteAgent" / "interaction_polish.jinja2"},
             "annotate_plot": {"response_model": VegaLiteSpecUpdate, "template": PROMPTS_DIR / "VegaLiteAgent" / "annotate_plot.jinja2"},
             "revise_output": {"response_model": RetrySpec, "template": PROMPTS_DIR / "VegaLiteAgent" / "revise_output.jinja2"},
+            "ai_explanation": {"response_model": PointExplanations, "template": PROMPTS_DIR / "VegaLiteAgent" / "ai_explanation.jinja2"},
         }
     )
 
@@ -918,8 +932,52 @@ class VegaLiteAgent(BaseCodeAgent):
                 out.spec = dump_yaml(normalized["spec"])
             log_debug(f"📊 Applied {step_name} updates and refreshed visualization")
 
+    async def _generate_ai_explanations(
+        self,
+        pipeline: Pipeline,
+        messages: list[Message],
+        context: TContext,
+    ) -> None:
+        """
+        Generate LLM-powered natural language explanations for each data row
+        and inject them as a new 'ai_explanation' column into the pipeline data.
+
+        After this method runs, pipeline.data is updated with the new column.
+        The pipeline's param watcher automatically triggers a UI re-render so
+        the tooltip picks up the new field without any additional code.
+        """
+        # 1. Get current pipeline data as pandas DataFrame
+        df = pipeline.data
+        if not isinstance(df, pd.DataFrame):
+            try:
+                df = df.to_pandas()
+            except AttributeError:
+                df = pd.DataFrame(df)
+
+        # 2. Build prompt variables
+        data_csv = df.to_csv(index=False)
+        user_query = self._last_user_query(messages)
+
+        # 3. Invoke LLM using the ai_explanation prompt template (same pattern as
+        #    _stream_prompt / _invoke_prompt used elsewhere in this agent).
+        #    response_model is picked up automatically from the prompts dict entry.
+        result = await self._invoke_prompt(
+            "ai_explanation",
+            messages,
+            context,
+            user_query=user_query,
+            data_csv=data_csv,
+        )
+
+        # 4. Inject explanations as a new column into the DataFrame
+        df["ai_explanation"] = result.explanations
+
+        # 5. Update pipeline.data — the param watcher will auto-trigger UI re-render
+        pipeline.data = df
+
     @staticmethod
     def _overview_item(editor: VegaLiteEditor) -> ParamFunction:
+
         """A plot for the "All" overview that tracks an editor's component.
 
         Binding to the editor's ``component`` means the overview re-renders when
@@ -1003,6 +1061,9 @@ class VegaLiteAgent(BaseCodeAgent):
         if not self.code_execution_enabled:
             for editor in editors:
                 state.execute(partial(self._polish_plot, editor, messages, context, doc))
+
+            # Step 5: Background LLM-driven row explanations (adds ai_explanation column)
+            state.execute(partial(self._generate_ai_explanations, pipeline, messages, context))
 
         out_context = await editors[-1].render_context()
         return outs, out_context

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -1008,6 +1008,22 @@ class VegaLiteAgent(BaseCodeAgent):
         return True
 
     @staticmethod
+    def _spec_has_aggregation(spec: dict) -> bool:
+        """
+        Return True if any encoding channel in the Vega-Lite spec uses an
+        aggregate function (e.g. mean, sum, count).
+
+        Adding a raw per-row field (ai_explanation) to a tooltip alongside
+        aggregated encodings causes Vega-Lite to group by that field too,
+        which silently splits a single bar into one bar per row.
+        """
+        encoding = spec.get("spec", spec).get("encoding", {})
+        return any(
+            isinstance(channel, dict) and "aggregate" in channel
+            for channel in encoding.values()
+        )
+
+    @staticmethod
     def _overview_item(editor: VegaLiteEditor) -> ParamFunction:
 
         """A plot for the "All" overview that tracks an editor's component.
@@ -1091,13 +1107,18 @@ class VegaLiteAgent(BaseCodeAgent):
 
         # Step 4: enhancements (LLM-driven creative decisions), per editable chart
         if not self.code_execution_enabled:
-            for editor in editors:
+            for editor, (spec, _) in zip(editors, charts):
                 state.execute(partial(self._polish_plot, editor, messages, context, doc))
                 # Step 5: Background LLM-driven row explanations, per chart.
-                # Each editor has its own pipeline (gridded charts get a chained
-                # pipeline from subset_gridded_to_2d). Run once per editor so
-                # every chart gets its own ai_explanation column — not just chart 1.
-                state.execute(partial(self._generate_ai_explanations, editor.component.pipeline, messages, context))
+                # Skip aggregate specs (mean/sum bar charts etc.): adding a raw
+                # per-row field to a tooltip alongside aggregated encodings makes
+                # Vega-Lite group by that field too, silently splitting one bar
+                # into many.
+                if not self._spec_has_aggregation(spec):
+                    state.execute(partial(
+                        self._generate_ai_explanations,
+                        editor.component.pipeline, messages, context,
+                    ))
 
         out_context = await editors[-1].render_context()
         return outs, out_context

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -30,7 +30,7 @@ from ..embeddings import NumpyEmbeddings, OpenAIEmbeddings
 from ..llm import Message, OpenAI
 from ..models import EscapeBaseModel, RetrySpec
 from ..utils import (
-    category_palette, get_data, get_gridded_metadata, get_schema,
+    PROFILE_SAMPLE_ROWS, category_palette, get_data, get_gridded_metadata, get_schema,
     has_categorical_color, load_json, log_debug, normalize_vegalite_spec,
     retry_llm_output, subset_gridded_to_2d,
 )
@@ -955,8 +955,19 @@ class VegaLiteAgent(BaseCodeAgent):
             except AttributeError:
                 df = pd.DataFrame(df)
 
-        # 2. Build prompt variables
-        data_csv = df.to_csv(index=False)
+        # 2. Build prompt variables — cap rows to avoid blowing the context window.
+        # We use PROFILE_SAMPLE_ROWS (same cap as the rest of the file) but take
+        # the HEAD (not a random sample) so explanations stay row-aligned: the
+        # LLM gets rows 0..N-1 and must return exactly that many explanations.
+        n_rows = len(df)
+        is_capped = n_rows > PROFILE_SAMPLE_ROWS
+        df_for_llm = df.head(PROFILE_SAMPLE_ROWS) if is_capped else df
+        if is_capped:
+            log_debug(
+                f"ai_explanation: DataFrame has {n_rows} rows — "
+                f"capping prompt to first {PROFILE_SAMPLE_ROWS} rows."
+            )
+        data_csv = df_for_llm.to_csv(index=False)
         user_query = self._last_user_query(messages)
 
         # 3. Invoke LLM using the ai_explanation prompt template (same pattern as
@@ -974,15 +985,22 @@ class VegaLiteAgent(BaseCodeAgent):
         # Guard against LLM returning a different number of items than rows —
         # pandas raises ValueError on length mismatch, which would silently
         # swallow inside this fire-and-forget task with no visible error.
+        # Note: LLM was given df_for_llm (capped) so we align against that length,
+        # then pad the remaining rows with empty string for the full df.
         explanations = result.explanations
-        n_rows = len(df)
-        if len(explanations) != n_rows:
+        capped_rows = len(df_for_llm)
+        if len(explanations) != capped_rows:
             log_debug(
                 f"ai_explanation: LLM returned {len(explanations)} items for "
-                f"{n_rows} rows — truncating/padding to match."
+                f"{capped_rows} capped rows — truncating/padding to match."
             )
             # Truncate if too many, pad with empty string if too few
-            explanations = (explanations + [""] * n_rows)[:n_rows]
+            explanations = (explanations + [""] * capped_rows)[:capped_rows]
+
+        # Pad remaining rows (beyond cap) with empty string
+        if is_capped:
+            explanations = explanations + [""] * (n_rows - capped_rows)
+
         df["ai_explanation"] = explanations
 
         # 5. Update pipeline.data — the param watcher will auto-trigger UI re-render

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -939,7 +939,7 @@ class VegaLiteAgent(BaseCodeAgent):
         pipeline: Pipeline,
         messages: list[Message],
         context: TContext,
-    ) -> None:
+    ) -> bool:
         """
         Generate LLM-powered natural language explanations for each data row
         and inject them as a new 'ai_explanation' column into the pipeline data.
@@ -1006,6 +1006,9 @@ class VegaLiteAgent(BaseCodeAgent):
 
         # 5. Update pipeline.data — the param watcher will auto-trigger UI re-render
         pipeline.data = df
+        # Signal success to @retry_llm_output — falsy return (None) would
+        # be treated as failure and trigger unnecessary retries.
+        return True
 
     @staticmethod
     def _overview_item(editor: VegaLiteEditor) -> ParamFunction:

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -4,7 +4,6 @@ from collections import Counter
 from functools import partial
 from typing import Any
 
-
 import param
 import requests
 
@@ -30,9 +29,9 @@ from ..embeddings import NumpyEmbeddings, OpenAIEmbeddings
 from ..llm import Message, OpenAI
 from ..models import EscapeBaseModel, RetrySpec
 from ..utils import (
-    category_palette, get_data, get_gridded_metadata, get_schema,
-    has_categorical_color, load_json, log_debug, normalize_vegalite_spec,
-    PROFILE_SAMPLE_ROWS, retry_llm_output, subset_gridded_to_2d,
+    PROFILE_SAMPLE_ROWS, category_palette, get_data, get_gridded_metadata,
+    get_schema, has_categorical_color, load_json, log_debug,
+    normalize_vegalite_spec, retry_llm_output, subset_gridded_to_2d,
 )
 from ..vector_store import DuckDBVectorStore
 from .base_code import BaseCodeAgent

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -933,6 +933,7 @@ class VegaLiteAgent(BaseCodeAgent):
                 out.spec = dump_yaml(normalized["spec"])
             log_debug(f"📊 Applied {step_name} updates and refreshed visualization")
 
+    @retry_llm_output()
     async def _generate_ai_explanations(
         self,
         pipeline: Pipeline,

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -1062,8 +1062,13 @@ class VegaLiteAgent(BaseCodeAgent):
             for editor in editors:
                 state.execute(partial(self._polish_plot, editor, messages, context, doc))
 
-            # Step 5: Background LLM-driven row explanations (adds ai_explanation column)
-            state.execute(partial(self._generate_ai_explanations, pipeline, messages, context))
+            # Step 5: Background LLM-driven row explanations (adds ai_explanation column).
+            # Use the pipeline that the first editor's chart actually renders from — for
+            # gridded data this is a chained pipeline returned by subset_gridded_to_2d,
+            # not the raw `pipeline`. Modifying the wrong pipeline would leave the
+            # ai_explanation column detached from the chart that is actually shown.
+            rendered_pipeline = editors[0].component.pipeline
+            state.execute(partial(self._generate_ai_explanations, rendered_pipeline, messages, context))
 
         out_context = await editors[-1].render_context()
         return outs, out_context

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -30,9 +30,9 @@ from ..embeddings import NumpyEmbeddings, OpenAIEmbeddings
 from ..llm import Message, OpenAI
 from ..models import EscapeBaseModel, RetrySpec
 from ..utils import (
-    PROFILE_SAMPLE_ROWS, category_palette, get_data, get_gridded_metadata, get_schema,
+    category_palette, get_data, get_gridded_metadata, get_schema,
     has_categorical_color, load_json, log_debug, normalize_vegalite_spec,
-    retry_llm_output, subset_gridded_to_2d,
+    PROFILE_SAMPLE_ROWS, retry_llm_output, subset_gridded_to_2d,
 )
 from ..vector_store import DuckDBVectorStore
 from .base_code import BaseCodeAgent

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -935,30 +935,27 @@ class VegaLiteAgent(BaseCodeAgent):
     @retry_llm_output()
     async def _generate_ai_explanations(
         self,
-        pipeline: Pipeline,
+        view: VegaLiteView,
         messages: list[Message],
         context: TContext,
     ) -> bool:
         """
         Generate LLM-powered natural language explanations for each data row
-        and inject them as a new 'ai_explanation' column into the pipeline data.
+        and store them on the view's own _ai_explanations param, keyed to the
+        row order of the data at generation time.
 
-        After this method runs, pipeline.data is updated with the new column.
-        The pipeline's param watcher automatically triggers a UI re-render so
-        the tooltip picks up the new field without any additional code.
-
-        Note: this mutates the pipeline's own data, so the ai_explanation
-        column is visible to anything else reading this pipeline afterward
-        (schema introspection, exports, another chart on the same table),
-        not just this chart's tooltip. respond() dedupes so only one call
-        runs per shared pipeline, but the column itself still leaks beyond
-        this one chart by design of the re-render mechanism.
+        Stored on the view rather than written into pipeline.data: the
+        pipeline can be shared by other charts and agents on the same table,
+        and a column that only exists to serve this one chart's tooltip
+        should not leak into their view of the data. Setting the param
+        triggers the same update()/rerender path pipeline.data changes would
+        have (see View._internal_params / view.update in views/base.py).
         """
         # 1. Get current pipeline data as pandas DataFrame.
         # get_data handles lazy frames (narwhals/polars) correctly and runs
         # off-thread — pd.DataFrame(lazyframe) would raise. Same pattern
         # used elsewhere in this file (e.g. _generate_altair_spec).
-        df = await get_data(pipeline)
+        df = await get_data(view.pipeline)
 
         # 2. Build prompt variables — cap rows to avoid blowing the context window.
         # We use PROFILE_SAMPLE_ROWS (same cap as the rest of the file) but take
@@ -1006,10 +1003,11 @@ class VegaLiteAgent(BaseCodeAgent):
         if is_capped:
             explanations = explanations + [""] * (n_rows - capped_rows)
 
-        df["ai_explanation"] = explanations
-
-        # 5. Update pipeline.data — the param watcher will auto-trigger UI re-render
-        pipeline.data = df
+        # 5. Store on the view. View.__init__ already watches every param but
+        # rerender/selection_expr/name and calls update() on change, so
+        # assigning this triggers the same update/rerender path pipeline.data
+        # would have, with no separate call needed.
+        view._ai_explanations = explanations
         # Signal success to @retry_llm_output — falsy return (None) would
         # be treated as failure and trigger unnecessary retries.
         return True
@@ -1123,25 +1121,20 @@ class VegaLiteAgent(BaseCodeAgent):
             # editors is built one-to-one from charts (Step 2 above), so the
             # lengths always match; strict=True surfaces it loudly if that
             # invariant ever breaks instead of silently dropping entries.
-            explained_pipelines: set[int] = set()
             for editor, (spec, _) in zip(editors, charts, strict=True):
                 state.execute(partial(self._polish_plot, editor, messages, context, doc))
                 # Step 5: Background LLM-driven row explanations, per chart.
                 # Skip aggregate specs (mean/sum bar charts etc.): adding a raw
                 # per-row field to a tooltip alongside aggregated encodings makes
                 # Vega-Lite group by that field too, silently splitting one bar
-                # into many.
-                pipeline = editor.component.pipeline
-                # subset_gridded_to_2d returns the same pipeline instance for
-                # every non-gridded chart, so two charts on one table would
-                # otherwise spawn concurrent tasks that read-modify-write the
-                # same pipeline.data, racing on the last write and paying for
-                # the same LLM call twice.
-                if not self._spec_has_aggregation(spec) and id(pipeline) not in explained_pipelines:
-                    explained_pipelines.add(id(pipeline))
+                # into many. Explanations are stored per-view (see
+                # VegaLiteView._ai_explanations), so charts sharing a pipeline
+                # each get their own independent background task with no
+                # shared state to race on.
+                if not self._spec_has_aggregation(spec):
                     state.execute(partial(
                         self._generate_ai_explanations,
-                        pipeline, messages, context,
+                        editor.component, messages, context,
                     ))
 
         out_context = await editors[-1].render_context()

--- a/lumen/ai/agents/vega_lite.py
+++ b/lumen/ai/agents/vega_lite.py
@@ -4,7 +4,7 @@ from collections import Counter
 from functools import partial
 from typing import Any
 
-import pandas as pd
+
 import param
 import requests
 
@@ -1094,14 +1094,11 @@ class VegaLiteAgent(BaseCodeAgent):
         if not self.code_execution_enabled:
             for editor in editors:
                 state.execute(partial(self._polish_plot, editor, messages, context, doc))
-
-            # Step 5: Background LLM-driven row explanations (adds ai_explanation column).
-            # Use the pipeline that the first editor's chart actually renders from — for
-            # gridded data this is a chained pipeline returned by subset_gridded_to_2d,
-            # not the raw `pipeline`. Modifying the wrong pipeline would leave the
-            # ai_explanation column detached from the chart that is actually shown.
-            rendered_pipeline = editors[0].component.pipeline
-            state.execute(partial(self._generate_ai_explanations, rendered_pipeline, messages, context))
+                # Step 5: Background LLM-driven row explanations, per chart.
+                # Each editor has its own pipeline (gridded charts get a chained
+                # pipeline from subset_gridded_to_2d). Run once per editor so
+                # every chart gets its own ai_explanation column — not just chart 1.
+                state.execute(partial(self._generate_ai_explanations, editor.component.pipeline, messages, context))
 
         out_context = await editors[-1].render_context()
         return outs, out_context

--- a/lumen/ai/prompts/VegaLiteAgent/ai_explanation.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/ai_explanation.jinja2
@@ -1,0 +1,29 @@
+You are a data analyst helping users understand charts and visualizations.
+
+The user asked: {{ user_query }}
+
+Below is the dataset shown in the chart (CSV format):
+
+```csv
+{{ data_csv }}
+```
+
+## Your Task
+
+For each row in the CSV above, write exactly one short explanation (1-2 sentences) that:
+- Describes what makes that specific data point **notable or interesting** in the context of the user's query and the chart being shown.
+- Uses plain English — no jargon, no column name references like "the value of body_mass_g". Instead say "the body mass" or "its weight".
+- Is concise and directly insightful.
+
+## Rules
+
+- Return **exactly as many explanations as there are data rows** (excluding the header row).
+- Preserve the **exact same order** as the input rows.
+- Do NOT include row numbers, bullet points, or any other prefix in each explanation.
+- If a row has no notable characteristics, say so briefly (e.g. "A typical specimen with average measurements across all traits.").
+
+## Example
+
+For a penguins dataset row: `Adelie,Torgersen,181,3750,MALE`
+
+Good explanation: "A male Adelie penguin from Torgersen Island with a relatively short flipper length of 181mm and body mass close to the species average."

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -49,7 +49,7 @@ Legends appear when mapping data to `color`, `size`, or `shape` in encoding.
 
 ## Tooltips
 
-Every chart MUST include a `tooltip` encoding array. This array must always contain the following exact field definition to display the AI-generated explanation:
+Every chart is required to include a `tooltip` encoding array. This array must always contain the following exact field definition to display the AI-generated explanation:
 `- {field: "ai_explanation", type: "nominal", title: "AI Insight"}`
 
 You should also include other relevant data fields (like the x and y axes values) in the tooltip array, but `ai_explanation` must always be present.

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -47,6 +47,13 @@ Legends appear when mapping data to `color`, `size`, or `shape` in encoding.
   - Use size only with single color: `color: {value: '#1f77b4'}`
   - Or disable one legend: `color: {field: value, scale: {scheme: blues}, legend: null}`
 
+## Tooltips
+
+Every chart MUST include a `tooltip` encoding array. This array must always contain the following exact field definition to display the AI-generated explanation:
+`- {field: "ai_explanation", type: "nominal", title: "AI Insight"}`
+
+You should also include other relevant data fields (like the x and y axes values) in the tooltip array, but `ai_explanation` must always be present.
+
 ## Key Patterns
 
 **Sort rankings**: `sort: "-x"` (horizontal) or `sort: "-y"` (vertical) on categorical axis. In a layered spec where layers bind different fields to that axis, `"-x"` cannot resolve and silently falls back to alphabetical — use an explicit sort field instead, and repeat it identically on every layer sharing that axis or the merge drops it:

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -47,12 +47,14 @@ Legends appear when mapping data to `color`, `size`, or `shape` in encoding.
   - Use size only with single color: `color: {value: '#1f77b4'}`
   - Or disable one legend: `color: {field: value, scale: {scheme: blues}, legend: null}`
 
+{%- if code_execution_enabled is defined and not code_execution_enabled %}
 ## Tooltips
 
 Every chart is required to include a `tooltip` encoding array. This array must always contain the following exact field definition to display the AI-generated explanation:
 `- {field: "ai_explanation", type: "nominal", title: "AI Insight"}`
 
 You should also include other relevant data fields (like the x and y axes values) in the tooltip array, but `ai_explanation` must always be present.
+{%- endif %}
 
 ## Key Patterns
 

--- a/lumen/ai/prompts/VegaLiteAgent/main.jinja2
+++ b/lumen/ai/prompts/VegaLiteAgent/main.jinja2
@@ -50,10 +50,10 @@ Legends appear when mapping data to `color`, `size`, or `shape` in encoding.
 {%- if code_execution_enabled is defined and not code_execution_enabled %}
 ## Tooltips
 
-Every chart is required to include a `tooltip` encoding array. This array must always contain the following exact field definition to display the AI-generated explanation:
+If the chart does NOT use aggregation (no `aggregate` on any encoding channel — every mark stays one row of the underlying data), include a `tooltip` encoding array containing this exact field definition to display the AI-generated explanation, alongside other relevant data fields (like the x and y axes values):
 `- {field: "ai_explanation", type: "nominal", title: "AI Insight"}`
 
-You should also include other relevant data fields (like the x and y axes values) in the tooltip array, but `ai_explanation` must always be present.
+If the chart DOES aggregate (mean/sum/count bar charts, etc.), do NOT add `ai_explanation` to the tooltip — the explanation is generated per underlying row and does not apply to an aggregated mark.
 {%- endif %}
 
 ## Key Patterns

--- a/lumen/tests/ai/test_vega_lite.py
+++ b/lumen/tests/ai/test_vega_lite.py
@@ -89,6 +89,35 @@ def test_main_prompt_guards_ungrouped_multi_series_lines():
     assert "aggregate" in text.lower()
 
 
+NON_AGGREGATED_ENCODING = {
+    "x": {"field": "a", "type": "nominal"},
+    "y": {"field": "v", "type": "quantitative"},
+}
+AGGREGATED_ENCODING = {
+    "x": {"field": "a", "type": "nominal"},
+    "y": {"aggregate": "mean", "field": "v", "type": "quantitative"},
+}
+
+
+@pytest.mark.parametrize(("spec", "expected"), [
+    ({"encoding": NON_AGGREGATED_ENCODING}, False),
+    ({"encoding": AGGREGATED_ENCODING}, True),
+    ({"spec": {"encoding": AGGREGATED_ENCODING}}, True),
+    ({"layer": [{"encoding": NON_AGGREGATED_ENCODING}, {"encoding": AGGREGATED_ENCODING}]}, True),
+    ({"layer": [{"encoding": NON_AGGREGATED_ENCODING}, {"mark": "rule"}]}, False),
+    ({"concat": [{"encoding": AGGREGATED_ENCODING}]}, True),
+    ({"hconcat": [{"encoding": NON_AGGREGATED_ENCODING}]}, False),
+    ({"vconcat": [{"encoding": NON_AGGREGATED_ENCODING}, {"encoding": AGGREGATED_ENCODING}]}, True),
+])
+def test_spec_has_aggregation_recurses_into_composite_specs(spec, expected):
+    """A raw per-row field (ai_explanation) added to a tooltip alongside an
+    aggregated encoding makes Vega-Lite group by it too, silently splitting a
+    bar into one per row. That failure mode is not limited to top-level specs:
+    an annotate_plot trend line, or any concat/facet, nests the aggregate
+    inside a composition container, so the check has to walk those too."""
+    assert VegaLiteAgent._spec_has_aggregation(spec) is expected
+
+
 CATEGORICAL_SPEC = {
     "mark": "bar",
     "encoding": {

--- a/lumen/tests/views/test_base.py
+++ b/lumen/tests/views/test_base.py
@@ -14,7 +14,7 @@ from lumen.state import state
 from lumen.tests.utils import Polygon, gpd, requires_geopandas
 from lumen.variables.base import Variables
 from lumen.views.base import (
-    DeckGLView, Panel, Table, VegaLiteView, View, hvOverlayView, hvPlotView,
+    DeckGLView, Table, VegaLiteView, View, hvOverlayView, hvPlotView,
 )
 
 # duckdb is a core dependency but the minimal test-core env omits it, and the
@@ -464,6 +464,82 @@ def test_vega_datasets_are_not_accumulated_across_renders(set_root):
     view.get_panel()
 
     assert set(view.spec["datasets"]) == {"populations"}
+
+
+def _scatter_spec():
+    return {
+        "mark": "point",
+        "encoding": {
+            "x": {"field": "A", "type": "quantitative"},
+            "y": {"field": "B", "type": "quantitative"},
+        },
+    }
+
+
+def test_vega_ai_explanations_stay_local_to_the_view(set_root):
+    """_ai_explanations backs VegaLiteAgent's per-row tooltip feature. It must
+    not leak into pipeline.data (shared by any other chart or agent on this
+    table), into a second view on the same pipeline, or into to_spec()."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    n_rows = len(pipeline.data)
+
+    view1 = VegaLiteView(spec=_scatter_spec(), pipeline=pipeline)
+    view2 = VegaLiteView(spec=_scatter_spec(), pipeline=pipeline)
+
+    # Force get_data()'s cache to populate on both views first, the same way
+    # an initial render would, since the leak this guards against only shows
+    # up on a *cached* read (get_data() only copies on the first call).
+    view1.get_data()
+    view2.get_data()
+
+    view1._ai_explanations = [f"row {i}" for i in range(n_rows)]
+
+    final_spec = view1.get_panel().object
+    assert "ai_explanation" in final_spec["data"]["values"].columns
+
+    assert "ai_explanation" not in view2.get_panel().object["data"]["values"].columns
+    assert "ai_explanation" not in pipeline.data.columns
+    assert "_ai_explanations" not in view1.to_spec()
+
+
+def test_vega_ai_explanations_pad_to_current_row_count(set_root):
+    """The pipeline may have re-queried since explanations were generated
+    (a filter, a new turn), so a stale, wrong-length list must degrade to
+    blank cells rather than raising."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    n_rows = len(pipeline.data)
+
+    view = VegaLiteView(spec=_scatter_spec(), pipeline=pipeline)
+    view._ai_explanations = ["only one explanation"]
+
+    final_spec = view.get_panel().object
+    values = final_spec["data"]["values"]
+    assert len(values) == n_rows
+    assert values["ai_explanation"].iloc[0] == "only one explanation"
+    assert (values["ai_explanation"].iloc[1:] == "").all()
+
+
+def test_vega_ai_explanations_assignment_triggers_rerender(set_root):
+    """View.__init__ watches every param but rerender/selection_expr/name and
+    calls update() on change, so setting _ai_explanations alone must trigger
+    a rerender -- the same path pipeline.data changing used to take -- with
+    no separate update() call needed from the agent."""
+    set_root(str(Path(__file__).parent.parent))
+    pipeline = Pipeline(source=FileSource(tables={'test': 'sources/test.csv'}), table="test")
+    view = VegaLiteView(spec=_scatter_spec(), pipeline=pipeline)
+
+    fired = []
+    view.param.watch(fired.append, 'rerender')
+
+    view._ai_explanations = ["x"]
+
+    # View.update() firing more than once per param change is a pre-existing
+    # quirk shared by every param on this class (confirmed with an unrelated
+    # param like title) -- the invariant this feature actually needs is that
+    # a rerender happens at all, not an exact count.
+    assert len(fired) >= 1
 
 
 def test_vega_layered_choropleth_registers_the_named_dataset(set_root):

--- a/lumen/views/base.py
+++ b/lumen/views/base.py
@@ -1628,6 +1628,15 @@ class VegaLiteView(View):
 
     _extension = 'vega'
 
+    # Per-row AI-generated tooltip text (VegaLiteAgent's _generate_ai_explanations).
+    # Kept on the view rather than written into pipeline.data: the pipeline can be
+    # shared by other charts and agents on the same table, and a column that only
+    # exists to serve one chart's tooltip should not leak into their view of the
+    # data, into exports, or into this view's own to_spec().
+    _ai_explanations = param.List(default=[])
+
+    _internal_params: ClassVar[list[str]] = [*View._internal_params, '_ai_explanations']
+
     @classmethod
     def _declares_own_data(cls, node: Any) -> bool:
         """Whether the spec supplies its own data (a url or inline values) anywhere.
@@ -1743,6 +1752,23 @@ class VegaLiteView(View):
 
     def _get_params(self) -> dict[str, Any]:
         df = self.get_data()
+        if self._ai_explanations:
+            # get_data() returns the same cached frame object on every call
+            # after the first (View._cache), which is also pipeline.data
+            # itself -- writing a column into df without copying here would
+            # mutate that shared frame, exactly the pipeline-wide leak this
+            # per-view param exists to avoid.
+            df = df.copy()
+            # The pipeline may have re-queried (filters, a new turn) since the
+            # explanations were generated, so the row count here is not
+            # guaranteed to match; pad/truncate rather than raise so a stale
+            # explanation set degrades to blank cells instead of breaking the
+            # chart.
+            explanations = self._ai_explanations
+            n_rows = len(df)
+            if len(explanations) != n_rows:
+                explanations = (explanations + [""] * n_rows)[:n_rows]
+            df["ai_explanation"] = explanations
         spec_data = self.spec.get('data', {})
         spec = dict(self.spec)
 


### PR DESCRIPTION
- Adds `_generate_ai_explanations` as a background task.
- Creates `ai_explanation.jinja2` prompt.
- Instructs `main.jinja2` to always embed `ai_explanation` in tooltip.

<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
This PR implements the "Explain Every Point" feature for the Vega-Lite Agent, adding intelligent, LLM-driven row explanations that render directly in the plot tooltips.

**Key Implementation Details:**
- Defined a `PointExplanations` Pydantic model to guarantee strict row-to-row output alignment from the LLM.
- Added a non-blocking background step (`_generate_ai_explanations`) running on `state.execute` that asynchronously generates insights from the DataFrame after the initial chart is rendered.
- Automatically injects the LLM explanations as a new `ai_explanation` column in `pipeline.data`, which triggers Lumen's built-in `param` watchers to automatically update the chart UI.
- Updated `main.jinja2` to unconditionally require the `ai_explanation` field in tooltip specs.

**How to verify:**
1. Run `lumen-ai serve penguins.csv`
2. Ask: "Create a scatter plot showing body mass on the y-axis and flipper length on the x-axis, colored by species. Make sure to use Vega-Lite."
3. Wait 2-3 seconds for the background task to complete, then hover over any data point. The tooltip will display a custom "AI Insight" detailing why that specific point is notable.

Fixes #1983


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Antigravity IDE (Gemini 3.1 Pro High)
Usage: Assisted in architectural decision making, mapping out the `state.execute` workflow for background tasks, writing the Pydantic models and Jinja templates, and updating the agent flow without causing blocking behavior.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Tests added and are passing (Note: Relying on core LLM tests, but manual verification confirms end-to-end functionality without blocking)
